### PR TITLE
Implement prompt profile management

### DIFF
--- a/DiffusionNexus.UI/Classes/DialogService.cs
+++ b/DiffusionNexus.UI/Classes/DialogService.cs
@@ -1,5 +1,7 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Layout;
+using Avalonia.Media;
 using System.Threading.Tasks;
 
 namespace DiffusionNexus.UI.Classes

--- a/DiffusionNexus.UI/Classes/DialogService.cs
+++ b/DiffusionNexus.UI/Classes/DialogService.cs
@@ -1,0 +1,105 @@
+using Avalonia.Controls;
+using Avalonia.Layout;
+using System.Threading.Tasks;
+
+namespace DiffusionNexus.UI.Classes
+{
+    public class DialogService : IDialogService
+    {
+        private readonly Window _owner;
+
+        public DialogService(Window owner)
+        {
+            _owner = owner;
+        }
+
+        public async Task<bool?> ShowConfirmationAsync(string message, bool allowCancel = false)
+        {
+            var tcs = new TaskCompletionSource<bool?>();
+            var dialog = new Window
+            {
+                Width = 300,
+                Height = 150,
+                Title = "Confirm",
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
+
+            var yesButton = new Button { Content = "Yes", Width = 80 };
+            var noButton = new Button { Content = "No", Width = 80 };
+            Button? cancelButton = null;
+
+            yesButton.Click += (_, _) => { tcs.TrySetResult(true); dialog.Close(); };
+            noButton.Click += (_, _) => { tcs.TrySetResult(false); dialog.Close(); };
+
+            var panel = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                Spacing = 10
+            };
+            panel.Children.Add(yesButton);
+            panel.Children.Add(noButton);
+
+            if (allowCancel)
+            {
+                cancelButton = new Button { Content = "Cancel", Width = 80 };
+                cancelButton.Click += (_, _) => { tcs.TrySetResult(null); dialog.Close(); };
+                panel.Children.Add(cancelButton);
+            }
+
+            dialog.Content = new StackPanel
+            {
+                Spacing = 10,
+                Margin = new Thickness(10),
+                Children =
+                {
+                    new TextBlock { Text = message, TextWrapping = TextWrapping.Wrap },
+                    panel
+                }
+            };
+
+            await dialog.ShowDialog(_owner);
+            return await tcs.Task;
+        }
+
+        public async Task<string?> ShowInputAsync(string message, string? defaultValue = null)
+        {
+            var tcs = new TaskCompletionSource<string?>();
+            var dialog = new Window
+            {
+                Width = 300,
+                Height = 170,
+                Title = "Input",
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
+
+            var textBox = new TextBox { Text = defaultValue ?? string.Empty };
+            var okButton = new Button { Content = "OK", Width = 80 };
+            var cancelButton = new Button { Content = "Cancel", Width = 80 };
+
+            okButton.Click += (_, _) => { tcs.TrySetResult(textBox.Text); dialog.Close(); };
+            cancelButton.Click += (_, _) => { tcs.TrySetResult(null); dialog.Close(); };
+
+            dialog.Content = new StackPanel
+            {
+                Spacing = 10,
+                Margin = new Thickness(10),
+                Children =
+                {
+                    new TextBlock { Text = message, TextWrapping = TextWrapping.Wrap },
+                    textBox,
+                    new StackPanel
+                    {
+                        Orientation = Orientation.Horizontal,
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        Spacing = 10,
+                        Children = { okButton, cancelButton }
+                    }
+                }
+            };
+
+            await dialog.ShowDialog(_owner);
+            return await tcs.Task;
+        }
+    }
+}

--- a/DiffusionNexus.UI/Classes/IDialogService.cs
+++ b/DiffusionNexus.UI/Classes/IDialogService.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+
+namespace DiffusionNexus.UI.Classes
+{
+    public interface IDialogService
+    {
+        Task<bool?> ShowConfirmationAsync(string message, bool allowCancel = false);
+        Task<string?> ShowInputAsync(string message, string? defaultValue = null);
+    }
+}

--- a/DiffusionNexus.UI/Classes/PromptProfileService.cs
+++ b/DiffusionNexus.UI/Classes/PromptProfileService.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using DiffusionNexus.UI.Models;
+
+namespace DiffusionNexus.UI.Classes
+{
+    public class PromptProfileService
+    {
+        private readonly string _filePath;
+
+        public PromptProfileService()
+        {
+            var folder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "DiffusionNexus");
+            Directory.CreateDirectory(folder);
+            _filePath = Path.Combine(folder, "prompt_profiles.json");
+        }
+
+        private async Task<Dictionary<string, PromptProfileModel>> LoadDictionaryAsync()
+        {
+            if (!File.Exists(_filePath))
+                return new();
+
+            var json = await File.ReadAllTextAsync(_filePath);
+            return JsonSerializer.Deserialize<Dictionary<string, PromptProfileModel>>(json) ?? new();
+        }
+
+        private async Task SaveDictionaryAsync(Dictionary<string, PromptProfileModel> dict)
+        {
+            var json = JsonSerializer.Serialize(dict, new JsonSerializerOptions { WriteIndented = true });
+            await File.WriteAllTextAsync(_filePath, json);
+        }
+
+        public async Task<List<PromptProfileModel>> LoadAllAsync()
+        {
+            var dict = await LoadDictionaryAsync();
+            return dict.Values.ToList();
+        }
+
+        public async Task<PromptProfileModel?> GetAsync(string name)
+        {
+            var dict = await LoadDictionaryAsync();
+            return dict.TryGetValue(name, out var profile) ? profile : null;
+        }
+
+        public async Task<bool> ExistsAsync(string name)
+        {
+            var dict = await LoadDictionaryAsync();
+            return dict.ContainsKey(name);
+        }
+
+        public async Task SaveAsync(PromptProfileModel profile)
+        {
+            var dict = await LoadDictionaryAsync();
+            dict[profile.Name] = profile;
+            await SaveDictionaryAsync(dict);
+        }
+
+        public async Task DeleteAsync(string name)
+        {
+            var dict = await LoadDictionaryAsync();
+            if (dict.Remove(name))
+                await SaveDictionaryAsync(dict);
+        }
+    }
+}

--- a/DiffusionNexus.UI/Models/PromptProfileModel.cs
+++ b/DiffusionNexus.UI/Models/PromptProfileModel.cs
@@ -1,0 +1,9 @@
+namespace DiffusionNexus.UI.Models
+{
+    public class PromptProfileModel
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Blacklist { get; set; } = string.Empty;
+        public string Whitelist { get; set; } = string.Empty;
+    }
+}

--- a/DiffusionNexus.UI/ViewModels/PromptEditViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/PromptEditViewModel.cs
@@ -1,0 +1,107 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using DiffusionNexus.UI.Classes;
+using DiffusionNexus.UI.Models;
+
+namespace DiffusionNexus.UI.ViewModels
+{
+    public partial class PromptEditViewModel : ObservableObject
+    {
+        private readonly PromptProfileService _service;
+
+        [ObservableProperty]
+        private ObservableCollection<string> _profiles = new();
+
+        [ObservableProperty]
+        private string? _selectedProfile;
+
+        [ObservableProperty]
+        private string? _blacklist;
+
+        [ObservableProperty]
+        private string? _whitelist;
+
+        public PromptEditViewModel() : this(new PromptProfileService())
+        {
+        }
+
+        public PromptEditViewModel(PromptProfileService service)
+        {
+            _service = service;
+            _ = LoadProfilesAsync();
+        }
+
+        private async Task LoadProfilesAsync()
+        {
+            var list = await _service.LoadAllAsync();
+            Profiles = new ObservableCollection<string>(list.Select(p => p.Name));
+        }
+
+        partial void OnSelectedProfileChanged(string? value)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+                _ = LoadSelectedProfileAsync(value);
+        }
+
+        private async Task LoadSelectedProfileAsync(string name)
+        {
+            var profile = await _service.GetAsync(name);
+            if (profile != null)
+            {
+                Blacklist = profile.Blacklist;
+                Whitelist = profile.Whitelist;
+            }
+        }
+
+        public async Task SaveProfileAsync(IDialogService dialog)
+        {
+            var name = SelectedProfile;
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                name = await dialog.ShowInputAsync("Enter name for new profile");
+                if (string.IsNullOrWhiteSpace(name))
+                    return;
+            }
+            else if (await _service.ExistsAsync(name))
+            {
+                var confirm = await dialog.ShowConfirmationAsync($"Profile '{name}' already exists. Overwrite?", true);
+                if (confirm == false)
+                {
+                    name = await dialog.ShowInputAsync("Enter name for new profile");
+                    if (string.IsNullOrWhiteSpace(name))
+                        return;
+                }
+                else if (confirm == null)
+                {
+                    return;
+                }
+            }
+
+            var profile = new PromptProfileModel
+            {
+                Name = name,
+                Blacklist = Blacklist ?? string.Empty,
+                Whitelist = Whitelist ?? string.Empty
+            };
+            await _service.SaveAsync(profile);
+            SelectedProfile = name;
+            await LoadProfilesAsync();
+        }
+
+        public async Task DeleteProfileAsync(IDialogService dialog)
+        {
+            if (string.IsNullOrWhiteSpace(SelectedProfile))
+                return;
+
+            var confirm = await dialog.ShowConfirmationAsync($"Do you really want to delete profile '{SelectedProfile}'?");
+            if (confirm != true)
+                return;
+
+            await _service.DeleteAsync(SelectedProfile);
+            SelectedProfile = null;
+            await LoadProfilesAsync();
+        }
+    }
+}

--- a/DiffusionNexus.UI/Views/PromptEditView.axaml
+++ b/DiffusionNexus.UI/Views/PromptEditView.axaml
@@ -21,7 +21,7 @@
         <StackPanel Spacing="2">
           <TextBlock Text="Profile"/>
           <ComboBox Name="ProfileComboBox" Width="150"
-                    Items="{Binding Profiles}"
+                    ItemsSource="{Binding Profiles}"
                     SelectedItem="{Binding SelectedProfile, Mode=TwoWay}"/>
         </StackPanel>
         <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Bottom">

--- a/DiffusionNexus.UI/Views/PromptEditView.axaml
+++ b/DiffusionNexus.UI/Views/PromptEditView.axaml
@@ -1,6 +1,11 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="DiffusionNexus.UI.Views.PromptEditView">
+             xmlns:vm="using:DiffusionNexus.UI.ViewModels"
+             x:Class="DiffusionNexus.UI.Views.PromptEditView"
+             x:DataType="vm:PromptEditViewModel">
+  <UserControl.DataContext>
+    <vm:PromptEditViewModel/>
+  </UserControl.DataContext>
   <Grid ColumnDefinitions="2*,3*" Margin="10" RowDefinitions="*">
     <!-- Image drop area -->
     <Border Grid.Column="0" DragDrop.AllowDrop="True"  x:Name="ImageDropBorder" BorderBrush="Gray" BorderThickness="1" Background="#22FFFFFF" CornerRadius="4" Margin="0,0,10,0">
@@ -12,9 +17,27 @@
 
     <!-- Right side for prompts -->
     <StackPanel Grid.Column="1" Spacing="10">
-      <StackPanel Spacing="2">
-        <TextBlock Text="Blacklist"/>
-        <TextBox Name="BlacklistBox" AcceptsReturn="True" TextWrapping="Wrap" Height="60"/>
+      <StackPanel Orientation="Horizontal" Spacing="10">
+        <StackPanel Spacing="2">
+          <TextBlock Text="Profile"/>
+          <ComboBox Name="ProfileComboBox" Width="150"
+                    Items="{Binding Profiles}"
+                    SelectedItem="{Binding SelectedProfile, Mode=TwoWay}"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Bottom">
+          <Button Name="SaveProfileButton" Content="Save" Width="80" Click="OnSaveProfile"/>
+          <Button Name="DeleteProfileButton" Content="Delete" Width="80" Click="OnDeleteProfile"/>
+        </StackPanel>
+      </StackPanel>
+      <StackPanel Orientation="Horizontal" Spacing="10">
+        <StackPanel Spacing="2">
+          <TextBlock Text="Blacklist"/>
+          <TextBox Name="BlacklistBox" Text="{Binding Blacklist, Mode=TwoWay}" AcceptsReturn="True" TextWrapping="Wrap" Height="60"/>
+        </StackPanel>
+        <StackPanel Spacing="2">
+          <TextBlock Text="Whitelist"/>
+          <TextBox Name="WhitelistBox" Text="{Binding Whitelist, Mode=TwoWay}" AcceptsReturn="True" TextWrapping="Wrap" Height="60"/>
+        </StackPanel>
       </StackPanel>
       <StackPanel Spacing="2">
         <TextBlock Text="Prompt"/>

--- a/DiffusionNexus.UI/Views/PromptEditView.axaml.cs
+++ b/DiffusionNexus.UI/Views/PromptEditView.axaml.cs
@@ -25,7 +25,8 @@ namespace DiffusionNexus.UI.Views
         private Avalonia.Controls.Image? _previewImage;
         private TextBox? _promptBox;
         private TextBox? _negativePromptBox;
-        private TextBox? _blacklistBox;
+        // Text boxes bound via XAML
+        private TextBox? _whitelistBox;
         private TextBox? _stepsBox;
         private TextBox? _samplerBox;
         private TextBox? _scheduleTypeBox;
@@ -44,6 +45,8 @@ namespace DiffusionNexus.UI.Views
         private TextBox? _hashesBox;
         private TextBox? _resourcesBox;
         private Button? _copyMetadataButton;
+        private Button? _saveProfileButton;
+        private Button? _deleteProfileButton;
         private string? _currentImagePath;
         private StableDiffusionMetadata? _metadata;
         private IBrush _defaultBorderBrush = Brushes.Transparent;
@@ -57,7 +60,7 @@ namespace DiffusionNexus.UI.Views
             _previewImage = this.FindControl<Avalonia.Controls.Image>("PreviewImage");
             _promptBox = this.FindControl<TextBox>("PromptBox");
             _negativePromptBox = this.FindControl<TextBox>("NegativePromptBox");
-            _blacklistBox = this.FindControl<TextBox>("BlacklistBox");
+            _whitelistBox = this.FindControl<TextBox>("WhitelistBox");
             _stepsBox = this.FindControl<TextBox>("StepsBox");
             _samplerBox = this.FindControl<TextBox>("SamplerBox");
             _scheduleTypeBox = this.FindControl<TextBox>("ScheduleTypeBox");
@@ -76,6 +79,8 @@ namespace DiffusionNexus.UI.Views
             _hashesBox = this.FindControl<TextBox>("HashesBox");
             _resourcesBox = this.FindControl<TextBox>("ResourcesBox");
             _copyMetadataButton = this.FindControl<Button>("CopyMetadataButton");
+            _saveProfileButton = this.FindControl<Button>("SaveProfileButton");
+            _deleteProfileButton = this.FindControl<Button>("DeleteProfileButton");
 
             if (_copyMetadataButton is not null)
                 _copyMetadataButton.Click += OnCopyMetadata;
@@ -386,10 +391,8 @@ namespace DiffusionNexus.UI.Views
 
         private void OnApplyBlacklist(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         {
-            if (_blacklistBox == null)
-                return;
-
-            var words = _blacklistBox.Text?
+            var vm = DataContext as ViewModels.PromptEditViewModel;
+            var words = vm?.Blacklist?
                 .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                 .Select(w => w.ToLowerInvariant())
                 .ToArray() ?? Array.Empty<string>();
@@ -438,6 +441,30 @@ namespace DiffusionNexus.UI.Views
             var topLevel = TopLevel.GetTopLevel(this);
             if (topLevel != null)
                 await topLevel.Clipboard.SetTextAsync(json);
+        }
+
+        private async void OnSaveProfile(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            if (this.VisualRoot is not Window window)
+                return;
+
+            if (DataContext is ViewModels.PromptEditViewModel vm)
+            {
+                var dialog = new DialogService(window);
+                await vm.SaveProfileAsync(dialog);
+            }
+        }
+
+        private async void OnDeleteProfile(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            if (this.VisualRoot is not Window window)
+                return;
+
+            if (DataContext is ViewModels.PromptEditViewModel vm)
+            {
+                var dialog = new DialogService(window);
+                await vm.DeleteProfileAsync(dialog);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add PromptProfile service and model for saving profiles
- create dialog service for prompts
- implement PromptEditViewModel for profile management
- extend PromptEditView UI with profile dropdown, whitelist textbox and save/delete buttons
- wire up new view model in PromptEditView

## Testing
- `dotnet build DiffusionNexus.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68557e7237f88332a0eb29b3e57c0073