### PR TITLE
Add log clear feature and combined filter options

### DIFF
--- a/DiffusionNexus.UI/Classes/ILogEventService.cs
+++ b/DiffusionNexus.UI/Classes/ILogEventService.cs
@@ -9,5 +9,6 @@ namespace DiffusionNexus.UI.Classes
         ObservableCollection<LogEntry> Entries { get; }
         LogEntry? LatestEntry { get; }
         void Publish(LogSeverity severity, string message);
+        void Clear();
     }
 }

--- a/DiffusionNexus.UI/Classes/LogEventService.cs
+++ b/DiffusionNexus.UI/Classes/LogEventService.cs
@@ -28,5 +28,11 @@ namespace DiffusionNexus.UI.Classes
             _entries.Add(entry);
             LatestEntry = entry;
         }
+
+        public void Clear()
+        {
+            _entries.Clear();
+            LatestEntry = null;
+        }
     }
 }

--- a/DiffusionNexus.UI/Classes/LogSeverityFilter.cs
+++ b/DiffusionNexus.UI/Classes/LogSeverityFilter.cs
@@ -1,0 +1,17 @@
+using DiffusionNexus.Service.Classes;
+
+namespace DiffusionNexus.UI.Classes
+{
+    public class LogSeverityFilter
+    {
+        public LogSeverityFilter(string name, params LogSeverity[] severities)
+        {
+            Name = name;
+            Severities = severities;
+        }
+
+        public string Name { get; }
+        public LogSeverity[] Severities { get; }
+        public override string ToString() => Name;
+    }
+}

--- a/DiffusionNexus.UI/Views/Controls/LogControl.axaml
+++ b/DiffusionNexus.UI/Views/Controls/LogControl.axaml
@@ -30,9 +30,9 @@
                         Orientation="Horizontal"
                         Spacing="10">
                         <ComboBox
-                            Width="100"
+                            Width="120"
                             ItemsSource="{Binding SeverityOptions}"
-                            SelectedItem="{Binding SelectedSeverity, Mode=TwoWay}">
+                            SelectedItem="{Binding SelectedFilter, Mode=TwoWay}">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate>
                                     <TextBlock Text="{Binding Converter={StaticResource NullToAllConverter}}" />
@@ -46,6 +46,10 @@
                         <Button
                             Command="{Binding ExportLogCommand}"
                             Content="Export"
+                            IsEnabled="{Binding HasVisibleEntries}" />
+                        <Button
+                            Command="{Binding ClearLogCommand}"
+                            Content="Clear"
                             IsEnabled="{Binding HasVisibleEntries}" />
                     </StackPanel>
                     


### PR DESCRIPTION
## Summary
- add `LogSeverityFilter` model
- support clearing log entries via `ILogEventService.Clear`
- extend `LogViewModel` with combined severity filters and clear command
- update `LogControl` UI with new Clear button and binding changes

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6868dcce69a08332b0d2e30e7373956a