### PR TITLE
Fix nullable warnings in service layer

### DIFF
--- a/DiffusionNexus.Service/Classes/CustomTagMap.cs
+++ b/DiffusionNexus.Service/Classes/CustomTagMap.cs
@@ -9,7 +9,7 @@ namespace DiffusionNexus.Service.Classes
     {
         //this is a list because in theory it should be possible to map multiple tags to a single folder
         public List<string> LookForTag { get; set; } = new List<string>();
-        public string MapToFolder { get; set; }
+        public string MapToFolder { get; set; } = string.Empty;
         public int Priority { get; set; }
     }
 

--- a/DiffusionNexus.Service/Classes/SelectedOptions.cs
+++ b/DiffusionNexus.Service/Classes/SelectedOptions.cs
@@ -2,8 +2,8 @@
 {
     public class SelectedOptions
     {
-        public string BasePath { get; set; }
-        public string TargetPath { get; set; }
+        public string BasePath { get; set; } = string.Empty;
+        public string TargetPath { get; set; } = string.Empty;
         public bool IsMoveOperation { get; set; }
         public bool OverrideFiles { get; set; }
         public bool CreateBaseFolders { get; set; }

--- a/DiffusionNexus.Service/Services/CivitaiMetaDataService.cs
+++ b/DiffusionNexus.Service/Services/CivitaiMetaDataService.cs
@@ -191,7 +191,7 @@ namespace DiffusionNexus.Service.Services
             return DiffusionTypes.UNASSIGNED; // Default if no match is found
         }
 
-        internal string GetModelVersionName(string modelInfoApiResponse)
+        internal string? GetModelVersionName(string modelInfoApiResponse)
         {
             using (JsonDocument doc = JsonDocument.Parse(modelInfoApiResponse))
             {

--- a/DiffusionNexus.Service/Services/CustomTagMapXmlService.cs
+++ b/DiffusionNexus.Service/Services/CustomTagMapXmlService.cs
@@ -51,7 +51,8 @@ namespace DiffusionNexus.Service.Services
                 XmlSerializer serializer = new XmlSerializer(typeof(ObservableCollection<CustomTagMap>));
                 using (StreamReader reader = new StreamReader(_filePath))
                 {
-                    return (ObservableCollection<CustomTagMap>)serializer.Deserialize(reader);
+                    var result = serializer.Deserialize(reader) as ObservableCollection<CustomTagMap>;
+                    return result ?? new ObservableCollection<CustomTagMap>();
                 }
             }
             catch (Exception ex)

--- a/DiffusionNexus.Service/Services/IModelMetadataProvider.cs
+++ b/DiffusionNexus.Service/Services/IModelMetadataProvider.cs
@@ -4,6 +4,6 @@ namespace DiffusionNexus.Service.Services;
 
 public interface IModelMetadataProvider
 {
-    Task<ModelClass> GetModelMetadataAsync(string identifier, CancellationToken cancellationToken = default, ModelClass model = null);
+    Task<ModelClass> GetModelMetadataAsync(string identifier, CancellationToken cancellationToken = default, ModelClass? model = null);
     Task<bool> CanHandleAsync(string identifier, CancellationToken cancellationToken = default);
 }

--- a/DiffusionNexus.Service/Services/LocalFileMetadataProvider.cs
+++ b/DiffusionNexus.Service/Services/LocalFileMetadataProvider.cs
@@ -58,12 +58,12 @@ public class LocalFileMetadataProvider : IModelMetadataProvider
         }
 
         if (root.TryGetProperty("baseModel", out var baseModel))
-            meta.DiffusionBaseModel = baseModel.GetString();
+            meta.DiffusionBaseModel = baseModel.GetString() ?? meta.DiffusionBaseModel;
 
         if (root.TryGetProperty("model", out var model))
         {
             if (model.TryGetProperty("name", out var name))
-                meta.ModelVersionName = name.GetString();
+                meta.ModelVersionName = name.GetString() ?? meta.ModelVersionName;
             if (model.TryGetProperty("type", out var type))
                 meta.ModelType = ModelMetadataUtils.ParseModelType(type.GetString());
             if (model.TryGetProperty("tags", out var tags))


### PR DESCRIPTION
## Summary
- handle potential null strings when loading local metadata
- avoid null assignments when loading from the Civitai API
- return empty list when XML deserialization fails
- initialize selected options and tag mappings with defaults
- allow passing null ModelClass to metadata providers
- update Civitai metadata helper method to return nullable string

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686c3240bf7483328a2db2e42703e152