### PR TITLE
Fix deprecated API usage warnings

### DIFF
--- a/DiffusionNexus.UI/ViewModels/BatchProcessingViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/BatchProcessingViewModel.cs
@@ -1,6 +1,8 @@
 ﻿using Avalonia.Controls;
+using Avalonia.Platform.Storage;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace DiffusionNexus.UI.ViewModels
@@ -44,22 +46,24 @@ namespace DiffusionNexus.UI.ViewModels
         private async Task OnBrowseSourceFolder(Window? window)
         {
             if (window is null) return;
-            var dlg = new OpenFolderDialog();
-            var result = await dlg.ShowAsync(window);
-            if (!string.IsNullOrEmpty(result))
+
+            var folders = await window.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions());
+            var path = folders.FirstOrDefault()?.TryGetLocalPath();
+            if (!string.IsNullOrEmpty(path))
             {
-                SourceFolder = result;
+                SourceFolder = path;
             }
         }
 
         private async Task OnBrowseTargetFolder(Window? window)
         {
             if (window is null) return;
-            var dlg = new OpenFolderDialog();
-            var result = await dlg.ShowAsync(window);
-            if (!string.IsNullOrEmpty(result))
+
+            var folders = await window.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions());
+            var path = folders.FirstOrDefault()?.TryGetLocalPath();
+            if (!string.IsNullOrEmpty(path))
             {
-                TargetFolder = result;
+                TargetFolder = path;
             }
         }
 

--- a/DiffusionNexus.UI/ViewModels/MainWindowViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/MainWindowViewModel.cs
@@ -51,7 +51,7 @@ namespace DiffusionNexus.UI.ViewModels
 
             ChangeModuleCommand = new RelayCommand<ModuleItem>(mod =>
             {
-                CurrentModuleView = mod.View;
+                CurrentModuleView = mod!.View;
             });
 
             OpenYoutubeCommand = new RelayCommand(() =>


### PR DESCRIPTION
## Summary
- use Avalonia StorageProvider for save dialog and folder picker
- migrate drag/drop file handling to `GetFiles`
- clean up PNG metadata handling
- silence nullable warnings in `MainWindowViewModel`

## Testing
- `dotnet build DiffusionNexus.sln`
- `dotnet test DiffusionNexus.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_685d8e1291a08332a5eb06b2ec01a37c