### PR TITLE
Add Forge style prompt option

### DIFF
--- a/DiffusionNexus.UI/Classes/SettingsModel.cs
+++ b/DiffusionNexus.UI/Classes/SettingsModel.cs
@@ -14,6 +14,7 @@ namespace DiffusionNexus.UI.Classes
         [ObservableProperty] private bool _deleteEmptySourceFolders;
         [ObservableProperty] private bool _generateVideoThumbnails = true;
         [ObservableProperty] private bool _showNsfw;
+        [ObservableProperty] private bool _useForgeStylePrompts = true;
 
         [JsonIgnore]
         public string? CivitaiApiKey { get; set; }

--- a/DiffusionNexus.UI/ViewModels/LoraHelperViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraHelperViewModel.cs
@@ -34,6 +34,7 @@ public partial class LoraHelperViewModel : ViewModelBase
     private bool _isLoadingPage;
     private const int PageSize = 50;
     private readonly LoraMetadataDownloadService _metadataDownloader;
+    private const double ForgePromptStrength = 0.75;
 
     [ObservableProperty]
     private bool showSuggestions;
@@ -387,6 +388,11 @@ public partial class LoraHelperViewModel : ViewModelBase
             try
             {
                 var text = string.Join(", ", card.Model.TrainedWords);
+                if (settings.UseForgeStylePrompts)
+                {
+                    var name = card.Model.SafeTensorFileName;
+                    text = $"<lora:{name}:{ForgePromptStrength}> " + text;
+                }
                 await clipboard.SetTextAsync(text);
                 Log("copied to clipboard", LogSeverity.Success);
             }

--- a/DiffusionNexus.UI/Views/SettingsView.axaml
+++ b/DiffusionNexus.UI/Views/SettingsView.axaml
@@ -51,6 +51,9 @@
           <CheckBox Content="Show NSFW by default"
                    IsChecked="{Binding Settings.ShowNsfw, Mode=TwoWay}"
                    Margin="0,5,0,0"/>
+          <CheckBox Content="A1111/Forge Style prompts"
+                   IsChecked="{Binding Settings.UseForgeStylePrompts, Mode=TwoWay}"
+                   Margin="0,5,0,0"/>
         </StackPanel>
       </Expander>
 


### PR DESCRIPTION
## Summary
- add `UseForgeStylePrompts` setting to model and settings view
- prepend `<lora:name:strength>` when copying trained words if enabled
- default strength constant 0.75

## Testing
- `dotnet test --no-build --logger "console;verbosity=normal"`

------
https://chatgpt.com/codex/tasks/task_e_686f88cc8ec8833292417b28f9afd758