### PR TITLE
Refactor dialog logic & shared paths

### DIFF
--- a/DiffusionNexus.UI/Classes/AppDataHelper.cs
+++ b/DiffusionNexus.UI/Classes/AppDataHelper.cs
@@ -1,0 +1,17 @@
+using System;
+using System.IO;
+
+namespace DiffusionNexus.UI.Classes
+{
+    public static class AppDataHelper
+    {
+        private const string AppFolderName = "DiffusionNexus";
+
+        public static string GetDataFolder()
+        {
+            var folder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), AppFolderName);
+            Directory.CreateDirectory(folder);
+            return folder;
+        }
+    }
+}

--- a/DiffusionNexus.UI/Classes/DialogService.cs
+++ b/DiffusionNexus.UI/Classes/DialogService.cs
@@ -103,5 +103,11 @@ namespace DiffusionNexus.UI.Classes
             await dialog.ShowDialog(_owner);
             return await tcs.Task;
         }
+
+        public async Task<bool> ShowOverwriteConfirmationAsync()
+        {
+            var result = await ShowConfirmationAsync("Overwrite the existing file?");
+            return result == true;
+        }
     }
 }

--- a/DiffusionNexus.UI/Classes/IDialogService.cs
+++ b/DiffusionNexus.UI/Classes/IDialogService.cs
@@ -6,5 +6,6 @@ namespace DiffusionNexus.UI.Classes
     {
         Task<bool?> ShowConfirmationAsync(string message, bool allowCancel = false);
         Task<string?> ShowInputAsync(string message, string? defaultValue = null);
+        Task<bool> ShowOverwriteConfirmationAsync();
     }
 }

--- a/DiffusionNexus.UI/Classes/PromptProfileService.cs
+++ b/DiffusionNexus.UI/Classes/PromptProfileService.cs
@@ -14,8 +14,7 @@ namespace DiffusionNexus.UI.Classes
 
         public PromptProfileService()
         {
-            var folder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "DiffusionNexus");
-            Directory.CreateDirectory(folder);
+            var folder = AppDataHelper.GetDataFolder();
             _filePath = Path.Combine(folder, "prompt_profiles.json");
         }
 
@@ -42,13 +41,13 @@ namespace DiffusionNexus.UI.Classes
         public async Task<PromptProfileModel?> GetProfileAsync(PromptProfileModel profile)
         {
             IList<PromptProfileModel> list = await LoadProfilesAsync();
-            return list.FirstOrDefault(profile);
+            return list.FirstOrDefault(x => x.Name == profile.Name);
         }
 
         public async Task<bool> ExistsByNameAsync(string name)
         {
             IList<PromptProfileModel> dict = await LoadProfilesAsync();
-            return dict.Select(x => x.Name == name) == null ? false : true;
+            return dict.Any(x => x.Name == name);
         }
 
         public async Task SaveAsync(PromptProfileModel profile)

--- a/DiffusionNexus.UI/Classes/SettingsService.cs
+++ b/DiffusionNexus.UI/Classes/SettingsService.cs
@@ -10,8 +10,7 @@ namespace DiffusionNexus.UI.Classes
         private readonly string _filePath;
         public SettingsService()
         {
-            var folder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "DiffusionNexus");
-            Directory.CreateDirectory(folder);
+            var folder = AppDataHelper.GetDataFolder();
             _filePath = Path.Combine(folder, "settings.json");
         }
 

--- a/DiffusionNexus.UI/Converters/IndexToPriorityConverter.cs
+++ b/DiffusionNexus.UI/Converters/IndexToPriorityConverter.cs
@@ -9,7 +9,17 @@ namespace DiffusionNexus.UI.Converters
     {
         public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
         {
-            // TODO: Implement
+            if (values.Count < 2 || values[1] is not IEnumerable<object?> collection)
+                return null;
+
+            var item = values[0];
+            var index = 0;
+            foreach (var obj in collection)
+            {
+                if (Equals(obj, item))
+                    return (index + 1).ToString();
+                index++;
+            }
             return null;
         }
     }

--- a/DiffusionNexus.UI/Converters/TagsDisplayConverter.cs
+++ b/DiffusionNexus.UI/Converters/TagsDisplayConverter.cs
@@ -1,6 +1,7 @@
 using Avalonia.Data.Converters;
 using System;
 using System.Globalization;
+using System.Collections.Generic;
 
 namespace DiffusionNexus.UI.Converters
 {
@@ -8,8 +9,10 @@ namespace DiffusionNexus.UI.Converters
     {
         public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
-            // TODO: Implement
-            return value;
+            if (value is null) return string.Empty;
+            if (value is IEnumerable<string> tags)
+                return string.Join(", ", tags);
+            return value.ToString();
         }
 
         public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/DiffusionNexus.UI/Views/PromptEditView.axaml.cs
+++ b/DiffusionNexus.UI/Views/PromptEditView.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Markup.Xaml;
+using DiffusionNexus.UI.Classes;
 using DiffusionNexus.UI.ViewModels;
 
 namespace DiffusionNexus.UI.Views;
@@ -11,6 +12,7 @@ public partial class PromptEditView : UserControl
     public PromptEditView()
     {
         InitializeComponent();
+        this.AttachedToVisualTree += OnAttached;
         var border = this.FindControl<Border>("ImageDropBorder");
         if (border != null)
         {
@@ -18,6 +20,14 @@ public partial class PromptEditView : UserControl
             border.AddHandler(DragDrop.DragLeaveEvent, (_, e) => ViewModel?.OnDragLeave(e));
             border.AddHandler(DragDrop.DragOverEvent, (_, e) => ViewModel?.OnDragOver(e));
             border.AddHandler(DragDrop.DropEvent, (_, e) => ViewModel?.OnDrop(e));
+        }
+    }
+
+    private void OnAttached(object? sender, VisualTreeAttachmentEventArgs e)
+    {
+        if (DataContext is PromptEditViewModel vm && VisualRoot is Window window)
+        {
+            vm.DialogService = new DialogService(window);
         }
     }
 


### PR DESCRIPTION
## Summary
- centralize appdata path creation via `AppDataHelper`
- fix `PromptProfileService` query logic
- extend `DialogService` with overwrite confirmation
- wire up `DialogService` in `PromptEditView`
- refactor metadata display and converters
- update `SettingsService` and `PromptProfileService` to use helper

## Testing
- `dotnet build DiffusionNexus.sln -c Release` *(fails: `dotnet` not found)*
- `dotnet test DiffusionNexus.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d0eebf6008332af0ccf8b8363dcb9