### PR TITLE
Consolidate metadata helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Automatic log expansion during processing.
 - Added path validation, disk space check and progress reporting.
 - New unit tests for helper methods.
+- Internal refactor consolidating metadata helper methods into `ModelMetadataUtils`.

--- a/DiffusionNexus.Service/Metadata/ModelMetadataUtils.cs
+++ b/DiffusionNexus.Service/Metadata/ModelMetadataUtils.cs
@@ -1,0 +1,73 @@
+using DiffusionNexus.Service.Helper;
+using System.Text.Json;
+
+namespace ModelMover.Core.Metadata;
+
+/// <summary>
+/// Shared helpers for parsing model metadata.
+/// </summary>
+internal static class ModelMetadataUtils
+{
+    /// <summary>
+    /// Parses a comma separated list of tags.
+    /// </summary>
+    /// <param name="rawTagString">String containing tags.</param>
+    /// <returns>Collection of tags without empty entries.</returns>
+    public static IEnumerable<string> ParseTags(string rawTagString)
+    {
+        if (string.IsNullOrWhiteSpace(rawTagString))
+            return Array.Empty<string>();
+
+        return rawTagString
+            .Split(',', StringSplitOptions.RemoveEmptyEntries)
+            .Select(t => t.Trim())
+            .Where(t => !string.IsNullOrWhiteSpace(t))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Parses a JSON array of tags.
+    /// </summary>
+    /// <param name="tags">JSON element representing an array.</param>
+    /// <returns>List of tags.</returns>
+    public static List<string> ParseTags(JsonElement tags)
+    {
+        var result = new List<string>();
+        foreach (var t in tags.EnumerateArray())
+        {
+            if (t.ValueKind == JsonValueKind.String)
+            {
+                var s = t.GetString();
+                if (!string.IsNullOrWhiteSpace(s))
+                    result.Add(s);
+            }
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Converts a type token to <see cref="DiffusionTypes"/>.
+    /// </summary>
+    public static DiffusionTypes ParseModelType(string? typeToken)
+    {
+        if (string.IsNullOrWhiteSpace(typeToken))
+            return DiffusionTypes.UNASSIGNED;
+        if (Enum.TryParse(typeToken.Replace(" ", string.Empty), true, out DiffusionTypes dt))
+            return dt;
+        return DiffusionTypes.UNASSIGNED;
+    }
+
+    /// <summary>
+    /// Extracts the base name from a file name removing known extensions.
+    /// </summary>
+    /// <param name="fileName">File name to process.</param>
+    /// <returns>Base name without extension.</returns>
+    public static string ExtractBaseName(string fileName)
+    {
+        var extension = StaticFileTypes.GeneralExtensions
+            .OrderByDescending(e => e.Length)
+            .FirstOrDefault(e => fileName.EndsWith(e, StringComparison.OrdinalIgnoreCase));
+
+        return extension != null ? fileName[..^extension.Length] : fileName;
+    }
+}

--- a/DiffusionNexus.Service/Properties/AssemblyInfo.cs
+++ b/DiffusionNexus.Service/Properties/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("DiffusionNexus.Tests")]

--- a/DiffusionNexus.Service/Services/CivitaiApiMetadataProvider.cs
+++ b/DiffusionNexus.Service/Services/CivitaiApiMetadataProvider.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using ModelMover.Core.Metadata;
 
 namespace DiffusionNexus.Service.Services;
 
@@ -88,35 +89,13 @@ public class CivitaiApiMetadataProvider : IModelMetadataProvider
     private static void ParseModelInfo(JsonElement root, ModelClass modelClass)
     {
         if (root.TryGetProperty("type", out var type))
-            modelClass.ModelType = ParseModelType(type.GetString());
+            modelClass.ModelType = ModelMetadataUtils.ParseModelType(type.GetString());
 
         if (root.TryGetProperty("tags", out var tags))
-            modelClass.Tags = ParseTags(tags);
+            modelClass.Tags = ModelMetadataUtils.ParseTags(tags);
         modelClass.CivitaiCategory = MetaDataUtilService.GetCategoryFromTags(modelClass.Tags);
     }
 
-    private static DiffusionTypes ParseModelType(string? type)
-    {
-        if (string.IsNullOrWhiteSpace(type))
-            return DiffusionTypes.UNASSIGNED;
-        if (Enum.TryParse(type.Replace(" ", string.Empty), true, out DiffusionTypes dt))
-            return dt;
-        return DiffusionTypes.UNASSIGNED;
-    }
 
-    private static List<string> ParseTags(JsonElement tags)
-    {
-        var result = new List<string>();
-        foreach (var t in tags.EnumerateArray())
-        {
-            if (t.ValueKind == JsonValueKind.String)
-            {
-                var s = t.GetString();
-                if (!string.IsNullOrWhiteSpace(s))
-                    result.Add(s);
-            }
-        }
-        return result;
-    }
 }
 

--- a/DiffusionNexus.Service/Services/JsonInfoFileReaderService.cs
+++ b/DiffusionNexus.Service/Services/JsonInfoFileReaderService.cs
@@ -1,6 +1,7 @@
 using DiffusionNexus.Service.Classes;
 using DiffusionNexus.Service.Helper;
 using Serilog;
+using ModelMover.Core.Metadata;
 
 namespace DiffusionNexus.Service.Services;
 
@@ -66,7 +67,7 @@ public class JsonInfoFileReaderService
         foreach (var filePath in files)
         {
             var fileInfo = new FileInfo(filePath);
-            var prefix = ExtractBaseName(fileInfo.Name).ToLower();
+            var prefix = ModelMetadataUtils.ExtractBaseName(fileInfo.Name).ToLower();
 
             if (!fileGroups.ContainsKey(prefix))
             {
@@ -96,18 +97,5 @@ public class JsonInfoFileReaderService
         return modelClasses;
     }
 
-    private static string ExtractBaseName(string fileName)
-    {
-        var extension = StaticFileTypes.GeneralExtensions
-            .OrderByDescending(e => e.Length)
-            .FirstOrDefault(e => fileName.EndsWith(e, StringComparison.OrdinalIgnoreCase));
-
-        if (extension != null)
-        {
-            return fileName.Substring(0, fileName.Length - extension.Length);
-        }
-
-        return fileName;
-    }
 }
 

--- a/DiffusionNexus.Tests/Service/Metadata/ModelMetadataUtilsTests.cs
+++ b/DiffusionNexus.Tests/Service/Metadata/ModelMetadataUtilsTests.cs
@@ -1,0 +1,54 @@
+using ModelMover.Core.Metadata;
+using System.Text.Json;
+using FluentAssertions;
+using Xunit;
+
+namespace DiffusionNexus.Tests.Service.Metadata;
+
+public class ModelMetadataUtilsTests
+{
+    [Fact]
+    public void ParseTags_String_ReturnsTokens()
+    {
+        var result = ModelMetadataUtils.ParseTags("Tag1, tag2,tag3");
+        result.Should().BeEquivalentTo(new[] { "Tag1", "tag2", "tag3" });
+    }
+
+    [Fact]
+    public void ParseTags_String_EmptyReturnsEmpty()
+    {
+        ModelMetadataUtils.ParseTags("").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseTags_JsonElement_ReturnsList()
+    {
+        using var doc = JsonDocument.Parse("[\"a\",\"b\",\"\",\"c\"]");
+        var result = ModelMetadataUtils.ParseTags(doc.RootElement);
+        result.Should().BeEquivalentTo(new[] { "a", "b", "c" });
+    }
+
+    [Fact]
+    public void ParseModelType_ValidToken_IsParsed()
+    {
+        ModelMetadataUtils.ParseModelType("lora").Should().Be(DiffusionTypes.LORA);
+    }
+
+    [Fact]
+    public void ParseModelType_InvalidToken_ReturnsUnassigned()
+    {
+        ModelMetadataUtils.ParseModelType("unknown").Should().Be(DiffusionTypes.UNASSIGNED);
+    }
+
+    [Fact]
+    public void ExtractBaseName_KnownExtension_IsRemoved()
+    {
+        ModelMetadataUtils.ExtractBaseName("model.preview.JPG").Should().Be("model");
+    }
+
+    [Fact]
+    public void ExtractBaseName_UnknownExtension_ReturnsInput()
+    {
+        ModelMetadataUtils.ExtractBaseName("file.unknown").Should().Be("file.unknown");
+    }
+}


### PR DESCRIPTION
## Summary
- centralize metadata helper methods in `ModelMetadataUtils`
- call shared helpers from providers
- expose internals to tests
- add comprehensive tests for `ModelMetadataUtils`
- update changelog

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_686a92e4c00c8332b74db39e45d8f97b