### PR TITLE
Add base model merge option for LoRA helper

### DIFF
--- a/DiffusionNexus.Tests/UI/ViewModels/LoraHelperTreeBuilderTests.cs
+++ b/DiffusionNexus.Tests/UI/ViewModels/LoraHelperTreeBuilderTests.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.Linq;
+using DiffusionNexus.Service.Services;
+using DiffusionNexus.UI.ViewModels;
+using FluentAssertions;
+using Xunit;
+
+namespace DiffusionNexus.Tests.UI.ViewModels;
+
+public class LoraHelperTreeBuilderTests
+{
+    [Fact]
+    public void BuildMergedSegments_UsesBaseModelAndRelativePath()
+    {
+        var sourcePath = "D:/Matrix/Models/My Models";
+        var folderPath = "D:/Matrix/Models/My Models/Flux.1 D/SubFolder";
+
+        var result = LoraHelperTreeBuilder.BuildMergedSegments(sourcePath, folderPath, "Flux.1 D");
+
+        result.Should().Equal(
+            new[]
+            {
+                LoraHelperTreeBuilder.BaseLoraRootName,
+                "Flux.1 D",
+                "SubFolder"
+            });
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("UNKNOWN")]
+    public void BuildMergedSegments_UsesUnknownFolderWhenBaseModelMissing(string? baseModel)
+    {
+        var sourcePath = "E:/Models";
+        var folderPath = "E:/Models/SomeModel";
+
+        var result = LoraHelperTreeBuilder.BuildMergedSegments(sourcePath, folderPath, baseModel);
+
+        result.Should().Equal(
+            new[]
+            {
+                LoraHelperTreeBuilder.BaseLoraRootName,
+                LoraHelperTreeBuilder.UnknownBaseModelFolderName,
+                "SomeModel"
+            });
+    }
+
+    [Fact]
+    public void BuildMergedFolderTree_MergesAndSortsByBaseModel()
+    {
+        var segments = new List<IReadOnlyList<string>>
+        {
+            new[] { LoraHelperTreeBuilder.BaseLoraRootName, "Flux.1 D", "Alpha" },
+            new[] { LoraHelperTreeBuilder.BaseLoraRootName, "Flux.1 D", "Alpha", "Nested" },
+            new[] { LoraHelperTreeBuilder.BaseLoraRootName, "Flux.1 D", "Beta" },
+            new[] { LoraHelperTreeBuilder.BaseLoraRootName, "SDXL", "Sample" }
+        };
+
+        var root = LoraHelperTreeBuilder.BuildMergedFolderTree(segments);
+
+        root.Should().NotBeNull();
+        root!.Name.Should().Be(LoraHelperTreeBuilder.BaseLoraRootName);
+        root.ModelCount.Should().Be(4);
+        root.Children.Select(c => c.Name).Should().Equal("Flux.1 D", "SDXL");
+
+        var fluxNode = root.Children[0];
+        fluxNode.ModelCount.Should().Be(3);
+        fluxNode.Children.Select(c => c.Name).Should().Equal("Alpha", "Beta");
+        fluxNode.Children[0].ModelCount.Should().Be(2);
+        fluxNode.Children[0].Children.Should().ContainSingle()
+            .Which.Name.Should().Be("Nested");
+        fluxNode.Children[0].Children[0].ModelCount.Should().Be(1);
+
+        var sdxlNode = root.Children[1];
+        sdxlNode.ModelCount.Should().Be(1);
+        sdxlNode.Children.Should().ContainSingle()
+            .Which.Name.Should().Be("Sample");
+    }
+}

--- a/DiffusionNexus.UI/Classes/SettingsModel.cs
+++ b/DiffusionNexus.UI/Classes/SettingsModel.cs
@@ -13,6 +13,7 @@ namespace DiffusionNexus.UI.Classes
         [ObservableProperty] private string? _loraSortTargetPath;
         [ObservableProperty] private string? _loraHelperFolderPath;
         [ObservableProperty] private ObservableCollection<LoraHelperSourceModel> _loraHelperSources = new();
+        [ObservableProperty] private bool _mergeLoraHelperSources;
         [ObservableProperty] private bool _deleteEmptySourceFolders;
         [ObservableProperty] private bool _generateVideoThumbnails = true;
         [ObservableProperty] private bool _showNsfw;

--- a/DiffusionNexus.UI/Classes/SettingsService.cs
+++ b/DiffusionNexus.UI/Classes/SettingsService.cs
@@ -39,6 +39,14 @@ namespace DiffusionNexus.UI.Classes
 
         public async Task SaveAsync(SettingsModel settings)
         {
+            for (var i = settings.LoraHelperSources.Count - 1; i >= 0; i--)
+            {
+                if (string.IsNullOrWhiteSpace(settings.LoraHelperSources[i].FolderPath))
+                {
+                    settings.LoraHelperSources.RemoveAt(i);
+                }
+            }
+
             // Encrypt API key before saving
             settings.EncryptedCivitaiApiKey = string.IsNullOrWhiteSpace(settings.CivitaiApiKey)
                 ? null

--- a/DiffusionNexus.UI/ViewModels/LoraCardViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraCardViewModel.cs
@@ -27,6 +27,9 @@ public partial class LoraCardViewModel : ViewModelBase
     [ObservableProperty]
     private string? folderPath;
 
+    [ObservableProperty]
+    private string? treePath;
+
     public IEnumerable<string> DiffusionTypes => Model is null
         ? Array.Empty<string>()
         : new[] { Model.ModelType.ToString() };

--- a/DiffusionNexus.UI/ViewModels/LoraHelperTreeBuilder.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraHelperTreeBuilder.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DiffusionNexus.Service.Services;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+internal static class LoraHelperTreeBuilder
+{
+    internal const string BaseLoraRootName = "Base Loras";
+    internal const string UnknownBaseModelFolderName = "Unknown Base Model";
+
+    private static readonly char[] PathSeparators =
+        { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar, '\\' };
+
+    internal static IReadOnlyList<string> BuildMergedSegments(
+        string sourcePath,
+        string? folderPath,
+        string? baseModel)
+    {
+        var segments = new List<string> { BaseLoraRootName };
+        var normalizedBaseModel = NormalizeBaseModel(baseModel);
+        var baseModelFolder = normalizedBaseModel ?? UnknownBaseModelFolderName;
+        segments.Add(baseModelFolder);
+
+        if (!string.IsNullOrWhiteSpace(folderPath))
+        {
+            var relativeSegments = GetRelativeSegments(sourcePath, folderPath!);
+            if (normalizedBaseModel != null &&
+                relativeSegments.Count > 0 &&
+                string.Equals(relativeSegments[0], normalizedBaseModel, StringComparison.OrdinalIgnoreCase))
+            {
+                relativeSegments.RemoveAt(0);
+            }
+
+            segments.AddRange(relativeSegments);
+        }
+
+        return segments;
+    }
+
+    internal static FolderNode? BuildMergedFolderTree(IEnumerable<IReadOnlyList<string>> entrySegments)
+    {
+        var segmentList = entrySegments
+            .Where(s => s != null && s.Count > 0)
+            .ToList();
+
+        if (segmentList.Count == 0)
+        {
+            return null;
+        }
+
+        var comparer = StringComparer.OrdinalIgnoreCase;
+        var nodes = new Dictionary<string, FolderNode>(comparer);
+
+        FolderNode EnsureNode(string path, string name, string? parentPath)
+        {
+            if (!nodes.TryGetValue(path, out var node))
+            {
+                node = new FolderNode
+                {
+                    Name = name,
+                    FullPath = path,
+                    IsExpanded = parentPath is null || comparer.Equals(parentPath, BaseLoraRootName)
+                };
+                nodes[path] = node;
+
+                if (parentPath != null && nodes.TryGetValue(parentPath, out var parent))
+                {
+                    parent.Children.Add(node);
+                }
+            }
+
+            return node;
+        }
+
+        foreach (var segments in segmentList)
+        {
+            var cumulative = new List<string>(segments.Count);
+            for (var i = 0; i < segments.Count; i++)
+            {
+                cumulative.Add(segments[i]);
+                var path = string.Join(Path.DirectorySeparatorChar, cumulative);
+                var parentPath = i == 0 ? null : string.Join(Path.DirectorySeparatorChar, cumulative.Take(i));
+                var node = EnsureNode(path, segments[i], parentPath);
+                node.ModelCount++;
+            }
+        }
+
+        if (!nodes.TryGetValue(BaseLoraRootName, out var root))
+        {
+            return null;
+        }
+
+        SortChildren(root, comparer);
+        return root;
+    }
+
+    private static void SortChildren(FolderNode node, StringComparer comparer)
+    {
+        node.Children.Sort((a, b) => comparer.Compare(a.Name, b.Name));
+        foreach (var child in node.Children)
+        {
+            SortChildren(child, comparer);
+        }
+    }
+
+    private static string? NormalizeBaseModel(string? baseModel)
+    {
+        if (string.IsNullOrWhiteSpace(baseModel))
+        {
+            return null;
+        }
+
+        var trimmed = baseModel.Trim();
+        return string.Equals(trimmed, "UNKNOWN", StringComparison.OrdinalIgnoreCase)
+            ? null
+            : trimmed;
+    }
+
+    private static List<string> GetRelativeSegments(string sourcePath, string folderPath)
+    {
+        var sourceSegments = SplitSegments(sourcePath);
+        var folderSegments = SplitSegments(folderPath);
+
+        var index = 0;
+        while (index < sourceSegments.Count &&
+               index < folderSegments.Count &&
+               string.Equals(sourceSegments[index], folderSegments[index], StringComparison.OrdinalIgnoreCase))
+        {
+            index++;
+        }
+
+        return folderSegments.Skip(index).ToList();
+    }
+
+    private static List<string> SplitSegments(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return new List<string>();
+        }
+
+        return path
+            .Split(PathSeparators, StringSplitOptions.RemoveEmptyEntries)
+            .ToList();
+    }
+}

--- a/DiffusionNexus.UI/ViewModels/LoraHelperViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraHelperViewModel.cs
@@ -35,9 +35,6 @@ public partial class LoraHelperViewModel : ViewModelBase
     private const int PageSize = 50;
     private readonly LoraMetadataDownloadService _metadataDownloader;
     private const double ForgePromptStrength = 0.75;
-    private static readonly char[] PathSeparators =
-        { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar, '\\' };
-
     [ObservableProperty]
     private bool showSuggestions;
 
@@ -207,7 +204,7 @@ public partial class LoraHelperViewModel : ViewModelBase
             return new CardEntry(model, sourcePath, folder, entryPath, null);
         }
 
-        var segments = BuildMergedSegments(sourcePath, folder, model.DiffusionBaseModel);
+        var segments = LoraHelperTreeBuilder.BuildMergedSegments(sourcePath, folder, model.DiffusionBaseModel);
         if (segments.Count == 0)
         {
             return null;
@@ -217,131 +214,14 @@ public partial class LoraHelperViewModel : ViewModelBase
         return new CardEntry(model, sourcePath, folder, mergedTreePath, segments);
     }
 
-    private static List<string> BuildMergedSegments(string sourcePath, string? folderPath, string? baseModel)
-    {
-        var segments = new List<string> { "Loras" };
-        var normalizedBaseModel = NormalizeBaseModel(baseModel);
-
-        if (!string.IsNullOrWhiteSpace(normalizedBaseModel))
-        {
-            segments.Add(normalizedBaseModel);
-        }
-        else
-        {
-            segments.Add(GetSourceName(sourcePath));
-        }
-
-        if (!string.IsNullOrWhiteSpace(folderPath))
-        {
-            var relativeSegments = GetRelativeSegments(sourcePath, folderPath!);
-            if (!string.IsNullOrWhiteSpace(normalizedBaseModel) && relativeSegments.Count > 0 &&
-                string.Equals(relativeSegments[0], normalizedBaseModel, StringComparison.OrdinalIgnoreCase))
-            {
-                relativeSegments.RemoveAt(0);
-            }
-
-            segments.AddRange(relativeSegments);
-        }
-
-        return segments;
-    }
-
-    private static string NormalizeBaseModel(string? baseModel)
-    {
-        if (string.IsNullOrWhiteSpace(baseModel))
-        {
-            return string.Empty;
-        }
-
-        var trimmed = baseModel.Trim();
-        return string.Equals(trimmed, "UNKNOWN", StringComparison.OrdinalIgnoreCase) ? string.Empty : trimmed;
-    }
-
-    private static string GetSourceName(string sourcePath)
-    {
-        var segments = SplitSegments(sourcePath);
-        return segments.Count == 0 ? sourcePath : segments[^1];
-    }
-
-    private static List<string> GetRelativeSegments(string sourcePath, string folderPath)
-    {
-        var sourceSegments = SplitSegments(sourcePath);
-        var folderSegments = SplitSegments(folderPath);
-
-        var index = 0;
-        while (index < sourceSegments.Count && index < folderSegments.Count &&
-               string.Equals(sourceSegments[index], folderSegments[index], StringComparison.OrdinalIgnoreCase))
-        {
-            index++;
-        }
-
-        return folderSegments.Skip(index).ToList();
-    }
-
-    private static List<string> SplitSegments(string? path)
-    {
-        if (string.IsNullOrWhiteSpace(path))
-        {
-            return new List<string>();
-        }
-
-        return path
-            .Split(PathSeparators, StringSplitOptions.RemoveEmptyEntries)
-            .ToList();
-    }
-
     private static FolderNode? BuildMergedFolderTree(IEnumerable<CardEntry> entries)
     {
-        var entryList = entries.Where(e => e.TreeSegments != null).ToList();
-        if (entryList.Count == 0)
-        {
-            return null;
-        }
+        var segments = entries
+            .Where(e => e.TreeSegments != null)
+            .Select(e => e.TreeSegments!)
+            .ToList();
 
-        var comparer = StringComparer.OrdinalIgnoreCase;
-        var nodes = new Dictionary<string, FolderNode>(comparer);
-
-        FolderNode EnsureNode(string path, string name, string? parentPath)
-        {
-            if (!nodes.TryGetValue(path, out var node))
-            {
-                node = new FolderNode
-                {
-                    Name = name,
-                    FullPath = path,
-                    IsExpanded = parentPath is null || comparer.Equals(parentPath, "Loras")
-                };
-                nodes[path] = node;
-
-                if (parentPath != null && nodes.TryGetValue(parentPath, out var parent))
-                {
-                    parent.Children.Add(node);
-                }
-            }
-
-            return node;
-        }
-
-        foreach (var entry in entryList)
-        {
-            var segments = entry.TreeSegments!;
-            if (segments.Count == 0)
-            {
-                continue;
-            }
-
-            var cumulative = new List<string>();
-            for (var i = 0; i < segments.Count; i++)
-            {
-                cumulative.Add(segments[i]);
-                var path = string.Join(Path.DirectorySeparatorChar, cumulative);
-                var parentPath = i == 0 ? null : string.Join(Path.DirectorySeparatorChar, cumulative.Take(i));
-                var node = EnsureNode(path, segments[i], parentPath);
-                node.ModelCount++;
-            }
-        }
-
-        return nodes.TryGetValue("Loras", out var root) ? root : null;
+        return LoraHelperTreeBuilder.BuildMergedFolderTree(segments);
     }
 
     private sealed record CardEntry(

--- a/DiffusionNexus.UI/Views/SettingsView.axaml
+++ b/DiffusionNexus.UI/Views/SettingsView.axaml
@@ -59,6 +59,9 @@
               </DataTemplate>
             </ItemsControl.ItemTemplate>
           </ItemsControl>
+          <CheckBox Content="Merge LoRA sources by base model"
+                   IsChecked="{Binding Settings.MergeLoraHelperSources, Mode=TwoWay}"
+                   Margin="0,5,0,0"/>
           <CheckBox Content="Automatic thumbnail generation from videos"
                    IsChecked="{Binding Settings.GenerateVideoThumbnails, Mode=TwoWay}"
                    Margin="0,5,0,0"/>

--- a/DiffusionNexus.UI/Views/SettingsView.axaml
+++ b/DiffusionNexus.UI/Views/SettingsView.axaml
@@ -59,7 +59,7 @@
               </DataTemplate>
             </ItemsControl.ItemTemplate>
           </ItemsControl>
-          <CheckBox Content="Merge LoRA sources by base model"
+          <CheckBox Content="Merge LoRA sources by base model (Experimental)"
                    IsChecked="{Binding Settings.MergeLoraHelperSources, Mode=TwoWay}"
                    Margin="0,5,0,0"/>
           <CheckBox Content="Automatic thumbnail generation from videos"


### PR DESCRIPTION
## Summary
- add a merge-by-base-model toggle for the LoRA helper settings UI and model
- prevent saving empty LoRA helper sources and store a tree path on cards for filtering
- merge LoRA helper folder trees across sources when the option is enabled

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68e2fe20775c8332aaca3f7f14392496