### PR TITLE
Implement prompt editing with blacklist support

### DIFF
--- a/DiffusionNexus.UI/Classes/PngMetadataReader.cs
+++ b/DiffusionNexus.UI/Classes/PngMetadataReader.cs
@@ -29,6 +29,10 @@ namespace DiffusionNexus.UI.Classes
 
         private static StableDiffusionMetadata Parse(string input)
         {
+            // Return an empty/default metadata if there's nothing to parse
+            if (string.IsNullOrWhiteSpace(input))
+                return new StableDiffusionMetadata();
+
             var meta = new StableDiffusionMetadata();
             var lines = input.Split('\n');
             if (lines.Length > 0)

--- a/DiffusionNexus.UI/Views/PromptEditView.axaml
+++ b/DiffusionNexus.UI/Views/PromptEditView.axaml
@@ -25,8 +25,9 @@
         <TextBox Name="NegativePromptBox" AcceptsReturn="True" TextWrapping="Wrap" Height="120"/>
       </StackPanel>
       <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10">
-        <Button Content="Save" Width="80"/>
-        <Button Content="Save As" Width="80"/>
+        <Button Content="Apply Blacklist" Width="110" Click="OnApplyBlacklist"/>
+        <Button Content="Save" Width="80" Click="OnSave"/>
+        <Button Content="Save As" Width="80" Click="OnSaveAs"/>
       </StackPanel>
     </StackPanel>
   </Grid>

--- a/DiffusionNexus.UI/Views/PromptEditView.axaml.cs
+++ b/DiffusionNexus.UI/Views/PromptEditView.axaml.cs
@@ -7,7 +7,10 @@ using Avalonia.Media.Imaging;
 using System;
 using System.IO;
 using System.Linq;
+using System.Text;
 using DiffusionNexus.UI.Classes;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Png;
 
 namespace DiffusionNexus.UI.Views
 {
@@ -18,7 +21,10 @@ namespace DiffusionNexus.UI.Views
         private Image? _previewImage;
         private TextBox? _promptBox;
         private TextBox? _negativePromptBox;
-        private readonly IBrush _defaultBorderBrush;
+        private TextBox? _blacklistBox;
+        private string? _currentImagePath;
+        private StableDiffusionMetadata? _metadata;
+        private readonly IBrush _defaultBorderBrush = Brushes.Transparent;
 
         public PromptEditView()
         {
@@ -29,6 +35,7 @@ namespace DiffusionNexus.UI.Views
             _previewImage = this.FindControl<Image>("PreviewImage");
             _promptBox = this.FindControl<TextBox>("PromptBox");
             _negativePromptBox = this.FindControl<TextBox>("NegativePromptBox");
+            _blacklistBox = this.FindControl<TextBox>("BlacklistBox");
 
             if (_imageDropBorder != null)
             {
@@ -107,7 +114,14 @@ namespace DiffusionNexus.UI.Views
                                 _promptBox.Text = meta.Prompt ?? string.Empty;
                             if (_negativePromptBox != null)
                                 _negativePromptBox.Text = meta.NegativePrompt ?? string.Empty;
+                            _metadata = meta;
                         }
+                        else
+                        {
+                            _metadata = null;
+                        }
+
+                        _currentImagePath = file;
                     }
                     catch (Exception)
                     {
@@ -161,6 +175,97 @@ namespace DiffusionNexus.UI.Views
                 _previewImage.Source = null;
                 _previewImage.IsVisible = false;
             }
+        }
+
+        private string BuildParametersString()
+        {
+            var prompt = _promptBox?.Text ?? string.Empty;
+            var negPrompt = _negativePromptBox?.Text ?? string.Empty;
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"Prompt: {prompt}");
+            sb.AppendLine($"Negative prompt: {negPrompt}");
+
+            if (_metadata != null)
+            {
+                var parts = new System.Collections.Generic.List<string>();
+                if (_metadata.Steps > 0) parts.Add($"Steps: {_metadata.Steps}");
+                if (!string.IsNullOrWhiteSpace(_metadata.Sampler)) parts.Add($"Sampler: {_metadata.Sampler}");
+                if (_metadata.CFGScale != 0) parts.Add($"CFG scale: {_metadata.CFGScale}");
+                if (_metadata.Seed != 0) parts.Add($"Seed: {_metadata.Seed}");
+                if (_metadata.Width > 0 && _metadata.Height > 0) parts.Add($"Size: {_metadata.Width}x{_metadata.Height}");
+                if (!string.IsNullOrWhiteSpace(_metadata.ModelHash)) parts.Add($"Model hash: {_metadata.ModelHash}");
+                if (parts.Count > 0)
+                    sb.AppendLine(string.Join(", ", parts));
+            }
+
+            return sb.ToString();
+        }
+
+        private void SaveImage(string path)
+        {
+            if (string.IsNullOrEmpty(_currentImagePath))
+                return;
+
+            using var image = Image.Load(_currentImagePath);
+            var pngMeta = image.Metadata.GetPngMetadata();
+            var parameters = BuildParametersString();
+            var existing = pngMeta.TextData.FirstOrDefault(t => t.Keyword == "parameters");
+            if (existing != null)
+                existing.Value = parameters;
+            else
+                pngMeta.TextData.Add(new PngTextData("parameters", parameters, null, null));
+
+            image.Save(path);
+        }
+
+        private void OnSave(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            if (string.IsNullOrEmpty(_currentImagePath))
+                return;
+
+            SaveImage(_currentImagePath);
+        }
+
+        private async void OnSaveAs(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            if (string.IsNullOrEmpty(_currentImagePath))
+                return;
+
+            var dialog = new SaveFileDialog
+            {
+                Filters = { new FileDialogFilter { Name = "PNG", Extensions = { "png" } } },
+                InitialFileName = Path.GetFileName(_currentImagePath)
+            };
+
+            if (this.VisualRoot is not Window window)
+                return;
+
+            var result = await dialog.ShowAsync(window);
+            if (!string.IsNullOrEmpty(result))
+            {
+                SaveImage(result);
+            }
+        }
+
+        private void OnApplyBlacklist(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            if (_blacklistBox == null)
+                return;
+
+            var words = _blacklistBox.Text?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? Array.Empty<string>();
+            if (_promptBox != null)
+                _promptBox.Text = ApplyBlacklist(_promptBox.Text, words);
+            if (_negativePromptBox != null)
+                _negativePromptBox.Text = ApplyBlacklist(_negativePromptBox.Text, words);
+        }
+
+        private static string ApplyBlacklist(string text, string[] words)
+        {
+            var parts = text.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                             .Select(p => p.Trim());
+            var filtered = parts.Where(p => !words.Contains(p, StringComparer.OrdinalIgnoreCase));
+            return string.Join(", ", filtered);
         }
     }
 }


### PR DESCRIPTION
## Summary
- enhance PromptEditView UI with new Apply Blacklist, Save and Save As buttons
- implement prompt editing and blacklist functionality in code-behind
- allow saving PNGs with updated prompt metadata

## Testing
- `dotnet build DiffusionNexus.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685408595fa08332abb2d8ec8af96a88