### PR TITLE
Add reusable prompt editor control and batch tab

### DIFF
--- a/DiffusionNexus.UI/ViewModels/BatchPromptEditViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/BatchPromptEditViewModel.cs
@@ -1,0 +1,31 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace DiffusionNexus.UI.ViewModels
+{
+    public partial class BatchPromptEditViewModel : ObservableObject
+    {
+        [ObservableProperty]
+        private string? _sourceFolder;
+
+        [ObservableProperty]
+        private string? _targetFolder;
+
+        [ObservableProperty]
+        private bool _useListOnly = true;
+
+        [ObservableProperty]
+        private bool _replaceAll;
+
+        partial void OnUseListOnlyChanged(bool value)
+        {
+            if (value)
+                ReplaceAll = false;
+        }
+
+        partial void OnReplaceAllChanged(bool value)
+        {
+            if (value)
+                UseListOnly = false;
+        }
+    }
+}

--- a/DiffusionNexus.UI/Views/Controls/PromptEditorControl.axaml
+++ b/DiffusionNexus.UI/Views/Controls/PromptEditorControl.axaml
@@ -1,6 +1,8 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="DiffusionNexus.UI.Views.Controls.PromptEditorControl">
+             xmlns:vm="using:DiffusionNexus.UI.ViewModels"
+             x:Class="DiffusionNexus.UI.Views.Controls.PromptEditorControl"
+             x:DataType="vm:PromptEditViewModel">
   <StackPanel Spacing="10">
     <StackPanel Orientation="Horizontal" Spacing="10">
       <StackPanel Spacing="2">

--- a/DiffusionNexus.UI/Views/Controls/PromptEditorControl.axaml
+++ b/DiffusionNexus.UI/Views/Controls/PromptEditorControl.axaml
@@ -1,0 +1,41 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="DiffusionNexus.UI.Views.Controls.PromptEditorControl">
+  <StackPanel Spacing="10">
+    <StackPanel Orientation="Horizontal" Spacing="10">
+      <StackPanel Spacing="2">
+        <TextBlock Text="Profile"/>
+        <ComboBox Name="ProfileComboBox" Width="150"
+                  ItemsSource="{Binding Profiles}"
+                  SelectedItem="{Binding SelectedProfile, Mode=TwoWay}"/>
+      </StackPanel>
+      <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Bottom">
+        <Button Name="SaveProfileButton" Content="Save" Width="80"/>
+        <Button Name="DeleteProfileButton" Content="Delete" Width="80"/>
+      </StackPanel>
+    </StackPanel>
+    <StackPanel Orientation="Horizontal" Spacing="10">
+      <StackPanel Spacing="2">
+        <TextBlock Text="Blacklist"/>
+        <TextBox Name="BlacklistBox" Text="{Binding Blacklist, Mode=TwoWay}" AcceptsReturn="True" TextWrapping="Wrap" Height="60" Width="150"/>
+      </StackPanel>
+      <StackPanel Spacing="2">
+        <TextBlock Text="Whitelist"/>
+        <TextBox Name="WhitelistBox" Text="{Binding Whitelist, Mode=TwoWay}" AcceptsReturn="True" TextWrapping="Wrap" Height="60" Width="150"/>
+      </StackPanel>
+    </StackPanel>
+    <StackPanel Spacing="2">
+      <TextBlock Text="Prompt"/>
+      <TextBox Name="PromptBox" AcceptsReturn="True" TextWrapping="Wrap" Height="120"/>
+    </StackPanel>
+    <StackPanel Spacing="2">
+      <TextBlock Text="Negative Prompt"/>
+      <TextBox Name="NegativePromptBox" AcceptsReturn="True" TextWrapping="Wrap" Height="120"/>
+    </StackPanel>
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10">
+      <Button Name="ApplyButton" Content="Apply List" Width="110"/>
+      <Button Name="SaveButton" Content="Save" Width="80"/>
+      <Button Name="SaveAsButton" Content="Save As" Width="80"/>
+    </StackPanel>
+  </StackPanel>
+</UserControl>

--- a/DiffusionNexus.UI/Views/Controls/PromptEditorControl.axaml.cs
+++ b/DiffusionNexus.UI/Views/Controls/PromptEditorControl.axaml.cs
@@ -1,0 +1,28 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Interactivity;
+
+namespace DiffusionNexus.UI.Views.Controls
+{
+    public partial class PromptEditorControl : UserControl
+    {
+        public PromptEditorControl()
+        {
+            InitializeComponent();
+
+            this.FindControl<Button>("SaveButton")?.AddHandler(Button.ClickEvent, (_, e) => SaveClicked?.Invoke(this, e));
+            this.FindControl<Button>("SaveAsButton")?.AddHandler(Button.ClickEvent, (_, e) => SaveAsClicked?.Invoke(this, e));
+            this.FindControl<Button>("ApplyButton")?.AddHandler(Button.ClickEvent, (_, e) => ApplyListClicked?.Invoke(this, e));
+            this.FindControl<Button>("SaveProfileButton")?.AddHandler(Button.ClickEvent, (_, e) => SaveProfileClicked?.Invoke(this, e));
+            this.FindControl<Button>("DeleteProfileButton")?.AddHandler(Button.ClickEvent, (_, e) => DeleteProfileClicked?.Invoke(this, e));
+        }
+
+        private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+        public event EventHandler<RoutedEventArgs>? SaveClicked;
+        public event EventHandler<RoutedEventArgs>? SaveAsClicked;
+        public event EventHandler<RoutedEventArgs>? ApplyListClicked;
+        public event EventHandler<RoutedEventArgs>? SaveProfileClicked;
+        public event EventHandler<RoutedEventArgs>? DeleteProfileClicked;
+    }
+}

--- a/DiffusionNexus.UI/Views/Controls/PromptEditorControl.axaml.cs
+++ b/DiffusionNexus.UI/Views/Controls/PromptEditorControl.axaml.cs
@@ -1,6 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using Avalonia.Interactivity;
+using System;
 
 namespace DiffusionNexus.UI.Views.Controls
 {

--- a/DiffusionNexus.UI/Views/PromptEditView.axaml
+++ b/DiffusionNexus.UI/Views/PromptEditView.axaml
@@ -2,7 +2,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:DiffusionNexus.UI.ViewModels"
              xmlns:ctrl="using:DiffusionNexus.UI.Views.Controls"
-             x:Class="DiffusionNexus.UI.Views.PromptEditView">
+             x:Class="DiffusionNexus.UI.Views.PromptEditView"
+             x:DataType="vm:PromptEditViewModel">
   <TabControl>
     <TabItem Header="Single Image">
       <Grid Margin="10">

--- a/DiffusionNexus.UI/Views/PromptEditView.axaml
+++ b/DiffusionNexus.UI/Views/PromptEditView.axaml
@@ -1,27 +1,25 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:DiffusionNexus.UI.ViewModels"
-             x:Class="DiffusionNexus.UI.Views.PromptEditView"
-             x:DataType="vm:PromptEditViewModel">
-  <UserControl.DataContext>
-    <vm:PromptEditViewModel/>
-  </UserControl.DataContext>
-  <Grid Margin="10" RowDefinitions="*">
-    <Grid.ColumnDefinitions>
-      <ColumnDefinition MinWidth="200"/>
-      <ColumnDefinition MinWidth="150"/>
-      <ColumnDefinition MinWidth="250"/>
-      </Grid.ColumnDefinitions>
-    <!-- Image drop area -->
-    <Border Grid.Column="0" DragDrop.AllowDrop="True"  x:Name="ImageDropBorder" BorderBrush="Gray" BorderThickness="1" Background="#22FFFFFF" CornerRadius="4" Margin="0,0,10,0">
-      <Grid>
-        <Image x:Name="PreviewImage"  Stretch="Uniform" Margin="5" IsVisible="False"/>
-        <TextBlock x:Name="DropText" Text="Drop image here"  HorizontalAlignment="Center" VerticalAlignment="Center"/>
-      </Grid>
-    </Border>
-
-    <!-- Middle side for Meta Data -->
-    <Border Grid.Column="1" BorderBrush="Gray" BorderThickness="1" Background="#22FFFFFF" CornerRadius="4" Margin="0,0,10,0">
+             xmlns:ctrl="using:DiffusionNexus.UI.Views.Controls"
+             x:Class="DiffusionNexus.UI.Views.PromptEditView">
+  <TabControl>
+    <TabItem Header="Single Image">
+      <Grid Margin="10">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition MinWidth="200"/>
+          <ColumnDefinition MinWidth="150"/>
+          <ColumnDefinition MinWidth="250"/>
+        </Grid.ColumnDefinitions>
+        <!-- Image drop area -->
+        <Border Grid.Column="0" DragDrop.AllowDrop="True" x:Name="ImageDropBorder" BorderBrush="Gray" BorderThickness="1" Background="#22FFFFFF" CornerRadius="4" Margin="0,0,10,0">
+          <Grid>
+            <Image x:Name="PreviewImage" Stretch="Uniform" Margin="5" IsVisible="False"/>
+            <TextBlock x:Name="DropText" Text="Drop image here" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+          </Grid>
+        </Border>
+        <!-- Metadata section -->
+        <Border Grid.Column="1" BorderBrush="Gray" BorderThickness="1" Background="#22FFFFFF" CornerRadius="4" Margin="0,0,10,0">
           <StackPanel x:Name="MetadataPanel" Spacing="4" Margin="0,10,0,0">
             <TextBlock Text="Metadata" Width="120"/>
             <StackPanel Orientation="Horizontal" Spacing="5">
@@ -94,46 +92,50 @@
             </StackPanel>
             <Button Name="CopyMetadataButton" Content="Copy all metadata" HorizontalAlignment="Right" Width="150"/>
           </StackPanel>
-  </Border>
-    
-    <!-- Right side for prompts -->
-    <StackPanel Grid.Column="2" Spacing="10">
-      <StackPanel Orientation="Horizontal" Spacing="10">
-        <StackPanel Spacing="2">
-          <TextBlock Text="Profile"/>
-          <ComboBox Name="ProfileComboBox" Width="150"
-                    ItemsSource="{Binding Profiles}"
-                    SelectedItem="{Binding SelectedProfile, Mode=TwoWay}"/>
+        </Border>
+        <!-- Prompt editor -->
+        <ctrl:PromptEditorControl x:Name="SingleEditor" Grid.Column="2"
+                                  SaveClicked="OnSave"
+                                  SaveAsClicked="OnSaveAs"
+                                  ApplyListClicked="OnApplyBlacklist"
+                                  SaveProfileClicked="OnSaveProfile"
+                                  DeleteProfileClicked="OnDeleteProfile">
+          <ctrl:PromptEditorControl.DataContext>
+            <vm:PromptEditViewModel/>
+          </ctrl:PromptEditorControl.DataContext>
+        </ctrl:PromptEditorControl>
+      </Grid>
+    </TabItem>
+    <TabItem Header="Batch Image">
+      <Grid Margin="10" ColumnDefinitions="250,*">
+        <Grid.DataContext>
+          <vm:BatchPromptEditViewModel/>
+        </Grid.DataContext>
+        <StackPanel Spacing="10" Grid.Column="0">
+          <StackPanel Orientation="Horizontal" Spacing="5">
+            <TextBlock Text="Source Folder" Width="100"/>
+            <TextBox x:Name="SourceFolderBox" Width="140" Text="{Binding SourceFolder, Mode=TwoWay}"/>
+            <Button Content="Browse..." Click="OnBrowseSourceFolder"/>
+          </StackPanel>
+          <StackPanel Orientation="Horizontal" Spacing="5">
+            <TextBlock Text="Target Folder" Width="100"/>
+            <TextBox x:Name="TargetFolderBox" Width="140" Text="{Binding TargetFolder, Mode=TwoWay}"/>
+            <Button Content="Browse..." Click="OnBrowseTargetFolder"/>
+          </StackPanel>
+          <StackPanel Orientation="Vertical" Spacing="5">
+            <RadioButton Content="Blacklist / Whitelist only" IsChecked="{Binding UseListOnly, Mode=TwoWay}"/>
+            <RadioButton Content="Replace all" IsChecked="{Binding ReplaceAll, Mode=TwoWay}"/>
+          </StackPanel>
         </StackPanel>
-        <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Bottom">
-          <Button Name="SaveProfileButton" Content="Save" Width="80" Click="OnSaveProfile"/>
-          <Button Name="DeleteProfileButton" Content="Delete" Width="80" Click="OnDeleteProfile"/>
-        </StackPanel>
-      </StackPanel>
-      <StackPanel Orientation="Horizontal" Spacing="10">
-        <StackPanel Spacing="2">
-          <TextBlock Text="Blacklist"/>
-          <TextBox Name="BlacklistBox" Text="{Binding Blacklist, Mode=TwoWay}" AcceptsReturn="True" TextWrapping="Wrap" Height="60" Width="150"/>
-        </StackPanel>
-        <StackPanel Spacing="2">
-          <TextBlock Text="Whitelist"/>
-          <TextBox Name="WhitelistBox" Text="{Binding Whitelist, Mode=TwoWay}" AcceptsReturn="True" TextWrapping="Wrap" Height="60" Width="150"/>
-        </StackPanel>
-      </StackPanel>
-      <StackPanel Spacing="2">
-        <TextBlock Text="Prompt"/>
-        <TextBox Name="PromptBox" AcceptsReturn="True" TextWrapping="Wrap" Height="120"/>
-      </StackPanel>
-      <StackPanel Spacing="2">
-        <TextBlock Text="Negative Prompt"/>
-        <TextBox Name="NegativePromptBox" AcceptsReturn="True" TextWrapping="Wrap" Height="120"/>
-      </StackPanel>
-      <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10">
-        <Button Content="Apply List" Width="110" Click="OnApplyBlacklist"/>
-        <Button Content="Save" Width="80" Click="OnSave"/>
-        <Button Content="Save As" Width="80" Click="OnSaveAs"/>
-      </StackPanel>
-
-    </StackPanel>
-  </Grid>
+        <ctrl:PromptEditorControl x:Name="BatchEditor" Grid.Column="1"
+                                  ApplyListClicked="OnApplyBlacklist"
+                                  SaveProfileClicked="OnSaveProfile"
+                                  DeleteProfileClicked="OnDeleteProfile">
+          <ctrl:PromptEditorControl.DataContext>
+            <vm:PromptEditViewModel/>
+          </ctrl:PromptEditorControl.DataContext>
+        </ctrl:PromptEditorControl>
+      </Grid>
+    </TabItem>
+  </TabControl>
 </UserControl>


### PR DESCRIPTION
## Summary
- extract prompt editing fields into `PromptEditorControl`
- introduce `BatchPromptEditViewModel` for batch folder settings
- refactor `PromptEditView` to use a tab control with single and batch editors
- update code-behind to work with new control and handle folder selection

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858305503a08332ba74005edc9a2cfc