### PR TITLE
Add processing overlay control and auto-scrolling log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+- Added busy overlay with progress and cancellation for LoRA sort.
+- Automatic log expansion during processing.
+- Added path validation, disk space check and progress reporting.
+- New unit tests for helper methods.

--- a/DiffusionNexus.LoraSort.Service.Tests/DiffusionNexus.LoraSort.Service.Tests.csproj
+++ b/DiffusionNexus.LoraSort.Service.Tests/DiffusionNexus.LoraSort.Service.Tests.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DiffusionNexus.LoraSort.Service\DiffusionNexus.LoraSort.Service.csproj" />
+    <ProjectReference Include="..\DiffusionNexus.UI\DiffusionNexus.UI.csproj" />
   </ItemGroup>
 
 </Project>

--- a/DiffusionNexus.LoraSort.Service.Tests/PathValidationTests.cs
+++ b/DiffusionNexus.LoraSort.Service.Tests/PathValidationTests.cs
@@ -1,0 +1,49 @@
+using DiffusionNexus.UI.ViewModels;
+using DiffusionNexus.UI.Classes;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DiffusionNexus.LoraSort.Service.Tests;
+
+public class PathValidationTests
+{
+    private class DummySettingsService : ISettingsService
+    {
+        public Task<SettingsModel> LoadAsync() => Task.FromResult(new SettingsModel());
+        public Task SaveAsync(SettingsModel settings) => Task.CompletedTask;
+    }
+
+    [Fact]
+    public void ValidatePaths_FailsForEmpty()
+    {
+        var vm = new LoraSortMainSettingsViewModel(new DummySettingsService());
+        Assert.False(vm.ValidatePaths());
+    }
+
+    [Fact]
+    public void IsPathTheSame_ReturnsTrue_ForIdentical()
+    {
+        var vm = new LoraSortMainSettingsViewModel(new DummySettingsService());
+        var path = Path.Combine(Path.GetTempPath(), "samepath");
+        vm.BasePath = path;
+        vm.TargetPath = path;
+        Assert.True(vm.IsPathTheSame());
+    }
+
+    [Fact]
+    public void DiskSpaceCheck_ReturnsTrue_ForSmallFolder()
+    {
+        var svc = new DiffusionNexus.LoraSort.Service.Services.FileControllerService();
+        var temp = Path.GetTempPath();
+        var dir = Directory.CreateDirectory(Path.Combine(temp, "diskcheck"));
+        try
+        {
+            Assert.True(svc.EnoughFreeSpaceOnDisk(dir.FullName, temp));
+        }
+        finally
+        {
+            Directory.Delete(dir.FullName, true);
+        }
+    }
+}

--- a/DiffusionNexus.LoraSort.Service/Services/FileControllerService.cs
+++ b/DiffusionNexus.LoraSort.Service/Services/FileControllerService.cs
@@ -3,13 +3,14 @@
  * For non-commercial use only. See LICENSE for details.
  */
 using DiffusionNexus.LoraSort.Service.Classes;
+using System;
 using System.Security.Cryptography;
 
 namespace DiffusionNexus.LoraSort.Service.Services
 {
     public class FileControllerService
     {
-        public async Task ComputeFolder(IProgress<ProgressReport> progress, CancellationToken cancellationToken, SelectedOptions options)
+        private async Task ComputeFolderInternal(IProgress<ProgressReport> progress, CancellationToken cancellationToken, SelectedOptions options)
         {
             progress?.Report(new ProgressReport
             {
@@ -53,6 +54,12 @@ namespace DiffusionNexus.LoraSort.Service.Services
                 StatusMessage = "==========> Finished processing.",
                 IsSuccessful = true
             });
+        }
+
+        public async Task ComputeFolder(IProgress<double>? progress, CancellationToken cancellationToken, SelectedOptions options)
+        {
+            Progress<ProgressReport>? wrapper = progress != null ? new Progress<ProgressReport>(p => progress.Report(p.Percentage ?? 0)) : null;
+            await ComputeFolderInternal(wrapper!, cancellationToken, options);
         }
 
         public bool EnoughFreeSpaceOnDisk(string sourcePath, string targetPath)

--- a/DiffusionNexus.UI/Classes/DialogService.cs
+++ b/DiffusionNexus.UI/Classes/DialogService.cs
@@ -109,5 +109,11 @@ namespace DiffusionNexus.UI.Classes
             var result = await ShowConfirmationAsync("Overwrite the existing file?");
             return result == true;
         }
+
+        public async Task<bool> ShowYesNoAsync(string message, string title)
+        {
+            var result = await ShowConfirmationAsync(message);
+            return result == true;
+        }
     }
 }

--- a/DiffusionNexus.UI/Classes/IDialogService.cs
+++ b/DiffusionNexus.UI/Classes/IDialogService.cs
@@ -7,5 +7,6 @@ namespace DiffusionNexus.UI.Classes
         Task<bool?> ShowConfirmationAsync(string message, bool allowCancel = false);
         Task<string?> ShowInputAsync(string message, string? defaultValue = null);
         Task<bool> ShowOverwriteConfirmationAsync();
+        Task<bool> ShowYesNoAsync(string message, string title);
     }
 }

--- a/DiffusionNexus.UI/DiffusionNexus.UI.csproj
+++ b/DiffusionNexus.UI/DiffusionNexus.UI.csproj
@@ -72,6 +72,9 @@
     <Compile Update="Views\Controls\BusyOverlay.axaml.cs">
       <DependentUpon>BusyOverlay.axaml</DependentUpon>
     </Compile>
+    <Compile Update="Views\Controls\ProcessingOverlayControl.axaml.cs">
+      <DependentUpon>ProcessingOverlayControl.axaml</DependentUpon>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/DiffusionNexus.UI/Properties/AssemblyInfo.cs
+++ b/DiffusionNexus.UI/Properties/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("DiffusionNexus.LoraSort.Service.Tests")]

--- a/DiffusionNexus.UI/ViewModels/LoraSortMainSettingsViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraSortMainSettingsViewModel.cs
@@ -5,6 +5,10 @@ using CommunityToolkit.Mvvm.Input;
 using DiffusionNexus.LoraSort.Service.Classes;
 using DiffusionNexus.LoraSort.Service.Services;
 using DiffusionNexus.UI.Classes;
+using Avalonia.Threading;
+using Avalonia;
+using Avalonia.Media;
+using DiffusionNexus.UI.Models;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -34,10 +38,16 @@ namespace DiffusionNexus.UI.ViewModels
         private string? statusText;
         [ObservableProperty]
         private string actionButtonText = "Go";
+        [ObservableProperty]
+        private bool isBusy;
+        [ObservableProperty]
+        private bool isIndeterminate = true;
 
         private readonly ISettingsService _settingsService;
         public IDialogService DialogService { get; set; } = null!;
         private Window? _window;
+        private MainWindowViewModel? _mainWindowVm;
+        private bool _originalLogExpanded;
 
         public IAsyncRelayCommand SelectBasePathCommand { get; }
         public IAsyncRelayCommand SelectTargetPathCommand { get; }
@@ -62,6 +72,37 @@ namespace DiffusionNexus.UI.ViewModels
         public void SetWindow(Window window)
         {
             _window = window;
+        }
+
+        public void SetMainWindowViewModel(MainWindowViewModel vm)
+        {
+            _mainWindowVm = vm;
+        }
+
+        private async Task ShowDialog(string message, string caption)
+        {
+            if (_window == null)
+                return;
+            var dialog = new Window
+            {
+                Width = 300,
+                Height = 150,
+                Title = caption,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
+            var ok = new Button { Content = "OK", Width = 80, HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center };
+            ok.Click += (_, _) => dialog.Close();
+            dialog.Content = new StackPanel
+            {
+                Margin = new Thickness(10),
+                Spacing = 10,
+                Children =
+                {
+                    new TextBlock { Text = message, TextWrapping = TextWrapping.Wrap },
+                    ok
+                }
+            };
+            await dialog.ShowDialog(_window);
         }
 
         private async Task LoadDefaultsAsync()
@@ -99,29 +140,34 @@ namespace DiffusionNexus.UI.ViewModels
             {
                 _cts?.Cancel();
             }
-
-            // TODO: Implement main action logic
-            StatusText = "Go clicked (not implemented)";
-            Progress = 0;
         }
 
-        private bool ValidatePaths()
+        internal bool ValidatePaths()
         {
-            return !string.IsNullOrEmpty(BasePath) && !string.IsNullOrEmpty(TargetPath);
+            return !string.IsNullOrWhiteSpace(BasePath) && !string.IsNullOrWhiteSpace(TargetPath);
         }
 
-        private void ShowMessageAndResetUI(string message, string caption)
+        private async Task ShowMessageAndResetUI(string message, string caption)
         {
-            // TODO: Write in UI log
+            Log(message, LogLevel.Warning);
+            await ShowDialog(message, caption);
             ResetUI();
+        }
+
+        private void SetStatus(string text)
+        {
+            StatusText = text;
+            Log(text);
         }
 
         private void SetProcessingUIState()
         {
             _isProcessing = true;
-            //TODO: Show Progress bar Overlay
-            //TODO: Expand log in MainView
-            //TODO: Show Cancel button
+            IsBusy = true;
+            ActionButtonText = "Cancel";
+            _originalLogExpanded = _mainWindowVm?.IsLogExpanded ?? false;
+            if (_mainWindowVm != null)
+                _mainWindowVm.IsLogExpanded = true;
             _cts = new CancellationTokenSource();
         }
 
@@ -133,62 +179,76 @@ namespace DiffusionNexus.UI.ViewModels
 
                 if (!ValidatePaths())
                 {
-                    ShowMessageAndResetUI("No path selected", "No Path");
+                    await ShowMessageAndResetUI("No path selected", "No Path");
                     return;
                 }
 
                 if (IsPathTheSame())
                 {
-                    ShowMessageAndResetUI("Select a different target than the source path.", "Source cannot be target path");
+                    await ShowMessageAndResetUI("Select a different target than the source path.", "Source cannot be target path");
                     return;
                 }
 
                 var controllerService = new FileControllerService();
 
-                //TODO: If user wants to copy files, we need to check if there is enough disk space available.
-                //if ((bool)radioCopy.IsChecked && !controllerService.EnoughFreeSpaceOnDisk(txtBasePath.Text, txtTargetPath.Text))
-                //{
-                //Todo: Write in UI log
-                //"You don't have enough disk space to copy the files.", "Insuficcent Diskspace"
-                return;
-                //}
+                if (IsCopyMode && !controllerService.EnoughFreeSpaceOnDisk(BasePath!, TargetPath!))
+                {
+                    Log("Insufficient disk space.", LogLevel.Warning);
+                    await ShowDialog("You don't have enough disk space to copy the files.", "Insufficient Disk Space");
+                    return;
+                }
 
-                bool moveOperation = false;
-                //If user selected "Move" operation instead of "Copy", we need to handle that.
-                //if (!(bool)radioCopy.IsChecked)
-                //{
-                //TODO: Show confirmation dialog "Moving instead of copying means that the original file order cannot be restored. Continue anyways?", "Are you sure?"
-                //if user selects "No" then return and reset UI;
-                //if ()
-                //{
-                //    ResetUI();
-                //    return;
-                //}
-                moveOperation = true;
-                //}
+                if (!IsCopyMode)
+                {
+                    var move = await DialogService.ShowYesNoAsync("Moving instead of copying means that the original file order cannot be restored. Continue anyways?", "Are you sure?");
+                    if (!move)
+                    {
+                        ResetUI();
+                        return;
+                    }
+                }
 
-                //TODO: Prepare progress indicator and start Pogressing
-                //await controllerService.ComputeFolder(progressIndicator, _cts.Token, new SelectedOptions()
-                //{
-                    //BasePath = BasePath,
-                    //TargetPath = TargetPath,
-                    //IsMoveOperation = moveOperation,
-                    //TODO: GET these values from UI
-                    //OverrideFiles = (bool)chbOverride.IsChecked,
-                    //CreateBaseFolders = (bool)chbBaseFolders.IsChecked,
-                    //UseCustomMappings = (bool)chbCustom.IsChecked,
-                    //ApiKey = SettingsManager.LoadApiKey()
-                //});
+                var settings = await _settingsService.LoadAsync();
+                var options = new SelectedOptions
+                {
+                    BasePath = BasePath!,
+                    TargetPath = TargetPath!,
+                    IsMoveOperation = !IsCopyMode,
+                    OverrideFiles = OverrideFiles,
+                    CreateBaseFolders = CreateBaseFolders,
+                    UseCustomMappings = UseCustomMappings,
+                    ApiKey = settings.CivitaiApiKey ?? string.Empty
+                };
+
+                SetStatus("Scanning…");
+                IsIndeterminate = true;
+                var first = true;
+                var progress = new Progress<double>(v =>
+                {
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        if (first)
+                        {
+                            IsIndeterminate = false;
+                            SetStatus("Copying…");
+                            first = false;
+                        }
+                        Progress = v;
+                    });
+                });
+
+                await controllerService.ComputeFolder(progress, _cts.Token, options);
+                SetStatus("Finalising…");
             }
 
             catch (OperationCanceledException)
             {
-                //TODO: Write in UI log
+                Log("Operation cancelled by user.");
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"Unexpected error: {ex.Message}");
-                //Log.Error($"Unexpected error: {ex.Message}");
+                Log($"Unexpected error: {ex.Message}", LogLevel.Error);
+                await ShowDialog("Unexpected error – see log for details.", "Error");
             }
             finally
             {
@@ -198,9 +258,17 @@ namespace DiffusionNexus.UI.ViewModels
         private void ResetUI()
         {
             _isProcessing = false;
+            IsBusy = false;
+            ActionButtonText = "Go";
+            Progress = 0;
+            StatusText = null;
+            _cts?.Dispose();
+            _cts = null!;
+            if (_mainWindowVm != null)
+                _mainWindowVm.IsLogExpanded = _originalLogExpanded;
         }
 
-        private bool IsPathTheSame()
+        internal bool IsPathTheSame()
         {
             return string.Compare(
                 Path.GetFullPath(BasePath).TrimEnd('\\'),

--- a/DiffusionNexus.UI/ViewModels/MainWindowViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/MainWindowViewModel.cs
@@ -28,6 +28,13 @@ namespace DiffusionNexus.UI.ViewModels
 
         public LogViewModel LogViewModel { get; } = new LogViewModel();
 
+        private bool _isLogExpanded;
+        public bool IsLogExpanded
+        {
+            get => _isLogExpanded;
+            set => SetProperty(ref _isLogExpanded, value);
+        }
+
         private bool _isMenuOpen = true;
         public bool IsMenuOpen
         {

--- a/DiffusionNexus.UI/ViewModels/ViewModelBase.cs
+++ b/DiffusionNexus.UI/ViewModels/ViewModelBase.cs
@@ -1,12 +1,18 @@
 ﻿using System.ComponentModel;
 using System.Diagnostics;
 using CommunityToolkit.Mvvm.ComponentModel;
+using DiffusionNexus.UI.Classes;
+using DiffusionNexus.UI.Models;
 
 namespace DiffusionNexus.UI.ViewModels
 {
     public class ViewModelBase : ObservableObject
     {
-        protected void Log(string message) => Debug.WriteLine(message);
+        protected void Log(string message, LogLevel level = LogLevel.Info)
+        {
+            LogEventService.Instance.Publish(level, message);
+            Debug.WriteLine(message);
+        }
 
         protected override void OnPropertyChanged(PropertyChangedEventArgs e)
         {

--- a/DiffusionNexus.UI/Views/Controls/LogControl.axaml
+++ b/DiffusionNexus.UI/Views/Controls/LogControl.axaml
@@ -34,7 +34,7 @@
               HorizontalAlignment="Center"
               VerticalAlignment="Bottom"
               Margin="0,0,0,40">
-        <ScrollViewer Height="200">
+        <ScrollViewer Height="200" x:Name="LogScroll">
           <ItemsControl ItemsSource="{Binding Entries}">
             <ItemsControl.ItemTemplate>
               <DataTemplate x:DataType="models:LogEntry">

--- a/DiffusionNexus.UI/Views/Controls/LogControl.axaml.cs
+++ b/DiffusionNexus.UI/Views/Controls/LogControl.axaml.cs
@@ -1,3 +1,4 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
@@ -5,9 +6,27 @@ namespace DiffusionNexus.UI.Views.Controls
 {
     public partial class LogControl : UserControl
     {
+        private ScrollViewer? _scroll;
+
         public LogControl()
         {
             InitializeComponent();
+            this.AttachedToVisualTree += OnAttached;
+            this.DataContextChanged += (_, _) => HookDataContext();
+        }
+
+        private void OnAttached(object? sender, VisualTreeAttachmentEventArgs e)
+        {
+            _scroll = this.FindControl<ScrollViewer>("LogScroll");
+            HookDataContext();
+        }
+
+        private void HookDataContext()
+        {
+            if (DataContext is ViewModels.LogViewModel vm)
+            {
+                vm.Entries.CollectionChanged += (_, _) => _scroll?.ScrollToEnd();
+            }
         }
 
         private void InitializeComponent()

--- a/DiffusionNexus.UI/Views/Controls/LoraSortMainSettingsControl.axaml
+++ b/DiffusionNexus.UI/Views/Controls/LoraSortMainSettingsControl.axaml
@@ -3,13 +3,15 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:DiffusionNexus.UI.ViewModels"
+             xmlns:controls="using:DiffusionNexus.UI.Views.Controls"
              mc:Ignorable="d"
              x:Class="DiffusionNexus.UI.Views.Controls.LoraSortMainSettingsControl"
              x:DataType="vm:LoraSortMainSettingsViewModel">
     <UserControl.DataContext>
         <vm:LoraSortMainSettingsViewModel/>
     </UserControl.DataContext>
-    <ScrollViewer Margin="10" VerticalScrollBarVisibility="Auto">
+    <Grid>
+      <ScrollViewer Margin="10" VerticalScrollBarVisibility="Auto">
         <StackPanel>
             <!-- LoRA Source Path Group -->
             <Border BorderBrush="Gray" BorderThickness="1" CornerRadius="5" Margin="0,0,0,10" Padding="10">
@@ -91,15 +93,12 @@
                            Content="{Binding ActionButtonText}" 
                            Command="{Binding GoCommand}"
                            Margin="0,10"/>
-                    <ProgressBar Value="{Binding Progress}" 
-                               Minimum="0" 
-                               Maximum="100" 
-                               Height="25" />
-                    <TextBlock Text="{Binding StatusText}" 
-                              Margin="0,35,0,0" 
-                              FontSize="14"/>
                 </StackPanel>
             </Border>
         </StackPanel>
-    </ScrollViewer>
+      </ScrollViewer>
+      <controls:ProcessingOverlayControl IsVisible="{Binding IsBusy}"
+                                  HorizontalAlignment="Stretch"
+                                  VerticalAlignment="Stretch"/>
+    </Grid>
 </UserControl>

--- a/DiffusionNexus.UI/Views/Controls/LoraSortMainSettingsControl.axaml.cs
+++ b/DiffusionNexus.UI/Views/Controls/LoraSortMainSettingsControl.axaml.cs
@@ -19,6 +19,8 @@ namespace DiffusionNexus.UI.Views.Controls
             if (DataContext is LoraSortMainSettingsViewModel vm && VisualRoot is Window window)
             {
                 vm.SetWindow(window);
+                if (window.DataContext is MainWindowViewModel mw)
+                    vm.SetMainWindowViewModel(mw);
             }
         }
 

--- a/DiffusionNexus.UI/Views/Controls/ProcessingOverlayControl.axaml
+++ b/DiffusionNexus.UI/Views/Controls/ProcessingOverlayControl.axaml
@@ -1,0 +1,15 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:DiffusionNexus.UI.ViewModels"
+             x:Class="DiffusionNexus.UI.Views.Controls.ProcessingOverlayControl"
+             IsHitTestVisible="{Binding IsBusy}"
+             x:DataType="vm:LoraSortMainSettingsViewModel">
+  <Border Background="#80000000">
+    <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="10">
+      <ProgressBar Width="200" Height="20"
+                   IsIndeterminate="{Binding IsIndeterminate}"
+                   Value="{Binding Progress}" Minimum="0" Maximum="100"/>
+      <Button Content="Cancel" Width="80" Command="{Binding GoCommand}"/>
+    </StackPanel>
+  </Border>
+</UserControl>

--- a/DiffusionNexus.UI/Views/Controls/ProcessingOverlayControl.axaml.cs
+++ b/DiffusionNexus.UI/Views/Controls/ProcessingOverlayControl.axaml.cs
@@ -1,0 +1,19 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace DiffusionNexus.UI.Views.Controls;
+
+public partial class ProcessingOverlayControl : UserControl
+{
+    public ProcessingOverlayControl()
+    {
+        InitializeComponent();
+        this.AttachedToVisualTree += (_, _) => DataContext ??= (Parent as Control)?.DataContext;
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/DiffusionNexus.UI/Views/MainWindow.axaml
+++ b/DiffusionNexus.UI/Views/MainWindow.axaml
@@ -88,7 +88,8 @@
     </SplitView.Content>
     </SplitView>
 
-    <!-- With this single line -->
-    <controls:LogControl Grid.Row="1" DataContext="{Binding LogViewModel}" />
+    <Expander Grid.Row="1" IsExpanded="{Binding IsLogExpanded}">
+      <controls:LogControl DataContext="{Binding LogViewModel}" />
+    </Expander>
   </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- use a dedicated ProcessingOverlayControl bound to the view model
- wire up Cancel button and remove inline progress elements
- auto-scroll log entries to newest message
- log status text changes for better visibility

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686249e7209c8332b87956cd5043ac5d