### PR TITLE
Fix Prompt Edit Save As

### DIFF
--- a/DiffusionNexus.UI/ViewModels/PromptEditViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/PromptEditViewModel.cs
@@ -61,15 +61,22 @@ namespace DiffusionNexus.UI.ViewModels
 
         public IRelayCommand ApplyBlacklistCommand { get; }
         public IAsyncRelayCommand SaveCommand { get; }
-        public IAsyncRelayCommand<Window?> SaveAsCommand { get; }
+        public IAsyncRelayCommand SaveAsCommand { get; }
         public IAsyncRelayCommand CopyMetadataCommand { get; }
+
+        private Window? _window;
 
         public PromptEditViewModel()
         {
             ApplyBlacklistCommand = new RelayCommand(OnApplyBlacklist);
             SaveCommand = new AsyncRelayCommand(OnSaveAsync);
-            SaveAsCommand = new AsyncRelayCommand<Window?>(OnSaveAsAsync);
+            SaveAsCommand = new AsyncRelayCommand(OnSaveAsAsync);
             CopyMetadataCommand = new AsyncRelayCommand(OnCopyMetadataAsync);
+        }
+
+        public void SetWindow(Window window)
+        {
+            _window = window;
         }
 
         public void OnDragEnter(DragEventArgs e)
@@ -240,15 +247,15 @@ namespace DiffusionNexus.UI.ViewModels
             Log($"image saved {_currentImagePath}", LogSeverity.Success);
         }
 
-        private async Task OnSaveAsAsync(Window window)
+        private async Task OnSaveAsAsync()
         {
-            if (string.IsNullOrEmpty(_currentImagePath) || window == null)
+            if (string.IsNullOrEmpty(_currentImagePath) || _window == null)
             {
                 Log("no image to save", LogSeverity.Error);
                 return;
             }
 
-            var file = await window.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            var file = await _window.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
                 SuggestedFileName = Path.GetFileName(_currentImagePath),
                 FileTypeChoices = new[] { new FilePickerFileType("PNG") { Patterns = new[] { "*.png" } } }

--- a/DiffusionNexus.UI/Views/PromptEditView.axaml
+++ b/DiffusionNexus.UI/Views/PromptEditView.axaml
@@ -108,7 +108,7 @@
           <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10">
             <Button Content="Apply List" Width="110" Command="{Binding ApplyBlacklistCommand}"/>
             <Button Content="Save" Width="80" Command="{Binding SaveCommand}" CommandParameter="{Binding $parent[UserControl].VisualRoot}"/>
-            <Button Content="Save As" Width="80" Command="{Binding SaveAsCommand}" CommandParameter="{Binding $parent[UserControl].VisualRoot}"/>
+            <Button Content="Save As" Width="80" Command="{Binding SaveAsCommand}"/>
           </StackPanel>
 
         </StackPanel>

--- a/DiffusionNexus.UI/Views/PromptEditView.axaml.cs
+++ b/DiffusionNexus.UI/Views/PromptEditView.axaml.cs
@@ -28,6 +28,7 @@ public partial class PromptEditView : UserControl
         if (DataContext is PromptEditViewModel vm && VisualRoot is Window window)
         {
             vm.DialogService = new DialogService(window);
+            vm.SetWindow(window);
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure `PromptEditViewModel` keeps a reference to the host window
- use the stored window for Save As so the command gets a non-null parameter
- adjust view to call `SetWindow` and update Save As button binding

## Testing
- `dotnet build DiffusionNexus.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6863114ba0548332a00bb31a91955eb4