### PR TITLE
Add empty folder cleanup option

### DIFF
--- a/DiffusionNexus.Service/Classes/SelectedOptions.cs
+++ b/DiffusionNexus.Service/Classes/SelectedOptions.cs
@@ -8,6 +8,7 @@
         public bool OverrideFiles { get; set; }
         public bool CreateBaseFolders { get; set; }
         public bool UseCustomMappings { get; set; }
+        public bool DeleteEmptySourceFolders { get; set; }
         /// <summary>
         /// Optional Civitai API key used for authenticated requests.
         /// Leave empty to perform anonymous requests.

--- a/DiffusionNexus.Service/Services/FileControllerService.cs
+++ b/DiffusionNexus.Service/Services/FileControllerService.cs
@@ -135,5 +135,22 @@ namespace DiffusionNexus.Service.Services
                 }
             }
         }
+
+        private static void DeleteEmptyDirectories(string path)
+        {
+            foreach (var directory in Directory.GetDirectories(path))
+            {
+                DeleteEmptyDirectories(directory);
+                if (!Directory.EnumerateFileSystemEntries(directory).Any())
+                {
+                    Directory.Delete(directory);
+                }
+            }
+        }
+
+        public Task DeleteEmptyDirectoriesAsync(string path)
+        {
+            return Task.Run(() => DeleteEmptyDirectories(path));
+        }
     }
 }

--- a/DiffusionNexus.Tests/Service/Services/FileControllerServiceTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/FileControllerServiceTests.cs
@@ -30,4 +30,23 @@ public class FileControllerServiceTests
             File.Delete(tempFile);
         }
     }
+
+    [Fact]
+    public async Task DeleteEmptyDirectoriesAsync_RemovesEmptyDirs()
+    {
+        var svc = new FileControllerService();
+        var basePath = Path.Combine(Path.GetTempPath(), "DeleteEmptyTest");
+        var emptyDir = Path.Combine(basePath, "empty");
+        var nonEmptyDir = Path.Combine(basePath, "nonempty");
+        Directory.CreateDirectory(emptyDir);
+        Directory.CreateDirectory(nonEmptyDir);
+        File.WriteAllText(Path.Combine(nonEmptyDir, "file.txt"), "content");
+
+        await svc.DeleteEmptyDirectoriesAsync(basePath);
+
+        Directory.Exists(emptyDir).Should().BeFalse();
+        Directory.Exists(nonEmptyDir).Should().BeTrue();
+
+        Directory.Delete(basePath, true);
+    }
 }

--- a/DiffusionNexus.UI/Classes/SettingsModel.cs
+++ b/DiffusionNexus.UI/Classes/SettingsModel.cs
@@ -11,6 +11,7 @@ namespace DiffusionNexus.UI.Classes
         [ObservableProperty] private string? _loraSortSourcePath;
         [ObservableProperty] private string? _loraSortTargetPath;
         [ObservableProperty] private string? _loraHelperFolderPath;
+        [ObservableProperty] private bool _deleteEmptySourceFolders;
 
         [JsonIgnore]
         public string? CivitaiApiKey { get; set; }

--- a/DiffusionNexus.UI/ViewModels/LoraSortMainSettingsViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraSortMainSettingsViewModel.cs
@@ -30,6 +30,8 @@ namespace DiffusionNexus.UI.ViewModels
         [ObservableProperty]
         private bool createBaseFolders = true;
         [ObservableProperty]
+        private bool deleteEmptySourceFolders;
+        [ObservableProperty]
         private bool useCustomMappings;
         [ObservableProperty]
         private double progress;
@@ -107,6 +109,7 @@ namespace DiffusionNexus.UI.ViewModels
             var settings = await _settingsService.LoadAsync();
             BasePath = settings.LoraSortSourcePath;
             TargetPath = settings.LoraSortTargetPath;
+            DeleteEmptySourceFolders = settings.DeleteEmptySourceFolders;
         }
 
         private async Task OnSelectBasePathAsync()
@@ -204,6 +207,7 @@ namespace DiffusionNexus.UI.ViewModels
                     IsMoveOperation = !IsCopyMode,
                     OverrideFiles = OverrideFiles,
                     CreateBaseFolders = CreateBaseFolders,
+                    DeleteEmptySourceFolders = DeleteEmptySourceFolders,
                     UseCustomMappings = UseCustomMappings,
                     ApiKey = settings.CivitaiApiKey ?? string.Empty
                 };
@@ -237,6 +241,11 @@ namespace DiffusionNexus.UI.ViewModels
                 });
 
                 await controllerService.ComputeFolder(progress, _cts.Token, options);
+                if (DeleteEmptySourceFolders)
+                {
+                    Log("Cleaning up empty folders…", LogSeverity.Info);
+                    await controllerService.DeleteEmptyDirectoriesAsync(BasePath!);
+                }
                 Log("Finalising…", LogSeverity.Info);
             }
 

--- a/DiffusionNexus.UI/Views/Controls/LoraSortMainSettingsControl.axaml
+++ b/DiffusionNexus.UI/Views/Controls/LoraSortMainSettingsControl.axaml
@@ -56,6 +56,13 @@
                        FontSize="16"
                        Margin="35,10,0,0"/>
             </StackPanel>
+            <StackPanel Orientation="Horizontal">
+              <CheckBox Name="DeleteEmptySourceCheck"
+                       Content="Delete Empty Source Folders"
+                       IsChecked="{Binding DeleteEmptySourceFolders}"
+                       FontSize="16"
+                       Margin="0,5,0,0"/>
+            </StackPanel>
             <TextBlock Text="Special:"
                       FontWeight="Bold"
                       FontSize="14"


### PR DESCRIPTION
## Summary
- add `DeleteEmptySourceFolders` property to user settings, Lora Sort view model and options
- show new "Delete Empty Source Folders" checkbox in Lora Sort view
- implement directory cleanup in `FileControllerService`
- trigger cleanup after sorting when option is enabled
- cover cleanup logic with a unit test

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6868d89ed08c83329049a0b9669131f8