### PR TITLE
Add metadata completeness tracking

### DIFF
--- a/DiffusionNexus.Service/Classes/MetadataFieldAttribute.cs
+++ b/DiffusionNexus.Service/Classes/MetadataFieldAttribute.cs
@@ -1,0 +1,2 @@
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class MetadataFieldAttribute : Attribute { }

--- a/DiffusionNexus.Service/Classes/ModelClass.cs
+++ b/DiffusionNexus.Service/Classes/ModelClass.cs
@@ -7,23 +7,68 @@ namespace DiffusionNexus.Service.Classes
 {
     public class ModelClass
     {
-        private string diffusionBaseModel = "UNKNOWN";
+        private const string Unknown = "UNKNOWN";
+        private string diffusionBaseModel = Unknown;
 
+        [MetadataField]
         public string DiffusionBaseModel
         {
             get => diffusionBaseModel;
             set => diffusionBaseModel = value == "SDXL 1.0" ? "SDXL" : value;
         }
 
-        public string SafeTensorFileName { get; set; }
-        public string ModelVersionName { get; set; }
-        public string? ModelId { get; set; }
-        public string? SHA256Hash { get; set; }
-        public DiffusionTypes ModelType { get; set; } = DiffusionTypes.OTHER;
-        public List<FileInfo> AssociatedFilesInfo { get; set; }
-        public List<string> Tags { get; set; } = new List<string>();
-        public CivitaiBaseCategories CivitaiCategory { get; set; } = CivitaiBaseCategories.UNASSIGNED;
-        public bool NoMetaData { get; set; }
-        public bool ErrorOnRetrievingMetaData { get; internal set; } = false;
+        [MetadataField] public string SafeTensorFileName { get; set; }
+        [MetadataField] public string ModelVersionName { get; set; }
+        [MetadataField] public string?  ModelId { get; set; }
+        [MetadataField] public string?  SHA256Hash { get; set; }
+        [MetadataField] public DiffusionTypes ModelType { get; set; } = DiffusionTypes.OTHER;
+        [MetadataField] public List<FileInfo> AssociatedFilesInfo { get; set; }
+        [MetadataField] public List<string>  Tags { get; set; } = new();
+        [MetadataField] public CivitaiBaseCategories CivitaiCategory { get; set; } = CivitaiBaseCategories.UNASSIGNED;
+
+        public bool NoMetaData { get; set; } = true;
+        public bool ErrorOnRetrievingMetaData { get; internal set; }
+
+        //------------------------------------------------------------------
+        // Helper: evaluate completeness whenever you need it
+        //------------------------------------------------------------------
+        public MetadataCompleteness GetCompleteness()
+        {
+            var metaProps = typeof(ModelClass)
+                            .GetProperties()
+                            .Where(p => Attribute.IsDefined(p, typeof(MetadataFieldAttribute)));
+
+            int total  = 0;
+            int filled = 0;
+
+            foreach (var prop in metaProps)
+            {
+                total++;
+                var value = prop.GetValue(this);
+
+                if (value switch
+                {
+                    null                      => false,
+                    string s                  => !string.IsNullOrWhiteSpace(s) && s != Unknown,
+                    System.Collections.IList list => list.Count > 0,
+                    DiffusionTypes t          => t != DiffusionTypes.OTHER,
+                    CivitaiBaseCategories cat => cat != CivitaiBaseCategories.UNASSIGNED,
+                    _                         => true
+                })
+                {
+                    filled++;
+                }
+            }
+
+            return filled == 0     ? MetadataCompleteness.None
+                 : filled == total ? MetadataCompleteness.Full
+                                   : MetadataCompleteness.Partial;
+        }
+
+        //------------------------------------------------------------------
+        // Convenience flags you can use anywhere in the codebase
+        //------------------------------------------------------------------
+        public bool HasAnyMetadata  => GetCompleteness() != MetadataCompleteness.None;
+        public bool HasFullMetadata => GetCompleteness() == MetadataCompleteness.Full;
     }
 }

--- a/DiffusionNexus.Service/Enum/MetadataCompleteness.cs
+++ b/DiffusionNexus.Service/Enum/MetadataCompleteness.cs
@@ -1,0 +1,6 @@
+public enum MetadataCompleteness
+{
+    None,
+    Partial,
+    Full
+}

--- a/DiffusionNexus.Service/Services/CivitaiApiMetadataProvider.cs
+++ b/DiffusionNexus.Service/Services/CivitaiApiMetadataProvider.cs
@@ -45,6 +45,7 @@ public class CivitaiApiMetadataProvider : IModelMetadataProvider
         if (versionRoot.TryGetProperty("name", out var versionName))
             meta.ModelVersionName = versionName.GetString();
 
+        meta.NoMetaData = !meta.HasAnyMetadata;
         return meta;
     }
 

--- a/DiffusionNexus.Service/Services/JsonInfoFileReaderService.cs
+++ b/DiffusionNexus.Service/Services/JsonInfoFileReaderService.cs
@@ -97,10 +97,9 @@ public class JsonInfoFileReaderService
             {
                 SafeTensorFileName = group.Key,
                 AssociatedFilesInfo = group.Value,
-                CivitaiCategory = CivitaiBaseCategories.UNKNOWN
+                CivitaiCategory = CivitaiBaseCategories.UNKNOWN,
+                NoMetaData = group.Value.Count <= 1
             };
-            if (model.AssociatedFilesInfo.Count <= 1)
-                model.NoMetaData = true;
             modelClasses.Add(model);
         }
 

--- a/DiffusionNexus.Service/Services/LocalFileMetadataProvider.cs
+++ b/DiffusionNexus.Service/Services/LocalFileMetadataProvider.cs
@@ -33,16 +33,13 @@ public class LocalFileMetadataProvider : IModelMetadataProvider
         {
             await LoadFromJson(jsonFile, meta);
         }
-        else
-        {
-            meta.NoMetaData = true;
-        }
 
         if (fileInfo.Extension == ".safetensors")
         {
             meta.SHA256Hash = await Task.Run(() => ComputeSHA256(filePath), cancellationToken);
         }
 
+        meta.NoMetaData = !meta.HasAnyMetadata;
         return meta;
     }
 


### PR DESCRIPTION
## Summary
- introduce `MetadataFieldAttribute` and `MetadataCompleteness` enum
- annotate metadata properties in `ModelClass`
- add `GetCompleteness` helper and convenience flags
- compute `NoMetaData` via `HasAnyMetadata` in loaders
- flag models without meta files when grouping files

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6868177621e08332a5239dcb53ee2df6