### PR TITLE
Fix overlay coverage and cancel button

### DIFF
--- a/DiffusionNexus.UI/Views/Controls/LoraSortMainSettingsControl.axaml
+++ b/DiffusionNexus.UI/Views/Controls/LoraSortMainSettingsControl.axaml
@@ -96,8 +96,5 @@
         </Border>
       </StackPanel>
     </ScrollViewer>
-    <controls:ProcessingOverlayControl IsVisible="{Binding IsBusy}"
-                                HorizontalAlignment="Stretch"
-                                VerticalAlignment="Stretch"/>
   </Grid>
 </UserControl>

--- a/DiffusionNexus.UI/Views/LoraSortView.axaml
+++ b/DiffusionNexus.UI/Views/LoraSortView.axaml
@@ -21,11 +21,18 @@
         </Border>
 
         <!-- Top Right - Custom Mappings -->
-        <Border Grid.Column="1" 
-                BorderBrush="Gray" BorderThickness="1" 
+        <Border Grid.Column="1"
+                BorderBrush="Gray" BorderThickness="1"
                 Margin="5" CornerRadius="4">
             <controls:LoraSortCustomMappingsControl x:Name="CustomMappingsControl" DataContext="{Binding CustomMappingsViewModel}"/>
         </Border>
-        
+
+        <!-- Processing overlay for the entire view -->
+        <controls:ProcessingOverlayControl Grid.ColumnSpan="2"
+                                           DataContext="{Binding MainSettingsViewModel}"
+                                           IsVisible="{Binding IsBusy}"
+                                           HorizontalAlignment="Stretch"
+                                           VerticalAlignment="Stretch"/>
+
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- expand the processing overlay to cover the whole LoraSort view
- remove the old overlay from LoraSortMainSettings control

## Testing
- `dotnet build DiffusionNexus.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6867afa9d1648332a89ac6d4c3345277