### PR TITLE
Update tests with FluentAssertions and Moq

### DIFF
--- a/DiffusionNexus.Tests/DataAccess/Infrastructure/FileConfigStoreTests.cs
+++ b/DiffusionNexus.Tests/DataAccess/Infrastructure/FileConfigStoreTests.cs
@@ -2,6 +2,7 @@ using DiffusionNexus.DataAccess.Entities;
 using DiffusionNexus.DataAccess.Infrastructure.Serialization;
 using DiffusionNexus.DataAccess.Infrastructure;
 using System.IO;
+using FluentAssertions;
 using Xunit;
 
 namespace DiffusionNexus.Tests.DataAccess.Infrastructure;
@@ -22,7 +23,7 @@ public class FileConfigStoreTests
             var setting = new AppSetting { Key = "Language", Value = "EN" };
             store.Save("settings", setting);
             var loaded = store.Load<AppSetting>("settings");
-            Assert.Equal(setting.Value, loaded.Value);
+            loaded.Value.Should().Be(setting.Value);
         }
         finally
         {

--- a/DiffusionNexus.Tests/DataAccess/Infrastructure/SerializerTests.cs
+++ b/DiffusionNexus.Tests/DataAccess/Infrastructure/SerializerTests.cs
@@ -1,5 +1,6 @@
 using DiffusionNexus.DataAccess.Entities;
 using DiffusionNexus.DataAccess.Infrastructure.Serialization;
+using FluentAssertions;
 using Xunit;
 
 namespace DiffusionNexus.Tests.DataAccess.Infrastructure;
@@ -15,7 +16,7 @@ public class SerializerTests
         var original = new AppSetting { Key = "Theme", Value = "Dark" };
         string payload = serializer.Serialize(original);
         var copy = serializer.Deserialize<AppSetting>(payload);
-        Assert.Equal(original.Key, copy.Key);
-        Assert.Equal(original.Value, copy.Value);
+        copy.Key.Should().Be(original.Key);
+        copy.Value.Should().Be(original.Value);
     }
 }

--- a/DiffusionNexus.Tests/LoraSort/Search/SearchIndexTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/Search/SearchIndexTests.cs
@@ -1,5 +1,6 @@
 using DiffusionNexus.Service.Search;
 using Xunit;
+using FluentAssertions;
 using System.Linq;
 
 namespace DiffusionNexus.Tests.LoraSort.Search;
@@ -11,7 +12,7 @@ public class SearchIndexTests
         var index = new SearchIndex();
         index.Build(new[] { "red car", "blue truck", "green car" });
         var result = index.Search("car").ToList();
-        Assert.Equal(new[] { 0, 2 }, result);
+        result.Should().Equal(new[] { 0, 2 });
     }
 
     [Fact]
@@ -20,6 +21,6 @@ public class SearchIndexTests
         var index = new SearchIndex();
         index.Build(new[] { "red car", "blue truck", "green car" });
         var sugg = index.Suggest("c", 10).ToList();
-        Assert.Contains("car", sugg);
+        sugg.Should().Contain("car");
     }
 }

--- a/DiffusionNexus.Tests/LoraSort/Services/CivitaiMetaDataServiceTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/Services/CivitaiMetaDataServiceTests.cs
@@ -2,9 +2,9 @@ using Moq;
 using FluentAssertions;
 using DiffusionNexus.Service.Services;
 
-namespace LorasAutoSort.Test
-{
-    public class CivitaiMetaDataServiceTests
+namespace DiffusionNexus.Tests.LoraSort.Services;
+
+public class CivitaiMetaDataServiceTests
     {
         private readonly Mock<ICivitaiApiClient> _mockApiClient;
         private readonly CivitaiMetaDataService _service;
@@ -155,4 +155,4 @@ namespace LorasAutoSort.Test
             result.Should().Be("12345");
         }
     }
-}
+

--- a/DiffusionNexus.Tests/LoraSort/Services/DuplicateScannerTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/Services/DuplicateScannerTests.cs
@@ -2,6 +2,7 @@ using DiffusionNexus.Service.Services;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 
 namespace DiffusionNexus.Tests.LoraSort.Services;
@@ -23,11 +24,11 @@ public class DuplicateScannerTests
 
             var scanner = new DuplicateScanner();
             var result = await scanner.ScanAsync(dir, null);
-            Assert.Single(result);
+            result.Should().ContainSingle();
             var set = result.First();
             var paths = new[] { set.FileA.FullName, set.FileB.FullName };
-            Assert.Contains(a, paths);
-            Assert.Contains(b, paths);
+            paths.Should().Contain(a);
+            paths.Should().Contain(b);
         }
         finally
         {

--- a/DiffusionNexus.Tests/LoraSort/Services/FileCopyServiceTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/Services/FileCopyServiceTests.cs
@@ -3,9 +3,9 @@ using DiffusionNexus.Service.Classes;
 using DiffusionNexus.Service.Services;
 using System.Collections.ObjectModel;
 
-namespace LorasAutoSort.Test
-{
-    public class FileCopyServiceTests : IDisposable
+namespace DiffusionNexus.Tests.LoraSort.Services;
+
+public class FileCopyServiceTests : IDisposable
     {
         private readonly string _testSourcePath;
         private readonly string _testTargetPath;
@@ -678,4 +678,3 @@ namespace LorasAutoSort.Test
             DeleteMappingFile();
         }
     }
-}

--- a/DiffusionNexus.Tests/LoraSort/Services/GroupFilesByPrefixTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/Services/GroupFilesByPrefixTests.cs
@@ -1,6 +1,7 @@
 using DiffusionNexus.Service.Services;
 using System.IO;
 using System.Linq;
+using FluentAssertions;
 using Xunit;
 
 namespace DiffusionNexus.Tests.LoraSort.Services;
@@ -18,9 +19,9 @@ public class GroupFilesByPrefixTests
             File.WriteAllText(Path.Combine(tempDir, "model2.ckpt"), string.Empty);
 
             var result = JsonInfoFileReaderService.GroupFilesByPrefix(tempDir);
-            Assert.Equal(2, result.Count);
+            result.Count.Should().Be(2);
             var first = result.First(m => m.SafeTensorFileName == "model1");
-            Assert.Equal(2, first.AssociatedFilesInfo.Count);
+            first.AssociatedFilesInfo.Count.Should().Be(2);
         }
         finally
         {

--- a/DiffusionNexus.Tests/LoraSort/Services/JsonInfoFileReaderServiceTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/Services/JsonInfoFileReaderServiceTests.cs
@@ -2,9 +2,9 @@ using FluentAssertions;
 using DiffusionNexus.Service.Services;
 using DiffusionNexus.Service.Classes;
 
-namespace LorasAutoSort.Test
-{
-    public class JsonInfoFileReaderServiceTests : IDisposable
+namespace DiffusionNexus.Tests.LoraSort.Services;
+
+public class JsonInfoFileReaderServiceTests : IDisposable
     {
         private readonly string _testDirectoryPath;
 
@@ -129,4 +129,3 @@ namespace LorasAutoSort.Test
             }
         }
     }
-}

--- a/DiffusionNexus.Tests/LoraSort/UI/LoraCardViewUiTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/UI/LoraCardViewUiTests.cs
@@ -10,6 +10,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
 using Xunit;
 
 namespace DiffusionNexus.Tests.LoraSort.UI;
@@ -32,7 +34,10 @@ public class LoraCardViewUiTests
                 }
             };
 
-            var vm = new LoraHelperViewModel(new FakeService());
+            var mock = new Mock<ISettingsService>();
+            mock.Setup(s => s.LoadAsync()).ReturnsAsync(new SettingsModel());
+            mock.Setup(s => s.SaveAsync(It.IsAny<SettingsModel>())).Returns(Task.CompletedTask);
+            var vm = new LoraHelperViewModel(mock.Object);
             vm.Cards.Add(cardVm);
             var view = new LoraHelperView { DataContext = vm };
             view.ApplyTemplate();
@@ -40,14 +45,8 @@ public class LoraCardViewUiTests
             view.Arrange(new Rect(0,0,300,300));
 
             var texts = view.GetVisualDescendants().OfType<TextBlock>().Select(t => t.Text).ToList();
-            Assert.Contains("LORA", texts);
-            Assert.Contains("SD15", texts);
+            texts.Should().Contain("LORA");
+            texts.Should().Contain("SD15");
         }, System.Threading.CancellationToken.None);
-    }
-
-    private class FakeService : ISettingsService
-    {
-        public Task<SettingsModel> LoadAsync() => Task.FromResult(new SettingsModel());
-        public Task SaveAsync(SettingsModel settings) => Task.CompletedTask;
     }
 }

--- a/DiffusionNexus.Tests/LoraSort/UnitTest1.cs
+++ b/DiffusionNexus.Tests/LoraSort/UnitTest1.cs
@@ -1,3 +1,4 @@
+using FluentAssertions;
 using Xunit;
 
 namespace DiffusionNexus.Tests.LoraSort;
@@ -7,5 +8,6 @@ public class UnitTest1
     [Fact]
     public void Test1()
     {
+        (1 + 1).Should().Be(2);
     }
 }

--- a/DiffusionNexus.Tests/LoraSort/ViewModels/LoraCardViewModelTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/ViewModels/LoraCardViewModelTests.cs
@@ -2,6 +2,7 @@ using DiffusionNexus.UI.ViewModels;
 using DiffusionNexus.Service.Classes;
 using System.Collections.Generic;
 using System.IO;
+using FluentAssertions;
 using Xunit;
 
 namespace DiffusionNexus.Tests.LoraSort.ViewModels;
@@ -23,9 +24,9 @@ public class LoraCardViewModelTests
 
         var vm = new LoraCardViewModel { Model = model };
 
-        Assert.Single(vm.DiffusionTypes);
-        Assert.Contains("LORA", vm.DiffusionTypes);
-        Assert.Equal("SD15", vm.DiffusionBaseModel);
+        vm.DiffusionTypes.Should().ContainSingle();
+        vm.DiffusionTypes.Should().Contain("LORA");
+        vm.DiffusionBaseModel.Should().Be("SD15");
     }
 
     [Fact]
@@ -33,7 +34,7 @@ public class LoraCardViewModelTests
     {
         var vm = new LoraCardViewModel { Model = null };
 
-        Assert.Empty(vm.DiffusionTypes);
-        Assert.Equal(string.Empty, vm.DiffusionBaseModel);
+        vm.DiffusionTypes.Should().BeEmpty();
+        vm.DiffusionBaseModel.Should().BeEmpty();
     }
 }


### PR DESCRIPTION
## Summary
- update namespaces for imported service tests
- switch all test assertions to FluentAssertions
- use Moq in relevant tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686662a565e48332955d7c249bcfa07b