### PR TITLE
Stabilize LoRA card updates

### DIFF
--- a/DiffusionNexus.Tests/LoraSort/Classes/LoraVariantClassifierTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/Classes/LoraVariantClassifierTests.cs
@@ -1,0 +1,125 @@
+using DiffusionNexus.UI.Classes;
+using DiffusionNexus.Service.Classes;
+using FluentAssertions;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace DiffusionNexus.Tests.LoraSort.Classes;
+
+public class LoraVariantClassifierTests
+{
+    [Theory]
+    [InlineData("wriggling_t2v_high_e100.safetensors", "wrigglingt2v", "High")]
+    [InlineData("wriggling_t2v_low_e100.safetensors", "wrigglingt2v", "Low")]
+    [InlineData("WANTT2VHIGHNOISEJIGGLE", "wantt2vjiggle", "High")]
+    [InlineData("WANTT2VLOWNOISEJIGGLE", "wantt2vjiggle", "Low")]
+    [InlineData("Pump_wan22_e20_high.safetensors", "pumpwan22", "High")]
+    [InlineData("Pump_wan22_e20_low.safetensors", "pumpwan22", "Low")]
+    [InlineData("scifi_wan_low_30 (1).safetensors", "scifiwan", "Low")]
+    [InlineData("scifi_wan_high_30 (1).safetensors", "scifiwan", "High")]
+    [InlineData("wriggling_i2v_high_e010.safetensors", "wrigglingi2v", "High")]
+    [InlineData("wriggling_i2v_low_e020.safetensors", "wrigglingi2v", "Low")]
+    [InlineData("wan22-f4c3spl4sh-100epoc-high-k3nk.safetensors", "wan22f4c3spl4shk3nk", "High")]
+    [InlineData("wan22-f4c3spl4sh-154epoc-low-k3nk.safetensors", "wan22f4c3spl4shk3nk", "Low")]
+    [InlineData("model_HN.safetensors", "model", "High")]
+    [InlineData("model_LN.safetensors", "model", "Low")]
+    [InlineData("WAN-2.2-I2V-BPlay-HIGH-v1.safetensors", "wan22i2vbplay", "High")]
+    [InlineData("WAN-2.2-I2V-BPlay-LOW-v1.safetensors", "wan22i2vbplay", "Low")]
+    [InlineData("Wan2.2 - I2V - King Machine - HIGH 14B.safetensors", "wan22i2vkingmachine", "High")]
+    [InlineData("Wan2.2 - I2V - King Machine - LOW 14B.safetensors", "wan22i2vkingmachine", "Low")]
+    [InlineData("AAG_MuscleMommyH_high_noise.safetensors", "aagmusclemommy", "High")]
+    [InlineData("AAG_MuscleMommyL_low_noise.safetensors", "aagmusclemommy", "Low")]
+    [InlineData("wan2.2_highnoise_cshot_v.1.0.safetensors", "wan22cshot", "High")]
+    [InlineData("wan2.2_lownoise_cshot_v1.0.safetensors", "wan22cshot", "Low")]
+    [InlineData("WAN-2.2-T2V-oggy Style-HIGH 14B.safetensors", "wan22t2voggystyle", "High")]
+    [InlineData("WAN-2.2-T2V-oggy Style-LOW 14B.safetensors", "wan22t2voggystyle", "Low")]
+    [InlineData("WAN-2.2-T2V-cial-HIGH 14B.safetensors", "wan22t2vcial", "High")]
+    [InlineData("WAN-2.2-T2V-cial-LOW 14B.safetensors", "wan22t2vcial", "Low")]
+    [InlineData("CassHamadaWan2.2HighNoise.safetensors", "casshamadawan2", "High")]
+    [InlineData("CassHamadaWan2.2HighNoise", "casshamadawan2", "High")]
+    [InlineData("CassHamadaWan2.2LowNoise.safetensors", "casshamadawan2", "Low")]
+    [InlineData("CassHamadaWan2.2LowNoise", "casshamadawan2", "Low")]
+    public void Classify_ReturnsExpectedNormalizationAndLabel(string fileName, string expectedKey, string expectedLabel)
+    {
+        var model = new ModelClass
+        {
+            SafeTensorFileName = fileName,
+            AssociatedFilesInfo = new List<FileInfo>()
+        };
+
+        var result = LoraVariantClassifier.Classify(model);
+
+        result.NormalizedKey.Should().Be(expectedKey);
+        result.VariantLabel.Should().Be(expectedLabel);
+    }
+
+    [Fact]
+    public void Classify_DoesNotMergeDistinctWanDownloads()
+    {
+        var inputs = new[]
+        {
+            "wan2.2_5b_c0wg1rl_72_000002500.safetensors",
+            "wan2.2_5b_cuflation_000003750.safetensors",
+            "wan2.2_5b_rsc_000002500.safetensors",
+            "wan2.1-i2v-480p-rsacp.safetensors",
+            "Wan2.1_i2v_cuinmouth_v1_7epo.safetensors"
+        };
+
+        var keys = inputs
+            .Select(fileName =>
+            {
+                var model = new ModelClass
+                {
+                    SafeTensorFileName = fileName,
+                    AssociatedFilesInfo = new List<FileInfo>()
+                };
+
+                return LoraVariantClassifier.Classify(model).NormalizedKey;
+            })
+            .ToList();
+
+        keys.Should().OnlyHaveUniqueItems();
+    }
+
+    [Fact]
+    public void Classify_FallsBackToModelVersionNameWhenSafeTensorMissing()
+    {
+        var high = new ModelClass
+        {
+            SafeTensorFileName = string.Empty,
+            ModelVersionName = "CassHamadaWan2.2HighNoise",
+            AssociatedFilesInfo = new List<FileInfo>()
+        };
+
+        var low = new ModelClass
+        {
+            SafeTensorFileName = null!,
+            ModelVersionName = "CassHamadaWan2.2LowNoise",
+            AssociatedFilesInfo = new List<FileInfo>()
+        };
+
+        var highResult = LoraVariantClassifier.Classify(high);
+        var lowResult = LoraVariantClassifier.Classify(low);
+
+        highResult.VariantLabel.Should().Be("High");
+        lowResult.VariantLabel.Should().Be("Low");
+        highResult.NormalizedKey.Should().Be(lowResult.NormalizedKey);
+    }
+
+    [Fact]
+    public void Classify_UsesModelVersionVariantWhenFileNameLacksVariant()
+    {
+        var model = new ModelClass
+        {
+            SafeTensorFileName = "wan_cshot_v1.safetensors",
+            ModelVersionName = "wan2.2_highnoise_cshot_v1.0",
+            AssociatedFilesInfo = new List<FileInfo>()
+        };
+
+        var result = LoraVariantClassifier.Classify(model);
+
+        result.NormalizedKey.Should().Be("wancshot");
+        result.VariantLabel.Should().Be("High");
+    }
+}

--- a/DiffusionNexus.Tests/LoraSort/UI/LoraCardViewUiTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/UI/LoraCardViewUiTests.cs
@@ -25,16 +25,19 @@ public class LoraCardViewUiTests
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(DiffusionNexus.UI.App));
         session.Dispatch(() => {
-            var cardVm = new LoraCardViewModel
+            var model = new ModelClass
             {
-                Model = new ModelClass
-                {
-                    SafeTensorFileName = "card",
-                    DiffusionBaseModel = "SD15",
-                    ModelType = DiffusionTypes.LORA,
-                    AssociatedFilesInfo = new List<FileInfo>()
-                }
+                SafeTensorFileName = "card",
+                DiffusionBaseModel = "SD15",
+                ModelType = DiffusionTypes.LORA,
+                AssociatedFilesInfo = new List<FileInfo>()
             };
+
+            var cardVm = new LoraCardViewModel();
+            cardVm.InitializeVariants(new[]
+            {
+                new ModelVariantViewModel(model, LoraVariantClassifier.DefaultVariantLabel)
+            });
 
             var mock = new Mock<ISettingsService>();
             mock.Setup(s => s.LoadAsync()).ReturnsAsync(new SettingsModel());

--- a/DiffusionNexus.Tests/LoraSort/ViewModels/LoraCardViewModelTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/ViewModels/LoraCardViewModelTests.cs
@@ -1,4 +1,5 @@
 using DiffusionNexus.UI.ViewModels;
+using DiffusionNexus.UI.Classes;
 using DiffusionNexus.Service.Classes;
 using System.Collections.Generic;
 using System.IO;
@@ -22,7 +23,11 @@ public class LoraCardViewModelTests
             AssociatedFilesInfo = new List<FileInfo>()
         };
 
-        var vm = new LoraCardViewModel { Model = model };
+        var vm = new LoraCardViewModel();
+        vm.InitializeVariants(new[]
+        {
+            new ModelVariantViewModel(model, LoraVariantClassifier.DefaultVariantLabel)
+        });
 
         vm.DiffusionTypes.Should().ContainSingle();
         vm.DiffusionTypes.Should().Contain("LORA");
@@ -32,7 +37,7 @@ public class LoraCardViewModelTests
     [Fact]
     public void DiffusionProperties_HandleNullModel()
     {
-        var vm = new LoraCardViewModel { Model = null };
+        var vm = new LoraCardViewModel();
 
         vm.DiffusionTypes.Should().BeEmpty();
         vm.DiffusionBaseModel.Should().BeEmpty();

--- a/DiffusionNexus.Tests/LoraSort/ViewModels/LoraHelperFilterTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/ViewModels/LoraHelperFilterTests.cs
@@ -30,7 +30,14 @@ public class LoraHelperFilterTests
             ModelVersionName = versionName ?? fileName,
             AssociatedFilesInfo = new List<FileInfo>()
         };
-        return new LoraCardViewModel { Model = model };
+
+        var card = new LoraCardViewModel();
+        card.InitializeVariants(new[]
+        {
+            new ModelVariantViewModel(model, LoraVariantClassifier.DefaultVariantLabel)
+        });
+
+        return card;
     }
 
     private static List<LoraCardViewModel> InvokeFilter(LoraHelperViewModel vm, string term)
@@ -49,7 +56,7 @@ public class LoraHelperFilterTests
         list.AddRange(cards);
 
         var indexNames = cards
-            .Select(c => $"{c.Model.SafeTensorFileName} {c.Model.ModelVersionName}")
+            .Select(c => c.GetSearchIndexText())
             .ToList();
 
         var indexNamesField = typeof(LoraHelperViewModel)
@@ -75,7 +82,7 @@ public class LoraHelperFilterTests
 
         BuildIndex(vm, cards);
         var result = InvokeFilter(vm, "night");
-        result.Select(c => c.Model.SafeTensorFileName).Should()
+        result.Select(c => c.Model!.SafeTensorFileName).Should()
             .BeEquivalentTo(new[] { "Fright Night", "0403 Halloween Nightmare_v1_pony", "t2v_model" });
     }
 

--- a/DiffusionNexus.Tests/LoraSort/ViewModels/LoraHelperSortTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/ViewModels/LoraHelperSortTests.cs
@@ -26,7 +26,14 @@ public class LoraHelperSortTests
             SafeTensorFileName = Path.GetFileNameWithoutExtension(filePath),
             AssociatedFilesInfo = new List<FileInfo> { new FileInfo(filePath) }
         };
-        return new LoraCardViewModel { Model = model };
+
+        var card = new LoraCardViewModel();
+        card.InitializeVariants(new[]
+        {
+            new ModelVariantViewModel(model, LoraVariantClassifier.DefaultVariantLabel)
+        });
+
+        return card;
     }
 
     [Fact]

--- a/DiffusionNexus.UI/Classes/LoraVariantClassifier.cs
+++ b/DiffusionNexus.UI/Classes/LoraVariantClassifier.cs
@@ -1,0 +1,382 @@
+using DiffusionNexus.Service.Classes;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace DiffusionNexus.UI.Classes;
+
+public static class LoraVariantClassifier
+{
+    public const string DefaultVariantLabel = "Default";
+
+    private static readonly string[] KnownExtensions =
+    {
+        ".safetensors",
+        ".pt",
+        ".pth",
+        ".ckpt",
+    };
+
+    private static readonly Dictionary<string, string> VariantLabels = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["highnoise"] = "High",
+        ["high"] = "High",
+        ["h"] = "High",
+        ["hn"] = "High",
+        ["lownoise"] = "Low",
+        ["low"] = "Low",
+        ["l"] = "Low",
+        ["ln"] = "Low",
+    };
+
+    private static readonly string[] VariantKeysByLength = VariantLabels
+        .Keys
+        .OrderByDescending(k => k.Length)
+        .ToArray();
+
+    private static readonly char[] TokenSeparators =
+    {
+        ' ', '_', '-', '.', '(', ')', '[', ']', '{', '}',
+    };
+
+    public static LoraVariantClassification Classify(ModelClass model)
+    {
+        if (model == null)
+        {
+            return new LoraVariantClassification(string.Empty, DefaultVariantLabel);
+        }
+
+        string normalizedKey = string.Empty;
+        string variantLabel = DefaultVariantLabel;
+
+        void Consider(string? candidate)
+        {
+            if (string.IsNullOrWhiteSpace(candidate))
+            {
+                return;
+            }
+
+            var result = Classify(candidate);
+
+            if (string.IsNullOrWhiteSpace(normalizedKey) && !string.IsNullOrWhiteSpace(result.NormalizedKey))
+            {
+                normalizedKey = result.NormalizedKey;
+            }
+
+            if (variantLabel == DefaultVariantLabel && result.VariantLabel != DefaultVariantLabel)
+            {
+                variantLabel = result.VariantLabel;
+            }
+        }
+
+        Consider(model.SafeTensorFileName);
+        Consider(model.ModelVersionName);
+
+        if (string.IsNullOrWhiteSpace(normalizedKey))
+        {
+            normalizedKey = NormalizeKey(model.SafeTensorFileName ?? model.ModelVersionName ?? string.Empty);
+        }
+
+        return new LoraVariantClassification(normalizedKey, variantLabel);
+    }
+
+    public static LoraVariantClassification Classify(string? safeTensorName)
+    {
+        var fileName = Path.GetFileName(safeTensorName ?? string.Empty) ?? string.Empty;
+        var baseName = fileName;
+
+        foreach (var extension in KnownExtensions)
+        {
+            if (!baseName.EndsWith(extension, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            baseName = baseName[..^extension.Length];
+            break;
+        }
+
+        if (string.IsNullOrWhiteSpace(baseName))
+        {
+            return new LoraVariantClassification(string.Empty, DefaultVariantLabel);
+        }
+
+        var tokens = baseName
+            .Split(TokenSeparators, StringSplitOptions.RemoveEmptyEntries)
+            .ToList();
+
+        if (tokens.Count == 0)
+        {
+            return new LoraVariantClassification(NormalizeKey(baseName), DefaultVariantLabel);
+        }
+
+        string variantLabel = DefaultVariantLabel;
+        if (TryExtractVariant(tokens, out var label))
+        {
+            variantLabel = label;
+        }
+
+        StripEmbeddedVariantTokens(tokens, ref variantLabel);
+
+        if (variantLabel == DefaultVariantLabel && TryExtractVariantFromCombined(baseName, out var combinedLabel, out var combinedKey))
+        {
+            variantLabel = combinedLabel;
+            if (!string.IsNullOrWhiteSpace(combinedKey))
+            {
+                return new LoraVariantClassification(combinedKey, variantLabel);
+            }
+        }
+
+        RemoveVersionTokens(tokens);
+
+        var normalizedKey = NormalizeKey(tokens);
+        if (string.IsNullOrWhiteSpace(normalizedKey))
+        {
+            normalizedKey = NormalizeKey(baseName);
+        }
+
+        return new LoraVariantClassification(normalizedKey, variantLabel);
+    }
+
+    private static void StripEmbeddedVariantTokens(List<string> tokens, ref string variantLabel)
+    {
+        for (int i = tokens.Count - 1; i >= 0; i--)
+        {
+            var token = tokens[i];
+            if (TryStripVariantSuffix(token, out var stripped, out var suffixLabel))
+            {
+                if (string.IsNullOrWhiteSpace(stripped))
+                {
+                    tokens.RemoveAt(i);
+                }
+                else
+                {
+                    tokens[i] = stripped;
+                }
+
+                if (variantLabel == DefaultVariantLabel && suffixLabel != DefaultVariantLabel)
+                {
+                    variantLabel = suffixLabel;
+                }
+            }
+        }
+    }
+
+    private static bool TryStripVariantSuffix(string token, out string strippedToken, out string variantLabel)
+    {
+        strippedToken = token;
+        variantLabel = DefaultVariantLabel;
+
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return false;
+        }
+
+        foreach (var variantKey in VariantKeysByLength)
+        {
+            if (token.Length <= variantKey.Length)
+            {
+                continue;
+            }
+
+            if (!token.EndsWith(variantKey, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (!TryGetVariantLabel(variantKey, out var label))
+            {
+                continue;
+            }
+
+            var suffix = token.Substring(token.Length - variantKey.Length, variantKey.Length);
+            if (!suffix.Any(char.IsUpper))
+            {
+                continue;
+            }
+
+            strippedToken = token[..^variantKey.Length];
+            variantLabel = label;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static void RemoveVersionTokens(List<string> tokens)
+    {
+        var removedVersionSuffix = false;
+
+        for (int i = tokens.Count - 1; i >= 0; i--)
+        {
+            if (!IsVersionToken(tokens, i))
+            {
+                continue;
+            }
+
+            var token = tokens[i];
+            if (!removedVersionSuffix && token.Any(char.IsDigit))
+            {
+                removedVersionSuffix = true;
+            }
+
+            tokens.RemoveAt(i);
+        }
+
+        if (!removedVersionSuffix)
+        {
+            return;
+        }
+
+        while (tokens.Count > 0 && IsVersionPrefixToken(tokens[^1]))
+        {
+            tokens.RemoveAt(tokens.Count - 1);
+        }
+    }
+
+    private static bool IsVersionToken(List<string> tokens, int index)
+    {
+        var token = tokens[index];
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return true;
+        }
+
+        token = token.Trim();
+        var lower = token.ToLowerInvariant();
+
+        if (lower.All(char.IsDigit))
+        {
+            return index >= tokens.Count - 1;
+        }
+
+        if (lower.StartsWith('v') && lower.Length > 1 && lower[1..].All(char.IsDigit))
+        {
+            return true;
+        }
+
+        if (lower.StartsWith('e') && lower.Length > 1 && lower[1..].All(char.IsDigit))
+        {
+            return true;
+        }
+
+        if (lower.Contains("epoc") || lower.Contains("epoch") || lower.Contains("iter") || lower.Contains("step"))
+        {
+            return true;
+        }
+
+        if (lower.EndsWith('b') && lower[..^1].All(char.IsDigit))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsVersionPrefixToken(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return false;
+        }
+
+        var lower = token.ToLowerInvariant();
+        return lower is "v" or "ver" or "vers" or "version";
+    }
+
+    private static bool TryExtractVariant(List<string> tokens, out string variantLabel)
+    {
+        for (int length = Math.Min(3, tokens.Count); length >= 1; length--)
+        {
+            for (int start = tokens.Count - length; start >= 0; start--)
+            {
+                var candidateTokens = tokens.Skip(start).Take(length);
+                var normalized = NormalizeKey(candidateTokens);
+                if (TryGetVariantLabel(normalized, out variantLabel!))
+                {
+                    tokens.RemoveRange(start, length);
+                    return true;
+                }
+            }
+        }
+
+        variantLabel = DefaultVariantLabel;
+        return false;
+    }
+
+    private static bool TryExtractVariantFromCombined(
+        string baseName,
+        out string variantLabel,
+        out string normalizedKey)
+    {
+        var normalized = NormalizeKey(baseName);
+        foreach (var variantKey in VariantKeysByLength)
+        {
+            if (variantKey.IndexOf("noise", StringComparison.OrdinalIgnoreCase) < 0)
+            {
+                continue;
+            }
+
+            var index = normalized.LastIndexOf(variantKey, StringComparison.Ordinal);
+            if (index < 0)
+            {
+                continue;
+            }
+
+            if (!TryGetVariantLabel(variantKey, out variantLabel!))
+            {
+                continue;
+            }
+
+            var trimmed = normalized.Remove(index, variantKey.Length);
+            normalizedKey = string.IsNullOrWhiteSpace(trimmed) ? normalized : trimmed;
+            return true;
+        }
+
+        variantLabel = DefaultVariantLabel;
+        normalizedKey = normalized;
+        return false;
+    }
+
+    private static bool TryGetVariantLabel(string candidate, out string variantLabel)
+    {
+        if (VariantLabels.TryGetValue(candidate, out variantLabel!))
+        {
+            return true;
+        }
+
+        var trimmed = candidate;
+        while (trimmed.Length > 0 && char.IsDigit(trimmed[^1]))
+        {
+            trimmed = trimmed[..^1];
+        }
+
+        if (trimmed.Length != candidate.Length && trimmed.Length > 0)
+        {
+            return VariantLabels.TryGetValue(trimmed, out variantLabel!);
+        }
+
+        variantLabel = DefaultVariantLabel;
+        return false;
+    }
+
+    private static string NormalizeKey(IEnumerable<string> tokens)
+    {
+        var joined = string.Join('_', tokens);
+        return NormalizeKey(joined);
+    }
+
+    private static string NormalizeKey(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return string.Empty;
+        }
+
+        var chars = text.Where(char.IsLetterOrDigit).ToArray();
+        return new string(chars).ToLowerInvariant();
+    }
+}
+
+public readonly record struct LoraVariantClassification(string NormalizedKey, string VariantLabel);

--- a/DiffusionNexus.UI/ViewModels/LoraHelperViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraHelperViewModel.cs
@@ -30,9 +30,6 @@ public partial class LoraHelperViewModel : ViewModelBase
     private CancellationTokenSource _suggestCts = new();
     private CancellationTokenSource _filterCts = new();
     private List<LoraCardViewModel> _filteredCards = new();
-    private int _nextIndex;
-    private bool _isLoadingPage;
-    private const int PageSize = 50;
     private readonly LoraMetadataDownloadService _metadataDownloader;
     private const double ForgePromptStrength = 0.75;
     [ObservableProperty]
@@ -167,32 +164,30 @@ public partial class LoraHelperViewModel : ViewModelBase
                 }
             });
 
+            var groupedCards = cardEntries
+                .GroupBy(CreateGroupKey)
+                .Select(CreateCardFromGroup)
+                .ToList();
+
             await Dispatcher.UIThread.InvokeAsync(() =>
             {
                 _allCards.Clear();
                 Cards.Clear();
             });
 
-            foreach (var entry in cardEntries)
+            foreach (var card in groupedCards)
             {
-                var card = new LoraCardViewModel
-                {
-                    Model = entry.Model,
-                    FolderPath = entry.FolderPath,
-                    TreePath = entry.TreePath,
-                    Parent = this
-                };
+                card.Parent = this;
                 _allCards.Add(card);
             }
 
+            _filteredCards = _allCards.ToList();
+
             await Dispatcher.UIThread.InvokeAsync(() =>
             {
-                DiffusionModelFilter.SetOptions(_allCards.Select(card => card.DiffusionBaseModel));
+                SyncCards(_filteredCards);
+                DiffusionModelFilter.SetOptions(_allCards.SelectMany(card => card.GetAllDiffusionBaseModels()));
             });
-
-            _filteredCards = _allCards.ToList();
-            _nextIndex = 0;
-            await LoadNextPageAsync();
 
             StartIndexing();
         }
@@ -204,12 +199,18 @@ public partial class LoraHelperViewModel : ViewModelBase
 
     private static CardEntry? CreateCardEntry(ModelClass model, string sourcePath, bool mergeSources)
     {
+        var classification = LoraVariantClassifier.Classify(model);
+        var normalizedKey = EnsureNormalizedKey(model, classification.NormalizedKey);
+        var variantLabel = string.IsNullOrWhiteSpace(classification.VariantLabel)
+            ? LoraVariantClassifier.DefaultVariantLabel
+            : classification.VariantLabel;
+
         var folder = model.AssociatedFilesInfo?.FirstOrDefault()?.DirectoryName;
 
         if (!mergeSources)
         {
             var entryPath = !string.IsNullOrWhiteSpace(folder) ? folder! : sourcePath;
-            return new CardEntry(model, sourcePath, folder, entryPath, null);
+            return new CardEntry(model, sourcePath, folder, entryPath, null, normalizedKey, variantLabel);
         }
 
         var segments = LoraHelperTreeBuilder.BuildMergedSegments(sourcePath, folder, model.DiffusionBaseModel);
@@ -219,7 +220,68 @@ public partial class LoraHelperViewModel : ViewModelBase
         }
 
         var mergedTreePath = string.Join(Path.DirectorySeparatorChar, segments);
-        return new CardEntry(model, sourcePath, folder, mergedTreePath, segments);
+        return new CardEntry(model, sourcePath, folder, mergedTreePath, segments, normalizedKey, variantLabel);
+    }
+
+    private static string EnsureNormalizedKey(ModelClass model, string normalizedKey)
+    {
+        if (!string.IsNullOrWhiteSpace(normalizedKey))
+        {
+            return normalizedKey;
+        }
+
+        var fallback = model.SafeTensorFileName;
+        if (!string.IsNullOrWhiteSpace(fallback))
+        {
+            var alt = LoraVariantClassifier.Classify(fallback).NormalizedKey;
+            if (!string.IsNullOrWhiteSpace(alt))
+            {
+                return alt;
+            }
+        }
+
+        fallback = model.ModelVersionName;
+        if (!string.IsNullOrWhiteSpace(fallback))
+        {
+            var alt = LoraVariantClassifier.Classify(fallback).NormalizedKey;
+            if (!string.IsNullOrWhiteSpace(alt))
+            {
+                return alt;
+            }
+        }
+
+        var baseName = model.SafeTensorFileName ?? model.ModelVersionName ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(baseName))
+        {
+            return Guid.NewGuid().ToString("N");
+        }
+
+        var cleaned = new string(baseName.Where(char.IsLetterOrDigit).ToArray());
+        return string.IsNullOrWhiteSpace(cleaned)
+            ? Guid.NewGuid().ToString("N")
+            : cleaned.ToLowerInvariant();
+    }
+
+    private static string CreateGroupKey(CardEntry entry)
+    {
+        var folder = string.IsNullOrWhiteSpace(entry.FolderPath) ? entry.SourcePath : entry.FolderPath;
+        var folderKey = folder?.ToLowerInvariant() ?? string.Empty;
+        return $"{folderKey}|{entry.NormalizedKey}";
+    }
+
+    private LoraCardViewModel CreateCardFromGroup(IGrouping<string, CardEntry> group)
+    {
+        var primary = group.First();
+        var card = new LoraCardViewModel
+        {
+            FolderPath = primary.FolderPath ?? primary.SourcePath,
+            TreePath = primary.TreePath,
+        };
+
+        var variants = group.Select(entry => new ModelVariantViewModel(entry.Model, entry.VariantLabel));
+        card.InitializeVariants(variants);
+
+        return card;
     }
 
     private static FolderNode? BuildMergedFolderTree(IEnumerable<CardEntry> entries)
@@ -237,7 +299,9 @@ public partial class LoraHelperViewModel : ViewModelBase
         string SourcePath,
         string? FolderPath,
         string TreePath,
-        IReadOnlyList<string>? TreeSegments);
+        IReadOnlyList<string>? TreeSegments,
+        string NormalizedKey,
+        string VariantLabel);
 
     private FolderItemViewModel ConvertFolder(FolderNode node)
     {
@@ -304,14 +368,12 @@ public partial class LoraHelperViewModel : ViewModelBase
             if (token.IsCancellationRequested)
                 return;
 
+            _filteredCards = list;
+
             await Dispatcher.UIThread.InvokeAsync(() =>
             {
-                Cards.Clear();
-                _filteredCards = list;
-                _nextIndex = 0;
+                SyncCards(_filteredCards);
             });
-
-            await LoadNextPageAsync();
         }
         finally
         {
@@ -348,46 +410,72 @@ public partial class LoraHelperViewModel : ViewModelBase
                 query = query.Where(c => MatchesSearch(c, search!));
             }
         }
-        Log($"Found: {_allCards.Where(x => x.Model.Nsfw == true).Count()} Nsfw Models", LogSeverity.Info);
+        Log($"Found: {_allCards.Count(x => x.Variants.Any(v => v.Model.Nsfw == true))} Nsfw Models", LogSeverity.Info);
 
         if (!ShowNsfw)
-            query = query.Where(c => c.Model?.Nsfw != true);
+            query = query.Where(c => c.HasAnySafeVariant);
 
         var selectedBaseModels = DiffusionModelFilter.SelectedModels.ToList();
         if (selectedBaseModels.Count > 0)
         {
             var baseModelSet = new HashSet<string>(selectedBaseModels, StringComparer.OrdinalIgnoreCase);
-            query = query.Where(card => baseModelSet.Contains(card.DiffusionBaseModel));
+            query = query.Where(card => card.MatchesBaseModel(baseModelSet));
         }
 
         var sorted = ApplySort(query);
         return sorted.ToList();
     }
 
-    private static bool MatchesSearch(LoraCardViewModel card, string search) =>
-        card.Model.SafeTensorFileName?.Contains(search, StringComparison.OrdinalIgnoreCase) == true ||
-        card.Model.ModelVersionName?.Contains(search, StringComparison.OrdinalIgnoreCase) == true;
-
-    public async Task LoadNextPageAsync()
+    private void SyncCards(IReadOnlyList<LoraCardViewModel> newCards)
     {
-        if (_isLoadingPage)
-            return;
-
-        if (_nextIndex >= _filteredCards.Count)
-            return;
-
-        _isLoadingPage = true;
-        var slice = _filteredCards.Skip(_nextIndex).Take(PageSize).ToList();
-        _nextIndex += slice.Count;
-
-        await Dispatcher.UIThread.InvokeAsync(() =>
+        if (Cards.Count == 0 && newCards.Count == 0)
         {
-            foreach (var card in slice)
-                Cards.Add(card);
-        });
+            return;
+        }
 
-        _isLoadingPage = false;
+        if (newCards.Count == 0)
+        {
+            Cards.Clear();
+            return;
+        }
+
+        var desired = new HashSet<LoraCardViewModel>(newCards);
+
+        for (int i = Cards.Count - 1; i >= 0; i--)
+        {
+            if (!desired.Contains(Cards[i]))
+            {
+                Cards.RemoveAt(i);
+            }
+        }
+
+        for (int i = 0; i < newCards.Count; i++)
+        {
+            var target = newCards[i];
+            if (i < Cards.Count)
+            {
+                if (!ReferenceEquals(Cards[i], target))
+                {
+                    var existingIndex = Cards.IndexOf(target);
+                    if (existingIndex >= 0)
+                    {
+                        Cards.Move(existingIndex, i);
+                    }
+                    else
+                    {
+                        Cards.Insert(i, target);
+                    }
+                }
+            }
+            else
+            {
+                Cards.Add(target);
+            }
+        }
     }
+
+    private static bool MatchesSearch(LoraCardViewModel card, string search) =>
+        card.MatchesSearch(search);
 
     private void ResetFilters()
     {
@@ -402,23 +490,15 @@ public partial class LoraHelperViewModel : ViewModelBase
         IEnumerable<LoraCardViewModel> sorted = SortMode switch
         {
             SortMode.Name => SortAscending
-                ? items.OrderBy(c => c.Model?.SafeTensorFileName, StringComparer.OrdinalIgnoreCase)
-                : items.OrderByDescending(c => c.Model?.SafeTensorFileName, StringComparer.OrdinalIgnoreCase),
+                ? items.OrderBy(c => c.SortKey, StringComparer.OrdinalIgnoreCase)
+                : items.OrderByDescending(c => c.SortKey, StringComparer.OrdinalIgnoreCase),
             SortMode.CreationDate => SortAscending
-                ? items.OrderBy(GetCreationDate)
-                : items.OrderByDescending(GetCreationDate),
+                ? items.OrderBy(c => c.NewestCreationDate)
+                : items.OrderByDescending(c => c.NewestCreationDate),
             _ => items
         };
 
         return sorted;
-    }
-
-    internal static DateTime GetCreationDate(LoraCardViewModel card)
-    {
-        var file = card.Model?.AssociatedFilesInfo.FirstOrDefault(f =>
-            f.Extension.Equals(".safetensors", StringComparison.OrdinalIgnoreCase) ||
-            f.Extension.Equals(".pt", StringComparison.OrdinalIgnoreCase));
-        return file?.CreationTime ?? DateTime.MinValue;
     }
 
     /// <summary>
@@ -428,7 +508,7 @@ public partial class LoraHelperViewModel : ViewModelBase
     private void StartIndexing()
     {
         _indexNames = _allCards
-            .Select(c => $"{c.Model.SafeTensorFileName ?? string.Empty} {c.Model.ModelVersionName ?? string.Empty}")
+            .Select(c => c.GetSearchIndexText())
             .ToList();
         var namesCopy = _indexNames.ToList();
         Task.Run(() => _searchIndex.Build(namesCopy));
@@ -484,37 +564,51 @@ public partial class LoraHelperViewModel : ViewModelBase
 
     public async Task DeleteCardAsync(LoraCardViewModel card)
     {
-        if (DialogService == null || card.Model == null)
+        var variant = card.SelectedVariant;
+        if (DialogService == null || variant?.Model == null)
             return;
 
-        var confirm = await DialogService.ShowConfirmationAsync($"Delete '{card.Model.SafeTensorFileName}'?");
+        var confirm = await DialogService.ShowConfirmationAsync($"Delete '{variant.Model.SafeTensorFileName}'?");
         if (confirm != true) return;
 
-        foreach (var file in card.Model.AssociatedFilesInfo)
+        foreach (var file in variant.Model.AssociatedFilesInfo)
         {
             try { File.Delete(file.FullName); } catch { }
         }
 
-        _allCards.Remove(card);
-        Cards.Remove(card);
+        var removed = card.RemoveVariant(variant);
+        if (!removed)
+        {
+            return;
+        }
+
+        if (card.Variants.Count == 0)
+        {
+            _allCards.Remove(card);
+            _filteredCards.Remove(card);
+            await Dispatcher.UIThread.InvokeAsync(() => SyncCards(_filteredCards));
+        }
+
         StartIndexing();
+        DiffusionModelFilter.SetOptions(_allCards.SelectMany(c => c.GetAllDiffusionBaseModels()));
     }
 
     public async Task OpenWebForCardAsync(LoraCardViewModel card)
     {
-        if (card.Model == null)
+        var model = card.SelectedVariant?.Model;
+        if (model == null)
             return;
 
         var settings = await _settingsService.LoadAsync();
         var apiKey = settings.CivitaiApiKey ?? string.Empty;
         string? id;
-        if (string.IsNullOrWhiteSpace(card.Model.ModelId))
+        if (string.IsNullOrWhiteSpace(model.ModelId))
         {
-            var result = await _metadataDownloader.EnsureMetadataAsync(card.Model, apiKey);
+            var result = await _metadataDownloader.EnsureMetadataAsync(model, apiKey);
             id = result.ModelId;
             if (string.IsNullOrWhiteSpace(id))
             {
-                Log($"Can't open Link. No Id found for {card.Model.ModelVersionName}", LogSeverity.Error);
+                Log($"Can't open Link. No Id found for {model.ModelVersionName}", LogSeverity.Error);
                 return;
 
             }
@@ -522,7 +616,7 @@ public partial class LoraHelperViewModel : ViewModelBase
         else
         {
             // If we already have the ID, just use it
-            id = card.Model.ModelId;
+            id = model.ModelId;
         }
 
         var url = $"https://civitai.com/models/{id}";
@@ -531,16 +625,17 @@ public partial class LoraHelperViewModel : ViewModelBase
 
     public async Task CopyTrainedWordsAsync(LoraCardViewModel card)
     {
-        if (card.Model == null)
+        var model = card.SelectedVariant?.Model;
+        if (model == null)
             return;
 
         var settings = await _settingsService.LoadAsync();
         var apiKey = settings.CivitaiApiKey ?? string.Empty;
-        await _metadataDownloader.EnsureMetadataAsync(card.Model, apiKey);
+        await _metadataDownloader.EnsureMetadataAsync(model, apiKey);
 
-        if (card.Model.TrainedWords.Count == 0 && (!settings.UseForgeStylePrompts))
+        if (model.TrainedWords.Count == 0 && (!settings.UseForgeStylePrompts))
         {
-            Log($"No trained words for {card.Model.ModelVersionName}", LogSeverity.Warning);
+            Log($"No trained words for {model.ModelVersionName}", LogSeverity.Warning);
             return;
         }
 
@@ -549,10 +644,10 @@ public partial class LoraHelperViewModel : ViewModelBase
         {
             try
             {
-                var text = string.Join(", ", card.Model.TrainedWords).TrimEnd();
+                var text = string.Join(", ", model.TrainedWords).TrimEnd();
                 if (settings.UseForgeStylePrompts)
                 {
-                    var name = card.Model.SafeTensorFileName;
+                    var name = model.SafeTensorFileName;
                     text = $"<lora:{name}:{ForgePromptStrength.ToString(System.Globalization.CultureInfo.InvariantCulture)}> " + text;
                 }
                 await clipboard.SetTextAsync(text);
@@ -567,7 +662,7 @@ public partial class LoraHelperViewModel : ViewModelBase
 
     private static IEnumerable<char> GetLoraNameShort(LoraCardViewModel card)
     {
-        string input = card.Model?.ModelVersionName ?? string.Empty;
+        string input = card.SelectedVariant?.Model.ModelVersionName ?? string.Empty;
         if (string.IsNullOrWhiteSpace(input))
             return input;
 
@@ -603,7 +698,8 @@ public partial class LoraHelperViewModel : ViewModelBase
 
     public async Task CopyModelNameAsync(LoraCardViewModel card)
     {
-        if (card.Model == null)
+        var model = card.SelectedVariant?.Model;
+        if (model == null)
             return;
 
         if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop &&
@@ -611,8 +707,8 @@ public partial class LoraHelperViewModel : ViewModelBase
         {
             try
             {
-                var text = card.Model.SafeTensorFileName;
-                await clipboard.SetTextAsync(card.Model.SafeTensorFileName);
+                var text = model.SafeTensorFileName;
+                await clipboard.SetTextAsync(model.SafeTensorFileName);
                 Log($"Filename: {text} copied to clipboard", LogSeverity.Success);
             }
             catch (Exception ex)
@@ -670,27 +766,33 @@ public partial class LoraHelperViewModel : ViewModelBase
             var settings = await _settingsService.LoadAsync();
             var apiKey = settings.CivitaiApiKey ?? string.Empty;
 
-            var missing = _allCards.Where(c => c.Model != null && !c.Model.HasFullMetadata).ToList();
+            var missing = _allCards
+                .SelectMany(card => card.Variants)
+                .Where(variant => variant.Model != null && !variant.Model.HasFullMetadata)
+                .ToList();
+
             Log($"{missing.Count} models missing metadata", LogSeverity.Info);
 
-            foreach (var card in missing)
+            foreach (var variant in missing)
             {
-                if (card.Model == null) continue;
-                Log($"Requesting metadata for {card.Model.ModelVersionName}", LogSeverity.Info);
-                var result = await _metadataDownloader.EnsureMetadataAsync(card.Model, apiKey);
+                var model = variant.Model;
+                if (model == null) continue;
+
+                Log($"Requesting metadata for {model.ModelVersionName}", LogSeverity.Info);
+                var result = await _metadataDownloader.EnsureMetadataAsync(model, apiKey);
                 switch (result.ResultType)
                 {
                     case MetadataDownloadResultType.AlreadyExists:
-                        Log($"{card.Model.ModelVersionName}: already has metadata", LogSeverity.Info);
+                        Log($"{model.ModelVersionName}: already has metadata", LogSeverity.Info);
                         break;
                     case MetadataDownloadResultType.Downloaded:
-                        Log($"{card.Model.ModelVersionName}: metadata downloaded", LogSeverity.Success);
+                        Log($"{model.ModelVersionName}: metadata downloaded", LogSeverity.Success);
                         break;
                     case MetadataDownloadResultType.NotFound:
-                        Log($"{card.Model.ModelVersionName}: not found on Civitai", LogSeverity.Error);
+                        Log($"{model.ModelVersionName}: not found on Civitai", LogSeverity.Error);
                         break;
                     case MetadataDownloadResultType.Error:
-                        Log($"{card.Model.ModelVersionName}: failed to download metadata - {result.ErrorMessage}", LogSeverity.Error);
+                        Log($"{model.ModelVersionName}: failed to download metadata - {result.ErrorMessage}", LogSeverity.Error);
                         break;
                 }
             }

--- a/DiffusionNexus.UI/ViewModels/ModelVariantViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/ModelVariantViewModel.cs
@@ -1,0 +1,49 @@
+using DiffusionNexus.Service.Classes;
+using DiffusionNexus.UI.Classes;
+using System;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+public class ModelVariantViewModel
+{
+    public ModelVariantViewModel(ModelClass model, string variantLabel)
+    {
+        Model = model ?? throw new ArgumentNullException(nameof(model));
+        VariantLabel = string.IsNullOrWhiteSpace(variantLabel)
+            ? LoraVariantClassifier.DefaultVariantLabel
+            : variantLabel;
+    }
+
+    public ModelClass Model { get; }
+
+    public string VariantLabel { get; }
+
+    public bool IsDefaultVariant => string.Equals(
+        VariantLabel,
+        LoraVariantClassifier.DefaultVariantLabel,
+        StringComparison.OrdinalIgnoreCase);
+
+    public string DisplayLabel => VariantLabel;
+
+    public string SearchText
+    {
+        get
+        {
+            var name = Model.SafeTensorFileName ?? string.Empty;
+            var version = Model.ModelVersionName ?? string.Empty;
+            return $"{VariantLabel} {name} {version}".Trim();
+        }
+    }
+
+    public bool MatchesSearch(string search)
+    {
+        if (string.IsNullOrWhiteSpace(search))
+        {
+            return true;
+        }
+
+        return (Model.SafeTensorFileName?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false)
+            || (Model.ModelVersionName?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false)
+            || (!string.IsNullOrWhiteSpace(VariantLabel) && VariantLabel.Contains(search, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml
@@ -101,6 +101,43 @@
                   </StackPanel>
                   <Border VerticalAlignment="Bottom" Background="#66000000" Padding="5">
                     <StackPanel>
+                      <ListBox ItemsSource="{Binding Variants}"
+                               SelectedItem="{Binding SelectedVariant, Mode=TwoWay}"
+                               Margin="0,0,0,4"
+                               Background="Transparent"
+                               BorderBrush="Transparent"
+                               SelectionMode="Single"
+                               IsVisible="{Binding HasMultipleVariants}"
+                               ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                               ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                        <ListBox.Styles>
+                          <Style Selector="ListBoxItem">
+                            <Setter Property="Margin" Value="0,0,4,0"/>
+                            <Setter Property="Padding" Value="8,4"/>
+                            <Setter Property="Background" Value="#33000000"/>
+                            <Setter Property="BorderBrush" Value="#55FFFFFF"/>
+                            <Setter Property="BorderThickness" Value="1"/>
+                            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+                          </Style>
+                          <Style Selector="ListBoxItem:pointerover">
+                            <Setter Property="Background" Value="#55000000"/>
+                          </Style>
+                          <Style Selector="ListBoxItem:selected">
+                            <Setter Property="Background" Value="#AAFFFFFF"/>
+                            <Setter Property="Foreground" Value="Black"/>
+                          </Style>
+                        </ListBox.Styles>
+                        <ListBox.ItemsPanel>
+                          <ItemsPanelTemplate>
+                            <StackPanel Orientation="Horizontal"/>
+                          </ItemsPanelTemplate>
+                        </ListBox.ItemsPanel>
+                        <ListBox.ItemTemplate>
+                          <DataTemplate x:DataType="vm:ModelVariantViewModel">
+                            <TextBlock Text="{Binding DisplayLabel}" FontSize="12" FontWeight="SemiBold"/>
+                          </DataTemplate>
+                        </ListBox.ItemTemplate>
+                      </ListBox>
                       <TextBlock Text="{Binding Model.ModelVersionName}" FontWeight="Bold" Foreground="White" TextWrapping="Wrap"/>
                       <TextBlock Text="{Binding Model.SafeTensorFileName}" FontSize="12" Foreground="#FFCCCCCC" TextWrapping="Wrap"/>
                       <Grid ColumnDefinitions="Auto,*">

--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml.cs
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml.cs
@@ -8,8 +8,6 @@ namespace DiffusionNexus.UI.Views;
 
 public partial class LoraHelperView : UserControl
 {
-    private ScrollViewer? _scroll;
-
     public LoraHelperView()
     {
         InitializeComponent();
@@ -34,24 +32,6 @@ public partial class LoraHelperView : UserControl
         {
             vm.DialogService = new DialogService(window);
             vm.SetWindow(window);
-        }
-
-        _scroll = this.FindControl<ScrollViewer>("CardScrollViewer");
-        if (_scroll != null)
-            _scroll.ScrollChanged += OnScrollChanged;
-    }
-
-    private async void OnScrollChanged(object? sender, ScrollChangedEventArgs e)
-    {
-        if (_scroll == null)
-            return;
-
-        if (DataContext is LoraHelperViewModel vm)
-        {
-            if (_scroll.Offset.Y + _scroll.Viewport.Height > _scroll.Extent.Height - 300)
-            {
-                await vm.LoadNextPageAsync();
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the incremental scroll paging with a simple one-shot card copy so filtered results no longer trigger repeated refreshes
- remove the scroll event hook from the LoRA helper view to avoid re-entrant loading and delete the obsolete pagination unit tests
- synchronize the LoRA card collection instead of clearing/repopulating so large folders keep their scroll position and show every card
- update card deletion to refresh the live card list on the UI thread when the final variant is removed

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68e39fcd6fac8332a247b4ba04dec35b