### PR TITLE
Add toggle for video thumbnail generation

### DIFF
--- a/DiffusionNexus.UI/Classes/SettingsModel.cs
+++ b/DiffusionNexus.UI/Classes/SettingsModel.cs
@@ -12,6 +12,7 @@ namespace DiffusionNexus.UI.Classes
         [ObservableProperty] private string? _loraSortTargetPath;
         [ObservableProperty] private string? _loraHelperFolderPath;
         [ObservableProperty] private bool _deleteEmptySourceFolders;
+        [ObservableProperty] private bool _generateVideoThumbnails = true;
 
         [JsonIgnore]
         public string? CivitaiApiKey { get; set; }

--- a/DiffusionNexus.UI/Classes/ThumbnailSettings.cs
+++ b/DiffusionNexus.UI/Classes/ThumbnailSettings.cs
@@ -7,5 +7,6 @@ namespace DiffusionNexus.UI.Classes
         public static int MaxWidth { get; set; } = 320;
         public static int JpegQuality { get; set; } = 80;
         public static TimeSpan VideoProbePosition { get; set; } = TimeSpan.FromSeconds(0.5);
+        public static bool GenerateVideoThumbnails { get; set; } = true;
     }
 }

--- a/DiffusionNexus.UI/ViewModels/LoraCardViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraCardViewModel.cs
@@ -58,7 +58,7 @@ public partial class LoraCardViewModel : ViewModelBase
         if (path is null || !File.Exists(path))
         {
             var media = GetPreviewMediaPath();
-            if (media is not null)
+            if (media is not null && ThumbnailSettings.GenerateVideoThumbnails)
             {
                 path = await ThumbnailGenerator.GenerateThumbnailAsync(media);
             }

--- a/DiffusionNexus.UI/ViewModels/LoraHelperViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraHelperViewModel.cs
@@ -78,6 +78,7 @@ public partial class LoraHelperViewModel : ViewModelBase
     {
         IsLoading = true;
         var settings = await _settingsService.LoadAsync();
+        ThumbnailSettings.GenerateVideoThumbnails = settings.GenerateVideoThumbnails;
         if (string.IsNullOrWhiteSpace(settings.LoraHelperFolderPath))
         {
             IsLoading = false;

--- a/DiffusionNexus.UI/Views/SettingsView.axaml
+++ b/DiffusionNexus.UI/Views/SettingsView.axaml
@@ -45,6 +45,9 @@
             <TextBox Text="{Binding Settings.LoraHelperFolderPath, Mode=TwoWay}" Width="350"/>
             <Button Content="Browse..." Command="{Binding BrowseLoraHelperFolderCommand}" CommandParameter="{Binding $parent[UserControl].VisualRoot}" />
           </StackPanel>
+          <CheckBox Content="Automatic thumbnail generation from videos"
+                   IsChecked="{Binding Settings.GenerateVideoThumbnails, Mode=TwoWay}"
+                   Margin="0,5,0,0"/>
         </StackPanel>
       </Expander>
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Thumbnail Generation
 
-DiffusionNexus automatically creates preview thumbnails for LoRA cards. When no static preview image is found but a matching `.gif` or `.mp4` exists, the application generates a WebP thumbnail on first load.
+DiffusionNexus automatically creates preview thumbnails for LoRA cards. When no static preview image is found but a matching `.gif` or `.mp4` exists, the application generates a WebP thumbnail on first load. This behaviour can be disabled in the **Lora Helper** settings.
 
 ### Dependencies
 - **Xabe.FFmpeg** – used to capture snapshots from video files. FFmpeg binaries are downloaded at runtime using `Xabe.FFmpeg.Downloader`.


### PR DESCRIPTION
## Summary
- add `GenerateVideoThumbnails` setting and bind it in Lora Helper settings
- respect the setting when generating thumbnails
- persist user preference in `ThumbnailSettings`
- document setting in README

## Testing
- `dotnet build DiffusionNexus.sln`
- `dotnet test DiffusionNexus.Tests/DiffusionNexus.Tests.csproj --no-build -v diag`

------
https://chatgpt.com/codex/tasks/task_e_686c278f5f448332809da8afded30317