### PR TITLE
Fix overlay position and cancel command

### DIFF
--- a/DiffusionNexus.UI/ViewModels/LoraSortMainSettingsViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraSortMainSettingsViewModel.cs
@@ -61,7 +61,7 @@ namespace DiffusionNexus.UI.ViewModels
             _settingsService = settingsService;
             SelectBasePathCommand = new AsyncRelayCommand(OnSelectBasePathAsync);
             SelectTargetPathCommand = new AsyncRelayCommand(OnSelectTargetPathAsync);
-            GoCommand = new AsyncRelayCommand(OnGo);
+            GoCommand = new AsyncRelayCommand(OnGo, AsyncRelayCommandOptions.AllowConcurrentExecutions);
             _ = LoadDefaultsAsync();
         }
 

--- a/DiffusionNexus.UI/Views/Controls/LoraSortMainSettingsControl.axaml
+++ b/DiffusionNexus.UI/Views/Controls/LoraSortMainSettingsControl.axaml
@@ -96,8 +96,5 @@
         </Border>
       </StackPanel>
     </ScrollViewer>
-    <controls:ProcessingOverlayControl IsVisible="{Binding IsBusy}"
-                                HorizontalAlignment="Stretch"
-                                VerticalAlignment="Stretch"/>
   </Grid>
 </UserControl>

--- a/DiffusionNexus.UI/Views/LoraSortView.axaml
+++ b/DiffusionNexus.UI/Views/LoraSortView.axaml
@@ -21,11 +21,16 @@
         </Border>
 
         <!-- Top Right - Custom Mappings -->
-        <Border Grid.Column="1" 
-                BorderBrush="Gray" BorderThickness="1" 
+        <Border Grid.Column="1"
+                BorderBrush="Gray" BorderThickness="1"
                 Margin="5" CornerRadius="4">
             <controls:LoraSortCustomMappingsControl x:Name="CustomMappingsControl" DataContext="{Binding CustomMappingsViewModel}"/>
         </Border>
-        
+
+        <controls:ProcessingOverlayControl DataContext="{Binding MainSettingsViewModel}"
+                                           IsVisible="{Binding IsBusy}"
+                                           HorizontalAlignment="Stretch"
+                                           VerticalAlignment="Stretch"/>
+
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- overlay the entire LoraSort view when processing
- remove the overlay from MainSettingsControl
- allow reusing the GoCommand for cancelling

## Testing
- `dotnet test DiffusionNexus.Tests/DiffusionNexus.Tests.csproj --no-restore --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6867afa9d1648332a89ac6d4c3345277