### PR TITLE
Implement metadata provider abstraction

### DIFF
--- a/DiffusionNexus.Service/Services/CivitaiApiMetadataProvider.cs
+++ b/DiffusionNexus.Service/Services/CivitaiApiMetadataProvider.cs
@@ -1,0 +1,96 @@
+using DiffusionNexus.Service.Classes;
+using Serilog;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.IO;
+using System.Collections.Generic;
+
+namespace DiffusionNexus.Service.Services;
+
+public class CivitaiApiMetadataProvider : IModelMetadataProvider
+{
+    private readonly ICivitaiApiClient _apiClient;
+    private readonly string _apiKey;
+
+    public CivitaiApiMetadataProvider(ICivitaiApiClient apiClient, string apiKey)
+    {
+        _apiClient = apiClient;
+        _apiKey = apiKey;
+    }
+
+    public Task<bool> CanHandleAsync(string identifier, CancellationToken cancellationToken = default)
+    {
+        bool match = identifier.Length == 64 && Regex.IsMatch(identifier, "^[a-fA-F0-9]+$");
+        return Task.FromResult(match);
+    }
+
+    public async Task<ModelClass> GetModelMetadataAsync(string sha256Hash, CancellationToken cancellationToken = default)
+    {
+        var model = new ModelClass
+        {
+            SafeTensorFileName = sha256Hash,
+            AssociatedFilesInfo = new List<FileInfo>()
+        };
+
+        var versionJson = await _apiClient.GetModelVersionByHashAsync(sha256Hash, _apiKey);
+        using var versionDoc = JsonDocument.Parse(versionJson);
+        var versionRoot = versionDoc.RootElement;
+
+        string? modelId = null;
+        if (versionRoot.TryGetProperty("modelId", out var modelIdEl))
+            modelId = modelIdEl.GetRawText().Trim('"');
+        if (versionRoot.TryGetProperty("baseModel", out var baseModel))
+            model.DiffusionBaseModel = baseModel.GetString() ?? model.DiffusionBaseModel;
+        if (versionRoot.TryGetProperty("name", out var versionName))
+            model.ModelVersionName = versionName.GetString() ?? model.ModelVersionName;
+
+        if (!string.IsNullOrEmpty(modelId))
+        {
+            var modelJson = await _apiClient.GetModelAsync(modelId, _apiKey);
+            using var modelDoc = JsonDocument.Parse(modelJson);
+            var modelRoot = modelDoc.RootElement;
+            ParseModelInfo(modelRoot, model);
+        }
+
+        model.CivitaiCategory = GetCategoryFromTags(model.Tags);
+        return model;
+    }
+
+    private static void ParseModelInfo(JsonElement root, ModelClass model)
+    {
+        if (root.TryGetProperty("type", out var type))
+            model.ModelType = ParseModelType(type.GetString());
+        if (root.TryGetProperty("tags", out var tags))
+            model.Tags = ParseTags(tags);
+    }
+
+    private static DiffusionTypes ParseModelType(string? type)
+    {
+        if (string.IsNullOrWhiteSpace(type))
+            return DiffusionTypes.OTHER;
+        var normalized = type.Replace(" ", string.Empty);
+        return Enum.TryParse<DiffusionTypes>(normalized, true, out var result) ? result : DiffusionTypes.OTHER;
+    }
+
+    private static List<string> ParseTags(JsonElement tags)
+    {
+        var list = new List<string>();
+        foreach (var el in tags.EnumerateArray())
+        {
+            var val = el.GetString();
+            if (!string.IsNullOrWhiteSpace(val))
+                list.Add(val);
+        }
+        return list;
+    }
+
+    private static CivitaiBaseCategories GetCategoryFromTags(List<string> tags)
+    {
+        foreach (var tag in tags)
+        {
+            if (Enum.TryParse(tag.Replace(" ", "_").ToUpper(), out CivitaiBaseCategories category))
+                return category;
+        }
+        return CivitaiBaseCategories.UNKNOWN;
+    }
+}

--- a/DiffusionNexus.Service/Services/CompositeMetadataProvider.cs
+++ b/DiffusionNexus.Service/Services/CompositeMetadataProvider.cs
@@ -1,0 +1,44 @@
+using DiffusionNexus.Service.Classes;
+using Serilog;
+using System.Collections.Generic;
+
+namespace DiffusionNexus.Service.Services;
+
+public class CompositeMetadataProvider : IModelMetadataProvider
+{
+    private readonly List<IModelMetadataProvider> _providers;
+
+    public CompositeMetadataProvider(params IModelMetadataProvider[] providers)
+    {
+        _providers = providers.ToList();
+    }
+
+    public async Task<bool> CanHandleAsync(string identifier, CancellationToken cancellationToken = default)
+    {
+        foreach (var provider in _providers)
+        {
+            if (await provider.CanHandleAsync(identifier, cancellationToken))
+                return true;
+        }
+        return false;
+    }
+
+    public async Task<ModelClass> GetModelMetadataAsync(string identifier, CancellationToken cancellationToken = default)
+    {
+        foreach (var provider in _providers)
+        {
+            if (await provider.CanHandleAsync(identifier, cancellationToken))
+            {
+                try
+                {
+                    return await provider.GetModelMetadataAsync(identifier, cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning(ex, "Provider {Provider} failed for {Identifier}", provider.GetType().Name, identifier);
+                }
+            }
+        }
+        throw new InvalidOperationException($"No provider could handle identifier: {identifier}");
+    }
+}

--- a/DiffusionNexus.Service/Services/IModelMetadataProvider.cs
+++ b/DiffusionNexus.Service/Services/IModelMetadataProvider.cs
@@ -1,0 +1,9 @@
+namespace DiffusionNexus.Service.Services;
+
+using DiffusionNexus.Service.Classes;
+
+public interface IModelMetadataProvider
+{
+    Task<ModelClass> GetModelMetadataAsync(string identifier, CancellationToken cancellationToken = default);
+    Task<bool> CanHandleAsync(string identifier, CancellationToken cancellationToken = default);
+}

--- a/DiffusionNexus.Service/Services/LocalFileMetadataProvider.cs
+++ b/DiffusionNexus.Service/Services/LocalFileMetadataProvider.cs
@@ -1,0 +1,145 @@
+using DiffusionNexus.Service.Classes;
+using DiffusionNexus.Service.Helper;
+using Serilog;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.IO;
+using System.Collections.Generic;
+
+namespace DiffusionNexus.Service.Services;
+
+public class LocalFileMetadataProvider : IModelMetadataProvider
+{
+    public Task<bool> CanHandleAsync(string identifier, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(File.Exists(identifier));
+    }
+
+    public async Task<ModelClass> GetModelMetadataAsync(string filePath, CancellationToken cancellationToken = default)
+    {
+        var file = new FileInfo(filePath);
+        var model = new ModelClass
+        {
+            SafeTensorFileName = ExtractBaseName(file.Name),
+            AssociatedFilesInfo = new List<FileInfo>()
+        };
+
+        string baseName = ExtractBaseName(file.Name);
+        var dir = file.Directory ?? new DirectoryInfo(Path.GetDirectoryName(filePath)!);
+
+        var civitai = dir.GetFiles($"{baseName}.civitai.info").FirstOrDefault();
+        var cmInfo = dir.GetFiles($"{baseName}.cm-info.json").FirstOrDefault();
+        var json = dir.GetFiles($"{baseName}.json").FirstOrDefault();
+
+        if (civitai != null)
+        {
+            model.AssociatedFilesInfo.Add(civitai);
+            await LoadFromCivitaiInfo(civitai, model);
+        }
+        else if (cmInfo != null)
+        {
+            model.AssociatedFilesInfo.Add(cmInfo);
+            await LoadFromCmInfo(cmInfo, model);
+        }
+        else if (json != null)
+        {
+            model.AssociatedFilesInfo.Add(json);
+            await LoadFromJson(json, model);
+        }
+
+        model.AssociatedFilesInfo.Add(file);
+
+        if (string.IsNullOrWhiteSpace(model.ModelVersionName))
+            model.ModelVersionName = baseName;
+
+        if (file.Extension.Equals(".safetensors", StringComparison.OrdinalIgnoreCase))
+        {
+            string _ = await Task.Run(() => ComputeSHA256(filePath), cancellationToken);
+        }
+        return model;
+    }
+
+    private static async Task LoadFromCivitaiInfo(FileInfo file, ModelClass model)
+    {
+        var json = await File.ReadAllTextAsync(file.FullName);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        if (root.TryGetProperty("baseModel", out var baseModel))
+            model.DiffusionBaseModel = baseModel.GetString() ?? model.DiffusionBaseModel;
+
+        if (root.TryGetProperty("model", out var modelElement))
+        {
+            if (modelElement.TryGetProperty("name", out var name))
+                model.ModelVersionName = name.GetString() ?? model.ModelVersionName;
+            if (modelElement.TryGetProperty("type", out var type))
+                model.ModelType = ParseModelType(type.GetString());
+            if (modelElement.TryGetProperty("tags", out var tags))
+                model.Tags = ParseTags(tags);
+        }
+    }
+
+    private static async Task LoadFromCmInfo(FileInfo file, ModelClass model)
+    {
+        var json = await File.ReadAllTextAsync(file.FullName);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        if (root.TryGetProperty("Tags", out var tags))
+            model.Tags = ParseTags(tags);
+        if (root.TryGetProperty("sd version", out var sdver))
+            model.DiffusionBaseModel = sdver.GetString() ?? model.DiffusionBaseModel;
+    }
+
+    private static async Task LoadFromJson(FileInfo file, ModelClass model)
+    {
+        var json = await File.ReadAllTextAsync(file.FullName);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        if (root.TryGetProperty("tags", out var tags))
+            model.Tags = ParseTags(tags);
+        if (root.TryGetProperty("sd version", out var sdver))
+            model.DiffusionBaseModel = sdver.GetString() ?? model.DiffusionBaseModel;
+    }
+
+    private static string ExtractBaseName(string fileName)
+    {
+        var ext = StaticFileTypes.GeneralExtensions
+            .OrderByDescending(e => e.Length)
+            .FirstOrDefault(e => fileName.EndsWith(e, StringComparison.OrdinalIgnoreCase));
+        return ext == null ? fileName : fileName[..^ext.Length];
+    }
+
+    private static DiffusionTypes ParseModelType(string? type)
+    {
+        if (string.IsNullOrWhiteSpace(type))
+            return DiffusionTypes.OTHER;
+        var normalized = type.Replace(" ", string.Empty);
+        return Enum.TryParse<DiffusionTypes>(normalized, true, out var result) ? result : DiffusionTypes.OTHER;
+    }
+
+    private static List<string> ParseTags(JsonElement tags)
+    {
+        var list = new List<string>();
+        foreach (var element in tags.EnumerateArray())
+        {
+            var val = element.GetString();
+            if (!string.IsNullOrWhiteSpace(val))
+                list.Add(val);
+        }
+        return list;
+    }
+
+    private static string ComputeSHA256(string path)
+    {
+        using var stream = File.OpenRead(path);
+        using var sha = SHA256.Create();
+        var bytes = sha.ComputeHash(stream);
+        var sb = new StringBuilder(bytes.Length * 2);
+        foreach (var b in bytes)
+            sb.Append(b.ToString("x2"));
+        return sb.ToString();
+    }
+}

--- a/DiffusionNexus.Service/Services/ModelMetadataService.cs
+++ b/DiffusionNexus.Service/Services/ModelMetadataService.cs
@@ -1,0 +1,18 @@
+using DiffusionNexus.Service.Classes;
+
+namespace DiffusionNexus.Service.Services;
+
+public class ModelMetadataService
+{
+    private readonly IModelMetadataProvider _provider;
+
+    public ModelMetadataService(IModelMetadataProvider provider)
+    {
+        _provider = provider;
+    }
+
+    public Task<ModelClass> GetModelMetadataAsync(string identifier, CancellationToken cancellationToken = default)
+    {
+        return _provider.GetModelMetadataAsync(identifier, cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary
- replace `ModelMetadata` with existing `ModelClass`
- adapt metadata provider interface to return `ModelClass`
- update local and API provider implementations
- adjust composite provider and service wrappers

## Testing
- `dotnet build DiffusionNexus.sln -v minimal`
- `dotnet test DiffusionNexus.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68668d990140833285b801d646b2f033