### PR TITLE
Add folder filtering and toolbar to LoRA helper

### DIFF
--- a/DiffusionNexus.UI/ViewModels/FolderItemViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/FolderItemViewModel.cs
@@ -11,6 +11,9 @@ public partial class FolderItemViewModel : ViewModelBase
     [ObservableProperty]
     private int modelCount;
 
+    [ObservableProperty]
+    private string? path;
+
     public ObservableCollection<FolderItemViewModel> Children { get; } = new();
 
     public string DisplayName => $"{Name} ({ModelCount})";

--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml
@@ -9,11 +9,17 @@
   <UserControl.Resources>
   </UserControl.Resources>
   <Grid RowDefinitions="Auto,*" ColumnDefinitions="Auto,*" Margin="10">
-    <TextBox Grid.ColumnSpan="2" Watermark="Search loras..." Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"/>
+    <Grid Grid.ColumnSpan="2" ColumnDefinitions="Auto,*,Auto,Auto,Auto,Auto" Margin="0,0,0,5">
+      <Button Grid.Column="0" Content="🔄" Width="36" Height="36" Command="{Binding ResetFiltersCommand}"/>
+      <TextBox Grid.Column="1" Watermark="Search loras..." Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="5,0"/>
+      <Button Grid.Column="2" Content="🔁" Width="36" Height="36" Margin="5,0,0,0"/>
+      <Button Grid.Column="3" Content="🧩" Width="36" Height="36" Margin="5,0,0,0"/>
+      <Button Grid.Column="4" Content="🧠" Width="36" Height="36" Margin="5,0,0,0"/>
+    </Grid>
     <ScrollViewer Grid.Row="1"
                   HorizontalScrollBarVisibility="Disabled"
                   VerticalScrollBarVisibility="Auto">
-      <TreeView ItemsSource="{Binding FolderItems}">
+      <TreeView ItemsSource="{Binding FolderItems}" SelectedItem="{Binding SelectedFolder, Mode=TwoWay}">
         <TreeView.ItemTemplate>
           <TreeDataTemplate ItemsSource="{Binding Children}" DataType="vm:FolderItemViewModel">
             <TextBlock Text="{Binding DisplayName}"/>


### PR DESCRIPTION
## Summary
- store folder paths on `FolderItemViewModel` and `LoraCard`
- track selected folder in `LoraHelperViewModel`
- filter LoRA cards by folder and search text simultaneously
- add Reset Filters command
- update UI with reset button, toolbar icons and folder TreeView selection

## Testing
- `dotnet build DiffusionNexus.sln -c Release`
- `dotnet test DiffusionNexus.sln`

------
https://chatgpt.com/codex/tasks/task_e_685fae6cda9c83328f540b19caabfcce