### PR TITLE
Fix startup binding exceptions

### DIFF
--- a/DiffusionNexus.UI/Views/Controls/LoraSortCustomMappingsControl.axaml
+++ b/DiffusionNexus.UI/Views/Controls/LoraSortCustomMappingsControl.axaml
@@ -4,7 +4,8 @@
              xmlns:vm="using:DiffusionNexus.UI.ViewModels"
              xmlns:svc="clr-namespace:DiffusionNexus.Service.Classes;assembly=DiffusionNexus.Service"
              x:Class="DiffusionNexus.UI.Views.Controls.LoraSortCustomMappingsControl"
-             x:DataType="vm:LoraSortCustomMappingsViewModel">
+             x:DataType="vm:LoraSortCustomMappingsViewModel"
+             DataContext="{x:Null}">
     <UserControl.Resources>
         <conv:TagsDisplayConverter x:Key="TagsDisplayConverter" />
         <conv:BooleanNotConverter x:Key="BooleanNotConverter" />

--- a/DiffusionNexus.UI/Views/Controls/LoraSortMainSettingsControl.axaml
+++ b/DiffusionNexus.UI/Views/Controls/LoraSortMainSettingsControl.axaml
@@ -6,7 +6,8 @@
              xmlns:controls="using:DiffusionNexus.UI.Views.Controls"
              mc:Ignorable="d"
              x:Class="DiffusionNexus.UI.Views.Controls.LoraSortMainSettingsControl"
-             x:DataType="vm:LoraSortMainSettingsViewModel">
+             x:DataType="vm:LoraSortMainSettingsViewModel"
+             DataContext="{x:Null}">
   <Grid>
     <ScrollViewer Margin="10" VerticalScrollBarVisibility="Auto">
       <StackPanel>

--- a/DiffusionNexus.UI/Views/Controls/ProcessingOverlayControl.axaml
+++ b/DiffusionNexus.UI/Views/Controls/ProcessingOverlayControl.axaml
@@ -3,7 +3,8 @@
              xmlns:vm="using:DiffusionNexus.UI.ViewModels"
              x:Class="DiffusionNexus.UI.Views.Controls.ProcessingOverlayControl"
              IsHitTestVisible="{Binding IsBusy}"
-             x:DataType="vm:LoraSortMainSettingsViewModel">
+             x:DataType="vm:LoraSortMainSettingsViewModel"
+             DataContext="{x:Null}">
   <Border Background="#80000000">
     <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="10">
       <ProgressBar Width="200" Height="20"


### PR DESCRIPTION
## Summary
- prevent invalid cast when Lora sort controls inherit parent DataContext
- set `DataContext="{x:Null}"` on all Lora sort user controls

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_686b7033a1fc833293aee322bd92c9ef