### PR TITLE
Improve hamburger sidebar layout

### DIFF
--- a/DiffusionNexus.Tests/DiffusionNexus.Tests.csproj
+++ b/DiffusionNexus.Tests/DiffusionNexus.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DiffusionNexus.UI\DiffusionNexus.UI.csproj" />
+  </ItemGroup>
+</Project>

--- a/DiffusionNexus.Tests/MainWindowViewModelTests.cs
+++ b/DiffusionNexus.Tests/MainWindowViewModelTests.cs
@@ -1,0 +1,17 @@
+using DiffusionNexus.UI.ViewModels;
+using Xunit;
+
+namespace DiffusionNexus.Tests
+{
+    public class MainWindowViewModelTests
+    {
+        [Fact]
+        public void ToggleMenuCommand_UpdatesLayout()
+        {
+            var vm = new MainWindowViewModel();
+            var initialWidth = vm.SidebarWidth;
+            vm.ToggleMenuCommand.Execute().Subscribe();
+            Assert.NotEqual(initialWidth, vm.SidebarWidth);
+        }
+    }
+}

--- a/DiffusionNexus.UI/ViewModels/MainWindowViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/MainWindowViewModel.cs
@@ -29,7 +29,25 @@ namespace DiffusionNexus.UI.ViewModels
         public bool IsMenuOpen
         {
             get => _isMenuOpen;
-            set => this.RaiseAndSetIfChanged(ref _isMenuOpen, value);
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _isMenuOpen, value);
+                UpdateLayoutFromMenuState();
+            }
+        }
+
+        private double _sidebarWidth = 200;
+        public double SidebarWidth
+        {
+            get => _sidebarWidth;
+            set => this.RaiseAndSetIfChanged(ref _sidebarWidth, value);
+        }
+
+        private double _mainContentScale = 1.0;
+        public double MainContentScale
+        {
+            get => _mainContentScale;
+            set => this.RaiseAndSetIfChanged(ref _mainContentScale, value);
         }
 
         private object _currentModuleView = null!;
@@ -67,6 +85,13 @@ namespace DiffusionNexus.UI.ViewModels
             });
 
             CurrentModuleView = Modules.First().View;
+            UpdateLayoutFromMenuState();
+        }
+
+        private void UpdateLayoutFromMenuState()
+        {
+            SidebarWidth = IsMenuOpen ? 200 : 0;
+            MainContentScale = IsMenuOpen ? 0.9 : 1.0;
         }
 
         private void OpenUrl(string url) => Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });

--- a/DiffusionNexus.UI/Views/MainWindow.axaml
+++ b/DiffusionNexus.UI/Views/MainWindow.axaml
@@ -15,13 +15,16 @@
     <vm:MainWindowViewModel/>
   </Window.DataContext>
 
-  <SplitView IsPaneOpen="{Binding IsMenuOpen}"
-             DisplayMode="CompactOverlay"
-             CompactPaneLength="60"
-             OpenPaneLength="200"
-             PanePlacement="Left">
+  <Grid>
+    <Grid.ColumnDefinitions>
+      <ColumnDefinition Width="Auto" />
+      <ColumnDefinition Width="*" />
+    </Grid.ColumnDefinitions>
+
     <!-- Sidebar Pane -->
-    <SplitView.Pane>
+    <Border Grid.Column="0"
+            Width="{Binding SidebarWidth}"
+            Transitions="<DoubleTransition Property=Width Duration=0:0:0.25 />">
       <StackPanel VerticalAlignment="Stretch" Spacing="10" Margin="0,10">
         <!-- Hamburger toggle -->
         <Button Content="☰" Command="{Binding ToggleMenuCommand}" HorizontalAlignment="Left"/>
@@ -48,11 +51,19 @@
           <Button Content="⚙ Settings" Command="{Binding OpenSettingsCommand}"/>
         </StackPanel>
       </StackPanel>
-    </SplitView.Pane>
+    </Border>
 
     <!-- Main content area -->
-    <SplitView.Content>
-      <ContentControl Content="{Binding CurrentModuleView}"/>
-    </SplitView.Content>
-  </SplitView>
+    <Border Grid.Column="1" PointerPressed="ContentArea_PointerPressed"
+            RenderTransformOrigin="0.5,0.5">
+      <Border.RenderTransform>
+        <ScaleTransform ScaleX="{Binding MainContentScale}" ScaleY="{Binding MainContentScale}" />
+      </Border.RenderTransform>
+      <Border.Transitions>
+        <DoubleTransition Property="RenderTransform.(ScaleTransform.ScaleX)" Duration="0:0:0.25"/>
+        <DoubleTransition Property="RenderTransform.(ScaleTransform.ScaleY)" Duration="0:0:0.25"/>
+      </Border.Transitions>
+      <ContentControl Content="{Binding CurrentModuleView}" />
+    </Border>
+  </Grid>
 </Window>

--- a/DiffusionNexus.UI/Views/MainWindow.axaml.cs
+++ b/DiffusionNexus.UI/Views/MainWindow.axaml.cs
@@ -1,5 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using Avalonia.Input;
+using DiffusionNexus.UI.ViewModels;
 
 namespace DiffusionNexus.UI.Views
 {
@@ -11,5 +13,11 @@ namespace DiffusionNexus.UI.Views
         }
 
         private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+        private void ContentArea_PointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (DataContext is MainWindowViewModel vm && vm.IsMenuOpen)
+                vm.IsMenuOpen = false;
+        }
     }
 }

--- a/DiffusionNexus.sln
+++ b/DiffusionNexus.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.14.36127.28 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DiffusionNexus.UI", "DiffusionNexus.UI\DiffusionNexus.UI.csproj", "{19C60AE1-F065-40A4-913F-3F19BDA229FF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DiffusionNexus.Tests", "DiffusionNexus.Tests\DiffusionNexus.Tests.csproj", "{27C7CAAA-3691-4B17-AD04-0C52104FD3C4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -13,9 +15,13 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{19C60AE1-F065-40A4-913F-3F19BDA229FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{19C60AE1-F065-40A4-913F-3F19BDA229FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{19C60AE1-F065-40A4-913F-3F19BDA229FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{19C60AE1-F065-40A4-913F-3F19BDA229FF}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {19C60AE1-F065-40A4-913F-3F19BDA229FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {19C60AE1-F065-40A4-913F-3F19BDA229FF}.Release|Any CPU.Build.0 = Release|Any CPU
+                {27C7CAAA-3691-4B17-AD04-0C52104FD3C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {27C7CAAA-3691-4B17-AD04-0C52104FD3C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {27C7CAAA-3691-4B17-AD04-0C52104FD3C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {27C7CAAA-3691-4B17-AD04-0C52104FD3C4}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# DiffusionNexus
+
+This repository contains an Avalonia UI application.
+
+## Sidebar behavior
+
+The sidebar no longer overlays the main content. Instead, it is part of a two column grid. When the hamburger button is pressed, the sidebar column expands to `200` pixels and the main content scales down slightly to provide focus.
+
+Animation durations and sizes are defined in `MainWindow.axaml` and can be tweaked via the `DoubleTransition` durations and the `SidebarWidth`/`MainContentScale` properties in `MainWindowViewModel`.


### PR DESCRIPTION
## Summary
- slide sidebar in/out by changing width instead of overlaying content
- scale main content slightly when menu is open
- add click-away behavior to collapse sidebar
- wire new layout properties in `MainWindowViewModel`
- document sidebar behavior
- add basic unit test project

## Testing
- `dotnet test DiffusionNexus.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68543437b6a083328d80e7d20466ac4f