### PR TITLE
Load local metadata for LoRA helper

### DIFF
--- a/DiffusionNexus.LoraSort.Service/Services/JsonInfoFileReaderService.cs
+++ b/DiffusionNexus.LoraSort.Service/Services/JsonInfoFileReaderService.cs
@@ -141,7 +141,7 @@ namespace DiffusionNexus.LoraSort.Service.Services
             }
         }
 
-        public async Task<List<ModelClass>> GetModelData(IProgress<ProgressReport>? progress, string jsonFilePath, CancellationToken cancellationToken)
+        public async Task<List<ModelClass>> GetModelData(IProgress<ProgressReport>? progress, string jsonFilePath, CancellationToken cancellationToken, bool fetchFromApi = true)
         {
             
             List<ModelClass> modelDataList = new List<ModelClass>();
@@ -164,17 +164,18 @@ namespace DiffusionNexus.LoraSort.Service.Services
 
                 if (model.NoMetaData == true)
                 {
-                    await UpdateModelDataFromCivitaiAPI(progress, model);
+                    if (fetchFromApi)
+                        await UpdateModelDataFromCivitaiAPI(progress, model);
                 }
                 else
                 {
-                    // Try to read from local file info first 
+                    // Try to read from local file info first
                     model.CivitaiCategory = GetMatchingCategory(model);
                     model.DiffusionBaseModel = GetBaseModelName(model);
                     model.ModelType = GetModelType(model);
 
                     // If local file info is insufficient try via online API
-                    if (model.DiffusionBaseModel == "UNKNOWN" || model.CivitaiCategory == CivitaiBaseCategories.UNKNOWN)
+                    if (fetchFromApi && (model.DiffusionBaseModel == "UNKNOWN" || model.CivitaiCategory == CivitaiBaseCategories.UNKNOWN))
                     {
                         await UpdateModelDataFromCivitaiAPI(progress, model);
                     }

--- a/DiffusionNexus.UI/ViewModels/LoraHelperViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraHelperViewModel.cs
@@ -77,7 +77,8 @@ public partial class LoraHelperViewModel : ViewModelBase
             FolderItems.Add(ConvertFolder(rootNode));
         });
 
-        var models = await Task.Run(() => discovery.CollectModels(settings.LoraHelperFolderPath));
+        var reader = new JsonInfoFileReaderService(settings.LoraHelperFolderPath!, settings.CivitaiApiKey ?? string.Empty);
+        var models = await reader.GetModelData(null, settings.LoraHelperFolderPath!, CancellationToken.None, fetchFromApi: false);
 
         await Dispatcher.UIThread.InvokeAsync(() =>
         {


### PR DESCRIPTION
## Summary
- read model metadata for the new text blocks in `LoraHelperView`
- allow `JsonInfoFileReaderService.GetModelData` to skip API calls when desired

## Testing
- `dotnet test DiffusionNexus.LoraSort.Service.Tests/DiffusionNexus.LoraSort.Service.Tests.csproj --no-build -v diag`

------
https://chatgpt.com/codex/tasks/task_e_6863edd67dd48332b196337f618d83cc