### PR TITLE
Add diffusion base model filtering to Lora Helper

### DIFF
--- a/DiffusionNexus.UI/ViewModels/DiffusionModelFilterOptionViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/DiffusionModelFilterOptionViewModel.cs
@@ -1,0 +1,42 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using System;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+public partial class DiffusionModelFilterOptionViewModel : ObservableObject
+{
+    private bool _suppressNotifications;
+
+    public DiffusionModelFilterOptionViewModel(string name)
+    {
+        DisplayName = name;
+    }
+
+    public string DisplayName { get; }
+
+    [ObservableProperty]
+    private bool isSelected;
+
+    internal event EventHandler? SelectionChanged;
+
+    internal void SetIsSelectedSilently(bool value)
+    {
+        try
+        {
+            _suppressNotifications = true;
+            IsSelected = value;
+        }
+        finally
+        {
+            _suppressNotifications = false;
+        }
+    }
+
+    partial void OnIsSelectedChanged(bool value)
+    {
+        if (!_suppressNotifications)
+        {
+            SelectionChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/DiffusionNexus.UI/ViewModels/DiffusionModelFilterViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/DiffusionModelFilterViewModel.cs
@@ -1,0 +1,93 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+public partial class DiffusionModelFilterViewModel : ObservableObject
+{
+    private bool _suppressSelectionNotifications;
+
+    public ObservableCollection<DiffusionModelFilterOptionViewModel> Options { get; } = new();
+
+    public event EventHandler? FiltersChanged;
+
+    public IEnumerable<string> SelectedModels => Options
+        .Where(o => o.IsSelected)
+        .Select(o => o.DisplayName);
+
+    public void SetOptions(IEnumerable<string> modelNames)
+    {
+        var comparer = StringComparer.OrdinalIgnoreCase;
+        var normalized = modelNames
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .Select(name => name.Trim())
+            .Distinct(comparer)
+            .OrderBy(name => name, comparer)
+            .ToList();
+
+        var previousSelections = Options
+            .ToDictionary(o => o.DisplayName, o => o.IsSelected, comparer);
+
+        foreach (var option in Options)
+        {
+            option.SelectionChanged -= OnOptionSelectionChanged;
+        }
+
+        Options.Clear();
+
+        try
+        {
+            _suppressSelectionNotifications = true;
+
+            foreach (var name in normalized)
+            {
+                var option = new DiffusionModelFilterOptionViewModel(name);
+                option.SelectionChanged += OnOptionSelectionChanged;
+
+                if (previousSelections.TryGetValue(name, out var isSelected) && isSelected)
+                {
+                    option.SetIsSelectedSilently(true);
+                }
+
+                Options.Add(option);
+            }
+        }
+        finally
+        {
+            _suppressSelectionNotifications = false;
+        }
+
+        FiltersChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    public void ClearSelection()
+    {
+        bool anyChanged = false;
+        foreach (var option in Options)
+        {
+            if (option.IsSelected)
+            {
+                option.SetIsSelectedSilently(false);
+                anyChanged = true;
+            }
+        }
+
+        if (anyChanged)
+        {
+            FiltersChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    private void OnOptionSelectionChanged(object? sender, EventArgs e)
+    {
+        if (_suppressSelectionNotifications)
+        {
+            return;
+        }
+
+        FiltersChanged?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/DiffusionNexus.UI/Views/Controls/DiffusionModelFilterControl.axaml
+++ b/DiffusionNexus.UI/Views/Controls/DiffusionModelFilterControl.axaml
@@ -1,0 +1,24 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:DiffusionNexus.UI.ViewModels"
+             x:Class="DiffusionNexus.UI.Views.Controls.DiffusionModelFilterControl"
+             x:DataType="vm:DiffusionModelFilterViewModel"
+             MinWidth="200"
+             MaxWidth="320"
+             Padding="12">
+  <StackPanel Spacing="8">
+    <TextBlock Text="Filter by base model" FontWeight="Bold" />
+    <ItemsControl ItemsSource="{Binding Options}">
+      <ItemsControl.ItemTemplate>
+        <DataTemplate x:DataType="vm:DiffusionModelFilterOptionViewModel">
+          <ToggleButton Content="{Binding DisplayName}"
+                        IsChecked="{Binding IsSelected, Mode=TwoWay}"
+                        HorizontalAlignment="Stretch"
+                        Margin="0,2"
+                        Padding="10,6"
+                        Classes="Accent"/>
+        </DataTemplate>
+      </ItemsControl.ItemTemplate>
+    </ItemsControl>
+  </StackPanel>
+</UserControl>

--- a/DiffusionNexus.UI/Views/Controls/DiffusionModelFilterControl.axaml.cs
+++ b/DiffusionNexus.UI/Views/Controls/DiffusionModelFilterControl.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace DiffusionNexus.UI.Views.Controls;
+
+public partial class DiffusionModelFilterControl : UserControl
+{
+    public DiffusionModelFilterControl()
+    {
+        InitializeComponent();
+    }
+}

--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml
@@ -15,7 +15,7 @@
     <conv:BooleanNotConverter x:Key="BooleanNotConverter"/>
   </UserControl.Resources>
   <Grid RowDefinitions="Auto,*" ColumnDefinitions="Auto,*" Margin="10">
-    <Grid Grid.ColumnSpan="2" ColumnDefinitions="Auto,1.5*,Auto,Auto,Auto,Auto,Auto,Auto" Margin="0,0,0,5">
+    <Grid Grid.ColumnSpan="2" ColumnDefinitions="Auto,1.5*,Auto,Auto,Auto,Auto,Auto,Auto,Auto" Margin="0,0,0,5">
       <Button Grid.Column="0" Content="◀️ Reset Filters" Width="120" Height="36" Command="{Binding ResetFiltersCommand}"/>
       <AutoCompleteBox x:Name="SearchBox"
                       Grid.Column="1"
@@ -43,6 +43,20 @@
       <Button Grid.Column="6" Content="🧠 Download Metadata" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Width="200" Height="36" Margin="5,0,0,0"
               Command="{Binding DownloadMissingMetadataCommand}"/>
       <Button Grid.Column="7" Content="🔄 Refresh" Width="120" Height="36" Margin="5,0,0,0" Command="{Binding RefreshCommand}"/>
+      <Button Grid.Column="8"
+              Width="48"
+              Height="36"
+              Margin="5,0,0,0"
+              ToolTip.Tip="Filter by base model">
+        <Button.Content>
+          <PathIcon Data="M3,6H5.55L11,13.5V19L13,21V13.5L18.45,6H21V4H3Z" Width="18" Height="18"/>
+        </Button.Content>
+        <Button.Flyout>
+          <Flyout Placement="BottomEdgeAlignedRight" ShowMode="Transient">
+            <controls:DiffusionModelFilterControl DataContext="{Binding DiffusionModelFilter}"/>
+          </Flyout>
+        </Button.Flyout>
+      </Button>
     </Grid>
     <ScrollViewer Grid.Row="1"
                   HorizontalScrollBarVisibility="Disabled"


### PR DESCRIPTION
## Summary
- introduce dedicated view models to manage diffusion base model filter options and selection events
- integrate the new filter into the Lora Helper view model to combine with existing search, folder, and NSFW filters
- add a flyout-based filter button to the Lora Helper toolbar with toggle buttons for each available base model

## Testing
- dotnet build DiffusionNexus.sln

------
https://chatgpt.com/codex/tasks/task_e_68e36406bf9c8332878613fdefecc4ca