### PR TITLE
Add CustomTagMap window

### DIFF
--- a/DiffusionNexus.UI/DiffusionNexus.UI.csproj
+++ b/DiffusionNexus.UI/DiffusionNexus.UI.csproj
@@ -66,6 +66,9 @@
     <Compile Update="Views\LoraHelperView.axaml.cs">
       <DependentUpon>LoraHelperView.axaml</DependentUpon>
     </Compile>
+    <Compile Update="Views\CustomTagMapWindow.axaml.cs">
+      <DependentUpon>CustomTagMapWindow.axaml</DependentUpon>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/DiffusionNexus.UI/ViewModels/CustomTagMapWindowViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/CustomTagMapWindowViewModel.cs
@@ -1,0 +1,91 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DiffusionNexus.LoraSort.Service.Classes;
+using DiffusionNexus.LoraSort.Service.Services;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+public partial class CustomTagMapWindowViewModel : ViewModelBase
+{
+    [ObservableProperty]
+    private string? tags;
+
+    [ObservableProperty]
+    private string? folder;
+
+    private readonly CustomTagMapXmlService _xmlService = new();
+    private Window? _window;
+
+    public IAsyncRelayCommand SaveCommand { get; }
+    public IRelayCommand CancelCommand { get; }
+
+    public CustomTagMapWindowViewModel()
+    {
+        SaveCommand = new AsyncRelayCommand(SaveAsync);
+        CancelCommand = new RelayCommand(Cancel);
+    }
+
+    public void SetWindow(Window window)
+    {
+        _window = window;
+    }
+
+    private void Cancel()
+    {
+        _window?.Close(false);
+    }
+
+    private async Task SaveAsync()
+    {
+        var tagList = (Tags ?? string.Empty)
+            .Split(',', StringSplitOptions.RemoveEmptyEntries)
+            .Select(t => t.Trim())
+            .Where(t => !string.IsNullOrWhiteSpace(t))
+            .ToList();
+
+        if (tagList.Count == 0 || string.IsNullOrWhiteSpace(Folder))
+        {
+            if (_window != null)
+            {
+                var warn = new Window
+                {
+                    Width = 300,
+                    Height = 150,
+                    Title = "Warning",
+                    WindowStartupLocation = WindowStartupLocation.CenterOwner
+                };
+                var ok = new Button { Content = "OK", Width = 80, HorizontalAlignment = HorizontalAlignment.Center };
+                ok.Click += (_, _) => warn.Close();
+                warn.Content = new StackPanel
+                {
+                    Margin = new Thickness(10),
+                    Spacing = 10,
+                    Children =
+                    {
+                        new TextBlock { Text = "Please enter at least one tag and a target folder.", TextWrapping = TextWrapping.Wrap },
+                        ok
+                    }
+                };
+                await warn.ShowDialog(_window);
+            }
+            return;
+        }
+
+        var mappings = _xmlService.LoadMappings();
+        mappings.Add(new CustomTagMap
+        {
+            LookForTag = tagList,
+            MapToFolder = Folder!.Trim(),
+            Priority = 0
+        });
+        _xmlService.SaveMappings(mappings);
+        _window?.Close(true);
+    }
+}

--- a/DiffusionNexus.UI/ViewModels/LoraSortCustomMappingsViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraSortCustomMappingsViewModel.cs
@@ -1,37 +1,62 @@
+using Avalonia.Controls;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using DiffusionNexus.LoraSort.Service.Classes;
+using DiffusionNexus.LoraSort.Service.Services;
 using System.Collections.ObjectModel;
+using System.Threading.Tasks;
 
-namespace DiffusionNexus.UI.ViewModels
+namespace DiffusionNexus.UI.ViewModels;
+
+public partial class LoraSortCustomMappingsViewModel : ViewModelBase
 {
-    public partial class LoraSortCustomMappingsViewModel : ViewModelBase
+    [ObservableProperty]
+    private ObservableCollection<CustomTagMap> customTagMappings = new();
+
+    [ObservableProperty]
+    private bool isCustomEnabled = true;
+
+    private readonly CustomTagMapXmlService _xmlService = new();
+    private Window? _window;
+
+    public IRelayCommand MoveUpCommand { get; }
+    public IRelayCommand MoveDownCommand { get; }
+    public IAsyncRelayCommand AddMappingCommand { get; }
+    public IRelayCommand DeleteAllMappingsCommand { get; }
+
+    public LoraSortCustomMappingsViewModel()
     {
-        [ObservableProperty]
-        private ObservableCollection<CustomTagMapping> customTagMappings = new();
-        [ObservableProperty]
-        private bool isCustomEnabled = true;
-
-        public IRelayCommand MoveUpCommand { get; }
-        public IRelayCommand MoveDownCommand { get; }
-        public IRelayCommand AddMappingCommand { get; }
-        public IRelayCommand RemoveMappingCommand { get; }
-        public IRelayCommand SaveAllMappingsCommand { get; }
-        public IRelayCommand DeleteAllMappingsCommand { get; }
-
-        public LoraSortCustomMappingsViewModel()
-        {
-            MoveUpCommand = new RelayCommand(() => { });
-            MoveDownCommand = new RelayCommand(() => { });
-            AddMappingCommand = new RelayCommand(() => { });
-            RemoveMappingCommand = new RelayCommand(() => { });
-            SaveAllMappingsCommand = new RelayCommand(() => { });
-            DeleteAllMappingsCommand = new RelayCommand(() => { });
-        }
+        MoveUpCommand = new RelayCommand<CustomTagMap?>(_ => { });
+        MoveDownCommand = new RelayCommand<CustomTagMap?>(_ => { });
+        AddMappingCommand = new AsyncRelayCommand(AddMappingAsync);
+        DeleteAllMappingsCommand = new RelayCommand(DeleteAllMappings);
+        LoadMappings();
     }
 
-    public class CustomTagMapping
+    public void SetWindow(Window window) => _window = window;
+
+    private void LoadMappings()
     {
-        public string? LookForTag { get; set; }
-        public string? MapToFolder { get; set; }
+        CustomTagMappings = _xmlService.LoadMappings();
+    }
+
+    private async Task AddMappingAsync()
+    {
+        if (_window is null) return;
+
+        var dialog = new Views.CustomTagMapWindow();
+        if (dialog.DataContext is CustomTagMapWindowViewModel vm)
+            vm.SetWindow(dialog);
+
+        var result = await dialog.ShowDialog<bool>(_window);
+        if (result)
+            LoadMappings();
+    }
+
+    private void DeleteAllMappings()
+    {
+        var path = System.IO.Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, "mappings.xml");
+        _xmlService.DeleteAllMappings(path);
+        CustomTagMappings.Clear();
     }
 }

--- a/DiffusionNexus.UI/Views/Controls/LoraSortCustomMappingsControl.axaml
+++ b/DiffusionNexus.UI/Views/Controls/LoraSortCustomMappingsControl.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:conv="using:DiffusionNexus.UI.Converters"
              xmlns:vm="using:DiffusionNexus.UI.ViewModels"
+             xmlns:svc="clr-namespace:DiffusionNexus.LoraSort.Service.Classes;assembly=DiffusionNexus.LoraSort.Service"
              x:Class="DiffusionNexus.UI.Views.Controls.LoraSortCustomMappingsControl"
              x:DataType="vm:LoraSortCustomMappingsViewModel">
     <UserControl.DataContext>
@@ -20,7 +21,7 @@
         <ListBox x:Name="lvMappings" Grid.Row="0" ItemsSource="{Binding CustomTagMappings}"
                  IsEnabled="{Binding IsCustomEnabled}">
             <ListBox.ItemTemplate>
-                <DataTemplate x:DataType="vm:CustomTagMapping">
+                <DataTemplate x:DataType="svc:CustomTagMap">
                     <Grid ColumnDefinitions="*,*,*,*" Margin="0,2">
                         <!-- Tags column with converter -->
                         <TextBlock Grid.Column="0" Text="{Binding LookForTag, Converter={StaticResource TagsDisplayConverter}}"/>
@@ -59,13 +60,9 @@
             <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Right">
                 <Button Content="Add Mapping" Width="130" Margin="0,0,10,0"
                         Command="{Binding AddMappingCommand}"/>
-                <Button Content="Remove Mapping" Width="130"
-                        Command="{Binding RemoveMappingCommand}"/>
             </StackPanel>
             <!-- Second row: Save All and Delete All -->
             <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
-                <Button Content="Save All Mappings" Width="130" Margin="0,0,10,0"
-                        Command="{Binding SaveAllMappingsCommand}"/>
                 <Button Content="Delete All" Width="130"
                         Command="{Binding DeleteAllMappingsCommand}"/>
             </StackPanel>

--- a/DiffusionNexus.UI/Views/Controls/LoraSortCustomMappingsControl.axaml.cs
+++ b/DiffusionNexus.UI/Views/Controls/LoraSortCustomMappingsControl.axaml.cs
@@ -1,3 +1,4 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using DiffusionNexus.UI.ViewModels;
@@ -10,6 +11,15 @@ namespace DiffusionNexus.UI.Views.Controls
         {
             InitializeComponent();
             DataContext = new LoraSortCustomMappingsViewModel();
+            this.AttachedToVisualTree += OnAttached;
+        }
+
+        private void OnAttached(object? sender, VisualTreeAttachmentEventArgs e)
+        {
+            if (DataContext is LoraSortCustomMappingsViewModel vm && VisualRoot is Window window)
+            {
+                vm.SetWindow(window);
+            }
         }
 
         private void InitializeComponent()

--- a/DiffusionNexus.UI/Views/CustomTagMapWindow.axaml
+++ b/DiffusionNexus.UI/Views/CustomTagMapWindow.axaml
@@ -1,0 +1,34 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:DiffusionNexus.UI.ViewModels"
+        x:Class="DiffusionNexus.UI.Views.CustomTagMapWindow"
+        x:DataType="vm:CustomTagMapWindowViewModel"
+        Width="400" Height="200"
+        Title="Custom Tag Mapping"
+        WindowStartupLocation="CenterOwner">
+    <Window.DataContext>
+        <vm:CustomTagMapWindowViewModel/>
+    </Window.DataContext>
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <TextBlock Grid.Row="0" Grid.Column="0" Text="Tags (comma-separated):" VerticalAlignment="Center" Margin="0,0,10,0"/>
+        <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Tags}"/>
+
+        <TextBlock Grid.Row="1" Grid.Column="0" Text="Target Folder:" VerticalAlignment="Center" Margin="0,10,10,0"/>
+        <TextBox Grid.Row="1" Grid.Column="1" Margin="0,10,0,0" Text="{Binding Folder}"/>
+
+        <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,20,0,0">
+            <Button Content="Save" Width="75" Command="{Binding SaveCommand}" Margin="0,0,10,0"/>
+            <Button Content="Cancel" Width="75" Command="{Binding CancelCommand}"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/DiffusionNexus.UI/Views/CustomTagMapWindow.axaml.cs
+++ b/DiffusionNexus.UI/Views/CustomTagMapWindow.axaml.cs
@@ -1,0 +1,23 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using DiffusionNexus.UI.ViewModels;
+
+namespace DiffusionNexus.UI.Views;
+
+public partial class CustomTagMapWindow : Window
+{
+    public CustomTagMapWindow()
+    {
+        InitializeComponent();
+        this.AttachedToVisualTree += OnAttached;
+    }
+
+    private void OnAttached(object? sender, VisualTreeAttachmentEventArgs e)
+    {
+        if (DataContext is CustomTagMapWindowViewModel vm)
+            vm.SetWindow(this);
+    }
+
+    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+}


### PR DESCRIPTION
## Summary
- add `CustomTagMapWindow` for creating new tag mappings
- implement `CustomTagMapWindowViewModel` with validation and immediate save
- wire Add Mapping button to open the new window and reload mappings
- remove unused buttons from LoraSort UI and link to new model

## Testing
- `dotnet test`
- `dotnet build --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_685fb67ec7388332a43c80afa0840bce