### PR TITLE
Improve metadata download logging

### DIFF
--- a/DiffusionNexus.Service/Classes/MetadataDownloadResult.cs
+++ b/DiffusionNexus.Service/Classes/MetadataDownloadResult.cs
@@ -1,0 +1,11 @@
+namespace DiffusionNexus.Service.Classes;
+
+public enum MetadataDownloadResultType
+{
+    AlreadyExists,
+    Downloaded,
+    NotFound,
+    Error
+}
+
+public record MetadataDownloadResult(MetadataDownloadResultType ResultType, string? ModelId = null, string? ErrorMessage = null);


### PR DESCRIPTION
## Summary
- return more detailed result info from `LoraMetadataDownloadService`
- log how many models need metadata and log results of each request
- hook up new result type in Lora helper view model

## Testing
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6874d1829540833285b2ed69ae8fbe18