### PR TITLE
Add diffusion model filter popup

### DIFF
--- a/DiffusionNexus.LoraSort.Service.Tests/LoraHelperFilterTests.cs
+++ b/DiffusionNexus.LoraSort.Service.Tests/LoraHelperFilterTests.cs
@@ -1,0 +1,69 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using DiffusionNexus.LoraSort.Service.Classes;
+using DiffusionNexus.UI.ViewModels;
+using DiffusionNexus.UI.Views;
+using DiffusionNexus.UI.Classes;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Avalonia.VisualTree;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+public class LoraHelperFilterTests
+{
+    [Fact]
+    public void ToggleCommandAddsAndRemovesModel()
+    {
+        var vm = new LoraHelperViewModel(new FakeService());
+        vm.ToggleModelCommand.Execute("SDXL");
+        Assert.Contains("SDXL", vm.SelectedDiffusionModels);
+        vm.ToggleModelCommand.Execute("SDXL");
+        Assert.DoesNotContain("SDXL", vm.SelectedDiffusionModels);
+    }
+
+    [Fact]
+    public void FilteringBySelectedModelsReturnsExpectedCards()
+    {
+        var vm = new LoraHelperViewModel(new FakeService());
+        var card1 = new LoraCardViewModel { Model = new ModelClass { ModelName = "a", DiffusionBaseModel = "SD 1.5", ModelType = DiffusionTypes.LORA, AssociatedFilesInfo = new List<FileInfo>() } };
+        var card2 = new LoraCardViewModel { Model = new ModelClass { ModelName = "b", DiffusionBaseModel = "SDXL", ModelType = DiffusionTypes.LORA, AssociatedFilesInfo = new List<FileInfo>() } };
+        var field = typeof(LoraHelperViewModel).GetField("_allCards", BindingFlags.NonPublic | BindingFlags.Instance);
+        field!.SetValue(vm, new List<LoraCardViewModel> { card1, card2 });
+        var method = typeof(LoraHelperViewModel).GetMethod("FilterCards", BindingFlags.NonPublic | BindingFlags.Instance);
+        var result = (List<LoraCardViewModel>)method!.Invoke(vm, new object?[] { null, null })!;
+        Assert.Equal(2, result.Count);
+        vm.SelectedDiffusionModels.Add("SDXL");
+        result = (List<LoraCardViewModel>)method.Invoke(vm, new object?[] { null, null })!;
+        Assert.Single(result);
+        Assert.Equal("SDXL", result[0].DiffusionBaseModel);
+    }
+
+    [Fact]
+    public void FlyoutContainsButtonsForEachModel()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(DiffusionNexus.UI.App));
+        session.Dispatch(() =>
+        {
+            var vm = new LoraHelperViewModel(new FakeService());
+            var view = new LoraHelperView { DataContext = vm };
+            view.ApplyTemplate();
+            view.Measure(new Size(300,300));
+            view.Arrange(new Rect(0,0,300,300));
+            var button = view.GetVisualDescendants().OfType<Button>().First(b => b.Content?.ToString() == "⚙");
+            var flyout = button.ContextFlyout as Flyout;
+            Assert.NotNull(flyout);
+            var itemsControl = (flyout!.Content as ItemsControl)!;
+            Assert.Equal(vm.DiffusionModels.Count, itemsControl.Items.Cast<object>().Count());
+        }, System.Threading.CancellationToken.None);
+    }
+
+    private class FakeService : ISettingsService
+    {
+        public Task<SettingsModel> LoadAsync() => Task.FromResult(new SettingsModel());
+        public Task SaveAsync(SettingsModel settings) => Task.CompletedTask;
+    }
+}

--- a/DiffusionNexus.LoraSort.Service.Tests/LoraHelperFilterTests.cs
+++ b/DiffusionNexus.LoraSort.Service.Tests/LoraHelperFilterTests.cs
@@ -54,7 +54,7 @@ public class LoraHelperFilterTests
             view.Measure(new Size(300,300));
             view.Arrange(new Rect(0,0,300,300));
             var button = view.GetVisualDescendants().OfType<Button>().First(b => b.Content?.ToString() == "⚙");
-            var flyout = button.ContextFlyout as Flyout;
+            var flyout = button.Flyout as Flyout;
             Assert.NotNull(flyout);
             var itemsControl = (flyout!.Content as ItemsControl)!;
             Assert.Equal(vm.DiffusionModels.Count, itemsControl.Items.Cast<object>().Count());

--- a/DiffusionNexus.LoraSort.Service.Tests/LoraHelperFilterTests.cs
+++ b/DiffusionNexus.LoraSort.Service.Tests/LoraHelperFilterTests.cs
@@ -61,6 +61,26 @@ public class LoraHelperFilterTests
         }, System.Threading.CancellationToken.None);
     }
 
+    [Fact]
+    public void SelectedModelsReflectInFlyoutToggleButtons()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(DiffusionNexus.UI.App));
+        session.Dispatch(() =>
+        {
+            var vm = new LoraHelperViewModel(new FakeService());
+            vm.ToggleModelCommand.Execute("SDXL");
+            var view = new LoraHelperView { DataContext = vm };
+            view.ApplyTemplate();
+            view.Measure(new Size(300,300));
+            view.Arrange(new Rect(0,0,300,300));
+            var button = view.GetVisualDescendants().OfType<Button>().First(b => b.Content?.ToString() == "⚙");
+            var flyout = (Flyout)button.Flyout!;
+            flyout.ShowAt(button);
+            var toggle = flyout.GetVisualDescendants().OfType<ToggleButton>().First(tb => tb.Content?.ToString() == "SDXL");
+            Assert.True(toggle.IsChecked);
+        }, System.Threading.CancellationToken.None);
+    }
+
     private class FakeService : ISettingsService
     {
         public Task<SettingsModel> LoadAsync() => Task.FromResult(new SettingsModel());

--- a/DiffusionNexus.UI/Converters/CollectionContainsConverter.cs
+++ b/DiffusionNexus.UI/Converters/CollectionContainsConverter.cs
@@ -1,4 +1,5 @@
 using Avalonia.Data.Converters;
+using Avalonia.Data;
 using System;
 using System.Globalization;
 using System.Collections.Generic;
@@ -17,7 +18,8 @@ namespace DiffusionNexus.UI.Converters
 
         public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            // This converter is intended for one-way bindings only
+            return BindingOperations.DoNothing;
         }
     }
 }

--- a/DiffusionNexus.UI/Converters/CollectionContainsConverter.cs
+++ b/DiffusionNexus.UI/Converters/CollectionContainsConverter.cs
@@ -1,0 +1,23 @@
+using Avalonia.Data.Converters;
+using System;
+using System.Globalization;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DiffusionNexus.UI.Converters
+{
+    public class CollectionContainsConverter : IValueConverter
+    {
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is IEnumerable<string> collection && parameter is string item)
+                return collection.Contains(item);
+            return false;
+        }
+
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/DiffusionNexus.UI/ViewModels/LoraHelperViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraHelperViewModel.cs
@@ -67,6 +67,7 @@ public partial class LoraHelperViewModel : ViewModelBase
         _settingsService = settingsService;
         ResetFiltersCommand = new RelayCommand(ResetFilters);
         ToggleModelCommand = new RelayCommand<string?>(ToggleModel);
+        SelectedDiffusionModels.CollectionChanged += (_, _) => OnPropertyChanged(nameof(SelectedDiffusionModels));
         _ = LoadAsync();
     }
 
@@ -204,6 +205,7 @@ public partial class LoraHelperViewModel : ViewModelBase
         SelectedFolder = null;
         SearchText = null;
         SelectedDiffusionModels.Clear();
+        OnPropertyChanged(nameof(SelectedDiffusionModels));
         _ = RefreshCardsAsync();
     }
 
@@ -216,6 +218,8 @@ public partial class LoraHelperViewModel : ViewModelBase
             SelectedDiffusionModels.Remove(model);
         else
             SelectedDiffusionModels.Add(model);
+
+        OnPropertyChanged(nameof(SelectedDiffusionModels));
 
         _ = RefreshCardsAsync();
     }

--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml
@@ -4,12 +4,14 @@
              xmlns:controls="using:DiffusionNexus.UI.Views.Controls"
              xmlns:conv="using:DiffusionNexus.UI.Converters"
              x:Class="DiffusionNexus.UI.Views.LoraHelperView"
+             x:Name="RootControl"
              x:DataType="vm:LoraHelperViewModel">
   <UserControl.DataContext>
     <vm:LoraHelperViewModel/>
   </UserControl.DataContext>
   <UserControl.Resources>
     <conv:TagsDisplayConverter x:Key="TagsDisplayConverter" />
+    <conv:CollectionContainsConverter x:Key="CollectionContainsConverter" />
   </UserControl.Resources>
   <Grid RowDefinitions="Auto,*" ColumnDefinitions="Auto,*" Margin="10">
     <Grid Grid.ColumnSpan="2" ColumnDefinitions="Auto,*,Auto,Auto,Auto,Auto" Margin="0,0,0,5">
@@ -25,6 +27,22 @@
       <Button Grid.Column="2" Content="🔁" Width="36" Height="36" Margin="5,0,0,0"/>
       <Button Grid.Column="3" Content="🧩" Width="36" Height="36" Margin="5,0,0,0"/>
       <Button Grid.Column="4" Content="🧠" Width="36" Height="36" Margin="5,0,0,0"/>
+      <Button Grid.Column="5" Content="⚙" Width="36" Height="36" Margin="5,0,0,0">
+      <Button.ContextFlyout>
+        <Flyout Placement="Bottom">
+          <ItemsControl ItemsSource="{Binding DiffusionModels}">
+            <ItemsControl.ItemTemplate>
+              <DataTemplate>
+                <ToggleButton Content="{Binding}" Margin="2"
+                              Command="{Binding DataContext.ToggleModelCommand, ElementName=RootControl}"
+                              CommandParameter="{Binding}"
+                              IsChecked="{Binding DataContext.SelectedDiffusionModels, ElementName=RootControl, Converter={StaticResource CollectionContainsConverter}, ConverterParameter={Binding}}"/>
+              </DataTemplate>
+            </ItemsControl.ItemTemplate>
+          </ItemsControl>
+        </Flyout>
+      </Button.ContextFlyout>
+      </Button>
     </Grid>
     <ScrollViewer Grid.Row="1"
                   HorizontalScrollBarVisibility="Disabled"

--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml
@@ -28,20 +28,20 @@
       <Button Grid.Column="3" Content="🧩" Width="36" Height="36" Margin="5,0,0,0"/>
       <Button Grid.Column="4" Content="🧠" Width="36" Height="36" Margin="5,0,0,0"/>
       <Button Grid.Column="5" Content="⚙" Width="36" Height="36" Margin="5,0,0,0">
-      <Button.ContextFlyout>
-        <Flyout Placement="Bottom">
-          <ItemsControl ItemsSource="{Binding DiffusionModels}">
-            <ItemsControl.ItemTemplate>
-              <DataTemplate>
-                <ToggleButton Content="{Binding}" Margin="2"
-                              Command="{Binding DataContext.ToggleModelCommand, ElementName=RootControl}"
-                              CommandParameter="{Binding}"
-                              IsChecked="{Binding DataContext.SelectedDiffusionModels, ElementName=RootControl, Converter={StaticResource CollectionContainsConverter}, ConverterParameter={Binding}}"/>
-              </DataTemplate>
-            </ItemsControl.ItemTemplate>
-          </ItemsControl>
-        </Flyout>
-      </Button.ContextFlyout>
+        <Button.Flyout>
+          <Flyout Placement="Bottom">
+            <ItemsControl ItemsSource="{Binding DiffusionModels}">
+              <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                  <ToggleButton Content="{Binding}" Margin="2"
+                                Command="{Binding DataContext.ToggleModelCommand, ElementName=RootControl}"
+                                CommandParameter="{Binding}"
+                                IsChecked="{Binding DataContext.SelectedDiffusionModels, ElementName=RootControl, Converter={StaticResource CollectionContainsConverter}, ConverterParameter={Binding}}"/>
+                </DataTemplate>
+              </ItemsControl.ItemTemplate>
+            </ItemsControl>
+          </Flyout>
+        </Button.Flyout>
       </Button>
     </Grid>
     <ScrollViewer Grid.Row="1"

--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml
@@ -36,7 +36,7 @@
                   <ToggleButton Content="{Binding}" Margin="2"
                                 Command="{Binding DataContext.ToggleModelCommand, ElementName=RootControl}"
                                 CommandParameter="{Binding}"
-                                IsChecked="{Binding DataContext.SelectedDiffusionModels, ElementName=RootControl, Converter={StaticResource CollectionContainsConverter}, ConverterParameter={Binding}}"/>
+                                IsChecked="{Binding DataContext.SelectedDiffusionModels, Mode=OneWay, ElementName=RootControl, Converter={StaticResource CollectionContainsConverter}, ConverterParameter={Binding}}"/>
                 </DataTemplate>
               </ItemsControl.ItemTemplate>
             </ItemsControl>


### PR DESCRIPTION
## Summary
- add list-based diffusion model filtering to LoraHelper view model
- create converter for toggle buttons
- implement filter popup in LoraHelperView
- test toggle behavior, filtering logic and popup

## Testing
- `dotnet build`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_686436e9ca448332855fd8b5da17022e