### PR TITLE
Async Lora search + reusable busy overlay

### DIFF
--- a/DiffusionNexus.UI/DiffusionNexus.UI.csproj
+++ b/DiffusionNexus.UI/DiffusionNexus.UI.csproj
@@ -69,6 +69,9 @@
     <Compile Update="Views\CustomTagMapWindow.axaml.cs">
       <DependentUpon>CustomTagMapWindow.axaml</DependentUpon>
     </Compile>
+    <Compile Update="Views\Controls\BusyOverlay.axaml.cs">
+      <DependentUpon>BusyOverlay.axaml</DependentUpon>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/DiffusionNexus.UI/Views/Controls/BusyOverlay.axaml
+++ b/DiffusionNexus.UI/Views/Controls/BusyOverlay.axaml
@@ -1,0 +1,10 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="DiffusionNexus.UI.Views.Controls.BusyOverlay">
+    <Border Background="#80000000">
+        <ProgressBar IsIndeterminate="True"
+                     Width="60" Height="60"
+                     HorizontalAlignment="Center"
+                     VerticalAlignment="Center"/>
+    </Border>
+</UserControl>

--- a/DiffusionNexus.UI/Views/Controls/BusyOverlay.axaml.cs
+++ b/DiffusionNexus.UI/Views/Controls/BusyOverlay.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace DiffusionNexus.UI.Views.Controls;
+
+public partial class BusyOverlay : UserControl
+{
+    public BusyOverlay()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:DiffusionNexus.UI.ViewModels"
+             xmlns:controls="using:DiffusionNexus.UI.Views.Controls"
              x:Class="DiffusionNexus.UI.Views.LoraHelperView"
              x:DataType="vm:LoraHelperViewModel">
   <UserControl.DataContext>
@@ -77,7 +78,9 @@
           </ItemsControl.ItemsPanel>
         </ItemsControl>
       </ScrollViewer>
-      <ProgressBar IsVisible="{Binding IsLoading}" IsIndeterminate="True" Width="120" Height="16" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+      <controls:BusyOverlay IsVisible="{Binding IsLoading}"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"/>
     </Grid>
   </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- add BusyOverlay user control for showing a loading animation
- show the busy overlay in the Lora Helper view
- make card filtering in `LoraHelperViewModel` asynchronous to avoid UI freezes
- register the new control in the project file

## Testing
- `dotnet format --no-restore`
- `dotnet test --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6861d72436c08332ad51c97247aac5c2