### PR TITLE
Add sort mode buttons for LoRA helper

### DIFF
--- a/DiffusionNexus.Tests/LoraSort/ViewModels/LoraHelperSortTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/ViewModels/LoraHelperSortTests.cs
@@ -1,0 +1,94 @@
+using DiffusionNexus.UI.ViewModels;
+using DiffusionNexus.Service.Classes;
+using DiffusionNexus.UI.Classes;
+using System.Collections.Generic;
+using System.IO;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace DiffusionNexus.Tests.LoraSort.ViewModels;
+
+public class LoraHelperSortTests
+{
+    private static LoraHelperViewModel CreateViewModel()
+    {
+        var mock = new Mock<ISettingsService>();
+        mock.Setup(s => s.LoadAsync()).ReturnsAsync(new SettingsModel());
+        mock.Setup(s => s.SaveAsync(It.IsAny<SettingsModel>())).Returns(Task.CompletedTask);
+        return new LoraHelperViewModel(mock.Object);
+    }
+
+    private static LoraCardViewModel CreateCard(string filePath)
+    {
+        var model = new ModelClass
+        {
+            SafeTensorFileName = Path.GetFileNameWithoutExtension(filePath),
+            AssociatedFilesInfo = new List<FileInfo> { new FileInfo(filePath) }
+        };
+        return new LoraCardViewModel { Model = model };
+    }
+
+    [Fact]
+    public void ApplySort_ByName_SortsAlphabetically()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var a = Path.Combine(dir, "a.safetensors");
+            var b = Path.Combine(dir, "b.safetensors");
+            var c = Path.Combine(dir, "c.safetensors");
+            File.WriteAllText(b, string.Empty);
+            File.WriteAllText(a, string.Empty);
+            File.WriteAllText(c, string.Empty);
+
+            var cards = new List<LoraCardViewModel>
+            {
+                CreateCard(b),
+                CreateCard(a),
+                CreateCard(c)
+            };
+
+            var vm = CreateViewModel();
+            vm.SortMode = SortMode.Name;
+            var result = vm.ApplySort(cards).ToList();
+            result.Select(r => r.Model!.SafeTensorFileName).Should().Equal("a", "b", "c");
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void ApplySort_ByCreationDate_NewestFirst()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var oldFile = Path.Combine(dir, "old.safetensors");
+            var newFile = Path.Combine(dir, "new.safetensors");
+            File.WriteAllText(oldFile, string.Empty);
+            File.WriteAllText(newFile, string.Empty);
+            File.SetCreationTime(oldFile, DateTime.Now.AddHours(-1));
+            File.SetCreationTime(newFile, DateTime.Now);
+
+            var cards = new List<LoraCardViewModel>
+            {
+                CreateCard(oldFile),
+                CreateCard(newFile)
+            };
+
+            var vm = CreateViewModel();
+            vm.SortMode = SortMode.CreationDate;
+            var result = vm.ApplySort(cards).ToList();
+            result.First().Model!.SafeTensorFileName.Should().Be("new");
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+}

--- a/DiffusionNexus.UI/ViewModels/SortMode.cs
+++ b/DiffusionNexus.UI/ViewModels/SortMode.cs
@@ -1,0 +1,7 @@
+namespace DiffusionNexus.UI.ViewModels;
+
+public enum SortMode
+{
+    Name,
+    CreationDate
+}

--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml
@@ -23,13 +23,11 @@
                                   IsDropDownOpen="{Binding ShowSuggestions}"                                
                                   Margin="5,0"
                                   MaxDropDownHeight="200"/>
-      <!--<Button Grid.Column="2" Content="ðŸ”" Width="36" Height="36" Margin="5,0,0,0"/>
-        <Button Grid.Column="3" Content="ðŸ§© Find Duplicates" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Width="200"  Height="36" Margin="5,0,0,0"
-                Command="{Binding ScanDuplicatesCommand}"
-                CommandParameter="{Binding $parent[UserControl].VisualRoot}"/>-->
-        <CheckBox Grid.Column="4" Content="Show NSFW" IsChecked="{Binding ShowNsfw}" VerticalAlignment="Center" Margin="5,0"/>
-        <Button Grid.Column="5" Content="🧠 Download Metadata" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Width="200" Height="36" Margin="5,0,0,0"
-                Command="{Binding DownloadMissingMetadataCommand}"/>
+      <Button Grid.Column="2" Content="Sort by Name" Width="120" Height="36" Margin="5,0,0,0" Command="{Binding SortByNameCommand}"/>
+      <Button Grid.Column="3" Content="Sort by Date" Width="120" Height="36" Margin="5,0,0,0" Command="{Binding SortByDateCommand}"/>
+      <CheckBox Grid.Column="4" Content="Show NSFW" IsChecked="{Binding ShowNsfw}" VerticalAlignment="Center" Margin="5,0"/>
+      <Button Grid.Column="5" Content="🧠 Download Metadata" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Width="200" Height="36" Margin="5,0,0,0"
+              Command="{Binding DownloadMissingMetadataCommand}"/>
       </Grid>
     <ScrollViewer Grid.Row="1"
                   HorizontalScrollBarVisibility="Disabled"


### PR DESCRIPTION
## Summary
- allow sorting LoRA cards by name or safetensor creation date
- add two buttons to Lora Helper view to switch sort modes
- expose sort logic with new `SortMode` enum
- add unit tests verifying sorting logic

## Testing
- `dotnet build DiffusionNexus.sln -c Release`
- `dotnet test DiffusionNexus.Tests/DiffusionNexus.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_687d1f891e548332a855c2fdf4fd195b