### PR TITLE
Extract Stable Diffusion metadata from PNG

### DIFF
--- a/DiffusionNexus.UI/Classes/PngMetadataReader.cs
+++ b/DiffusionNexus.UI/Classes/PngMetadataReader.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Png;
+
+namespace DiffusionNexus.UI.Classes
+{
+    public static class PngMetadataReader
+    {
+        public static StableDiffusionMetadata? ReadMetadata(string path)
+        {
+            using var image = Image.Load(path, out var format);
+            if (format is not PngFormat)
+                return null;
+
+            var pngMeta = image.Metadata.GetPngMetadata();
+            var textData = pngMeta.TextData.FirstOrDefault(t => t.Keyword == "parameters");
+            if (textData == null)
+                return null;
+            return Parse(textData.Value);
+        }
+
+        private static StableDiffusionMetadata Parse(string input)
+        {
+            var meta = new StableDiffusionMetadata();
+            var lines = input.Split('\n');
+            if (lines.Length > 0)
+                meta.Prompt = lines[0].Replace("Prompt:", string.Empty).Trim();
+            if (lines.Length > 1)
+                meta.NegativePrompt = lines[1].Replace("Negative prompt:", string.Empty).Trim();
+
+            for (int i = 2; i < lines.Length; i++)
+            {
+                foreach (var part in lines[i].Split(',', StringSplitOptions.RemoveEmptyEntries))
+                {
+                    var kv = part.Split(new[] { ':', '=' }, 2);
+                    if (kv.Length != 2) continue;
+                    var key = kv[0].Trim();
+                    var value = kv[1].Trim();
+
+                    switch (key)
+                    {
+                        case "Steps":
+                            if (int.TryParse(value, out var steps)) meta.Steps = steps;
+                            break;
+                        case "Sampler":
+                            meta.Sampler = value;
+                            break;
+                        case "CFG scale":
+                            if (float.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var cfg)) meta.CFGScale = cfg;
+                            break;
+                        case "Seed":
+                            if (long.TryParse(value, out var seed)) meta.Seed = seed;
+                            break;
+                        case "Size":
+                            var dims = value.Split('x');
+                            if (dims.Length == 2)
+                            {
+                                int.TryParse(dims[0], out var w);
+                                int.TryParse(dims[1], out var h);
+                                meta.Width = w;
+                                meta.Height = h;
+                            }
+                            break;
+                        case "Model hash":
+                            meta.ModelHash = value;
+                            break;
+                    }
+                }
+            }
+            return meta;
+        }
+    }
+}
+

--- a/DiffusionNexus.UI/Classes/StableDiffusionMetadata.cs
+++ b/DiffusionNexus.UI/Classes/StableDiffusionMetadata.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace DiffusionNexus.UI.Classes
+{
+    public class StableDiffusionMetadata
+    {
+        public string? Prompt { get; set; }
+        public string? NegativePrompt { get; set; }
+        public int Steps { get; set; }
+        public string? Sampler { get; set; }
+        public float CFGScale { get; set; }
+        public long Seed { get; set; }
+        public int Width { get; set; }
+        public int Height { get; set; }
+        public string? ModelHash { get; set; }
+    }
+}
+

--- a/DiffusionNexus.UI/DiffusionNexus.UI.csproj
+++ b/DiffusionNexus.UI/DiffusionNexus.UI.csproj
@@ -27,5 +27,6 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="ReactiveUI" Version="20.3.1" />
     <PackageReference Include="System.Reactive" Version="6.0.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
   </ItemGroup>
 </Project>

--- a/DiffusionNexus.UI/Views/PromptEditView.axaml.cs
+++ b/DiffusionNexus.UI/Views/PromptEditView.axaml.cs
@@ -7,6 +7,7 @@ using Avalonia.Media.Imaging;
 using System;
 using System.IO;
 using System.Linq;
+using DiffusionNexus.UI.Classes;
 
 namespace DiffusionNexus.UI.Views
 {
@@ -15,6 +16,8 @@ namespace DiffusionNexus.UI.Views
         private Border? _imageDropBorder;
         private TextBlock? _dropText;
         private Image? _previewImage;
+        private TextBox? _promptBox;
+        private TextBox? _negativePromptBox;
         private readonly IBrush _defaultBorderBrush;
 
         public PromptEditView()
@@ -24,6 +27,8 @@ namespace DiffusionNexus.UI.Views
             _imageDropBorder = this.FindControl<Border>("ImageDropBorder");
             _dropText = this.FindControl<TextBlock>("DropText");
             _previewImage = this.FindControl<Image>("PreviewImage");
+            _promptBox = this.FindControl<TextBox>("PromptBox");
+            _negativePromptBox = this.FindControl<TextBox>("NegativePromptBox");
 
             if (_imageDropBorder != null)
             {
@@ -92,6 +97,16 @@ namespace DiffusionNexus.UI.Views
                         if (_dropText != null)
                         {
                             _dropText.IsVisible = false;
+                        }
+
+                        // extract metadata and populate prompt boxes
+                        var meta = PngMetadataReader.ReadMetadata(file);
+                        if (meta != null)
+                        {
+                            if (_promptBox != null)
+                                _promptBox.Text = meta.Prompt ?? string.Empty;
+                            if (_negativePromptBox != null)
+                                _negativePromptBox.Text = meta.NegativePrompt ?? string.Empty;
                         }
                     }
                     catch (Exception)


### PR DESCRIPTION
## Summary
- add StableDiffusionMetadata model and PNG metadata reader
- populate prompt boxes with extracted metadata when dropping an image
- reference ImageSharp library for PNG reading

## Testing
- `dotnet build DiffusionNexus.UI/DiffusionNexus.UI.csproj -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853fd501bc4833286e95ccc7373b520