### PR TITLE
Improve variant detection for metadata-based grouping and stabilize pagination

### DIFF
--- a/DiffusionNexus.Tests/LoraSort/Classes/LoraVariantClassifierTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/Classes/LoraVariantClassifierTests.cs
@@ -1,0 +1,125 @@
+using DiffusionNexus.UI.Classes;
+using DiffusionNexus.Service.Classes;
+using FluentAssertions;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace DiffusionNexus.Tests.LoraSort.Classes;
+
+public class LoraVariantClassifierTests
+{
+    [Theory]
+    [InlineData("wriggling_t2v_high_e100.safetensors", "wrigglingt2v", "High")]
+    [InlineData("wriggling_t2v_low_e100.safetensors", "wrigglingt2v", "Low")]
+    [InlineData("WANTT2VHIGHNOISEJIGGLE", "wantt2vjiggle", "High")]
+    [InlineData("WANTT2VLOWNOISEJIGGLE", "wantt2vjiggle", "Low")]
+    [InlineData("Pump_wan22_e20_high.safetensors", "pumpwan22", "High")]
+    [InlineData("Pump_wan22_e20_low.safetensors", "pumpwan22", "Low")]
+    [InlineData("scifi_wan_low_30 (1).safetensors", "scifiwan", "Low")]
+    [InlineData("scifi_wan_high_30 (1).safetensors", "scifiwan", "High")]
+    [InlineData("wriggling_i2v_high_e010.safetensors", "wrigglingi2v", "High")]
+    [InlineData("wriggling_i2v_low_e020.safetensors", "wrigglingi2v", "Low")]
+    [InlineData("wan22-f4c3spl4sh-100epoc-high-k3nk.safetensors", "wan22f4c3spl4shk3nk", "High")]
+    [InlineData("wan22-f4c3spl4sh-154epoc-low-k3nk.safetensors", "wan22f4c3spl4shk3nk", "Low")]
+    [InlineData("model_HN.safetensors", "model", "High")]
+    [InlineData("model_LN.safetensors", "model", "Low")]
+    [InlineData("WAN-2.2-I2V-BPlay-HIGH-v1.safetensors", "wan22i2vbplay", "High")]
+    [InlineData("WAN-2.2-I2V-BPlay-LOW-v1.safetensors", "wan22i2vbplay", "Low")]
+    [InlineData("Wan2.2 - I2V - King Machine - HIGH 14B.safetensors", "wan22i2vkingmachine", "High")]
+    [InlineData("Wan2.2 - I2V - King Machine - LOW 14B.safetensors", "wan22i2vkingmachine", "Low")]
+    [InlineData("AAG_MuscleMommyH_high_noise.safetensors", "aagmusclemommy", "High")]
+    [InlineData("AAG_MuscleMommyL_low_noise.safetensors", "aagmusclemommy", "Low")]
+    [InlineData("wan2.2_highnoise_cshot_v.1.0.safetensors", "wan22cshot", "High")]
+    [InlineData("wan2.2_lownoise_cshot_v1.0.safetensors", "wan22cshot", "Low")]
+    [InlineData("WAN-2.2-T2V-oggy Style-HIGH 14B.safetensors", "wan22t2voggystyle", "High")]
+    [InlineData("WAN-2.2-T2V-oggy Style-LOW 14B.safetensors", "wan22t2voggystyle", "Low")]
+    [InlineData("WAN-2.2-T2V-cial-HIGH 14B.safetensors", "wan22t2vcial", "High")]
+    [InlineData("WAN-2.2-T2V-cial-LOW 14B.safetensors", "wan22t2vcial", "Low")]
+    [InlineData("CassHamadaWan2.2HighNoise.safetensors", "casshamadawan2", "High")]
+    [InlineData("CassHamadaWan2.2HighNoise", "casshamadawan2", "High")]
+    [InlineData("CassHamadaWan2.2LowNoise.safetensors", "casshamadawan2", "Low")]
+    [InlineData("CassHamadaWan2.2LowNoise", "casshamadawan2", "Low")]
+    public void Classify_ReturnsExpectedNormalizationAndLabel(string fileName, string expectedKey, string expectedLabel)
+    {
+        var model = new ModelClass
+        {
+            SafeTensorFileName = fileName,
+            AssociatedFilesInfo = new List<FileInfo>()
+        };
+
+        var result = LoraVariantClassifier.Classify(model);
+
+        result.NormalizedKey.Should().Be(expectedKey);
+        result.VariantLabel.Should().Be(expectedLabel);
+    }
+
+    [Fact]
+    public void Classify_DoesNotMergeDistinctWanDownloads()
+    {
+        var inputs = new[]
+        {
+            "wan2.2_5b_c0wg1rl_72_000002500.safetensors",
+            "wan2.2_5b_cuflation_000003750.safetensors",
+            "wan2.2_5b_rsc_000002500.safetensors",
+            "wan2.1-i2v-480p-rsacp.safetensors",
+            "Wan2.1_i2v_cuinmouth_v1_7epo.safetensors"
+        };
+
+        var keys = inputs
+            .Select(fileName =>
+            {
+                var model = new ModelClass
+                {
+                    SafeTensorFileName = fileName,
+                    AssociatedFilesInfo = new List<FileInfo>()
+                };
+
+                return LoraVariantClassifier.Classify(model).NormalizedKey;
+            })
+            .ToList();
+
+        keys.Should().OnlyHaveUniqueItems();
+    }
+
+    [Fact]
+    public void Classify_FallsBackToModelVersionNameWhenSafeTensorMissing()
+    {
+        var high = new ModelClass
+        {
+            SafeTensorFileName = string.Empty,
+            ModelVersionName = "CassHamadaWan2.2HighNoise",
+            AssociatedFilesInfo = new List<FileInfo>()
+        };
+
+        var low = new ModelClass
+        {
+            SafeTensorFileName = null!,
+            ModelVersionName = "CassHamadaWan2.2LowNoise",
+            AssociatedFilesInfo = new List<FileInfo>()
+        };
+
+        var highResult = LoraVariantClassifier.Classify(high);
+        var lowResult = LoraVariantClassifier.Classify(low);
+
+        highResult.VariantLabel.Should().Be("High");
+        lowResult.VariantLabel.Should().Be("Low");
+        highResult.NormalizedKey.Should().Be(lowResult.NormalizedKey);
+    }
+
+    [Fact]
+    public void Classify_UsesModelVersionVariantWhenFileNameLacksVariant()
+    {
+        var model = new ModelClass
+        {
+            SafeTensorFileName = "wan_cshot_v1.safetensors",
+            ModelVersionName = "wan2.2_highnoise_cshot_v1.0",
+            AssociatedFilesInfo = new List<FileInfo>()
+        };
+
+        var result = LoraVariantClassifier.Classify(model);
+
+        result.NormalizedKey.Should().Be("wancshot");
+        result.VariantLabel.Should().Be("High");
+    }
+}

--- a/DiffusionNexus.Tests/LoraSort/UI/LoraCardViewUiTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/UI/LoraCardViewUiTests.cs
@@ -25,16 +25,19 @@ public class LoraCardViewUiTests
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(DiffusionNexus.UI.App));
         session.Dispatch(() => {
-            var cardVm = new LoraCardViewModel
+            var model = new ModelClass
             {
-                Model = new ModelClass
-                {
-                    SafeTensorFileName = "card",
-                    DiffusionBaseModel = "SD15",
-                    ModelType = DiffusionTypes.LORA,
-                    AssociatedFilesInfo = new List<FileInfo>()
-                }
+                SafeTensorFileName = "card",
+                DiffusionBaseModel = "SD15",
+                ModelType = DiffusionTypes.LORA,
+                AssociatedFilesInfo = new List<FileInfo>()
             };
+
+            var cardVm = new LoraCardViewModel();
+            cardVm.InitializeVariants(new[]
+            {
+                new ModelVariantViewModel(model, LoraVariantClassifier.DefaultVariantLabel)
+            });
 
             var mock = new Mock<ISettingsService>();
             mock.Setup(s => s.LoadAsync()).ReturnsAsync(new SettingsModel());

--- a/DiffusionNexus.Tests/LoraSort/ViewModels/LoraCardViewModelTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/ViewModels/LoraCardViewModelTests.cs
@@ -1,4 +1,5 @@
 using DiffusionNexus.UI.ViewModels;
+using DiffusionNexus.UI.Classes;
 using DiffusionNexus.Service.Classes;
 using System.Collections.Generic;
 using System.IO;
@@ -22,7 +23,11 @@ public class LoraCardViewModelTests
             AssociatedFilesInfo = new List<FileInfo>()
         };
 
-        var vm = new LoraCardViewModel { Model = model };
+        var vm = new LoraCardViewModel();
+        vm.InitializeVariants(new[]
+        {
+            new ModelVariantViewModel(model, LoraVariantClassifier.DefaultVariantLabel)
+        });
 
         vm.DiffusionTypes.Should().ContainSingle();
         vm.DiffusionTypes.Should().Contain("LORA");
@@ -32,7 +37,7 @@ public class LoraCardViewModelTests
     [Fact]
     public void DiffusionProperties_HandleNullModel()
     {
-        var vm = new LoraCardViewModel { Model = null };
+        var vm = new LoraCardViewModel();
 
         vm.DiffusionTypes.Should().BeEmpty();
         vm.DiffusionBaseModel.Should().BeEmpty();

--- a/DiffusionNexus.Tests/LoraSort/ViewModels/LoraHelperFilterTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/ViewModels/LoraHelperFilterTests.cs
@@ -30,7 +30,14 @@ public class LoraHelperFilterTests
             ModelVersionName = versionName ?? fileName,
             AssociatedFilesInfo = new List<FileInfo>()
         };
-        return new LoraCardViewModel { Model = model };
+
+        var card = new LoraCardViewModel();
+        card.InitializeVariants(new[]
+        {
+            new ModelVariantViewModel(model, LoraVariantClassifier.DefaultVariantLabel)
+        });
+
+        return card;
     }
 
     private static List<LoraCardViewModel> InvokeFilter(LoraHelperViewModel vm, string term)
@@ -49,7 +56,7 @@ public class LoraHelperFilterTests
         list.AddRange(cards);
 
         var indexNames = cards
-            .Select(c => $"{c.Model.SafeTensorFileName} {c.Model.ModelVersionName}")
+            .Select(c => c.GetSearchIndexText())
             .ToList();
 
         var indexNamesField = typeof(LoraHelperViewModel)
@@ -75,7 +82,7 @@ public class LoraHelperFilterTests
 
         BuildIndex(vm, cards);
         var result = InvokeFilter(vm, "night");
-        result.Select(c => c.Model.SafeTensorFileName).Should()
+        result.Select(c => c.Model!.SafeTensorFileName).Should()
             .BeEquivalentTo(new[] { "Fright Night", "0403 Halloween Nightmare_v1_pony", "t2v_model" });
     }
 

--- a/DiffusionNexus.Tests/LoraSort/ViewModels/LoraHelperPaginationTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/ViewModels/LoraHelperPaginationTests.cs
@@ -1,0 +1,85 @@
+using DiffusionNexus.UI.ViewModels;
+using DiffusionNexus.Service.Classes;
+using DiffusionNexus.UI.Classes;
+using FluentAssertions;
+using Moq;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace DiffusionNexus.Tests.LoraSort.ViewModels;
+
+public class LoraHelperPaginationTests
+{
+    private static LoraHelperViewModel CreateViewModel()
+    {
+        var mock = new Mock<ISettingsService>();
+        mock.Setup(s => s.LoadAsync()).ReturnsAsync(new SettingsModel());
+        mock.Setup(s => s.SaveAsync(It.IsAny<SettingsModel>())).Returns(Task.CompletedTask);
+        return new LoraHelperViewModel(mock.Object);
+    }
+
+    private static LoraCardViewModel CreateCard(string fileName)
+    {
+        var model = new ModelClass
+        {
+            SafeTensorFileName = fileName,
+            ModelVersionName = fileName,
+            AssociatedFilesInfo = new List<FileInfo>()
+        };
+
+        var card = new LoraCardViewModel();
+        card.InitializeVariants(new[]
+        {
+            new ModelVariantViewModel(model, LoraVariantClassifier.DefaultVariantLabel)
+        });
+
+        return card;
+    }
+
+    [Fact]
+    public void HasMoreCards_ReturnsTrueWhenFilteredExceedsLoaded()
+    {
+        var vm = CreateViewModel();
+        var filteredField = typeof(LoraHelperViewModel)
+            .GetField("_filteredCards", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        var filtered = new List<LoraCardViewModel>
+        {
+            CreateCard("a"),
+            CreateCard("b"),
+        };
+
+        filteredField!.SetValue(vm, filtered);
+
+        var loadedField = typeof(LoraHelperViewModel)
+            .GetField("_loadedCardCount", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        loadedField!.SetValue(vm, 1);
+
+        vm.HasMoreCards.Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasMoreCards_ReturnsFalseWhenAllCardsLoaded()
+    {
+        var vm = CreateViewModel();
+        var filteredField = typeof(LoraHelperViewModel)
+            .GetField("_filteredCards", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        var filtered = new List<LoraCardViewModel>
+        {
+            CreateCard("a"),
+            CreateCard("b"),
+        };
+
+        filteredField!.SetValue(vm, filtered);
+
+        var loadedField = typeof(LoraHelperViewModel)
+            .GetField("_loadedCardCount", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        loadedField!.SetValue(vm, 2);
+
+        vm.HasMoreCards.Should().BeFalse();
+    }
+}

--- a/DiffusionNexus.Tests/LoraSort/ViewModels/LoraHelperSortTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/ViewModels/LoraHelperSortTests.cs
@@ -26,7 +26,14 @@ public class LoraHelperSortTests
             SafeTensorFileName = Path.GetFileNameWithoutExtension(filePath),
             AssociatedFilesInfo = new List<FileInfo> { new FileInfo(filePath) }
         };
-        return new LoraCardViewModel { Model = model };
+
+        var card = new LoraCardViewModel();
+        card.InitializeVariants(new[]
+        {
+            new ModelVariantViewModel(model, LoraVariantClassifier.DefaultVariantLabel)
+        });
+
+        return card;
     }
 
     [Fact]

--- a/DiffusionNexus.UI/Classes/LoraVariantClassifier.cs
+++ b/DiffusionNexus.UI/Classes/LoraVariantClassifier.cs
@@ -1,0 +1,382 @@
+using DiffusionNexus.Service.Classes;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace DiffusionNexus.UI.Classes;
+
+public static class LoraVariantClassifier
+{
+    public const string DefaultVariantLabel = "Default";
+
+    private static readonly string[] KnownExtensions =
+    {
+        ".safetensors",
+        ".pt",
+        ".pth",
+        ".ckpt",
+    };
+
+    private static readonly Dictionary<string, string> VariantLabels = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["highnoise"] = "High",
+        ["high"] = "High",
+        ["h"] = "High",
+        ["hn"] = "High",
+        ["lownoise"] = "Low",
+        ["low"] = "Low",
+        ["l"] = "Low",
+        ["ln"] = "Low",
+    };
+
+    private static readonly string[] VariantKeysByLength = VariantLabels
+        .Keys
+        .OrderByDescending(k => k.Length)
+        .ToArray();
+
+    private static readonly char[] TokenSeparators =
+    {
+        ' ', '_', '-', '.', '(', ')', '[', ']', '{', '}',
+    };
+
+    public static LoraVariantClassification Classify(ModelClass model)
+    {
+        if (model == null)
+        {
+            return new LoraVariantClassification(string.Empty, DefaultVariantLabel);
+        }
+
+        string normalizedKey = string.Empty;
+        string variantLabel = DefaultVariantLabel;
+
+        void Consider(string? candidate)
+        {
+            if (string.IsNullOrWhiteSpace(candidate))
+            {
+                return;
+            }
+
+            var result = Classify(candidate);
+
+            if (string.IsNullOrWhiteSpace(normalizedKey) && !string.IsNullOrWhiteSpace(result.NormalizedKey))
+            {
+                normalizedKey = result.NormalizedKey;
+            }
+
+            if (variantLabel == DefaultVariantLabel && result.VariantLabel != DefaultVariantLabel)
+            {
+                variantLabel = result.VariantLabel;
+            }
+        }
+
+        Consider(model.SafeTensorFileName);
+        Consider(model.ModelVersionName);
+
+        if (string.IsNullOrWhiteSpace(normalizedKey))
+        {
+            normalizedKey = NormalizeKey(model.SafeTensorFileName ?? model.ModelVersionName ?? string.Empty);
+        }
+
+        return new LoraVariantClassification(normalizedKey, variantLabel);
+    }
+
+    public static LoraVariantClassification Classify(string? safeTensorName)
+    {
+        var fileName = Path.GetFileName(safeTensorName ?? string.Empty) ?? string.Empty;
+        var baseName = fileName;
+
+        foreach (var extension in KnownExtensions)
+        {
+            if (!baseName.EndsWith(extension, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            baseName = baseName[..^extension.Length];
+            break;
+        }
+
+        if (string.IsNullOrWhiteSpace(baseName))
+        {
+            return new LoraVariantClassification(string.Empty, DefaultVariantLabel);
+        }
+
+        var tokens = baseName
+            .Split(TokenSeparators, StringSplitOptions.RemoveEmptyEntries)
+            .ToList();
+
+        if (tokens.Count == 0)
+        {
+            return new LoraVariantClassification(NormalizeKey(baseName), DefaultVariantLabel);
+        }
+
+        string variantLabel = DefaultVariantLabel;
+        if (TryExtractVariant(tokens, out var label))
+        {
+            variantLabel = label;
+        }
+
+        StripEmbeddedVariantTokens(tokens, ref variantLabel);
+
+        if (variantLabel == DefaultVariantLabel && TryExtractVariantFromCombined(baseName, out var combinedLabel, out var combinedKey))
+        {
+            variantLabel = combinedLabel;
+            if (!string.IsNullOrWhiteSpace(combinedKey))
+            {
+                return new LoraVariantClassification(combinedKey, variantLabel);
+            }
+        }
+
+        RemoveVersionTokens(tokens);
+
+        var normalizedKey = NormalizeKey(tokens);
+        if (string.IsNullOrWhiteSpace(normalizedKey))
+        {
+            normalizedKey = NormalizeKey(baseName);
+        }
+
+        return new LoraVariantClassification(normalizedKey, variantLabel);
+    }
+
+    private static void StripEmbeddedVariantTokens(List<string> tokens, ref string variantLabel)
+    {
+        for (int i = tokens.Count - 1; i >= 0; i--)
+        {
+            var token = tokens[i];
+            if (TryStripVariantSuffix(token, out var stripped, out var suffixLabel))
+            {
+                if (string.IsNullOrWhiteSpace(stripped))
+                {
+                    tokens.RemoveAt(i);
+                }
+                else
+                {
+                    tokens[i] = stripped;
+                }
+
+                if (variantLabel == DefaultVariantLabel && suffixLabel != DefaultVariantLabel)
+                {
+                    variantLabel = suffixLabel;
+                }
+            }
+        }
+    }
+
+    private static bool TryStripVariantSuffix(string token, out string strippedToken, out string variantLabel)
+    {
+        strippedToken = token;
+        variantLabel = DefaultVariantLabel;
+
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return false;
+        }
+
+        foreach (var variantKey in VariantKeysByLength)
+        {
+            if (token.Length <= variantKey.Length)
+            {
+                continue;
+            }
+
+            if (!token.EndsWith(variantKey, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (!TryGetVariantLabel(variantKey, out var label))
+            {
+                continue;
+            }
+
+            var suffix = token.Substring(token.Length - variantKey.Length, variantKey.Length);
+            if (!suffix.Any(char.IsUpper))
+            {
+                continue;
+            }
+
+            strippedToken = token[..^variantKey.Length];
+            variantLabel = label;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static void RemoveVersionTokens(List<string> tokens)
+    {
+        var removedVersionSuffix = false;
+
+        for (int i = tokens.Count - 1; i >= 0; i--)
+        {
+            if (!IsVersionToken(tokens, i))
+            {
+                continue;
+            }
+
+            var token = tokens[i];
+            if (!removedVersionSuffix && token.Any(char.IsDigit))
+            {
+                removedVersionSuffix = true;
+            }
+
+            tokens.RemoveAt(i);
+        }
+
+        if (!removedVersionSuffix)
+        {
+            return;
+        }
+
+        while (tokens.Count > 0 && IsVersionPrefixToken(tokens[^1]))
+        {
+            tokens.RemoveAt(tokens.Count - 1);
+        }
+    }
+
+    private static bool IsVersionToken(List<string> tokens, int index)
+    {
+        var token = tokens[index];
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return true;
+        }
+
+        token = token.Trim();
+        var lower = token.ToLowerInvariant();
+
+        if (lower.All(char.IsDigit))
+        {
+            return index >= tokens.Count - 1;
+        }
+
+        if (lower.StartsWith('v') && lower.Length > 1 && lower[1..].All(char.IsDigit))
+        {
+            return true;
+        }
+
+        if (lower.StartsWith('e') && lower.Length > 1 && lower[1..].All(char.IsDigit))
+        {
+            return true;
+        }
+
+        if (lower.Contains("epoc") || lower.Contains("epoch") || lower.Contains("iter") || lower.Contains("step"))
+        {
+            return true;
+        }
+
+        if (lower.EndsWith('b') && lower[..^1].All(char.IsDigit))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsVersionPrefixToken(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return false;
+        }
+
+        var lower = token.ToLowerInvariant();
+        return lower is "v" or "ver" or "vers" or "version";
+    }
+
+    private static bool TryExtractVariant(List<string> tokens, out string variantLabel)
+    {
+        for (int length = Math.Min(3, tokens.Count); length >= 1; length--)
+        {
+            for (int start = tokens.Count - length; start >= 0; start--)
+            {
+                var candidateTokens = tokens.Skip(start).Take(length);
+                var normalized = NormalizeKey(candidateTokens);
+                if (TryGetVariantLabel(normalized, out variantLabel!))
+                {
+                    tokens.RemoveRange(start, length);
+                    return true;
+                }
+            }
+        }
+
+        variantLabel = DefaultVariantLabel;
+        return false;
+    }
+
+    private static bool TryExtractVariantFromCombined(
+        string baseName,
+        out string variantLabel,
+        out string normalizedKey)
+    {
+        var normalized = NormalizeKey(baseName);
+        foreach (var variantKey in VariantKeysByLength)
+        {
+            if (variantKey.IndexOf("noise", StringComparison.OrdinalIgnoreCase) < 0)
+            {
+                continue;
+            }
+
+            var index = normalized.LastIndexOf(variantKey, StringComparison.Ordinal);
+            if (index < 0)
+            {
+                continue;
+            }
+
+            if (!TryGetVariantLabel(variantKey, out variantLabel!))
+            {
+                continue;
+            }
+
+            var trimmed = normalized.Remove(index, variantKey.Length);
+            normalizedKey = string.IsNullOrWhiteSpace(trimmed) ? normalized : trimmed;
+            return true;
+        }
+
+        variantLabel = DefaultVariantLabel;
+        normalizedKey = normalized;
+        return false;
+    }
+
+    private static bool TryGetVariantLabel(string candidate, out string variantLabel)
+    {
+        if (VariantLabels.TryGetValue(candidate, out variantLabel!))
+        {
+            return true;
+        }
+
+        var trimmed = candidate;
+        while (trimmed.Length > 0 && char.IsDigit(trimmed[^1]))
+        {
+            trimmed = trimmed[..^1];
+        }
+
+        if (trimmed.Length != candidate.Length && trimmed.Length > 0)
+        {
+            return VariantLabels.TryGetValue(trimmed, out variantLabel!);
+        }
+
+        variantLabel = DefaultVariantLabel;
+        return false;
+    }
+
+    private static string NormalizeKey(IEnumerable<string> tokens)
+    {
+        var joined = string.Join('_', tokens);
+        return NormalizeKey(joined);
+    }
+
+    private static string NormalizeKey(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return string.Empty;
+        }
+
+        var chars = text.Where(char.IsLetterOrDigit).ToArray();
+        return new string(chars).ToLowerInvariant();
+    }
+}
+
+public readonly record struct LoraVariantClassification(string NormalizedKey, string VariantLabel);

--- a/DiffusionNexus.UI/ViewModels/ModelVariantViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/ModelVariantViewModel.cs
@@ -1,0 +1,49 @@
+using DiffusionNexus.Service.Classes;
+using DiffusionNexus.UI.Classes;
+using System;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+public class ModelVariantViewModel
+{
+    public ModelVariantViewModel(ModelClass model, string variantLabel)
+    {
+        Model = model ?? throw new ArgumentNullException(nameof(model));
+        VariantLabel = string.IsNullOrWhiteSpace(variantLabel)
+            ? LoraVariantClassifier.DefaultVariantLabel
+            : variantLabel;
+    }
+
+    public ModelClass Model { get; }
+
+    public string VariantLabel { get; }
+
+    public bool IsDefaultVariant => string.Equals(
+        VariantLabel,
+        LoraVariantClassifier.DefaultVariantLabel,
+        StringComparison.OrdinalIgnoreCase);
+
+    public string DisplayLabel => VariantLabel;
+
+    public string SearchText
+    {
+        get
+        {
+            var name = Model.SafeTensorFileName ?? string.Empty;
+            var version = Model.ModelVersionName ?? string.Empty;
+            return $"{VariantLabel} {name} {version}".Trim();
+        }
+    }
+
+    public bool MatchesSearch(string search)
+    {
+        if (string.IsNullOrWhiteSpace(search))
+        {
+            return true;
+        }
+
+        return (Model.SafeTensorFileName?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false)
+            || (Model.ModelVersionName?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false)
+            || (!string.IsNullOrWhiteSpace(VariantLabel) && VariantLabel.Contains(search, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml
@@ -101,6 +101,43 @@
                   </StackPanel>
                   <Border VerticalAlignment="Bottom" Background="#66000000" Padding="5">
                     <StackPanel>
+                      <ListBox ItemsSource="{Binding Variants}"
+                               SelectedItem="{Binding SelectedVariant, Mode=TwoWay}"
+                               Margin="0,0,0,4"
+                               Background="Transparent"
+                               BorderBrush="Transparent"
+                               SelectionMode="Single"
+                               IsVisible="{Binding HasMultipleVariants}"
+                               ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                               ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                        <ListBox.Styles>
+                          <Style Selector="ListBoxItem">
+                            <Setter Property="Margin" Value="0,0,4,0"/>
+                            <Setter Property="Padding" Value="8,4"/>
+                            <Setter Property="Background" Value="#33000000"/>
+                            <Setter Property="BorderBrush" Value="#55FFFFFF"/>
+                            <Setter Property="BorderThickness" Value="1"/>
+                            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+                          </Style>
+                          <Style Selector="ListBoxItem:pointerover">
+                            <Setter Property="Background" Value="#55000000"/>
+                          </Style>
+                          <Style Selector="ListBoxItem:selected">
+                            <Setter Property="Background" Value="#AAFFFFFF"/>
+                            <Setter Property="Foreground" Value="Black"/>
+                          </Style>
+                        </ListBox.Styles>
+                        <ListBox.ItemsPanel>
+                          <ItemsPanelTemplate>
+                            <StackPanel Orientation="Horizontal"/>
+                          </ItemsPanelTemplate>
+                        </ListBox.ItemsPanel>
+                        <ListBox.ItemTemplate>
+                          <DataTemplate x:DataType="vm:ModelVariantViewModel">
+                            <TextBlock Text="{Binding DisplayLabel}" FontSize="12" FontWeight="SemiBold"/>
+                          </DataTemplate>
+                        </ListBox.ItemTemplate>
+                      </ListBox>
                       <TextBlock Text="{Binding Model.ModelVersionName}" FontWeight="Bold" Foreground="White" TextWrapping="Wrap"/>
                       <TextBlock Text="{Binding Model.SafeTensorFileName}" FontSize="12" Foreground="#FFCCCCCC" TextWrapping="Wrap"/>
                       <Grid ColumnDefinitions="Auto,*">

--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml.cs
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml.cs
@@ -48,6 +48,11 @@ public partial class LoraHelperView : UserControl
 
         if (DataContext is LoraHelperViewModel vm)
         {
+            if (vm.IsLoading || !vm.HasMoreCards)
+            {
+                return;
+            }
+
             if (_scroll.Offset.Y + _scroll.Viewport.Height > _scroll.Extent.Height - 300)
             {
                 await vm.LoadNextPageAsync();


### PR DESCRIPTION
## Summary
- update the LoRA variant classifier to strip only known model extensions and reuse model metadata when the safe tensor filename is missing, ensuring normalized keys stay aligned while variant labels propagate from alternate sources
- extend the classifier test suite with extensionless filenames and metadata fallback scenarios so high/low variants continue to group correctly
- track filtered pagination state and batch-add cards so long folders no longer trigger scroll resets or infinite reloads while browsing grouped LoRAs
- refresh the pagination unit tests to cover the new loaded-card tracking logic

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68e39fcd6fac8332a247b4ba04dec35b