### PR TITLE
Implement metadata provider abstraction

### DIFF
--- a/DiffusionNexus.Service/Classes/ModelMetadata.cs
+++ b/DiffusionNexus.Service/Classes/ModelMetadata.cs
@@ -1,0 +1,13 @@
+namespace DiffusionNexus.Service.Classes;
+
+public class ModelMetadata
+{
+    public string ModelId { get; set; } = string.Empty;
+    public string ModelVersionName { get; set; } = string.Empty;
+    public string BaseModel { get; set; } = string.Empty;
+    public DiffusionTypes ModelType { get; set; } = DiffusionTypes.OTHER;
+    public List<string> Tags { get; set; } = new();
+    public CivitaiBaseCategories Category { get; set; } = CivitaiBaseCategories.UNASSIGNED;
+    public string SHA256Hash { get; set; } = string.Empty;
+    public Dictionary<string, object> AdditionalData { get; set; } = new();
+}

--- a/DiffusionNexus.Service/Services/CivitaiApiMetadataProvider.cs
+++ b/DiffusionNexus.Service/Services/CivitaiApiMetadataProvider.cs
@@ -1,0 +1,78 @@
+using DiffusionNexus.Service.Classes;
+using Serilog;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace DiffusionNexus.Service.Services;
+
+public class CivitaiApiMetadataProvider : IModelMetadataProvider
+{
+    private readonly ICivitaiApiClient _apiClient;
+    private readonly string _apiKey;
+
+    public CivitaiApiMetadataProvider(ICivitaiApiClient apiClient, string apiKey)
+    {
+        _apiClient = apiClient;
+        _apiKey = apiKey;
+    }
+
+    public Task<bool> CanHandleAsync(string identifier, CancellationToken cancellationToken = default)
+    {
+        bool match = identifier.Length == 64 && Regex.IsMatch(identifier, "^[a-fA-F0-9]+$");
+        return Task.FromResult(match);
+    }
+
+    public async Task<ModelMetadata> GetModelMetadataAsync(string sha256Hash, CancellationToken cancellationToken = default)
+    {
+        var metadata = new ModelMetadata { SHA256Hash = sha256Hash };
+
+        var versionJson = await _apiClient.GetModelVersionByHashAsync(sha256Hash, _apiKey);
+        using var versionDoc = JsonDocument.Parse(versionJson);
+        var versionRoot = versionDoc.RootElement;
+
+        if (versionRoot.TryGetProperty("modelId", out var modelIdEl))
+            metadata.ModelId = modelIdEl.GetRawText().Trim('"');
+        if (versionRoot.TryGetProperty("baseModel", out var baseModel))
+            metadata.BaseModel = baseModel.GetString() ?? metadata.BaseModel;
+        if (versionRoot.TryGetProperty("name", out var versionName))
+            metadata.ModelVersionName = versionName.GetString() ?? metadata.ModelVersionName;
+
+        if (!string.IsNullOrEmpty(metadata.ModelId))
+        {
+            var modelJson = await _apiClient.GetModelAsync(metadata.ModelId, _apiKey);
+            using var modelDoc = JsonDocument.Parse(modelJson);
+            var modelRoot = modelDoc.RootElement;
+            ParseModelInfo(modelRoot, metadata);
+        }
+
+        return metadata;
+    }
+
+    private static void ParseModelInfo(JsonElement root, ModelMetadata metadata)
+    {
+        if (root.TryGetProperty("type", out var type))
+            metadata.ModelType = ParseModelType(type.GetString());
+        if (root.TryGetProperty("tags", out var tags))
+            metadata.Tags = ParseTags(tags);
+    }
+
+    private static DiffusionTypes ParseModelType(string? type)
+    {
+        if (string.IsNullOrWhiteSpace(type))
+            return DiffusionTypes.OTHER;
+        var normalized = type.Replace(" ", string.Empty);
+        return Enum.TryParse<DiffusionTypes>(normalized, true, out var result) ? result : DiffusionTypes.OTHER;
+    }
+
+    private static List<string> ParseTags(JsonElement tags)
+    {
+        var list = new List<string>();
+        foreach (var el in tags.EnumerateArray())
+        {
+            var val = el.GetString();
+            if (!string.IsNullOrWhiteSpace(val))
+                list.Add(val);
+        }
+        return list;
+    }
+}

--- a/DiffusionNexus.Service/Services/CompositeMetadataProvider.cs
+++ b/DiffusionNexus.Service/Services/CompositeMetadataProvider.cs
@@ -1,0 +1,43 @@
+using DiffusionNexus.Service.Classes;
+using Serilog;
+
+namespace DiffusionNexus.Service.Services;
+
+public class CompositeMetadataProvider : IModelMetadataProvider
+{
+    private readonly List<IModelMetadataProvider> _providers;
+
+    public CompositeMetadataProvider(params IModelMetadataProvider[] providers)
+    {
+        _providers = providers.ToList();
+    }
+
+    public async Task<bool> CanHandleAsync(string identifier, CancellationToken cancellationToken = default)
+    {
+        foreach (var provider in _providers)
+        {
+            if (await provider.CanHandleAsync(identifier, cancellationToken))
+                return true;
+        }
+        return false;
+    }
+
+    public async Task<ModelMetadata> GetModelMetadataAsync(string identifier, CancellationToken cancellationToken = default)
+    {
+        foreach (var provider in _providers)
+        {
+            if (await provider.CanHandleAsync(identifier, cancellationToken))
+            {
+                try
+                {
+                    return await provider.GetModelMetadataAsync(identifier, cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning(ex, "Provider {Provider} failed for {Identifier}", provider.GetType().Name, identifier);
+                }
+            }
+        }
+        throw new InvalidOperationException($"No provider could handle identifier: {identifier}");
+    }
+}

--- a/DiffusionNexus.Service/Services/IModelMetadataProvider.cs
+++ b/DiffusionNexus.Service/Services/IModelMetadataProvider.cs
@@ -1,0 +1,9 @@
+namespace DiffusionNexus.Service.Services;
+
+using DiffusionNexus.Service.Classes;
+
+public interface IModelMetadataProvider
+{
+    Task<ModelMetadata> GetModelMetadataAsync(string identifier, CancellationToken cancellationToken = default);
+    Task<bool> CanHandleAsync(string identifier, CancellationToken cancellationToken = default);
+}

--- a/DiffusionNexus.Service/Services/LocalFileMetadataProvider.cs
+++ b/DiffusionNexus.Service/Services/LocalFileMetadataProvider.cs
@@ -1,0 +1,127 @@
+using DiffusionNexus.Service.Classes;
+using DiffusionNexus.Service.Helper;
+using Serilog;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace DiffusionNexus.Service.Services;
+
+public class LocalFileMetadataProvider : IModelMetadataProvider
+{
+    public Task<bool> CanHandleAsync(string identifier, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(File.Exists(identifier));
+    }
+
+    public async Task<ModelMetadata> GetModelMetadataAsync(string filePath, CancellationToken cancellationToken = default)
+    {
+        var file = new FileInfo(filePath);
+        var metadata = new ModelMetadata();
+
+        string baseName = ExtractBaseName(file.Name);
+        var dir = file.Directory ?? new DirectoryInfo(Path.GetDirectoryName(filePath)!);
+
+        var civitai = dir.GetFiles($"{baseName}.civitai.info").FirstOrDefault();
+        var cmInfo = dir.GetFiles($"{baseName}.cm-info.json").FirstOrDefault();
+        var json = dir.GetFiles($"{baseName}.json").FirstOrDefault();
+
+        if (civitai != null)
+            await LoadFromCivitaiInfo(civitai, metadata);
+        else if (cmInfo != null)
+            await LoadFromCmInfo(cmInfo, metadata);
+        else if (json != null)
+            await LoadFromJson(json, metadata);
+
+        if (string.IsNullOrWhiteSpace(metadata.ModelVersionName))
+            metadata.ModelVersionName = baseName;
+
+        if (file.Extension.Equals(".safetensors", StringComparison.OrdinalIgnoreCase))
+            metadata.SHA256Hash = await Task.Run(() => ComputeSHA256(filePath), cancellationToken);
+
+        return metadata;
+    }
+
+    private static async Task LoadFromCivitaiInfo(FileInfo file, ModelMetadata metadata)
+    {
+        var json = await File.ReadAllTextAsync(file.FullName);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        if (root.TryGetProperty("baseModel", out var baseModel))
+            metadata.BaseModel = baseModel.GetString() ?? metadata.BaseModel;
+
+        if (root.TryGetProperty("model", out var model))
+        {
+            if (model.TryGetProperty("name", out var name))
+                metadata.ModelVersionName = name.GetString() ?? metadata.ModelVersionName;
+            if (model.TryGetProperty("type", out var type))
+                metadata.ModelType = ParseModelType(type.GetString());
+            if (model.TryGetProperty("tags", out var tags))
+                metadata.Tags = ParseTags(tags);
+        }
+    }
+
+    private static async Task LoadFromCmInfo(FileInfo file, ModelMetadata metadata)
+    {
+        var json = await File.ReadAllTextAsync(file.FullName);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        if (root.TryGetProperty("Tags", out var tags))
+            metadata.Tags = ParseTags(tags);
+        if (root.TryGetProperty("sd version", out var sdver))
+            metadata.BaseModel = sdver.GetString() ?? metadata.BaseModel;
+    }
+
+    private static async Task LoadFromJson(FileInfo file, ModelMetadata metadata)
+    {
+        var json = await File.ReadAllTextAsync(file.FullName);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        if (root.TryGetProperty("tags", out var tags))
+            metadata.Tags = ParseTags(tags);
+        if (root.TryGetProperty("sd version", out var sdver))
+            metadata.BaseModel = sdver.GetString() ?? metadata.BaseModel;
+    }
+
+    private static string ExtractBaseName(string fileName)
+    {
+        var ext = StaticFileTypes.GeneralExtensions
+            .OrderByDescending(e => e.Length)
+            .FirstOrDefault(e => fileName.EndsWith(e, StringComparison.OrdinalIgnoreCase));
+        return ext == null ? fileName : fileName[..^ext.Length];
+    }
+
+    private static DiffusionTypes ParseModelType(string? type)
+    {
+        if (string.IsNullOrWhiteSpace(type))
+            return DiffusionTypes.OTHER;
+        var normalized = type.Replace(" ", string.Empty);
+        return Enum.TryParse<DiffusionTypes>(normalized, true, out var result) ? result : DiffusionTypes.OTHER;
+    }
+
+    private static List<string> ParseTags(JsonElement tags)
+    {
+        var list = new List<string>();
+        foreach (var element in tags.EnumerateArray())
+        {
+            var val = element.GetString();
+            if (!string.IsNullOrWhiteSpace(val))
+                list.Add(val);
+        }
+        return list;
+    }
+
+    private static string ComputeSHA256(string path)
+    {
+        using var stream = File.OpenRead(path);
+        using var sha = SHA256.Create();
+        var bytes = sha.ComputeHash(stream);
+        var sb = new StringBuilder(bytes.Length * 2);
+        foreach (var b in bytes)
+            sb.Append(b.ToString("x2"));
+        return sb.ToString();
+    }
+}

--- a/DiffusionNexus.Service/Services/ModelMetadataService.cs
+++ b/DiffusionNexus.Service/Services/ModelMetadataService.cs
@@ -1,0 +1,18 @@
+using DiffusionNexus.Service.Classes;
+
+namespace DiffusionNexus.Service.Services;
+
+public class ModelMetadataService
+{
+    private readonly IModelMetadataProvider _provider;
+
+    public ModelMetadataService(IModelMetadataProvider provider)
+    {
+        _provider = provider;
+    }
+
+    public Task<ModelMetadata> GetModelMetadataAsync(string identifier, CancellationToken cancellationToken = default)
+    {
+        return _provider.GetModelMetadataAsync(identifier, cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ModelMetadata` core data model
- introduce `IModelMetadataProvider` and provider implementations
- support local file and Civitai API metadata sources
- add `CompositeMetadataProvider` and `ModelMetadataService`

## Testing
- `dotnet build DiffusionNexus.sln -v minimal`
- `dotnet test DiffusionNexus.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68668d990140833285b801d646b2f033