### PR TITLE
Fix unit tests and improve metadata handling

### DIFF
--- a/DiffusionNexus.Service/Helper/StaticFileTypes.cs
+++ b/DiffusionNexus.Service/Helper/StaticFileTypes.cs
@@ -31,6 +31,7 @@ namespace DiffusionNexus.Service.Helper
         ".safetensors",
         ".thumb",
         ".json",
-        ".pt"];
+        ".pt",
+        ".yaml"];
     }
 }

--- a/DiffusionNexus.Service/Services/CustomTagMapXmlService.cs
+++ b/DiffusionNexus.Service/Services/CustomTagMapXmlService.cs
@@ -7,7 +7,12 @@ namespace DiffusionNexus.Service.Services
 {
     public class CustomTagMapXmlService
     {
-        string filePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "mappings.xml");
+        private readonly string _filePath;
+
+        public CustomTagMapXmlService(string? filePath = null)
+        {
+            _filePath = filePath ?? Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "mappings.xml");
+        }
         /// <summary>
         /// Saves the given collection of CustomTagMap objects to an XML file.
         /// </summary>
@@ -18,7 +23,7 @@ namespace DiffusionNexus.Service.Services
             try
             {
                 XmlSerializer serializer = new XmlSerializer(typeof(ObservableCollection<CustomTagMap>));
-                using (StreamWriter writer = new StreamWriter(filePath))
+                using (StreamWriter writer = new StreamWriter(_filePath))
                 {
                     serializer.Serialize(writer, mappings);
                 }
@@ -40,11 +45,11 @@ namespace DiffusionNexus.Service.Services
         {
             try
             {
-                if (!File.Exists(filePath))
+                if (!File.Exists(_filePath))
                     return new ObservableCollection<CustomTagMap>();
 
                 XmlSerializer serializer = new XmlSerializer(typeof(ObservableCollection<CustomTagMap>));
-                using (StreamReader reader = new StreamReader(filePath))
+                using (StreamReader reader = new StreamReader(_filePath))
                 {
                     return (ObservableCollection<CustomTagMap>)serializer.Deserialize(reader);
                 }
@@ -60,13 +65,14 @@ namespace DiffusionNexus.Service.Services
         /// Deletes the mappings XML file if it exists.
         /// </summary>
         /// <param name="filePath">The full path to the mappings XML file.</param>
-        public void DeleteAllMappings(string filePath)
+        public void DeleteAllMappings(string? filePath = null)
         {
             try
             {
-                if (File.Exists(filePath))
+                var path = filePath ?? _filePath;
+                if (File.Exists(path))
                 {
-                    File.Delete(filePath);
+                    File.Delete(path);
                 }
             }
             catch (Exception ex)

--- a/DiffusionNexus.Service/Services/JsonInfoFileReaderService.cs
+++ b/DiffusionNexus.Service/Services/JsonInfoFileReaderService.cs
@@ -49,6 +49,7 @@ public class JsonInfoFileReaderService
             {
                 Log.Error(ex, "Error retrieving metadata for {Model}", model.SafeTensorFileName);
                 model.ErrorOnRetrievingMetaData = true;
+                model.NoMetaData = true;
             }
         }
 
@@ -87,6 +88,11 @@ public class JsonInfoFileReaderService
         var modelClasses = new List<ModelClass>();
         foreach (var group in fileGroups)
         {
+            if (!group.Value.Any(f => StaticFileTypes.ModelExtensions.Contains(f.Extension, StringComparer.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
             var model = new ModelClass
             {
                 SafeTensorFileName = group.Key,

--- a/DiffusionNexus.Tests/LoraSort/Services/CivitaiApiMetadataProvider.cs
+++ b/DiffusionNexus.Tests/LoraSort/Services/CivitaiApiMetadataProvider.cs
@@ -11,7 +11,7 @@ public class CivitaiApiMetadataProviderTests
     private readonly Mock<ICivitaiApiClient> _mockApiClient;
     private readonly CivitaiApiMetadataProvider _provider;
     private const string TestApiKey = "test-api-key";
-    private const string ValidSha256Hash = "a1b2c3d4e5f6789012345678901234567890123456789012345678901234567890";
+    private const string ValidSha256Hash = "a1b2c3d4e5f67890123456789012345678901234567890123456789012345678";
 
     public CivitaiApiMetadataProviderTests()
     {
@@ -27,7 +27,7 @@ public class CivitaiApiMetadataProviderTests
     }
 
     [Theory]
-    [InlineData("a1b2c3d4e5f6789012345678901234567890123456789012345678901234567890", true)]
+    [InlineData("a1b2c3d4e5f67890123456789012345678901234567890123456789012345678", true)]
     [InlineData("invalid-hash", false)]
     [InlineData("12345", false)]
     [InlineData("", false)]
@@ -124,7 +124,7 @@ public class CivitaiApiMetadataProviderTests
         _mockApiClient.Setup(x => x.GetModelVersionByHashAsync(ValidSha256Hash, TestApiKey))
                      .ReturnsAsync("{ invalid json");
 
-        await Assert.ThrowsAsync<JsonException>(() => 
+        await Assert.ThrowsAnyAsync<JsonException>(() =>
             _provider.GetModelMetadataAsync(ValidSha256Hash));
     }
 }

--- a/DiffusionNexus.Tests/LoraSort/Services/CustomTagMapXmlServiceTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/Services/CustomTagMapXmlServiceTests.cs
@@ -15,8 +15,8 @@ namespace DiffusionNexus.Tests.Service
 
         public CustomTagMapXmlServiceTests()
         {
-            _service = new CustomTagMapXmlService();
             _testFilePath = Path.Combine(Path.GetTempPath(), "test_mappings.xml");
+            _service = new CustomTagMapXmlService(_testFilePath);
         }
 
         public void Dispose()

--- a/DiffusionNexus.Tests/LoraSort/Services/JsonInfoFileReaderServiceTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/Services/JsonInfoFileReaderServiceTests.cs
@@ -284,7 +284,7 @@ public class JsonInfoFileReaderServiceTests : IDisposable
         model.SafeTensorFileName.Should().Be("model");
         model.AssociatedFilesInfo.Should().HaveCount(3);
         model.AssociatedFilesInfo.Select(f => f.Extension)
-            .Should().Contain(new[] { ".safetensors", ".civitai.info", ".yaml" });
+            .Should().Contain(new[] { ".safetensors", ".info", ".yaml" });
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- allow `CustomTagMapXmlService` to accept a file path
- recognize `.yaml` files as valid metadata extensions
- skip file groups without model files when reading metadata
- mark models with invalid JSON as lacking metadata
- correct test data and expectations

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6867eaf3d6cc83328453a90024df42d3