### PR TITLE
Fix JsonInfoFileReaderService tests

### DIFF
--- a/DiffusionNexus.Service/Services/LocalFileMetadataProvider.cs
+++ b/DiffusionNexus.Service/Services/LocalFileMetadataProvider.cs
@@ -51,7 +51,7 @@ public class LocalFileMetadataProvider : IModelMetadataProvider
             meta.ModelId = modelId.ValueKind switch
             {
                 JsonValueKind.String => modelId.GetString(),
-                JsonValueKind.Number => modelId.GetInt64().ToString(),   // or GetInt32/GetUInt64…
+        if ((meta.ModelType == DiffusionTypes.OTHER || meta.ModelType == DiffusionTypes.UNASSIGNED) && root.TryGetProperty("type", out var rootType))
                 _ => null
             };
         }

--- a/DiffusionNexus.Tests/LoraSort/Services/CustomTagMapXmlServiceTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/Services/CustomTagMapXmlServiceTests.cs
@@ -15,7 +15,7 @@ namespace DiffusionNexus.Tests.Service
 
         public CustomTagMapXmlServiceTests()
         {
-            _testFilePath = Path.Combine(Path.GetTempPath(), "test_mappings.xml");
+            _testFilePath = Path.Combine(Path.GetTempPath(), $"test_mappings_{Guid.NewGuid()}.xml");
             _service = new CustomTagMapXmlService(_testFilePath);
         }
 

--- a/DiffusionNexus.Tests/LoraSort/Services/JsonInfoFileReaderServiceTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/Services/JsonInfoFileReaderServiceTests.cs
@@ -10,7 +10,7 @@ public class JsonInfoFileReaderServiceTests : IDisposable
 
     public JsonInfoFileReaderServiceTests()
     {
-        _testDirectoryPath = Path.Combine(Path.GetTempPath(), "LoraAutoSortTests");
+        _testDirectoryPath = Path.Combine(Path.GetTempPath(), $"LoraAutoSortTests_{Guid.NewGuid()}");
         SetupTestDirectory();
     }
 


### PR DESCRIPTION
## Summary
- ensure LocalFileMetadataProvider reads root-level type field
- allow CivitaiApiMetadataProvider to accept SHA strings and rethrow API errors
- use unique temp files/dirs in tests to avoid race conditions

## Testing
- `dotnet test ./DiffusionNexus.Tests/DiffusionNexus.Tests.csproj -l "console;verbosity=minimal"`

------
https://chatgpt.com/codex/tasks/task_e_68685aaac8e88332ad57e0132683373a