### PR TITLE
Group LoRA variants and add selector

### DIFF
--- a/DiffusionNexus.Tests/LoraSort/Classes/LoraVariantClassifierTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/Classes/LoraVariantClassifierTests.cs
@@ -9,14 +9,26 @@ namespace DiffusionNexus.Tests.LoraSort.Classes;
 public class LoraVariantClassifierTests
 {
     [Theory]
-    [InlineData("wriggling_t2v_high_e100.safetensors", "wrigglingt2ve100", "High")]
-    [InlineData("wriggling_t2v_low_e100.safetensors", "wrigglingt2ve100", "Low")]
+    [InlineData("wriggling_t2v_high_e100.safetensors", "wrigglingt2v", "High")]
+    [InlineData("wriggling_t2v_low_e100.safetensors", "wrigglingt2v", "Low")]
     [InlineData("WANTT2VHIGHNOISEJIGGLE", "wantt2vjiggle", "High")]
     [InlineData("WANTT2VLOWNOISEJIGGLE", "wantt2vjiggle", "Low")]
-    [InlineData("Pump_wan22_e20_high.safetensors", "pumpwan22e20", "High")]
-    [InlineData("Pump_wan22_e20_low.safetensors", "pumpwan22e20", "Low")]
+    [InlineData("Pump_wan22_e20_high.safetensors", "pumpwan22", "High")]
+    [InlineData("Pump_wan22_e20_low.safetensors", "pumpwan22", "Low")]
     [InlineData("scifi_wan_low_30 (1).safetensors", "scifiwan", "Low")]
     [InlineData("scifi_wan_high_30 (1).safetensors", "scifiwan", "High")]
+    [InlineData("wriggling_i2v_high_e010.safetensors", "wrigglingi2v", "High")]
+    [InlineData("wriggling_i2v_low_e020.safetensors", "wrigglingi2v", "Low")]
+    [InlineData("wan22-f4c3spl4sh-100epoc-high-k3nk.safetensors", "wan22f4c3spl4shk3nk", "High")]
+    [InlineData("wan22-f4c3spl4sh-154epoc-low-k3nk.safetensors", "wan22f4c3spl4shk3nk", "Low")]
+    [InlineData("model_HN.safetensors", "model", "High")]
+    [InlineData("model_LN.safetensors", "model", "Low")]
+    [InlineData("WAN-2.2-I2V-BPlay-HIGH-v1.safetensors", "wan22i2vbplay", "High")]
+    [InlineData("WAN-2.2-I2V-BPlay-LOW-v1.safetensors", "wan22i2vbplay", "Low")]
+    [InlineData("Wan2.2 - I2V - King Machine - HIGH 14B.safetensors", "wan22i2vkingmachine", "High")]
+    [InlineData("Wan2.2 - I2V - King Machine - LOW 14B.safetensors", "wan22i2vkingmachine", "Low")]
+    [InlineData("AAG_MuscleMommyH_high_noise.safetensors", "aagmusclemommy", "High")]
+    [InlineData("AAG_MuscleMommyL_low_noise.safetensors", "aagmusclemommy", "Low")]
     public void Classify_ReturnsExpectedNormalizationAndLabel(string fileName, string expectedKey, string expectedLabel)
     {
         var model = new ModelClass

--- a/DiffusionNexus.Tests/LoraSort/Classes/LoraVariantClassifierTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/Classes/LoraVariantClassifierTests.cs
@@ -1,0 +1,33 @@
+using DiffusionNexus.UI.Classes;
+using DiffusionNexus.Service.Classes;
+using FluentAssertions;
+using System.Collections.Generic;
+using System.IO;
+
+namespace DiffusionNexus.Tests.LoraSort.Classes;
+
+public class LoraVariantClassifierTests
+{
+    [Theory]
+    [InlineData("wriggling_t2v_high_e100.safetensors", "wrigglingt2ve100", "High")]
+    [InlineData("wriggling_t2v_low_e100.safetensors", "wrigglingt2ve100", "Low")]
+    [InlineData("WANTT2VHIGHNOISEJIGGLE", "wantt2vjiggle", "High")]
+    [InlineData("WANTT2VLOWNOISEJIGGLE", "wantt2vjiggle", "Low")]
+    [InlineData("Pump_wan22_e20_high.safetensors", "pumpwan22e20", "High")]
+    [InlineData("Pump_wan22_e20_low.safetensors", "pumpwan22e20", "Low")]
+    [InlineData("scifi_wan_low_30 (1).safetensors", "scifiwan", "Low")]
+    [InlineData("scifi_wan_high_30 (1).safetensors", "scifiwan", "High")]
+    public void Classify_ReturnsExpectedNormalizationAndLabel(string fileName, string expectedKey, string expectedLabel)
+    {
+        var model = new ModelClass
+        {
+            SafeTensorFileName = fileName,
+            AssociatedFilesInfo = new List<FileInfo>()
+        };
+
+        var result = LoraVariantClassifier.Classify(model);
+
+        result.NormalizedKey.Should().Be(expectedKey);
+        result.VariantLabel.Should().Be(expectedLabel);
+    }
+}

--- a/DiffusionNexus.Tests/LoraSort/UI/LoraCardViewUiTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/UI/LoraCardViewUiTests.cs
@@ -25,16 +25,19 @@ public class LoraCardViewUiTests
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(DiffusionNexus.UI.App));
         session.Dispatch(() => {
-            var cardVm = new LoraCardViewModel
+            var model = new ModelClass
             {
-                Model = new ModelClass
-                {
-                    SafeTensorFileName = "card",
-                    DiffusionBaseModel = "SD15",
-                    ModelType = DiffusionTypes.LORA,
-                    AssociatedFilesInfo = new List<FileInfo>()
-                }
+                SafeTensorFileName = "card",
+                DiffusionBaseModel = "SD15",
+                ModelType = DiffusionTypes.LORA,
+                AssociatedFilesInfo = new List<FileInfo>()
             };
+
+            var cardVm = new LoraCardViewModel();
+            cardVm.InitializeVariants(new[]
+            {
+                new ModelVariantViewModel(model, LoraVariantClassifier.DefaultVariantLabel)
+            });
 
             var mock = new Mock<ISettingsService>();
             mock.Setup(s => s.LoadAsync()).ReturnsAsync(new SettingsModel());

--- a/DiffusionNexus.Tests/LoraSort/ViewModels/LoraCardViewModelTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/ViewModels/LoraCardViewModelTests.cs
@@ -1,4 +1,5 @@
 using DiffusionNexus.UI.ViewModels;
+using DiffusionNexus.UI.Classes;
 using DiffusionNexus.Service.Classes;
 using System.Collections.Generic;
 using System.IO;
@@ -22,7 +23,11 @@ public class LoraCardViewModelTests
             AssociatedFilesInfo = new List<FileInfo>()
         };
 
-        var vm = new LoraCardViewModel { Model = model };
+        var vm = new LoraCardViewModel();
+        vm.InitializeVariants(new[]
+        {
+            new ModelVariantViewModel(model, LoraVariantClassifier.DefaultVariantLabel)
+        });
 
         vm.DiffusionTypes.Should().ContainSingle();
         vm.DiffusionTypes.Should().Contain("LORA");
@@ -32,7 +37,7 @@ public class LoraCardViewModelTests
     [Fact]
     public void DiffusionProperties_HandleNullModel()
     {
-        var vm = new LoraCardViewModel { Model = null };
+        var vm = new LoraCardViewModel();
 
         vm.DiffusionTypes.Should().BeEmpty();
         vm.DiffusionBaseModel.Should().BeEmpty();

--- a/DiffusionNexus.Tests/LoraSort/ViewModels/LoraHelperFilterTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/ViewModels/LoraHelperFilterTests.cs
@@ -30,7 +30,14 @@ public class LoraHelperFilterTests
             ModelVersionName = versionName ?? fileName,
             AssociatedFilesInfo = new List<FileInfo>()
         };
-        return new LoraCardViewModel { Model = model };
+
+        var card = new LoraCardViewModel();
+        card.InitializeVariants(new[]
+        {
+            new ModelVariantViewModel(model, LoraVariantClassifier.DefaultVariantLabel)
+        });
+
+        return card;
     }
 
     private static List<LoraCardViewModel> InvokeFilter(LoraHelperViewModel vm, string term)
@@ -49,7 +56,7 @@ public class LoraHelperFilterTests
         list.AddRange(cards);
 
         var indexNames = cards
-            .Select(c => $"{c.Model.SafeTensorFileName} {c.Model.ModelVersionName}")
+            .Select(c => c.GetSearchIndexText())
             .ToList();
 
         var indexNamesField = typeof(LoraHelperViewModel)
@@ -75,7 +82,7 @@ public class LoraHelperFilterTests
 
         BuildIndex(vm, cards);
         var result = InvokeFilter(vm, "night");
-        result.Select(c => c.Model.SafeTensorFileName).Should()
+        result.Select(c => c.Model!.SafeTensorFileName).Should()
             .BeEquivalentTo(new[] { "Fright Night", "0403 Halloween Nightmare_v1_pony", "t2v_model" });
     }
 

--- a/DiffusionNexus.Tests/LoraSort/ViewModels/LoraHelperPaginationTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/ViewModels/LoraHelperPaginationTests.cs
@@ -1,0 +1,82 @@
+using DiffusionNexus.UI.ViewModels;
+using DiffusionNexus.Service.Classes;
+using DiffusionNexus.UI.Classes;
+using FluentAssertions;
+using Moq;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace DiffusionNexus.Tests.LoraSort.ViewModels;
+
+public class LoraHelperPaginationTests
+{
+    private static LoraHelperViewModel CreateViewModel()
+    {
+        var mock = new Mock<ISettingsService>();
+        mock.Setup(s => s.LoadAsync()).ReturnsAsync(new SettingsModel());
+        mock.Setup(s => s.SaveAsync(It.IsAny<SettingsModel>())).Returns(Task.CompletedTask);
+        return new LoraHelperViewModel(mock.Object);
+    }
+
+    private static LoraCardViewModel CreateCard(string fileName)
+    {
+        var model = new ModelClass
+        {
+            SafeTensorFileName = fileName,
+            ModelVersionName = fileName,
+            AssociatedFilesInfo = new List<FileInfo>()
+        };
+
+        var card = new LoraCardViewModel();
+        card.InitializeVariants(new[]
+        {
+            new ModelVariantViewModel(model, LoraVariantClassifier.DefaultVariantLabel)
+        });
+
+        return card;
+    }
+
+    [Fact]
+    public void HasMoreCards_ReturnsTrueWhenFilteredExceedsLoaded()
+    {
+        var vm = CreateViewModel();
+        var filteredField = typeof(LoraHelperViewModel)
+            .GetField("_filteredCards", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        var filtered = new List<LoraCardViewModel>
+        {
+            CreateCard("a"),
+            CreateCard("b"),
+        };
+
+        filteredField!.SetValue(vm, filtered);
+
+        vm.Cards.Clear();
+        vm.Cards.Add(filtered[0]);
+
+        vm.HasMoreCards.Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasMoreCards_ReturnsFalseWhenAllCardsLoaded()
+    {
+        var vm = CreateViewModel();
+        var filteredField = typeof(LoraHelperViewModel)
+            .GetField("_filteredCards", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        var filtered = new List<LoraCardViewModel>
+        {
+            CreateCard("a"),
+            CreateCard("b"),
+        };
+
+        filteredField!.SetValue(vm, filtered);
+
+        vm.Cards.Clear();
+        vm.Cards.Add(filtered[0]);
+        vm.Cards.Add(filtered[1]);
+
+        vm.HasMoreCards.Should().BeFalse();
+    }
+}

--- a/DiffusionNexus.Tests/LoraSort/ViewModels/LoraHelperSortTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/ViewModels/LoraHelperSortTests.cs
@@ -26,7 +26,14 @@ public class LoraHelperSortTests
             SafeTensorFileName = Path.GetFileNameWithoutExtension(filePath),
             AssociatedFilesInfo = new List<FileInfo> { new FileInfo(filePath) }
         };
-        return new LoraCardViewModel { Model = model };
+
+        var card = new LoraCardViewModel();
+        card.InitializeVariants(new[]
+        {
+            new ModelVariantViewModel(model, LoraVariantClassifier.DefaultVariantLabel)
+        });
+
+        return card;
     }
 
     [Fact]

--- a/DiffusionNexus.UI/Classes/LoraVariantClassifier.cs
+++ b/DiffusionNexus.UI/Classes/LoraVariantClassifier.cs
@@ -1,0 +1,105 @@
+using DiffusionNexus.Service.Classes;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace DiffusionNexus.UI.Classes;
+
+public static class LoraVariantClassifier
+{
+    public const string DefaultVariantLabel = "Default";
+
+    private static readonly Dictionary<string, string> VariantLabels = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["high"] = "High",
+        ["h"] = "High",
+        ["highnoise"] = "High Noise",
+        ["lownoise"] = "Low Noise",
+        ["low"] = "Low",
+        ["l"] = "Low",
+    };
+
+    private static readonly char[] TokenSeparators =
+    {
+        ' ', '_', '-', '.', '(', ')', '[', ']', '{', '}',
+    };
+
+    public static LoraVariantClassification Classify(ModelClass model)
+    {
+        if (model == null)
+        {
+            return new LoraVariantClassification(string.Empty, DefaultVariantLabel);
+        }
+
+        return Classify(model.SafeTensorFileName);
+    }
+
+    public static LoraVariantClassification Classify(string? safeTensorName)
+    {
+        var baseName = Path.GetFileNameWithoutExtension(safeTensorName ?? string.Empty) ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(baseName))
+        {
+            return new LoraVariantClassification(string.Empty, DefaultVariantLabel);
+        }
+
+        var tokens = baseName
+            .Split(TokenSeparators, StringSplitOptions.RemoveEmptyEntries)
+            .ToList();
+
+        if (tokens.Count == 0)
+        {
+            return new LoraVariantClassification(NormalizeKey(baseName), DefaultVariantLabel);
+        }
+
+        string variantLabel = DefaultVariantLabel;
+        if (TryExtractVariant(tokens, out var label))
+        {
+            variantLabel = label;
+        }
+
+        var normalizedKey = NormalizeKey(tokens);
+        if (string.IsNullOrWhiteSpace(normalizedKey))
+        {
+            normalizedKey = NormalizeKey(baseName);
+        }
+
+        return new LoraVariantClassification(normalizedKey, variantLabel);
+    }
+
+    private static bool TryExtractVariant(List<string> tokens, out string variantLabel)
+    {
+        for (int length = Math.Min(2, tokens.Count); length >= 1; length--)
+        {
+            var candidateTokens = tokens.Skip(tokens.Count - length).Take(length);
+            var normalized = NormalizeKey(candidateTokens);
+            if (VariantLabels.TryGetValue(normalized, out variantLabel!))
+            {
+                tokens.RemoveRange(tokens.Count - length, length);
+                return true;
+            }
+        }
+
+        variantLabel = DefaultVariantLabel;
+        return false;
+    }
+
+    private static string NormalizeKey(IEnumerable<string> tokens)
+    {
+        var joined = string.Join('_', tokens);
+        return NormalizeKey(joined);
+    }
+
+    private static string NormalizeKey(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return string.Empty;
+        }
+
+        var chars = text.Where(char.IsLetterOrDigit).ToArray();
+        return new string(chars).ToLowerInvariant();
+    }
+}
+
+public readonly record struct LoraVariantClassification(string NormalizedKey, string VariantLabel);

--- a/DiffusionNexus.UI/ViewModels/LoraHelperViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraHelperViewModel.cs
@@ -167,27 +167,26 @@ public partial class LoraHelperViewModel : ViewModelBase
                 }
             });
 
+            var groupedCards = cardEntries
+                .GroupBy(CreateGroupKey)
+                .Select(CreateCardFromGroup)
+                .ToList();
+
             await Dispatcher.UIThread.InvokeAsync(() =>
             {
                 _allCards.Clear();
                 Cards.Clear();
             });
 
-            foreach (var entry in cardEntries)
+            foreach (var card in groupedCards)
             {
-                var card = new LoraCardViewModel
-                {
-                    Model = entry.Model,
-                    FolderPath = entry.FolderPath,
-                    TreePath = entry.TreePath,
-                    Parent = this
-                };
+                card.Parent = this;
                 _allCards.Add(card);
             }
 
             await Dispatcher.UIThread.InvokeAsync(() =>
             {
-                DiffusionModelFilter.SetOptions(_allCards.Select(card => card.DiffusionBaseModel));
+                DiffusionModelFilter.SetOptions(_allCards.SelectMany(card => card.GetAllDiffusionBaseModels()));
             });
 
             _filteredCards = _allCards.ToList();
@@ -204,12 +203,18 @@ public partial class LoraHelperViewModel : ViewModelBase
 
     private static CardEntry? CreateCardEntry(ModelClass model, string sourcePath, bool mergeSources)
     {
+        var classification = LoraVariantClassifier.Classify(model);
+        var normalizedKey = EnsureNormalizedKey(model, classification.NormalizedKey);
+        var variantLabel = string.IsNullOrWhiteSpace(classification.VariantLabel)
+            ? LoraVariantClassifier.DefaultVariantLabel
+            : classification.VariantLabel;
+
         var folder = model.AssociatedFilesInfo?.FirstOrDefault()?.DirectoryName;
 
         if (!mergeSources)
         {
             var entryPath = !string.IsNullOrWhiteSpace(folder) ? folder! : sourcePath;
-            return new CardEntry(model, sourcePath, folder, entryPath, null);
+            return new CardEntry(model, sourcePath, folder, entryPath, null, normalizedKey, variantLabel);
         }
 
         var segments = LoraHelperTreeBuilder.BuildMergedSegments(sourcePath, folder, model.DiffusionBaseModel);
@@ -219,7 +224,68 @@ public partial class LoraHelperViewModel : ViewModelBase
         }
 
         var mergedTreePath = string.Join(Path.DirectorySeparatorChar, segments);
-        return new CardEntry(model, sourcePath, folder, mergedTreePath, segments);
+        return new CardEntry(model, sourcePath, folder, mergedTreePath, segments, normalizedKey, variantLabel);
+    }
+
+    private static string EnsureNormalizedKey(ModelClass model, string normalizedKey)
+    {
+        if (!string.IsNullOrWhiteSpace(normalizedKey))
+        {
+            return normalizedKey;
+        }
+
+        var fallback = model.SafeTensorFileName;
+        if (!string.IsNullOrWhiteSpace(fallback))
+        {
+            var alt = LoraVariantClassifier.Classify(fallback).NormalizedKey;
+            if (!string.IsNullOrWhiteSpace(alt))
+            {
+                return alt;
+            }
+        }
+
+        fallback = model.ModelVersionName;
+        if (!string.IsNullOrWhiteSpace(fallback))
+        {
+            var alt = LoraVariantClassifier.Classify(fallback).NormalizedKey;
+            if (!string.IsNullOrWhiteSpace(alt))
+            {
+                return alt;
+            }
+        }
+
+        var baseName = model.SafeTensorFileName ?? model.ModelVersionName ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(baseName))
+        {
+            return Guid.NewGuid().ToString("N");
+        }
+
+        var cleaned = new string(baseName.Where(char.IsLetterOrDigit).ToArray());
+        return string.IsNullOrWhiteSpace(cleaned)
+            ? Guid.NewGuid().ToString("N")
+            : cleaned.ToLowerInvariant();
+    }
+
+    private static string CreateGroupKey(CardEntry entry)
+    {
+        var folder = string.IsNullOrWhiteSpace(entry.FolderPath) ? entry.SourcePath : entry.FolderPath;
+        var folderKey = folder?.ToLowerInvariant() ?? string.Empty;
+        return $"{folderKey}|{entry.NormalizedKey}";
+    }
+
+    private LoraCardViewModel CreateCardFromGroup(IGrouping<string, CardEntry> group)
+    {
+        var primary = group.First();
+        var card = new LoraCardViewModel
+        {
+            FolderPath = primary.FolderPath ?? primary.SourcePath,
+            TreePath = primary.TreePath,
+        };
+
+        var variants = group.Select(entry => new ModelVariantViewModel(entry.Model, entry.VariantLabel));
+        card.InitializeVariants(variants);
+
+        return card;
     }
 
     private static FolderNode? BuildMergedFolderTree(IEnumerable<CardEntry> entries)
@@ -237,7 +303,9 @@ public partial class LoraHelperViewModel : ViewModelBase
         string SourcePath,
         string? FolderPath,
         string TreePath,
-        IReadOnlyList<string>? TreeSegments);
+        IReadOnlyList<string>? TreeSegments,
+        string NormalizedKey,
+        string VariantLabel);
 
     private FolderItemViewModel ConvertFolder(FolderNode node)
     {
@@ -348,16 +416,16 @@ public partial class LoraHelperViewModel : ViewModelBase
                 query = query.Where(c => MatchesSearch(c, search!));
             }
         }
-        Log($"Found: {_allCards.Where(x => x.Model.Nsfw == true).Count()} Nsfw Models", LogSeverity.Info);
+        Log($"Found: {_allCards.Count(x => x.Variants.Any(v => v.Model.Nsfw == true))} Nsfw Models", LogSeverity.Info);
 
         if (!ShowNsfw)
-            query = query.Where(c => c.Model?.Nsfw != true);
+            query = query.Where(c => c.HasAnySafeVariant);
 
         var selectedBaseModels = DiffusionModelFilter.SelectedModels.ToList();
         if (selectedBaseModels.Count > 0)
         {
             var baseModelSet = new HashSet<string>(selectedBaseModels, StringComparer.OrdinalIgnoreCase);
-            query = query.Where(card => baseModelSet.Contains(card.DiffusionBaseModel));
+            query = query.Where(card => card.MatchesBaseModel(baseModelSet));
         }
 
         var sorted = ApplySort(query);
@@ -365,8 +433,7 @@ public partial class LoraHelperViewModel : ViewModelBase
     }
 
     private static bool MatchesSearch(LoraCardViewModel card, string search) =>
-        card.Model.SafeTensorFileName?.Contains(search, StringComparison.OrdinalIgnoreCase) == true ||
-        card.Model.ModelVersionName?.Contains(search, StringComparison.OrdinalIgnoreCase) == true;
+        card.MatchesSearch(search);
 
     public async Task LoadNextPageAsync()
     {
@@ -402,23 +469,15 @@ public partial class LoraHelperViewModel : ViewModelBase
         IEnumerable<LoraCardViewModel> sorted = SortMode switch
         {
             SortMode.Name => SortAscending
-                ? items.OrderBy(c => c.Model?.SafeTensorFileName, StringComparer.OrdinalIgnoreCase)
-                : items.OrderByDescending(c => c.Model?.SafeTensorFileName, StringComparer.OrdinalIgnoreCase),
+                ? items.OrderBy(c => c.SortKey, StringComparer.OrdinalIgnoreCase)
+                : items.OrderByDescending(c => c.SortKey, StringComparer.OrdinalIgnoreCase),
             SortMode.CreationDate => SortAscending
-                ? items.OrderBy(GetCreationDate)
-                : items.OrderByDescending(GetCreationDate),
+                ? items.OrderBy(c => c.NewestCreationDate)
+                : items.OrderByDescending(c => c.NewestCreationDate),
             _ => items
         };
 
         return sorted;
-    }
-
-    internal static DateTime GetCreationDate(LoraCardViewModel card)
-    {
-        var file = card.Model?.AssociatedFilesInfo.FirstOrDefault(f =>
-            f.Extension.Equals(".safetensors", StringComparison.OrdinalIgnoreCase) ||
-            f.Extension.Equals(".pt", StringComparison.OrdinalIgnoreCase));
-        return file?.CreationTime ?? DateTime.MinValue;
     }
 
     /// <summary>
@@ -428,7 +487,7 @@ public partial class LoraHelperViewModel : ViewModelBase
     private void StartIndexing()
     {
         _indexNames = _allCards
-            .Select(c => $"{c.Model.SafeTensorFileName ?? string.Empty} {c.Model.ModelVersionName ?? string.Empty}")
+            .Select(c => c.GetSearchIndexText())
             .ToList();
         var namesCopy = _indexNames.ToList();
         Task.Run(() => _searchIndex.Build(namesCopy));
@@ -484,37 +543,51 @@ public partial class LoraHelperViewModel : ViewModelBase
 
     public async Task DeleteCardAsync(LoraCardViewModel card)
     {
-        if (DialogService == null || card.Model == null)
+        var variant = card.SelectedVariant;
+        if (DialogService == null || variant?.Model == null)
             return;
 
-        var confirm = await DialogService.ShowConfirmationAsync($"Delete '{card.Model.SafeTensorFileName}'?");
+        var confirm = await DialogService.ShowConfirmationAsync($"Delete '{variant.Model.SafeTensorFileName}'?");
         if (confirm != true) return;
 
-        foreach (var file in card.Model.AssociatedFilesInfo)
+        foreach (var file in variant.Model.AssociatedFilesInfo)
         {
             try { File.Delete(file.FullName); } catch { }
         }
 
-        _allCards.Remove(card);
-        Cards.Remove(card);
+        var removed = card.RemoveVariant(variant);
+        if (!removed)
+        {
+            return;
+        }
+
+        if (card.Variants.Count == 0)
+        {
+            _allCards.Remove(card);
+            _filteredCards.Remove(card);
+            Cards.Remove(card);
+        }
+
         StartIndexing();
+        DiffusionModelFilter.SetOptions(_allCards.SelectMany(c => c.GetAllDiffusionBaseModels()));
     }
 
     public async Task OpenWebForCardAsync(LoraCardViewModel card)
     {
-        if (card.Model == null)
+        var model = card.SelectedVariant?.Model;
+        if (model == null)
             return;
 
         var settings = await _settingsService.LoadAsync();
         var apiKey = settings.CivitaiApiKey ?? string.Empty;
         string? id;
-        if (string.IsNullOrWhiteSpace(card.Model.ModelId))
+        if (string.IsNullOrWhiteSpace(model.ModelId))
         {
-            var result = await _metadataDownloader.EnsureMetadataAsync(card.Model, apiKey);
+            var result = await _metadataDownloader.EnsureMetadataAsync(model, apiKey);
             id = result.ModelId;
             if (string.IsNullOrWhiteSpace(id))
             {
-                Log($"Can't open Link. No Id found for {card.Model.ModelVersionName}", LogSeverity.Error);
+                Log($"Can't open Link. No Id found for {model.ModelVersionName}", LogSeverity.Error);
                 return;
 
             }
@@ -522,7 +595,7 @@ public partial class LoraHelperViewModel : ViewModelBase
         else
         {
             // If we already have the ID, just use it
-            id = card.Model.ModelId;
+            id = model.ModelId;
         }
 
         var url = $"https://civitai.com/models/{id}";
@@ -531,16 +604,17 @@ public partial class LoraHelperViewModel : ViewModelBase
 
     public async Task CopyTrainedWordsAsync(LoraCardViewModel card)
     {
-        if (card.Model == null)
+        var model = card.SelectedVariant?.Model;
+        if (model == null)
             return;
 
         var settings = await _settingsService.LoadAsync();
         var apiKey = settings.CivitaiApiKey ?? string.Empty;
-        await _metadataDownloader.EnsureMetadataAsync(card.Model, apiKey);
+        await _metadataDownloader.EnsureMetadataAsync(model, apiKey);
 
-        if (card.Model.TrainedWords.Count == 0 && (!settings.UseForgeStylePrompts))
+        if (model.TrainedWords.Count == 0 && (!settings.UseForgeStylePrompts))
         {
-            Log($"No trained words for {card.Model.ModelVersionName}", LogSeverity.Warning);
+            Log($"No trained words for {model.ModelVersionName}", LogSeverity.Warning);
             return;
         }
 
@@ -549,10 +623,10 @@ public partial class LoraHelperViewModel : ViewModelBase
         {
             try
             {
-                var text = string.Join(", ", card.Model.TrainedWords).TrimEnd();
+                var text = string.Join(", ", model.TrainedWords).TrimEnd();
                 if (settings.UseForgeStylePrompts)
                 {
-                    var name = card.Model.SafeTensorFileName;
+                    var name = model.SafeTensorFileName;
                     text = $"<lora:{name}:{ForgePromptStrength.ToString(System.Globalization.CultureInfo.InvariantCulture)}> " + text;
                 }
                 await clipboard.SetTextAsync(text);
@@ -567,7 +641,7 @@ public partial class LoraHelperViewModel : ViewModelBase
 
     private static IEnumerable<char> GetLoraNameShort(LoraCardViewModel card)
     {
-        string input = card.Model?.ModelVersionName ?? string.Empty;
+        string input = card.SelectedVariant?.Model.ModelVersionName ?? string.Empty;
         if (string.IsNullOrWhiteSpace(input))
             return input;
 
@@ -603,7 +677,8 @@ public partial class LoraHelperViewModel : ViewModelBase
 
     public async Task CopyModelNameAsync(LoraCardViewModel card)
     {
-        if (card.Model == null)
+        var model = card.SelectedVariant?.Model;
+        if (model == null)
             return;
 
         if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop &&
@@ -611,8 +686,8 @@ public partial class LoraHelperViewModel : ViewModelBase
         {
             try
             {
-                var text = card.Model.SafeTensorFileName;
-                await clipboard.SetTextAsync(card.Model.SafeTensorFileName);
+                var text = model.SafeTensorFileName;
+                await clipboard.SetTextAsync(model.SafeTensorFileName);
                 Log($"Filename: {text} copied to clipboard", LogSeverity.Success);
             }
             catch (Exception ex)
@@ -670,27 +745,33 @@ public partial class LoraHelperViewModel : ViewModelBase
             var settings = await _settingsService.LoadAsync();
             var apiKey = settings.CivitaiApiKey ?? string.Empty;
 
-            var missing = _allCards.Where(c => c.Model != null && !c.Model.HasFullMetadata).ToList();
+            var missing = _allCards
+                .SelectMany(card => card.Variants)
+                .Where(variant => variant.Model != null && !variant.Model.HasFullMetadata)
+                .ToList();
+
             Log($"{missing.Count} models missing metadata", LogSeverity.Info);
 
-            foreach (var card in missing)
+            foreach (var variant in missing)
             {
-                if (card.Model == null) continue;
-                Log($"Requesting metadata for {card.Model.ModelVersionName}", LogSeverity.Info);
-                var result = await _metadataDownloader.EnsureMetadataAsync(card.Model, apiKey);
+                var model = variant.Model;
+                if (model == null) continue;
+
+                Log($"Requesting metadata for {model.ModelVersionName}", LogSeverity.Info);
+                var result = await _metadataDownloader.EnsureMetadataAsync(model, apiKey);
                 switch (result.ResultType)
                 {
                     case MetadataDownloadResultType.AlreadyExists:
-                        Log($"{card.Model.ModelVersionName}: already has metadata", LogSeverity.Info);
+                        Log($"{model.ModelVersionName}: already has metadata", LogSeverity.Info);
                         break;
                     case MetadataDownloadResultType.Downloaded:
-                        Log($"{card.Model.ModelVersionName}: metadata downloaded", LogSeverity.Success);
+                        Log($"{model.ModelVersionName}: metadata downloaded", LogSeverity.Success);
                         break;
                     case MetadataDownloadResultType.NotFound:
-                        Log($"{card.Model.ModelVersionName}: not found on Civitai", LogSeverity.Error);
+                        Log($"{model.ModelVersionName}: not found on Civitai", LogSeverity.Error);
                         break;
                     case MetadataDownloadResultType.Error:
-                        Log($"{card.Model.ModelVersionName}: failed to download metadata - {result.ErrorMessage}", LogSeverity.Error);
+                        Log($"{model.ModelVersionName}: failed to download metadata - {result.ErrorMessage}", LogSeverity.Error);
                         break;
                 }
             }

--- a/DiffusionNexus.UI/ViewModels/LoraHelperViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraHelperViewModel.cs
@@ -188,8 +188,17 @@ public partial class LoraHelperViewModel : ViewModelBase
                 DiffusionModelFilter.SetOptions(_allCards.SelectMany(card => card.GetAllDiffusionBaseModels()));
             });
 
-            _filteredCards = _allCards.ToList();
-            await LoadNextPageAsync();
+            var snapshot = _allCards.ToList();
+            await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                _filteredCards = snapshot;
+                Cards.Clear();
+                foreach (var card in snapshot)
+                {
+                    Cards.Add(card);
+                }
+                OnPropertyChanged(nameof(HasMoreCards));
+            });
 
             StartIndexing();
         }
@@ -372,11 +381,14 @@ public partial class LoraHelperViewModel : ViewModelBase
 
             await Dispatcher.UIThread.InvokeAsync(() =>
             {
-                Cards.Clear();
                 _filteredCards = list;
+                Cards.Clear();
+                foreach (var card in list)
+                {
+                    Cards.Add(card);
+                }
+                OnPropertyChanged(nameof(HasMoreCards));
             });
-
-            await LoadNextPageAsync();
         }
         finally
         {
@@ -453,6 +465,7 @@ public partial class LoraHelperViewModel : ViewModelBase
                 {
                     Cards.Add(_filteredCards[i]);
                 }
+                OnPropertyChanged(nameof(HasMoreCards));
             });
         }
         finally

--- a/DiffusionNexus.UI/ViewModels/ModelVariantViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/ModelVariantViewModel.cs
@@ -1,0 +1,49 @@
+using DiffusionNexus.Service.Classes;
+using DiffusionNexus.UI.Classes;
+using System;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+public class ModelVariantViewModel
+{
+    public ModelVariantViewModel(ModelClass model, string variantLabel)
+    {
+        Model = model ?? throw new ArgumentNullException(nameof(model));
+        VariantLabel = string.IsNullOrWhiteSpace(variantLabel)
+            ? LoraVariantClassifier.DefaultVariantLabel
+            : variantLabel;
+    }
+
+    public ModelClass Model { get; }
+
+    public string VariantLabel { get; }
+
+    public bool IsDefaultVariant => string.Equals(
+        VariantLabel,
+        LoraVariantClassifier.DefaultVariantLabel,
+        StringComparison.OrdinalIgnoreCase);
+
+    public string DisplayLabel => VariantLabel;
+
+    public string SearchText
+    {
+        get
+        {
+            var name = Model.SafeTensorFileName ?? string.Empty;
+            var version = Model.ModelVersionName ?? string.Empty;
+            return $"{VariantLabel} {name} {version}".Trim();
+        }
+    }
+
+    public bool MatchesSearch(string search)
+    {
+        if (string.IsNullOrWhiteSpace(search))
+        {
+            return true;
+        }
+
+        return (Model.SafeTensorFileName?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false)
+            || (Model.ModelVersionName?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false)
+            || (!string.IsNullOrWhiteSpace(VariantLabel) && VariantLabel.Contains(search, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml
@@ -101,6 +101,43 @@
                   </StackPanel>
                   <Border VerticalAlignment="Bottom" Background="#66000000" Padding="5">
                     <StackPanel>
+                      <ListBox ItemsSource="{Binding Variants}"
+                               SelectedItem="{Binding SelectedVariant, Mode=TwoWay}"
+                               Margin="0,0,0,4"
+                               Background="Transparent"
+                               BorderBrush="Transparent"
+                               SelectionMode="Single"
+                               IsVisible="{Binding HasMultipleVariants}"
+                               ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                               ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                        <ListBox.Styles>
+                          <Style Selector="ListBoxItem">
+                            <Setter Property="Margin" Value="0,0,4,0"/>
+                            <Setter Property="Padding" Value="8,4"/>
+                            <Setter Property="Background" Value="#33000000"/>
+                            <Setter Property="BorderBrush" Value="#55FFFFFF"/>
+                            <Setter Property="BorderThickness" Value="1"/>
+                            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+                          </Style>
+                          <Style Selector="ListBoxItem:pointerover">
+                            <Setter Property="Background" Value="#55000000"/>
+                          </Style>
+                          <Style Selector="ListBoxItem:selected">
+                            <Setter Property="Background" Value="#AAFFFFFF"/>
+                            <Setter Property="Foreground" Value="Black"/>
+                          </Style>
+                        </ListBox.Styles>
+                        <ListBox.ItemsPanel>
+                          <ItemsPanelTemplate>
+                            <StackPanel Orientation="Horizontal"/>
+                          </ItemsPanelTemplate>
+                        </ListBox.ItemsPanel>
+                        <ListBox.ItemTemplate>
+                          <DataTemplate x:DataType="vm:ModelVariantViewModel">
+                            <TextBlock Text="{Binding DisplayLabel}" FontSize="12" FontWeight="SemiBold"/>
+                          </DataTemplate>
+                        </ListBox.ItemTemplate>
+                      </ListBox>
                       <TextBlock Text="{Binding Model.ModelVersionName}" FontWeight="Bold" Foreground="White" TextWrapping="Wrap"/>
                       <TextBlock Text="{Binding Model.SafeTensorFileName}" FontSize="12" Foreground="#FFCCCCCC" TextWrapping="Wrap"/>
                       <Grid ColumnDefinitions="Auto,*">

--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml.cs
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml.cs
@@ -48,6 +48,11 @@ public partial class LoraHelperView : UserControl
 
         if (DataContext is LoraHelperViewModel vm)
         {
+            if (vm.IsLoading || !vm.HasMoreCards)
+            {
+                return;
+            }
+
             if (_scroll.Offset.Y + _scroll.Viewport.Height > _scroll.Extent.Height - 300)
             {
                 await vm.LoadNextPageAsync();


### PR DESCRIPTION
## Summary
- classify LoRA filenames into normalized keys and variant labels
- group models with shared base keys into cards that expose selectable variants and updated filtering/search logic
- surface a UI list for switching between variants on each LoRA card

## Testing
- dotnet build DiffusionNexus.UI/DiffusionNexus.UI.csproj

------
https://chatgpt.com/codex/tasks/task_e_68e39fcd6fac8332a247b4ba04dec35b