### PR TITLE
Add support for multiple LoRA helper sources

### DIFF
--- a/DiffusionNexus.UI/Classes/LoraHelperSourceModel.cs
+++ b/DiffusionNexus.UI/Classes/LoraHelperSourceModel.cs
@@ -1,0 +1,12 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace DiffusionNexus.UI.Classes;
+
+public partial class LoraHelperSourceModel : ObservableObject
+{
+    [ObservableProperty]
+    private string _folderPath = string.Empty;
+
+    [ObservableProperty]
+    private bool _isEnabled = true;
+}

--- a/DiffusionNexus.UI/Classes/SettingsModel.cs
+++ b/DiffusionNexus.UI/Classes/SettingsModel.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using System.Collections.ObjectModel;
 using System.Text.Json.Serialization;
 
 namespace DiffusionNexus.UI.Classes
@@ -11,6 +12,7 @@ namespace DiffusionNexus.UI.Classes
         [ObservableProperty] private string? _loraSortSourcePath;
         [ObservableProperty] private string? _loraSortTargetPath;
         [ObservableProperty] private string? _loraHelperFolderPath;
+        [ObservableProperty] private ObservableCollection<LoraHelperSourceModel> _loraHelperSources = new();
         [ObservableProperty] private bool _deleteEmptySourceFolders;
         [ObservableProperty] private bool _generateVideoThumbnails = true;
         [ObservableProperty] private bool _showNsfw;

--- a/DiffusionNexus.UI/Classes/SettingsService.cs
+++ b/DiffusionNexus.UI/Classes/SettingsService.cs
@@ -25,6 +25,15 @@ namespace DiffusionNexus.UI.Classes
             var model = _store.Load<SettingsModel>("settings");
             // Decrypt API key after loading
             model.CivitaiApiKey = SecureStorageHelper.DecryptString(model.EncryptedCivitaiApiKey);
+            if (!string.IsNullOrWhiteSpace(model.LoraHelperFolderPath) && model.LoraHelperSources.Count == 0)
+            {
+                model.LoraHelperSources.Add(new LoraHelperSourceModel
+                {
+                    FolderPath = model.LoraHelperFolderPath,
+                    IsEnabled = true
+                });
+                model.LoraHelperFolderPath = null;
+            }
             return model;
         }
 
@@ -34,6 +43,7 @@ namespace DiffusionNexus.UI.Classes
             settings.EncryptedCivitaiApiKey = string.IsNullOrWhiteSpace(settings.CivitaiApiKey)
                 ? null
                 : SecureStorageHelper.EncryptString(settings.CivitaiApiKey);
+            settings.LoraHelperFolderPath = null;
             _store.Save("settings", settings);
             await Task.CompletedTask;
         }

--- a/DiffusionNexus.UI/ViewModels/SettingsViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/SettingsViewModel.cs
@@ -21,7 +21,9 @@ namespace DiffusionNexus.UI.ViewModels
         public IRelayCommand DeleteApiKeyCommand { get; }
         public IAsyncRelayCommand BrowseLoraSortSourceCommand { get; }
         public IAsyncRelayCommand BrowseLoraSortTargetCommand { get; }
-        public IAsyncRelayCommand BrowseLoraHelperFolderCommand { get; }
+        public IAsyncRelayCommand<LoraHelperSourceModel?> BrowseLoraHelperSourceCommand { get; }
+        public IRelayCommand AddLoraHelperSourceCommand { get; }
+        public IRelayCommand<LoraHelperSourceModel?> RemoveLoraHelperSourceCommand { get; }
 
         private readonly ILogEventService _logEventService;
 
@@ -37,7 +39,9 @@ namespace DiffusionNexus.UI.ViewModels
             DeleteApiKeyCommand = new RelayCommand(DeleteApiKey);
             BrowseLoraSortSourceCommand = new AsyncRelayCommand(BrowseLoraSortSourceAsync);
             BrowseLoraSortTargetCommand = new AsyncRelayCommand(BrowseLoraSortTargetAsync);
-            BrowseLoraHelperFolderCommand = new AsyncRelayCommand(BrowseLoraHelperFolderAsync);
+            BrowseLoraHelperSourceCommand = new AsyncRelayCommand<LoraHelperSourceModel?>(BrowseLoraHelperSourceAsync);
+            AddLoraHelperSourceCommand = new RelayCommand(AddLoraHelperSource);
+            RemoveLoraHelperSourceCommand = new RelayCommand<LoraHelperSourceModel?>(RemoveLoraHelperSource, source => source != null);
             _ = LoadAsync();
         }
 
@@ -80,13 +84,30 @@ namespace DiffusionNexus.UI.ViewModels
                 Settings.LoraSortTargetPath = path;
         }
 
-        private async Task BrowseLoraHelperFolderAsync()
+        private void AddLoraHelperSource()
         {
-            if (_window is null) return;
+            Settings.LoraHelperSources.Add(new LoraHelperSourceModel());
+        }
+
+        private void RemoveLoraHelperSource(LoraHelperSourceModel? source)
+        {
+            if (source is null)
+            {
+                return;
+            }
+
+            Settings.LoraHelperSources.Remove(source);
+        }
+
+        private async Task BrowseLoraHelperSourceAsync(LoraHelperSourceModel? source)
+        {
+            if (_window is null || source is null) return;
             var folders = await _window.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions());
             var path = folders.FirstOrDefault()?.TryGetLocalPath();
             if (!string.IsNullOrEmpty(path))
-                Settings.LoraHelperFolderPath = path;
+            {
+                source.FolderPath = path;
+            }
         }
     }
 }

--- a/DiffusionNexus.UI/Views/SettingsView.axaml
+++ b/DiffusionNexus.UI/Views/SettingsView.axaml
@@ -39,12 +39,26 @@
 
       <Expander Header="Lora Helper" IsExpanded="False" Width="600">
         <StackPanel Spacing="5" Margin="10">
-          <TextBlock Text="Lora Location"/>
-          <StackPanel Orientation="Horizontal" Spacing="5">
-            <TextBlock Text="Folder Path" Width="100"/>
-            <TextBox Text="{Binding Settings.LoraHelperFolderPath, Mode=TwoWay}" Width="350"/>
-            <Button Content="Browse..." Command="{Binding BrowseLoraHelperFolderCommand}" CommandParameter="{Binding $parent[UserControl].VisualRoot}" />
+          <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Center">
+            <TextBlock Text="LoRA Sources" VerticalAlignment="Center"/>
+            <Button Content="+" Width="28" Command="{Binding AddLoraHelperSourceCommand}"/>
           </StackPanel>
+          <ItemsControl ItemsSource="{Binding Settings.LoraHelperSources}">
+            <ItemsControl.ItemTemplate>
+              <DataTemplate>
+                <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Center" Margin="0,2,0,2">
+                  <Button Content="-" Width="28"
+                          Command="{Binding $parent[UserControl].DataContext.RemoveLoraHelperSourceCommand}"
+                          CommandParameter="{Binding}"/>
+                  <CheckBox Content="Enabled" IsChecked="{Binding IsEnabled, Mode=TwoWay}" VerticalAlignment="Center"/>
+                  <TextBox Text="{Binding FolderPath, Mode=TwoWay}" Width="300"/>
+                  <Button Content="Browse..."
+                          Command="{Binding $parent[UserControl].DataContext.BrowseLoraHelperSourceCommand}"
+                          CommandParameter="{Binding}"/>
+                </StackPanel>
+              </DataTemplate>
+            </ItemsControl.ItemTemplate>
+          </ItemsControl>
           <CheckBox Content="Automatic thumbnail generation from videos"
                    IsChecked="{Binding Settings.GenerateVideoThumbnails, Mode=TwoWay}"
                    Margin="0,5,0,0"/>


### PR DESCRIPTION
## Summary
- add a settings model for individual LoRA helper sources and migrate existing single path configurations
- update the settings view and view-model to manage a list of sources with add/remove, browse, and enable toggles
- teach the LoRA helper view-model to load models from all enabled sources and update duplicate scanning defaults

## Testing
- dotnet build DiffusionNexus.sln

------
https://chatgpt.com/codex/tasks/task_e_68e292310ed48332b1815aa813241447