### PR TITLE
Refactor metadata via provider pattern

### DIFF
--- a/DiffusionNexus.Service/Services/DuplicateScanner.cs
+++ b/DiffusionNexus.Service/Services/DuplicateScanner.cs
@@ -1,4 +1,6 @@
 using DiffusionNexus.Service.Classes;
+using DiffusionNexus.Service.Services.Metadata;
+using System.Net.Http;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -42,7 +44,7 @@ public class DuplicateScanner
 
     private static async Task<Dictionary<string, ModelClass>> BuildMetadataLookupAsync(string folder, CancellationToken token)
     {
-        var reader = new JsonInfoFileReaderService(folder, string.Empty);
+        var reader = new ModelMetadataService(new CivitaiApiClient(new HttpClient()), string.Empty);
         var metas = await reader.GetModelData(null, folder, token, fetchFromApi: false);
         var lookup = new Dictionary<string, ModelClass>(StringComparer.OrdinalIgnoreCase);
         foreach (var m in metas)

--- a/DiffusionNexus.Service/Services/FileControllerService.cs
+++ b/DiffusionNexus.Service/Services/FileControllerService.cs
@@ -4,6 +4,8 @@
  */
 using DiffusionNexus.Service.Classes;
 using System;
+using DiffusionNexus.Service.Services.Metadata;
+using System.Net.Http;
 using System.Security.Cryptography;
 
 namespace DiffusionNexus.Service.Services
@@ -21,8 +23,8 @@ namespace DiffusionNexus.Service.Services
             // Throw if cancellation is requested
             cancellationToken.ThrowIfCancellationRequested();
 
-            var jsonReader = new JsonInfoFileReaderService(options.BasePath, options.ApiKey);
-            List<ModelClass> models = await jsonReader.GetModelData(progress, options.BasePath, cancellationToken);
+            var metadataService = new ModelMetadataService(new CivitaiApiClient(new HttpClient()), options.ApiKey);
+            List<ModelClass> models = await metadataService.GetModelData(progress, options.BasePath, cancellationToken);
 
             if (models == null || models.Count == 0)
             {

--- a/DiffusionNexus.Service/Services/Metadata/CivitaiApiMetadataProvider.cs
+++ b/DiffusionNexus.Service/Services/Metadata/CivitaiApiMetadataProvider.cs
@@ -1,0 +1,76 @@
+using DiffusionNexus.Service.Classes;
+using System.Text.Json;
+
+namespace DiffusionNexus.Service.Services.Metadata
+{
+    public class CivitaiApiMetadataProvider : IModelMetadataProvider
+    {
+        private readonly ICivitaiApiClient _apiClient;
+        private readonly string _apiKey;
+
+        public CivitaiApiMetadataProvider(ICivitaiApiClient apiClient, string apiKey)
+        {
+            _apiClient = apiClient;
+            _apiKey = apiKey;
+        }
+
+        public Task<bool> CanHandleAsync(string identifier, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(identifier.Length == 64 && System.Text.RegularExpressions.Regex.IsMatch(identifier, "^[a-fA-F0-9]+$"));
+        }
+
+        public async Task<ModelClass?> GetModelMetadataAsync(string sha256Hash, CancellationToken cancellationToken = default)
+        {
+            var metadata = new ModelClass();
+
+            var versionJson = await _apiClient.GetModelVersionByHashAsync(sha256Hash, _apiKey);
+            using var versionDoc = JsonDocument.Parse(versionJson);
+            var versionRoot = versionDoc.RootElement;
+
+            if (versionRoot.TryGetProperty("modelId", out var modelId))
+            {
+                metadata.SafeTensorFileName = sha256Hash;
+                var modelJson = await _apiClient.GetModelAsync(modelId.GetString()!, _apiKey);
+                using var modelDoc = JsonDocument.Parse(modelJson);
+                ParseModelInfo(modelDoc.RootElement, metadata);
+            }
+
+            if (versionRoot.TryGetProperty("baseModel", out var baseModel))
+                metadata.DiffusionBaseModel = baseModel.GetString() ?? metadata.DiffusionBaseModel;
+
+            if (versionRoot.TryGetProperty("name", out var versionName))
+                metadata.ModelVersionName = versionName.GetString();
+
+            return metadata;
+        }
+
+        private static void ParseModelInfo(JsonElement root, ModelClass metadata)
+        {
+            if (root.TryGetProperty("type", out var type))
+                metadata.ModelType = ParseModelType(type.GetString());
+
+            if (root.TryGetProperty("tags", out var tags))
+                metadata.Tags = ParseTags(tags);
+        }
+
+        private static DiffusionTypes ParseModelType(string? type)
+        {
+            if (string.IsNullOrWhiteSpace(type))
+                return DiffusionTypes.OTHER;
+            var cleaned = type.Replace(" ", string.Empty).ToUpperInvariant();
+            return Enum.TryParse(cleaned, true, out DiffusionTypes result) ? result : DiffusionTypes.OTHER;
+        }
+
+        private static List<string> ParseTags(JsonElement tags)
+        {
+            var list = new List<string>();
+            foreach (var t in tags.EnumerateArray())
+            {
+                var s = t.GetString();
+                if (!string.IsNullOrWhiteSpace(s))
+                    list.Add(s);
+            }
+            return list;
+        }
+    }
+}

--- a/DiffusionNexus.Service/Services/Metadata/CivitaiHelperMetadataProvider.cs
+++ b/DiffusionNexus.Service/Services/Metadata/CivitaiHelperMetadataProvider.cs
@@ -1,0 +1,132 @@
+using DiffusionNexus.Service.Classes;
+using DiffusionNexus.Service.Helper;
+using Serilog;
+using System.Text.Json;
+
+namespace DiffusionNexus.Service.Services.Metadata
+{
+    public class CivitaiHelperMetadataProvider : IModelMetadataProvider
+    {
+        public Task<bool> CanHandleAsync(string identifier, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(File.Exists(identifier));
+        }
+
+        public async Task<ModelClass?> GetModelMetadataAsync(string filePath, CancellationToken cancellationToken = default)
+        {
+            var info = new FileInfo(filePath);
+            if (!info.Exists)
+            {
+                return null;
+            }
+
+            var metadata = new ModelClass
+            {
+                SafeTensorFileName = ExtractBaseName(info.Name),
+                AssociatedFilesInfo = new List<FileInfo>()
+            };
+
+            var directory = info.Directory;
+            if (directory == null) return metadata;
+
+            var baseName = ExtractBaseName(info.Name);
+            var civitaiInfoFile = directory.GetFiles($"{baseName}.civitai.info").FirstOrDefault();
+            var jsonFile = directory.GetFiles($"{baseName}.json").FirstOrDefault();
+            var cmInfoFile = directory.GetFiles($"{baseName}.cm-info.json").FirstOrDefault();
+
+            if (civitaiInfoFile != null)
+            {
+                await LoadFromCivitaiInfo(civitaiInfoFile, metadata, cancellationToken);
+            }
+            else if (jsonFile != null)
+            {
+                await LoadFromJson(jsonFile, metadata, cancellationToken);
+            }
+
+            if (cmInfoFile != null)
+            {
+                await LoadTagsFromJson(cmInfoFile, "Tags", metadata, cancellationToken);
+            }
+
+            metadata.AssociatedFilesInfo = directory.GetFiles($"{baseName}*").ToList();
+            return metadata;
+        }
+
+        private static async Task LoadFromCivitaiInfo(FileInfo file, ModelClass metadata, CancellationToken token)
+        {
+            var json = await File.ReadAllTextAsync(file.FullName, token);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            if (root.TryGetProperty("baseModel", out var baseModel))
+                metadata.DiffusionBaseModel = baseModel.GetString() ?? metadata.DiffusionBaseModel;
+
+            if (root.TryGetProperty("model", out var model))
+            {
+                if (model.TryGetProperty("name", out var name))
+                    metadata.ModelVersionName = name.GetString();
+
+                if (model.TryGetProperty("type", out var type))
+                    metadata.ModelType = ParseModelType(type.GetString());
+
+                if (model.TryGetProperty("tags", out var tags))
+                    metadata.Tags = ParseTags(tags);
+            }
+        }
+
+        private static async Task LoadFromJson(FileInfo file, ModelClass metadata, CancellationToken token)
+        {
+            var json = await File.ReadAllTextAsync(file.FullName, token);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            if (root.TryGetProperty("sd version", out var version))
+                metadata.DiffusionBaseModel = version.GetString() ?? metadata.DiffusionBaseModel;
+        }
+
+        private static async Task LoadTagsFromJson(FileInfo file, string property, ModelClass metadata, CancellationToken token)
+        {
+            var json = await File.ReadAllTextAsync(file.FullName, token);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            if (root.TryGetProperty(property, out var tagElement))
+            {
+                metadata.Tags = ParseTags(tagElement);
+            }
+            else if (root.TryGetProperty("model", out var model) && model.TryGetProperty(property, out var nested))
+            {
+                metadata.Tags = ParseTags(nested);
+            }
+        }
+
+        private static List<string> ParseTags(JsonElement tags)
+        {
+            var list = new List<string>();
+            foreach (var t in tags.EnumerateArray())
+            {
+                var s = t.GetString();
+                if (!string.IsNullOrWhiteSpace(s))
+                    list.Add(s);
+            }
+            return list;
+        }
+
+        private static DiffusionTypes ParseModelType(string? type)
+        {
+            if (string.IsNullOrWhiteSpace(type))
+                return DiffusionTypes.OTHER;
+            var cleaned = type.Replace(" ", string.Empty).ToUpperInvariant();
+            return Enum.TryParse(cleaned, true, out DiffusionTypes result) ? result : DiffusionTypes.OTHER;
+        }
+
+        private static string ExtractBaseName(string fileName)
+        {
+            var extensions = StaticFileTypes.GeneralExtensions.OrderByDescending(e => e.Length);
+            foreach (var ext in extensions)
+            {
+                if (fileName.EndsWith(ext, StringComparison.OrdinalIgnoreCase))
+                    return fileName.Substring(0, fileName.Length - ext.Length);
+            }
+            return Path.GetFileNameWithoutExtension(fileName);
+        }
+    }
+}

--- a/DiffusionNexus.Service/Services/Metadata/CompositeMetadataProvider.cs
+++ b/DiffusionNexus.Service/Services/Metadata/CompositeMetadataProvider.cs
@@ -1,0 +1,59 @@
+using DiffusionNexus.Service.Classes;
+
+namespace DiffusionNexus.Service.Services.Metadata
+{
+    public class CompositeMetadataProvider : IModelMetadataProvider
+    {
+        private readonly IModelMetadataProvider[] _providers;
+
+        public CompositeMetadataProvider(params IModelMetadataProvider[] providers)
+        {
+            _providers = providers;
+        }
+
+        public async Task<bool> CanHandleAsync(string identifier, CancellationToken cancellationToken = default)
+        {
+            foreach (var p in _providers)
+            {
+                if (await p.CanHandleAsync(identifier, cancellationToken))
+                    return true;
+            }
+            return false;
+        }
+
+        public async Task<ModelClass?> GetModelMetadataAsync(string identifier, CancellationToken cancellationToken = default)
+        {
+            var result = new ModelClass();
+            foreach (var p in _providers)
+            {
+                if (await p.CanHandleAsync(identifier, cancellationToken))
+                {
+                    var meta = await p.GetModelMetadataAsync(identifier, cancellationToken);
+                    if (meta != null)
+                    {
+                        Merge(result, meta);
+                    }
+                }
+            }
+            return result;
+        }
+
+        private static void Merge(ModelClass target, ModelClass source)
+        {
+            if (!string.IsNullOrWhiteSpace(source.ModelVersionName))
+                target.ModelVersionName = source.ModelVersionName;
+
+            if (!string.IsNullOrWhiteSpace(source.DiffusionBaseModel) && target.DiffusionBaseModel == "UNKNOWN")
+                target.DiffusionBaseModel = source.DiffusionBaseModel;
+
+            if (source.ModelType != DiffusionTypes.OTHER)
+                target.ModelType = source.ModelType;
+
+            if (source.Tags != null && source.Tags.Count > 0)
+                target.Tags = source.Tags;
+
+            if (source.CivitaiCategory != CivitaiBaseCategories.UNASSIGNED)
+                target.CivitaiCategory = source.CivitaiCategory;
+        }
+    }
+}

--- a/DiffusionNexus.Service/Services/Metadata/IModelMetadataProvider.cs
+++ b/DiffusionNexus.Service/Services/Metadata/IModelMetadataProvider.cs
@@ -1,0 +1,9 @@
+using DiffusionNexus.Service.Classes;
+namespace DiffusionNexus.Service.Services.Metadata
+{
+    public interface IModelMetadataProvider
+    {
+        Task<ModelClass?> GetModelMetadataAsync(string identifier, CancellationToken cancellationToken = default);
+        Task<bool> CanHandleAsync(string identifier, CancellationToken cancellationToken = default);
+    }
+}

--- a/DiffusionNexus.Service/Services/ModelDiscoveryService.cs
+++ b/DiffusionNexus.Service/Services/ModelDiscoveryService.cs
@@ -1,5 +1,7 @@
 using DiffusionNexus.Service.Classes;
 using DiffusionNexus.Service.Helper;
+using DiffusionNexus.Service.Services.Metadata;
+using System.Net.Http;
 
 namespace DiffusionNexus.Service.Services;
 
@@ -43,7 +45,8 @@ public class ModelDiscoveryService
 
     public List<ModelClass> CollectModels(string rootDirectory)
     {
-        var models = JsonInfoFileReaderService.GroupFilesByPrefix(rootDirectory);
+        var metadataService = new ModelMetadataService(new CivitaiApiClient(new HttpClient()), string.Empty);
+        var models = metadataService.GroupFilesByPrefix(rootDirectory);
 
         foreach (var model in models)
         {

--- a/DiffusionNexus.Service/Services/ModelMetadataService.cs
+++ b/DiffusionNexus.Service/Services/ModelMetadataService.cs
@@ -1,0 +1,140 @@
+using DiffusionNexus.Service.Classes;
+using DiffusionNexus.Service.Helper;
+using DiffusionNexus.Service.Services.Metadata;
+using Serilog;
+using System.Security.Cryptography;
+
+namespace DiffusionNexus.Service.Services
+{
+    public class ModelMetadataService
+    {
+        private readonly CompositeMetadataProvider _provider;
+        private readonly CivitaiApiMetadataProvider _apiProvider;
+        private readonly CivitaiHelperMetadataProvider _localProvider;
+
+        public ModelMetadataService(ICivitaiApiClient apiClient, string apiKey)
+        {
+            _apiProvider = new CivitaiApiMetadataProvider(apiClient, apiKey);
+            _localProvider = new CivitaiHelperMetadataProvider();
+            _provider = new CompositeMetadataProvider(_localProvider, _apiProvider);
+        }
+
+        public List<ModelClass> GroupFilesByPrefix(string rootDirectory)
+        {
+            var fileGroups = new Dictionary<string, List<FileInfo>>();
+            string[] files = Directory.GetFiles(rootDirectory, "*", SearchOption.AllDirectories);
+            foreach (var filePath in files)
+            {
+                var fileInfo = new FileInfo(filePath);
+                var prefix = ExtractBaseName(fileInfo.Name).ToLowerInvariant();
+                if (!fileGroups.ContainsKey(prefix))
+                {
+                    fileGroups[prefix] = new List<FileInfo>();
+                }
+                fileGroups[prefix].Add(fileInfo);
+            }
+
+            var modelClasses = new List<ModelClass>();
+            foreach (var group in fileGroups)
+            {
+                var model = new ModelClass
+                {
+                    SafeTensorFileName = group.Key,
+                    AssociatedFilesInfo = group.Value,
+                    CivitaiCategory = CivitaiBaseCategories.UNKNOWN,
+                    NoMetaData = group.Value.Count <= 1
+                };
+                modelClasses.Add(model);
+            }
+            return modelClasses;
+        }
+
+        public async Task<List<ModelClass>> GetModelData(IProgress<ProgressReport>? progress, string folder, CancellationToken token, bool fetchFromApi = true)
+        {
+            var models = GroupFilesByPrefix(folder);
+            int count = 1;
+            foreach (var model in models)
+            {
+                token.ThrowIfCancellationRequested();
+                var safeTensor = model.AssociatedFilesInfo.FirstOrDefault(f => f.Extension == ".safetensors");
+                if (safeTensor == null)
+                {
+                    model.NoMetaData = true;
+                    continue;
+                }
+
+                var meta = await _localProvider.GetModelMetadataAsync(safeTensor.FullName, token);
+                if (meta != null)
+                {
+                    Merge(model, meta);
+                }
+
+                bool needApi = fetchFromApi && (model.DiffusionBaseModel == "UNKNOWN" || model.ModelType == DiffusionTypes.OTHER);
+                if (needApi)
+                {
+                    try
+                    {
+                        var hash = ComputeSHA256(safeTensor.FullName);
+                        var apiMeta = await _apiProvider.GetModelMetadataAsync(hash, token);
+                        if (apiMeta != null)
+                        {
+                            Merge(model, apiMeta);
+                            model.NoMetaData = false;
+                            model.CivitaiCategory = GetCategoryFromTags(model.Tags);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex, "API metadata fetch failed for {File}", safeTensor.FullName);
+                        model.ErrorOnRetrievingMetaData = true;
+                    }
+                }
+                count++;
+            }
+            return models;
+        }
+
+        private static void Merge(ModelClass target, ModelClass source)
+        {
+            if (!string.IsNullOrWhiteSpace(source.ModelVersionName))
+                target.ModelVersionName = source.ModelVersionName;
+
+            if (!string.IsNullOrWhiteSpace(source.DiffusionBaseModel) && target.DiffusionBaseModel == "UNKNOWN")
+                target.DiffusionBaseModel = source.DiffusionBaseModel;
+
+            if (source.ModelType != DiffusionTypes.OTHER)
+                target.ModelType = source.ModelType;
+
+            if (source.Tags != null && source.Tags.Count > 0)
+                target.Tags = source.Tags;
+        }
+
+        private static string ExtractBaseName(string fileName)
+        {
+            var extension = StaticFileTypes.GeneralExtensions.OrderByDescending(e => e.Length).FirstOrDefault(e => fileName.EndsWith(e, StringComparison.OrdinalIgnoreCase));
+            if (extension != null)
+                return fileName.Substring(0, fileName.Length - extension.Length);
+            return fileName;
+        }
+
+        private static string ComputeSHA256(string filePath)
+        {
+            using FileStream stream = File.OpenRead(filePath);
+            using SHA256 sha256 = SHA256.Create();
+            byte[] hashBytes = sha256.ComputeHash(stream);
+            return BitConverter.ToString(hashBytes).Replace("-", string.Empty).ToLowerInvariant();
+        }
+
+        private static CivitaiBaseCategories GetCategoryFromTags(List<string> tags)
+        {
+            foreach (string tag in tags)
+            {
+                if (Enum.TryParse(tag.Replace(" ", "_").ToUpperInvariant(), out CivitaiBaseCategories category))
+                {
+                    return category;
+                }
+            }
+            return CivitaiBaseCategories.UNKNOWN;
+        }
+    }
+}

--- a/DiffusionNexus.Tests/LoraSort/Services/GroupFilesByPrefixTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/Services/GroupFilesByPrefixTests.cs
@@ -1,4 +1,6 @@
 using DiffusionNexus.Service.Services;
+using DiffusionNexus.Service.Services.Metadata;
+using System.Net.Http;
 using System.IO;
 using System.Linq;
 using FluentAssertions;
@@ -18,7 +20,8 @@ public class GroupFilesByPrefixTests
             File.WriteAllText(Path.Combine(tempDir, "model1.preview.png"), string.Empty);
             File.WriteAllText(Path.Combine(tempDir, "model2.ckpt"), string.Empty);
 
-            var result = JsonInfoFileReaderService.GroupFilesByPrefix(tempDir);
+            var service = new ModelMetadataService(new CivitaiApiClient(new HttpClient()), string.Empty);
+            var result = service.GroupFilesByPrefix(tempDir);
             result.Count.Should().Be(2);
             var first = result.First(m => m.SafeTensorFileName == "model1");
             first.AssociatedFilesInfo.Count.Should().Be(2);

--- a/DiffusionNexus.Tests/LoraSort/Services/JsonInfoFileReaderServiceTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/Services/JsonInfoFileReaderServiceTests.cs
@@ -1,6 +1,8 @@
 using FluentAssertions;
 using DiffusionNexus.Service.Services;
+using DiffusionNexus.Service.Services.Metadata;
 using DiffusionNexus.Service.Classes;
+using System.Net.Http;
 
 namespace DiffusionNexus.Tests.LoraSort.Services;
 
@@ -41,7 +43,8 @@ public class JsonInfoFileReaderServiceTests : IDisposable
             }
 
             // Act
-            var result = JsonInfoFileReaderService.GroupFilesByPrefix(_testDirectoryPath);
+            var service = new ModelMetadataService(new CivitaiApiClient(new HttpClient()), string.Empty);
+            var result = service.GroupFilesByPrefix(_testDirectoryPath);
 
             // Assert
             result.Should().HaveCount(2);
@@ -77,7 +80,8 @@ public class JsonInfoFileReaderServiceTests : IDisposable
             }
 
             // Act
-            var result = JsonInfoFileReaderService.GroupFilesByPrefix(_testDirectoryPath);
+            var service = new ModelMetadataService(new CivitaiApiClient(new HttpClient()), string.Empty);
+            var result = service.GroupFilesByPrefix(_testDirectoryPath);
 
             // Assert
             var modelWithMeta = result.First(m => m.SafeTensorFileName == "model_with_meta");
@@ -106,7 +110,7 @@ public class JsonInfoFileReaderServiceTests : IDisposable
                 File.WriteAllText(Path.Combine(_testDirectoryPath, fileName), content);
             }
 
-            var service = new JsonInfoFileReaderService(_testDirectoryPath, "test-api-key");
+            var service = new ModelMetadataService(new CivitaiApiClient(new HttpClient()), "test-api-key");
             var progress = new Progress<ProgressReport>();
             var cts = new CancellationTokenSource();
 

--- a/DiffusionNexus.UI/ViewModels/LoraHelperViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraHelperViewModel.cs
@@ -5,6 +5,8 @@ using DiffusionNexus.Service.Classes;
 using DiffusionNexus.Service.Search;
 using DiffusionNexus.Service.Services;
 using DiffusionNexus.UI.Classes;
+using DiffusionNexus.Service.Services.Metadata;
+using System.Net.Http;
 using Avalonia.Controls;
 using Avalonia.Platform.Storage;
 using System;
@@ -86,7 +88,7 @@ public partial class LoraHelperViewModel : ViewModelBase
             FolderItems.Add(ConvertFolder(rootNode));
         });
 
-        var reader = new JsonInfoFileReaderService(settings.LoraHelperFolderPath!, settings.CivitaiApiKey ?? string.Empty);
+        var reader = new ModelMetadataService(new CivitaiApiClient(new HttpClient()), settings.CivitaiApiKey ?? string.Empty);
         var models = await reader.GetModelData(null, settings.LoraHelperFolderPath!, CancellationToken.None, fetchFromApi: false);
 
         await Dispatcher.UIThread.InvokeAsync(() =>


### PR DESCRIPTION
## Summary
- add IModelMetadataProvider interface and new Civitai providers
- add ModelMetadataService that composes local and API providers
- switch services and view model to use new metadata service
- update tests for new service

## Testing
- `dotnet test --no-build` *(fails: Build succeeded but tests didn't run)*

------
https://chatgpt.com/codex/tasks/task_e_6867113c4a1c8332a0581b9bf068af40