### PR TITLE
Async initialization for LoRA cards

### DIFF
--- a/DiffusionNexus.UI/Converters/PathToBitmapConverter.cs
+++ b/DiffusionNexus.UI/Converters/PathToBitmapConverter.cs
@@ -1,0 +1,34 @@
+using Avalonia.Data.Converters;
+using Avalonia.Media.Imaging;
+using System;
+using System.Globalization;
+using System.IO;
+
+namespace DiffusionNexus.UI.Converters;
+
+public class PathToBitmapConverter : IValueConverter
+{
+    public static readonly PathToBitmapConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is string path && File.Exists(path))
+        {
+            try
+            {
+                using var stream = File.OpenRead(path);
+                return new Bitmap(stream);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml
@@ -1,11 +1,15 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:DiffusionNexus.UI.ViewModels"
+             xmlns:conv="using:DiffusionNexus.UI.Converters"
              x:Class="DiffusionNexus.UI.Views.LoraHelperView"
              x:DataType="vm:LoraHelperViewModel">
   <UserControl.DataContext>
     <vm:LoraHelperViewModel/>
   </UserControl.DataContext>
+  <UserControl.Resources>
+    <conv:PathToBitmapConverter x:Key="PathToBitmap"/>
+  </UserControl.Resources>
   <Grid RowDefinitions="Auto,*" ColumnDefinitions="200,*" Margin="10">
     <TextBox Grid.ColumnSpan="2" Watermark="Search loras..." Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"/>
     <TreeView Grid.Row="1" ItemsSource="{Binding FolderItems}">
@@ -15,22 +19,31 @@
         </TreeDataTemplate>
       </TreeView.ItemTemplate>
     </TreeView>
-    <ItemsControl Grid.Column="1" Grid.Row="1" ItemsSource="{Binding Cards}">
-      <ItemsControl.ItemTemplate>
-        <DataTemplate x:DataType="vm:LoraCard">
-          <Border Background="#333333" Padding="10" Margin="5" Width="200" Height="200">
-            <StackPanel Spacing="5">
-              <TextBlock Text="{Binding Name}" FontWeight="Bold"/>
-              <TextBlock Text="{Binding Description}" TextWrapping="Wrap"/>
-            </StackPanel>
-          </Border>
-        </DataTemplate>
-      </ItemsControl.ItemTemplate>
-      <ItemsControl.ItemsPanel>
-        <ItemsPanelTemplate>
-          <WrapPanel/>
-        </ItemsPanelTemplate>
-      </ItemsControl.ItemsPanel>
-    </ItemsControl>
+    <Grid Grid.Column="1" Grid.Row="1">
+      <ItemsControl ItemsSource="{Binding Cards}">
+        <ItemsControl.ItemTemplate>
+          <DataTemplate x:DataType="vm:LoraCard">
+            <Border Background="#333333" Padding="10" Margin="5" Width="200" Height="230">
+              <DockPanel LastChildFill="False">
+                <StackPanel DockPanel.Dock="Top" Spacing="5">
+                  <Image Source="{Binding PreviewImagePath, Converter={StaticResource PathToBitmap}}" Height="120" Stretch="UniformToFill"/>
+                  <TextBlock Text="{Binding Name}" FontWeight="Bold" TextWrapping="Wrap"/>
+                </StackPanel>
+                <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="5">
+                  <Button Content="🌐" Width="24" Height="24"/>
+                  <Button Content="📋" Width="24" Height="24"/>
+                </StackPanel>
+              </DockPanel>
+            </Border>
+          </DataTemplate>
+        </ItemsControl.ItemTemplate>
+        <ItemsControl.ItemsPanel>
+          <ItemsPanelTemplate>
+            <WrapPanel/>
+          </ItemsPanelTemplate>
+        </ItemsControl.ItemsPanel>
+      </ItemsControl>
+      <ProgressRing IsActive="{Binding IsLoading}" Width="50" Height="50" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    </Grid>
   </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- asynchronously load LoRA cards so the UI stays responsive
- show a progress ring while cards are building
- add a converter for converting file paths to bitmaps
- display preview image and placeholder buttons for each card

## Testing
- `dotnet test DiffusionNexus.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_685f27f874988332af103a3a4fefce8a