### PR TITLE
Add duplicate scanning results UI

### DIFF
--- a/DiffusionNexus.UI/Converters/BooleanToBrushConverter.cs
+++ b/DiffusionNexus.UI/Converters/BooleanToBrushConverter.cs
@@ -1,0 +1,24 @@
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+using System;
+using System.Globalization;
+
+namespace DiffusionNexus.UI.Converters;
+
+public class BooleanToBrushConverter : IValueConverter
+{
+    public IBrush TrueBrush { get; set; } = Brushes.LightGreen;
+    public IBrush FalseBrush { get; set; } = Brushes.Transparent;
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is bool b)
+            return b ? TrueBrush : FalseBrush;
+        return FalseBrush;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/DiffusionNexus.UI/DiffusionNexus.UI.csproj
+++ b/DiffusionNexus.UI/DiffusionNexus.UI.csproj
@@ -75,6 +75,12 @@
     <Compile Update="Views\Controls\ProcessingOverlayControl.axaml.cs">
       <DependentUpon>ProcessingOverlayControl.axaml</DependentUpon>
     </Compile>
+    <Compile Update="Views\Controls\LoraCardControl.axaml.cs">
+      <DependentUpon>LoraCardControl.axaml</DependentUpon>
+    </Compile>
+    <Compile Update="Views\Controls\DuplicateResultControl.axaml.cs">
+      <DependentUpon>DuplicateResultControl.axaml</DependentUpon>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/DiffusionNexus.UI/ViewModels/DuplicateItemViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/DuplicateItemViewModel.cs
@@ -1,0 +1,70 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DiffusionNexus.LoraSort.Service.Classes;
+using DiffusionNexus.LoraSort.Service.Services;
+using DiffusionNexus.UI.Classes;
+using System.IO;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+public partial class DuplicateItemViewModel : ViewModelBase
+{
+    public FileInfo FileA { get; }
+    public FileInfo FileB { get; }
+    public ModelClass? MetaA { get; }
+    public ModelClass? MetaB { get; }
+
+    [ObservableProperty]
+    private bool keepA;
+
+    [ObservableProperty]
+    private bool keepB;
+
+    public double SizeMb => FileA.Length / 1024d / 1024d;
+
+    public LoraCardViewModel? CardA { get; }
+    public LoraCardViewModel? CardB { get; }
+
+    public IRelayCommand ToggleKeepACommand { get; }
+    public IRelayCommand ToggleKeepBCommand { get; }
+
+    private readonly LoraHelperViewModel _parent;
+
+    public DuplicateItemViewModel(LoraHelperViewModel parent, DuplicateSet set)
+    {
+        _parent = parent;
+        FileA = set.FileA;
+        FileB = set.FileB;
+        MetaA = set.MetaA;
+        MetaB = set.MetaB;
+        if (MetaA != null)
+            CardA = new LoraCardViewModel { Name = MetaA.ModelName, Model = MetaA, Parent = parent };
+        if (MetaB != null)
+            CardB = new LoraCardViewModel { Name = MetaB.ModelName, Model = MetaB, Parent = parent };
+        ToggleKeepACommand = new RelayCommand(OnToggleA);
+        ToggleKeepBCommand = new RelayCommand(OnToggleB);
+    }
+
+    partial void OnKeepAChanged(bool value)
+    {
+        if (value)
+            _parent.AddKeepFile(FileA.FullName);
+        else
+            _parent.RemoveKeepFile(FileA.FullName);
+        OnPropertyChanged(nameof(IsResolved));
+    }
+
+    partial void OnKeepBChanged(bool value)
+    {
+        if (value)
+            _parent.AddKeepFile(FileB.FullName);
+        else
+            _parent.RemoveKeepFile(FileB.FullName);
+        OnPropertyChanged(nameof(IsResolved));
+    }
+
+    private void OnToggleA() => KeepA = !KeepA;
+    private void OnToggleB() => KeepB = !KeepB;
+
+    public bool IsResolved => KeepA || KeepB;
+}

--- a/DiffusionNexus.UI/Views/Controls/DuplicateResultControl.axaml
+++ b/DiffusionNexus.UI/Views/Controls/DuplicateResultControl.axaml
@@ -1,0 +1,44 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:DiffusionNexus.UI.ViewModels"
+             xmlns:controls="using:DiffusionNexus.UI.Views.Controls"
+             xmlns:conv="using:DiffusionNexus.UI.Converters"
+             x:Class="DiffusionNexus.UI.Views.Controls.DuplicateResultControl"
+             x:DataType="vm:LoraHelperViewModel">
+  <UserControl.Resources>
+    <conv:BooleanToBrushConverter x:Key="BoolBrush" />
+  </UserControl.Resources>
+  <StackPanel Margin="10" Spacing="5">
+    <TextBlock Text="{Binding ScanHeadline}" FontWeight="Bold"/>
+    <TextBlock Text="Click on the columns to select entries for keeping" FontStyle="Italic"/>
+    <DataGrid ItemsSource="{Binding DuplicateItems}" AutoGenerateColumns="False" HeadersVisibility="Column" Margin="0,5,0,0">
+      <DataGrid.Columns>
+        <DataGridTemplateColumn Header="File A">
+          <DataGridTemplateColumn.CellTemplate>
+            <DataTemplate x:DataType="vm:DuplicateItemViewModel">
+              <Button Command="{Binding ToggleKeepACommand}" BorderBrush="Gray" BorderThickness="0"
+                      Background="{Binding KeepA, Converter={StaticResource BoolBrush}}">
+                <Button.Content>
+                  <TextBlock Text="{Binding FileA.Name}"/>
+                </Button.Content>
+              </Button>
+            </DataTemplate>
+          </DataGridTemplateColumn.CellTemplate>
+        </DataGridTemplateColumn>
+        <DataGridTemplateColumn Header="File B">
+          <DataGridTemplateColumn.CellTemplate>
+            <DataTemplate x:DataType="vm:DuplicateItemViewModel">
+              <Button Command="{Binding ToggleKeepBCommand}" BorderBrush="Gray" BorderThickness="0"
+                      Background="{Binding KeepB, Converter={StaticResource BoolBrush}}">
+                <Button.Content>
+                  <TextBlock Text="{Binding FileB.Name}"/>
+                </Button.Content>
+              </Button>
+            </DataTemplate>
+          </DataGridTemplateColumn.CellTemplate>
+        </DataGridTemplateColumn>
+        <DataGridTextColumn Header="Size (MB)" Binding="{Binding SizeMb}"/>
+      </DataGrid.Columns>
+    </DataGrid>
+  </StackPanel>
+</UserControl>

--- a/DiffusionNexus.UI/Views/Controls/DuplicateResultControl.axaml.cs
+++ b/DiffusionNexus.UI/Views/Controls/DuplicateResultControl.axaml.cs
@@ -1,0 +1,18 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace DiffusionNexus.UI.Views.Controls;
+
+public partial class DuplicateResultControl : UserControl
+{
+    public DuplicateResultControl()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/DiffusionNexus.UI/Views/Controls/LoraCardControl.axaml
+++ b/DiffusionNexus.UI/Views/Controls/LoraCardControl.axaml
@@ -1,0 +1,28 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:DiffusionNexus.UI.ViewModels"
+             xmlns:conv="using:DiffusionNexus.UI.Converters"
+             x:Class="DiffusionNexus.UI.Views.Controls.LoraCardControl"
+             x:DataType="vm:LoraCardViewModel">
+  <UserControl.Resources>
+    <conv:TagsDisplayConverter x:Key="TagsDisplayConverter" />
+  </UserControl.Resources>
+  <Border Background="#333333" Padding="5" Margin="5" Width="250" Height="300">
+    <Grid>
+      <Image Source="{Binding PreviewImage}" Stretch="UniformToFill"/>
+      <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Top">
+        <Border BorderBrush="White" BorderThickness="1" Padding="2" Margin="2">
+          <TextBlock Text="{Binding DiffusionTypes, Converter={StaticResource TagsDisplayConverter}}" FontSize="12"/>
+        </Border>
+        <Border BorderBrush="White" BorderThickness="1" Padding="2" Margin="2,2,0,2">
+          <TextBlock Text="{Binding DiffusionBaseModel}" FontSize="12"/>
+        </Border>
+      </StackPanel>
+      <Border VerticalAlignment="Bottom" Background="#66000000" Padding="5">
+        <StackPanel>
+          <TextBlock Text="{Binding Name}" FontWeight="Bold" Foreground="White" TextWrapping="Wrap"/>
+        </StackPanel>
+      </Border>
+    </Grid>
+  </Border>
+</UserControl>

--- a/DiffusionNexus.UI/Views/Controls/LoraCardControl.axaml.cs
+++ b/DiffusionNexus.UI/Views/Controls/LoraCardControl.axaml.cs
@@ -1,0 +1,18 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace DiffusionNexus.UI.Views.Controls;
+
+public partial class LoraCardControl : UserControl
+{
+    public LoraCardControl()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml
@@ -93,6 +93,8 @@
       <controls:BusyOverlay IsVisible="{Binding IsLoading}"
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"/>
+      <controls:ProcessingOverlayControl IsVisible="{Binding IsScanning}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
+      <controls:DuplicateResultControl IsVisible="{Binding ShowDuplicateResults}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
     </Grid>
   </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- show scan progress and results in Lora helper
- create DuplicateResultControl and LoraCardControl
- add BooleanToBrushConverter and DuplicateItemViewModel to track selections

## Testing
- `dotnet build`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6865498eef2c8332bc47124f38148660