### PR TITLE
Enhance LogControl with filter/export

### DIFF
--- a/DiffusionNexus.UI/Classes/ILogEventService.cs
+++ b/DiffusionNexus.UI/Classes/ILogEventService.cs
@@ -8,6 +8,6 @@ namespace DiffusionNexus.UI.Classes
     {
         ObservableCollection<LogEntry> Entries { get; }
         LogEntry? LatestEntry { get; }
-        void Publish(LogLevel level, string message);
+        void Publish(LogSeverity severity, string message);
     }
 }

--- a/DiffusionNexus.UI/Classes/LogEventService.cs
+++ b/DiffusionNexus.UI/Classes/LogEventService.cs
@@ -22,12 +22,12 @@ namespace DiffusionNexus.UI.Classes
             private set => SetProperty(ref _latestEntry, value);
         }
 
-        public void Publish(LogLevel level, string message)
+        public void Publish(LogSeverity severity, string message)
         {
             var entry = new LogEntry
             {
                 Timestamp = DateTime.Now,
-                Level = level,
+                Severity = severity,
                 Message = message
             };
             _entries.Add(entry);

--- a/DiffusionNexus.UI/Converters/LogLevelToBrushConverter.cs
+++ b/DiffusionNexus.UI/Converters/LogLevelToBrushConverter.cs
@@ -10,13 +10,13 @@ namespace DiffusionNexus.UI.Converters
     {
         public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
-            if (value is LogLevel level)
+            if (value is LogSeverity level)
             {
                 return level switch
                 {
-                    LogLevel.Success => Brushes.DarkGreen,
-                    LogLevel.Warning => Brushes.Gold,
-                    LogLevel.Error => Brushes.IndianRed,
+                    LogSeverity.Warning => Brushes.Gold,
+                    LogSeverity.Error => Brushes.IndianRed,
+                    LogSeverity.Debug => Brushes.DarkGray,
                     _ => Brushes.Gray,
                 };
             }

--- a/DiffusionNexus.UI/Models/LogEntry.cs
+++ b/DiffusionNexus.UI/Models/LogEntry.cs
@@ -2,18 +2,23 @@ using System;
 
 namespace DiffusionNexus.UI.Models
 {
-    public enum LogLevel
+    public enum LogSeverity
     {
         Info,
-        Success,
         Warning,
-        Error
+        Error,
+        Debug
     }
 
     public class LogEntry
     {
         public DateTime Timestamp { get; set; }
         public string Message { get; set; } = string.Empty;
-        public LogLevel Level { get; set; }
+        public LogSeverity Severity { get; set; }
+
+        public string ToLine()
+        {
+            return $"[{Timestamp:HH:mm:ss}] [{Severity.ToString().ToUpper()}] {Message}";
+        }
     }
 }

--- a/DiffusionNexus.UI/ViewModels/LogViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LogViewModel.cs
@@ -4,12 +4,24 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DiffusionNexus.UI.Classes;
 using DiffusionNexus.UI.Models;
+using Avalonia.Controls;
+using Avalonia.Platform.Storage;
+using Avalonia;
+using System.Collections.Specialized;
+using System.IO;
+using System.Linq;
+using System;
+using System.Threading.Tasks;
 
 namespace DiffusionNexus.UI.ViewModels
 {
     public partial class LogViewModel : ViewModelBase
     {
         private readonly ILogEventService _service;
+        private readonly ObservableCollection<LogEntry> _visibleEntries = new();
+        public ObservableCollection<LogEntry> VisibleEntries => _visibleEntries;
+
+        private Window? _window;
 
         public LogViewModel() : this(LogEventService.Instance) { }
 
@@ -17,14 +29,25 @@ namespace DiffusionNexus.UI.ViewModels
         {
             _service = service;
             _service.PropertyChanged += ServiceOnPropertyChanged;
-            _service.Publish(LogLevel.Info, "Log service initialized.");
-            _service.Publish(LogLevel.Success, "Log service ready.");
+            _service.Entries.CollectionChanged += EntriesOnCollectionChanged;
+            foreach (var e in _service.Entries)
+                _visibleEntries.Add(e);
+            _service.Publish(LogSeverity.Info, "Log service initialized.");
+            _service.Publish(LogSeverity.Info, "Log service ready.");
+
+            ExportLogCommand = new AsyncRelayCommand(ExportAsync, () => CanExport);
+            CopyLogCommand = new AsyncRelayCommand(CopyAsync, () => CanCopy);
         }
 
         public ObservableCollection<LogEntry> Entries => _service.Entries;
 
         public LogEntry? LatestEntry => _service.LatestEntry;
-        
+
+        [ObservableProperty]
+        private LogSeverity? _selectedSeverity;
+
+        public Array SeverityOptions { get; } = Enum.GetValues(typeof(LogSeverity));
+
         [ObservableProperty]
         private string _buttonText = OverlayButtonText;
 
@@ -44,6 +67,69 @@ namespace DiffusionNexus.UI.ViewModels
                     System.Diagnostics.Debug.WriteLine($"IsOverlayVisible changed to: {value}");
                     OnPropertyChanged();  // Explicit notification
                 }
+            }
+        }
+
+        partial void OnSelectedSeverityChanged(LogSeverity? value)
+        {
+            ApplyFilter();
+        }
+
+        private void EntriesOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (e.NewItems != null)
+            {
+                foreach (LogEntry entry in e.NewItems)
+                {
+                    if (IsVisible(entry))
+                        _visibleEntries.Add(entry);
+                }
+                OnPropertyChanged(nameof(CanExport));
+                OnPropertyChanged(nameof(CanCopy));
+                ExportLogCommand.NotifyCanExecuteChanged();
+                CopyLogCommand.NotifyCanExecuteChanged();
+            }
+        }
+
+        private bool IsVisible(LogEntry entry) => !_selectedSeverity.HasValue || entry.Severity == _selectedSeverity.Value;
+
+        private void ApplyFilter()
+        {
+            _visibleEntries.Clear();
+            foreach (var entry in _service.Entries)
+                if (IsVisible(entry))
+                    _visibleEntries.Add(entry);
+            OnPropertyChanged(nameof(CanExport));
+            OnPropertyChanged(nameof(CanCopy));
+            ExportLogCommand.NotifyCanExecuteChanged();
+            CopyLogCommand.NotifyCanExecuteChanged();
+        }
+
+        public void SetWindow(Window window) => _window = window;
+
+        public bool CanExport => _visibleEntries.Count > 0;
+        public bool CanCopy => _visibleEntries.Count > 0;
+
+        public IAsyncRelayCommand ExportLogCommand { get; }
+        public IAsyncRelayCommand CopyLogCommand { get; }
+
+        private async Task ExportAsync()
+        {
+            if (_window == null) return;
+            var file = await _window.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions { SuggestedFileName = "log.txt" });
+            var path = file?.TryGetLocalPath();
+            if (!string.IsNullOrEmpty(path))
+            {
+                File.WriteAllLines(path, _visibleEntries.Select(e => e.ToLine()));
+            }
+        }
+
+        private async Task CopyAsync()
+        {
+            if (_window?.Clipboard != null)
+            {
+                var text = string.Join(Environment.NewLine, _visibleEntries.Select(e => e.ToLine()));
+                await _window.Clipboard.SetTextAsync(text);
             }
         }
 

--- a/DiffusionNexus.UI/Views/Controls/LogControl.axaml
+++ b/DiffusionNexus.UI/Views/Controls/LogControl.axaml
@@ -12,7 +12,7 @@
   <Grid RowDefinitions="Auto,*">
     <!-- Status Bar -->
     <Border Grid.Row="0"
-            Background="{Binding LatestEntry.Level, Converter={StaticResource LogLevelToBrushConverter}}">
+            Background="{Binding LatestEntry.Severity, Converter={StaticResource LogLevelToBrushConverter}}">
       <Grid ColumnDefinitions="*,Auto" Height="36" VerticalAlignment="Center">
         <TextBlock Text="{Binding LatestEntry.Message}"
                  Margin="5,0"
@@ -34,8 +34,14 @@
               HorizontalAlignment="Center"
               VerticalAlignment="Bottom"
               Margin="0,0,0,40">
-        <ScrollViewer Height="200">
-          <ItemsControl ItemsSource="{Binding Entries}">
+        <Grid RowDefinitions="Auto,*">
+          <StackPanel Orientation="Horizontal" Spacing="5">
+            <ComboBox Width="100" SelectedItem="{Binding SelectedSeverity}" ItemsSource="{Binding SeverityOptions}" />
+            <Button Content="Copy" Command="{Binding CopyLogCommand}" IsEnabled="{Binding CanCopy}" />
+            <Button Content="Export" Command="{Binding ExportLogCommand}" IsEnabled="{Binding CanExport}" />
+          </StackPanel>
+          <ScrollViewer Grid.Row="1" Height="200" Name="LogScrollViewer">
+            <ItemsControl ItemsSource="{Binding VisibleEntries}">
             <ItemsControl.ItemTemplate>
               <DataTemplate x:DataType="models:LogEntry">
                 <StackPanel Orientation="Horizontal"
@@ -44,17 +50,18 @@
                   <TextBlock Width="150"
                            Text="{Binding Timestamp, StringFormat=HH:mm:ss dd.MM.yyyy}"/>
                   <TextBlock Width="70"
-                           Text="{Binding Level}"
+                           Text="{Binding Severity}"
                            Foreground="White"
-                           Background="{Binding Level, Converter={StaticResource LogLevelToBrushConverter}}"
+                           Background="{Binding Severity, Converter={StaticResource LogLevelToBrushConverter}}"
                            HorizontalAlignment="Center"
                            TextAlignment="Center"/>
                   <TextBlock Text="{Binding Message}"/>
                 </StackPanel>
               </DataTemplate>
             </ItemsControl.ItemTemplate>
-          </ItemsControl>
-        </ScrollViewer>
+            </ItemsControl>
+          </ScrollViewer>
+        </Grid>
       </Border>
     </Border>
   </Grid>

--- a/DiffusionNexus.UI/Views/Controls/LogControl.axaml.cs
+++ b/DiffusionNexus.UI/Views/Controls/LogControl.axaml.cs
@@ -1,18 +1,48 @@
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using Avalonia;
 
 namespace DiffusionNexus.UI.Views.Controls
 {
     public partial class LogControl : UserControl
     {
+        private ScrollViewer? _scrollViewer;
+        private bool _autoScroll = true;
+
         public LogControl()
         {
             InitializeComponent();
+            this.AttachedToVisualTree += OnAttached;
         }
 
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
+            _scrollViewer = this.FindControl<ScrollViewer>("LogScrollViewer");
+        }
+
+        private void OnAttached(object? sender, VisualTreeAttachmentEventArgs e)
+        {
+            if (DataContext is ViewModels.LogViewModel vm && VisualRoot is Window w)
+            {
+                vm.SetWindow(w);
+                vm.VisibleEntries.CollectionChanged += (_, __) => ScrollIfNeeded();
+            }
+            if (_scrollViewer != null)
+                _scrollViewer.ScrollChanged += ScrollViewerOnScrollChanged;
+        }
+
+        private void ScrollViewerOnScrollChanged(object? sender, ScrollChangedEventArgs e)
+        {
+            if (_scrollViewer == null) return;
+            var maxOffset = _scrollViewer.Extent.Height - _scrollViewer.Viewport.Height;
+            _autoScroll = _scrollViewer.Offset.Y >= maxOffset - 1;
+        }
+
+        private void ScrollIfNeeded()
+        {
+            if (_autoScroll)
+                _scrollViewer?.ScrollToEnd();
         }
     }
 }

--- a/DiffusionNexus.UI/Views/Controls/LoraSortMainSettingsControl.axaml.cs
+++ b/DiffusionNexus.UI/Views/Controls/LoraSortMainSettingsControl.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using DiffusionNexus.UI.ViewModels;
+using DiffusionNexus.UI.Classes;
 
 namespace DiffusionNexus.UI.Views.Controls
 {
@@ -10,7 +11,7 @@ namespace DiffusionNexus.UI.Views.Controls
         public LoraSortMainSettingsControl()
         {
             InitializeComponent();
-            DataContext = new LoraSortMainSettingsViewModel();
+            DataContext = new LoraSortMainSettingsViewModel(new SettingsService(), LogEventService.Instance);
             this.AttachedToVisualTree += OnAttached;
         }
 


### PR DESCRIPTION
## Summary
- define `LogSeverity` and extend `LogEntry`
- update logging service interface and service
- implement severity filter, copy and export in `LogViewModel`
- connect progress reporting from LoRA sort settings to the log
- update `LogControl` UI with filter dropdown, buttons and auto‑scroll

## Testing
- `dotnet restore DiffusionNexus.sln`
- `dotnet build DiffusionNexus.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6862bad4e9708332aa7a150b8a7b258b