### PR TITLE
Add WAN LoRA variant grouping

### DIFF
--- a/DiffusionNexus.Service/Services/JsonInfoFileReaderService.cs
+++ b/DiffusionNexus.Service/Services/JsonInfoFileReaderService.cs
@@ -40,11 +40,13 @@ public class JsonInfoFileReaderService
             {
                 progress?.Report(new ProgressReport { StatusMessage = $"Processing metadata for {safetensors.Name}", LogLevel = LogSeverity.Info });
                 ModelClass meta = await _metadataFetcher(safetensors.FullName, progress, cancellationToken);
+                model.ModelId = meta.ModelId;
                 model.DiffusionBaseModel = meta.DiffusionBaseModel;
                 model.ModelType = meta.ModelType;
                 model.ModelVersionName = string.IsNullOrWhiteSpace(meta.ModelVersionName) ? model.SafeTensorFileName : meta.ModelVersionName;
                 model.Tags = meta.Tags;
-                model.Nsfw = meta.Nsfw; 
+                model.Nsfw = meta.Nsfw;
+                model.TrainedWords = meta.TrainedWords;
                 model.CivitaiCategory = MetaDataUtilService.GetCategoryFromTags(model.Tags);
                 var completeness = meta.HasFullMetadata ? "complete" : meta.HasAnyMetadata ? "partial" : "none";
                 var level = meta.HasFullMetadata ? LogSeverity.Success : LogSeverity.Warning;

--- a/DiffusionNexus.Tests/UI/ViewModels/LoraVariantClassifierTests.cs
+++ b/DiffusionNexus.Tests/UI/ViewModels/LoraVariantClassifierTests.cs
@@ -1,0 +1,202 @@
+using DiffusionNexus.Service.Classes;
+using DiffusionNexus.UI.ViewModels;
+using FluentAssertions;
+using System.IO;
+
+namespace DiffusionNexus.Tests.UI.ViewModels;
+
+public class LoraVariantClassifierTests
+{
+    [Theory]
+    [InlineData("wriggling_t2v_high_e100.safetensors", "wrigglingt2v", "High")]
+    [InlineData("wriggling_t2v_low_e100.safetensors", "wrigglingt2v", "Low")]
+    [InlineData("WANTT2VHIGHNOISEJIGGLE", "wantt2vjiggle", "High")]
+    [InlineData("WANTT2VLOWNOISEJIGGLE", "wantt2vjiggle", "Low")]
+    [InlineData("Pump_wan22_e20_high.safetensors", "pumpwan22", "High")]
+    [InlineData("Pump_wan22_e20_low.safetensors", "pumpwan22", "Low")]
+    [InlineData("scifi_wan_low_30 (1).safetensors", "scifiwan", "Low")]
+    [InlineData("scifi_wan_high_30 (1).safetensors", "scifiwan", "High")]
+    [InlineData("wriggling_i2v_high_e010.safetensors", "wrigglingi2v", "High")]
+    [InlineData("wriggling_i2v_low_e020.safetensors", "wrigglingi2v", "Low")]
+    [InlineData("wan22-f4c3spl4sh-100epoc-high-k3nk.safetensors", "wan22f4c3spl4shk3nk", "High")]
+    [InlineData("wan22-f4c3spl4sh-154epoc-low-k3nk.safetensors", "wan22f4c3spl4shk3nk", "Low")]
+    [InlineData("model_HN.safetensors", "model", "High")]
+    [InlineData("model_LN.safetensors", "model", "Low")]
+    [InlineData("WAN-2.2-I2V-BPlay-HIGH-v1.safetensors", "wan22i2vbplay", "High")]
+    [InlineData("WAN-2.2-I2V-BPlay-LOW-v1.safetensors", "wan22i2vbplay", "Low")]
+    [InlineData("WAN-2.2-T2V-oggy Style-HIGH 14B.safetensors", "wan22t2voggystyle", "High")]
+    [InlineData("WAN-2.2-T2V-oggy Style-LOW 14B.safetensors", "wan22t2voggystyle", "Low")]
+    [InlineData("WAN-2.2-T2V-cial-HIGH 14B.safetensors", "wan22t2vcial", "High")]
+    [InlineData("WAN-2.2-T2V-cial-LOW 14B.safetensors", "wan22t2vcial", "Low")]
+    [InlineData("CassHamadaWan2.2HighNoise.safetensors", "casshamadawan2", "High")]
+    [InlineData("CassHamadaWan2.2HighNoise", "casshamadawan2", "High")]
+    [InlineData("CassHamadaWan2.2LowNoise.safetensors", "casshamadawan2", "Low")]
+    [InlineData("CassHamadaWan2.2LowNoise", "casshamadawan2", "Low")]
+    [InlineData("AAG_MuscleMommyH_high_noise.safetensors", "aagmusclemommy", "High")]
+    [InlineData("AAG_MuscleMommyL_low_noise.safetensors", "aagmusclemommy", "Low")]
+    [InlineData("wan2.2_highnoise_cshot_v.1.0.safetensors", "wan22cshot", "High")]
+    [InlineData("wan2.2_lownoise_cshot_v1.0.safetensors", "wan22cshot", "Low")]
+    [InlineData("WAN-2.2-I2V-BPlay-HIGH-v1", "wan22i2vbplay", "High")]
+    [InlineData("WAN-2.2-I2V-BPlay-LOW-v1", "wan22i2vbplay", "Low")]
+    [InlineData("Wan2.2 - I2V - King Machine - HIGH 14B.safetensors", "wan22i2vkingmachine", "High")]
+    [InlineData("Wan2.2 - I2V - King Machine - LOW 14B.safetensors", "wan22i2vkingmachine", "Low")]
+    [InlineData("WAN-2.2-T2V-oggy Style-HIGH 14B", "wan22t2voggystyle", "High")]
+    [InlineData("WAN-2.2-T2V-oggy Style-LOW 14B", "wan22t2voggystyle", "Low")]
+    public void Classify_ReturnsExpectedNormalizationAndLabel(string fileName, string expectedKey, string expectedLabel)
+    {
+        var model = new ModelClass
+        {
+            SafeTensorFileName = fileName,
+            AssociatedFilesInfo = new List<FileInfo>()
+        };
+
+        var result = LoraVariantClassifier.Classify(model);
+
+        result.NormalizedKey.Should().Be(expectedKey);
+        result.VariantLabel.Should().Be(expectedLabel);
+    }
+
+    [Fact]
+    public void Classify_DoesNotMergeDistinctWanDownloads()
+    {
+        var inputs = new[]
+        {
+            "wan2.2_5b_c0wg1rl_72_000002500.safetensors",
+            "wan2.2_5b_cuflation_000003750.safetensors",
+            "wan2.2_5b_rsc_000002500.safetensors",
+            "wan2.1-i2v-480p-rsacp.safetensors",
+            "Wan2.1_i2v_cuinmouth_v1_7epo.safetensors"
+        };
+
+        var keys = inputs
+            .Select(fileName =>
+            {
+                var model = new ModelClass
+                {
+                    SafeTensorFileName = fileName,
+                    AssociatedFilesInfo = new List<FileInfo>()
+                };
+
+                return LoraVariantClassifier.Classify(model).NormalizedKey;
+            })
+            .ToList();
+
+        keys.Should().OnlyHaveUniqueItems();
+    }
+
+    [Fact]
+    public void Classify_FallsBackToModelVersionNameWhenSafeTensorMissing()
+    {
+        var high = new ModelClass
+        {
+            SafeTensorFileName = string.Empty,
+            ModelVersionName = "CassHamadaWan2.2HighNoise",
+            AssociatedFilesInfo = new List<FileInfo>()
+        };
+
+        var low = new ModelClass
+        {
+            SafeTensorFileName = null!,
+            ModelVersionName = "CassHamadaWan2.2LowNoise",
+            AssociatedFilesInfo = new List<FileInfo>()
+        };
+
+        var highResult = LoraVariantClassifier.Classify(high);
+        var lowResult = LoraVariantClassifier.Classify(low);
+
+        highResult.VariantLabel.Should().Be("High");
+        lowResult.VariantLabel.Should().Be("Low");
+        highResult.NormalizedKey.Should().Be(lowResult.NormalizedKey);
+    }
+
+    [Fact]
+    public void Classify_UsesModelVersionVariantWhenFileNameLacksVariant()
+    {
+        var model = new ModelClass
+        {
+            SafeTensorFileName = "wan_cshot_v1.safetensors",
+            ModelVersionName = "wan2.2_highnoise_cshot_v1.0",
+            AssociatedFilesInfo = new List<FileInfo>()
+        };
+
+        var result = LoraVariantClassifier.Classify(model);
+
+        result.NormalizedKey.Should().Be("wancshot");
+        result.VariantLabel.Should().Be("High");
+    }
+
+    [Fact]
+    public void Merge_GroupsVariantsWithMatchingModelIdAndBaseModel()
+    {
+        var seeds = new List<LoraCardSeed>
+        {
+            CreateSeed("WAN-2.2-I2V-BPlay-HIGH-v1.safetensors", "1", "Wan Video 2.2"),
+            CreateSeed("WAN-2.2-I2V-BPlay-LOW-v1.safetensors", "1", "Wan Video 2.2")
+        };
+
+        var entries = LoraVariantMerger.Merge(seeds);
+
+        entries.Should().HaveCount(1);
+        var entry = entries.Single();
+        entry.Variants.Should().HaveCount(2);
+        entry.Variants.Select(v => v.Label).Should().Contain(new[] { "High", "Low" });
+        entry.Model.SafeTensorFileName.Should().Be("WAN-2.2-I2V-BPlay-HIGH-v1.safetensors");
+    }
+
+    [Fact]
+    public void Merge_DoesNotCombineWhenModelIdDiffers()
+    {
+        var seeds = new List<LoraCardSeed>
+        {
+            CreateSeed("WAN-2.2-I2V-BPlay-HIGH-v1.safetensors", "1", "Wan Video 2.2"),
+            CreateSeed("WAN-2.2-I2V-BPlay-LOW-v1.safetensors", "2", "Wan Video 2.2")
+        };
+
+        var entries = LoraVariantMerger.Merge(seeds);
+
+        entries.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Merge_DoesNotCombineWhenBaseModelDiffers()
+    {
+        var seeds = new List<LoraCardSeed>
+        {
+            CreateSeed("WAN-2.2-I2V-BPlay-HIGH-v1.safetensors", "1", "Wan Video 2.2"),
+            CreateSeed("WAN-2.2-I2V-BPlay-LOW-v1.safetensors", "1", "Different Base")
+        };
+
+        var entries = LoraVariantMerger.Merge(seeds);
+
+        entries.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Merge_PrefersFirstSeedPaths()
+    {
+        var first = CreateSeed("WAN-2.2-I2V-BPlay-HIGH-v1.safetensors", "1", "Wan Video 2.2");
+        var second = CreateSeed("WAN-2.2-I2V-BPlay-LOW-v1.safetensors", "1", "Wan Video 2.2");
+        second = second with { FolderPath = "other", SourcePath = "otherSource", TreePath = "otherTree" };
+
+        var entries = LoraVariantMerger.Merge(new[] { first, second });
+
+        entries.Should().HaveCount(1);
+        var entry = entries.Single();
+        entry.FolderPath.Should().Be(first.FolderPath);
+        entry.SourcePath.Should().Be(first.SourcePath);
+        entry.TreePath.Should().Be(first.TreePath);
+    }
+
+    private static LoraCardSeed CreateSeed(string fileName, string modelId, string baseModel)
+    {
+        var model = new ModelClass
+        {
+            SafeTensorFileName = fileName,
+            ModelId = modelId,
+            DiffusionBaseModel = baseModel,
+            AssociatedFilesInfo = new List<FileInfo>()
+        };
+
+        return new LoraCardSeed(model, "source", "folder", "tree", Array.Empty<string>());
+    }
+}

--- a/DiffusionNexus.UI/ViewModels/LoraVariantClassifier.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraVariantClassifier.cs
@@ -1,0 +1,491 @@
+using DiffusionNexus.Service.Classes;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+internal sealed record LoraVariantClassification(string NormalizedKey, string? VariantLabel);
+
+internal static class LoraVariantClassifier
+{
+    private static readonly Dictionary<string, string> VariantLabels = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["highnoise"] = "High",
+        ["high_noise"] = "High",
+        ["high"] = "High",
+        ["hn"] = "High",
+        ["lownoise"] = "Low",
+        ["low_noise"] = "Low",
+        ["low"] = "Low",
+        ["ln"] = "Low",
+    };
+
+    private static readonly char[] TokenSeparators =
+    {
+        ' ', '_', '-', '.', '(', ')', '[', ']', '{', '}',
+    };
+
+    public static LoraVariantClassification Classify(ModelClass model)
+    {
+        if (model == null)
+        {
+            throw new ArgumentNullException(nameof(model));
+        }
+
+        var primary = NormalizeSource(model.SafeTensorFileName);
+        var classification = ClassifyFromSource(primary);
+
+        if (string.IsNullOrWhiteSpace(classification.VariantLabel) || string.IsNullOrWhiteSpace(classification.NormalizedKey))
+        {
+            var fallback = NormalizeSource(model.ModelVersionName);
+            if (!string.IsNullOrWhiteSpace(fallback))
+            {
+                var fallbackResult = ClassifyFromSource(fallback);
+                var variant = !string.IsNullOrWhiteSpace(classification.VariantLabel)
+                    ? classification.VariantLabel
+                    : fallbackResult.VariantLabel;
+
+                var key = !string.IsNullOrWhiteSpace(classification.NormalizedKey)
+                    ? classification.NormalizedKey
+                    : fallbackResult.NormalizedKey;
+
+                classification = new LoraVariantClassification(key, variant);
+            }
+        }
+
+        return classification;
+    }
+
+    private static string? NormalizeSource(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var trimmed = value.Trim();
+        var extension = Path.GetExtension(trimmed);
+
+        if (!string.IsNullOrWhiteSpace(extension) && IsKnownExtension(extension))
+        {
+            var withoutExtension = Path.GetFileNameWithoutExtension(trimmed);
+            return string.IsNullOrWhiteSpace(withoutExtension) ? trimmed : withoutExtension;
+        }
+
+        return trimmed;
+    }
+
+    private static bool IsKnownExtension(string extension) => extension.Equals(".safetensors", StringComparison.OrdinalIgnoreCase)
+        || extension.Equals(".pt", StringComparison.OrdinalIgnoreCase)
+        || extension.Equals(".ckpt", StringComparison.OrdinalIgnoreCase)
+        || extension.Equals(".bin", StringComparison.OrdinalIgnoreCase);
+
+    private static LoraVariantClassification ClassifyFromSource(string? source)
+    {
+        if (string.IsNullOrWhiteSpace(source))
+        {
+            return new LoraVariantClassification(string.Empty, null);
+        }
+
+        var label = DetectVariantLabel(source);
+        var key = BuildNormalizedKey(source, label);
+        return new LoraVariantClassification(key, label);
+    }
+
+    private static string? DetectVariantLabel(string source)
+    {
+        foreach (var kvp in VariantLabels.OrderByDescending(k => k.Key.Length))
+        {
+            if (ContainsToken(source, kvp.Key))
+            {
+                return kvp.Value;
+            }
+        }
+
+        var tokens = Tokenize(source);
+        foreach (var token in tokens)
+        {
+            if (VariantLabels.TryGetValue(token, out var label))
+            {
+                return label;
+            }
+
+            var trimmed = TrimNumericEdges(token);
+            if (!string.Equals(trimmed, token, StringComparison.OrdinalIgnoreCase) &&
+                VariantLabels.TryGetValue(trimmed, out label))
+            {
+                return label;
+            }
+
+            label = DetectEmbeddedVariant(token);
+            if (!string.IsNullOrWhiteSpace(label))
+            {
+                return label;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? DetectEmbeddedVariant(string token)
+    {
+        foreach (var kvp in VariantLabels.OrderByDescending(k => k.Key.Length))
+        {
+            var key = kvp.Key;
+            var index = token.IndexOf(key, StringComparison.OrdinalIgnoreCase);
+            while (index >= 0)
+            {
+                var before = index > 0 ? token[index - 1] : (char?)null;
+                var afterIndex = index + key.Length;
+                var after = afterIndex < token.Length ? token[afterIndex] : (char?)null;
+
+                if (!IsLowercaseLetter(before) && !IsLowercaseLetter(after))
+                {
+                    return kvp.Value;
+                }
+
+                index = token.IndexOf(key, index + 1, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsLowercaseLetter(char? value) => value.HasValue && char.IsLetter(value.Value) && char.IsLower(value.Value);
+
+    private static string BuildNormalizedKey(string source, string? variantLabel)
+    {
+        var sanitized = RemoveVariantSegments(source);
+        var tokens = Tokenize(sanitized);
+
+        if (tokens.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var processed = new List<string>();
+        for (var i = 0; i < tokens.Count; i++)
+        {
+            var token = tokens[i];
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                continue;
+            }
+
+            var lower = token.ToLower(CultureInfo.InvariantCulture);
+
+            if (VariantLabels.ContainsKey(lower))
+            {
+                continue;
+            }
+
+            if (string.Equals(lower, "noise", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (IsVersionToken(lower))
+            {
+                continue;
+            }
+
+            if (StartsWithDigit(lower))
+            {
+                if (lower.All(char.IsDigit))
+                {
+                    if (!HasSubsequentAlphabeticToken(tokens, i))
+                    {
+                        continue;
+                    }
+                }
+                else
+                {
+                    continue;
+                }
+            }
+
+            var normalized = NormalizeToken(token, variantLabel);
+            if (!string.IsNullOrWhiteSpace(normalized))
+            {
+                processed.Add(normalized);
+            }
+        }
+
+        return processed.Count == 0
+            ? string.Empty
+            : string.Concat(processed).ToLower(CultureInfo.InvariantCulture);
+    }
+
+    private static List<string> Tokenize(string source)
+    {
+        return source
+            .Split(TokenSeparators, StringSplitOptions.RemoveEmptyEntries)
+            .Select(token => token.Trim())
+            .Where(token => !string.IsNullOrWhiteSpace(token))
+            .ToList();
+    }
+
+    private static string RemoveVariantSegments(string source)
+    {
+        var result = source;
+        foreach (var key in VariantLabels.Keys.OrderByDescending(k => k.Length))
+        {
+            result = RemoveToken(result, key);
+        }
+
+        return result;
+    }
+
+    private static string RemoveToken(string source, string token)
+    {
+        if (string.IsNullOrWhiteSpace(source) || string.IsNullOrWhiteSpace(token))
+        {
+            return source;
+        }
+
+        var comparison = StringComparison.OrdinalIgnoreCase;
+        var index = 0;
+        while (index < source.Length)
+        {
+            var found = source.IndexOf(token, index, comparison);
+            if (found < 0)
+            {
+                break;
+            }
+
+            var startBoundary = found == 0 || !char.IsLetterOrDigit(source[found - 1]);
+            var endPos = found + token.Length;
+            var endBoundary = endPos >= source.Length || !char.IsLetterOrDigit(source[endPos]);
+
+            if (startBoundary && endBoundary)
+            {
+                source = source.Remove(found, token.Length);
+                continue;
+            }
+
+            index = found + 1;
+        }
+
+        return source;
+    }
+
+    private static bool ContainsToken(string source, string token)
+    {
+        if (string.IsNullOrWhiteSpace(source) || string.IsNullOrWhiteSpace(token))
+        {
+            return false;
+        }
+
+        var comparison = StringComparison.OrdinalIgnoreCase;
+        var index = 0;
+        while (index < source.Length)
+        {
+            var found = source.IndexOf(token, index, comparison);
+            if (found < 0)
+            {
+                return false;
+            }
+
+            var startBoundary = found == 0 || !char.IsLetterOrDigit(source[found - 1]);
+            var endPos = found + token.Length;
+            var endBoundary = endPos >= source.Length || !char.IsLetterOrDigit(source[endPos]);
+
+            if (startBoundary && endBoundary)
+            {
+                return true;
+            }
+
+            index = found + 1;
+        }
+
+        return false;
+    }
+
+    private static string NormalizeToken(string token, string? variantLabel)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return string.Empty;
+        }
+
+        if (variantLabel is null)
+        {
+            return token;
+        }
+
+        if (string.Equals(variantLabel, "High", StringComparison.OrdinalIgnoreCase))
+        {
+            token = TrimSuffix(token, "hn");
+            token = TrimSuffix(token, "h");
+        }
+        else if (string.Equals(variantLabel, "Low", StringComparison.OrdinalIgnoreCase))
+        {
+            token = TrimSuffix(token, "ln");
+            token = TrimSuffix(token, "l");
+        }
+
+        foreach (var key in GetVariantKeys(variantLabel))
+        {
+            token = RemoveSubstring(token, key);
+        }
+
+        return token;
+    }
+
+    private static IEnumerable<string> GetVariantKeys(string? variantLabel)
+    {
+        if (string.IsNullOrWhiteSpace(variantLabel))
+        {
+            yield break;
+        }
+
+        foreach (var pair in VariantLabels)
+        {
+            if (string.Equals(pair.Value, variantLabel, StringComparison.OrdinalIgnoreCase))
+            {
+                yield return pair.Key;
+            }
+        }
+    }
+
+    private static string RemoveSubstring(string token, string key)
+    {
+        if (string.IsNullOrWhiteSpace(token) || string.IsNullOrWhiteSpace(key))
+        {
+            return token;
+        }
+
+        var comparison = StringComparison.OrdinalIgnoreCase;
+        var index = token.IndexOf(key, comparison);
+        while (index >= 0)
+        {
+            token = token.Remove(index, key.Length);
+            index = token.IndexOf(key, comparison);
+        }
+
+        return token;
+    }
+
+    private static string TrimSuffix(string token, string suffix)
+    {
+        if (token.Length <= suffix.Length)
+        {
+            return token;
+        }
+
+        if (token.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+        {
+            var segment = token[^suffix.Length..];
+            if (!segment.Any(char.IsUpper))
+            {
+                return token;
+            }
+
+            var preceding = token[token.Length - suffix.Length - 1];
+            if (!char.IsDigit(preceding))
+            {
+                return token[..^suffix.Length];
+            }
+        }
+
+        return token;
+    }
+
+    private static string TrimNumericEdges(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return token;
+        }
+
+        var start = 0;
+        while (start < token.Length && char.IsDigit(token[start]))
+        {
+            start++;
+        }
+
+        var end = token.Length - 1;
+        while (end >= start && char.IsDigit(token[end]))
+        {
+            end--;
+        }
+
+        return start > end ? string.Empty : token[start..(end + 1)];
+    }
+
+    private static bool IsVersionToken(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return false;
+        }
+
+        if (token.StartsWith("ver", StringComparison.OrdinalIgnoreCase) ||
+            token.StartsWith("version", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (string.Equals(token, "v", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (token[0] == 'v' && token.Length > 1 && token[1..].All(char.IsDigit))
+        {
+            return true;
+        }
+
+        if (token[0] == 'e' && token.Length > 1 && token[1..].All(char.IsDigit))
+        {
+            return true;
+        }
+
+        if (token.StartsWith("epoch", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool StartsWithDigit(string token) => !string.IsNullOrWhiteSpace(token) && char.IsDigit(token[0]);
+
+    private static bool HasSubsequentAlphabeticToken(IReadOnlyList<string> tokens, int index)
+    {
+        for (var i = index + 1; i < tokens.Count; i++)
+        {
+            var token = tokens[i];
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                continue;
+            }
+
+            var lower = token.ToLower(CultureInfo.InvariantCulture);
+            if (VariantLabels.ContainsKey(lower))
+            {
+                continue;
+            }
+
+            if (IsVersionToken(lower))
+            {
+                continue;
+            }
+
+            if (lower.All(char.IsDigit))
+            {
+                continue;
+            }
+
+            if (lower.Any(char.IsLetter))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/DiffusionNexus.UI/ViewModels/LoraVariantMerger.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraVariantMerger.cs
@@ -1,0 +1,193 @@
+using DiffusionNexus.Service.Classes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+internal static class LoraVariantMerger
+{
+    private static readonly StringComparer LabelComparer = StringComparer.OrdinalIgnoreCase;
+
+    public static IReadOnlyList<LoraCardEntry> Merge(IEnumerable<LoraCardSeed> seeds)
+    {
+        if (seeds == null)
+        {
+            throw new ArgumentNullException(nameof(seeds));
+        }
+
+        var order = new List<object>();
+        var groupLookup = new Dictionary<GroupKey, VariantGroup>();
+
+        foreach (var seed in seeds)
+        {
+            var classification = LoraVariantClassifier.Classify(seed.Model);
+            if (IsMergeCandidate(seed.Model, classification))
+            {
+                var key = new GroupKey(classification.NormalizedKey!, seed.Model.ModelId!, seed.Model.DiffusionBaseModel);
+                if (!groupLookup.TryGetValue(key, out var group))
+                {
+                    group = new VariantGroup(seed);
+                    groupLookup.Add(key, group);
+                    order.Add(group);
+                }
+
+                group.AddVariant(classification.VariantLabel!, seed.Model);
+            }
+            else
+            {
+                order.Add(CreateEntry(seed, classification));
+            }
+        }
+
+        return order
+            .Select(item => item switch
+            {
+                VariantGroup group => group.ToEntry(),
+                LoraCardEntry entry => entry,
+                _ => throw new InvalidOperationException("Unexpected order entry type.")
+            })
+            .ToList();
+    }
+
+    private static bool IsMergeCandidate(ModelClass model, LoraVariantClassification classification)
+    {
+        if (model == null)
+        {
+            return false;
+        }
+
+        if (classification == null)
+        {
+            return false;
+        }
+
+        if (!string.Equals(classification.VariantLabel, "High", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(classification.VariantLabel, "Low", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(classification.NormalizedKey))
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(model.ModelId))
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(model.DiffusionBaseModel))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static LoraCardEntry CreateEntry(LoraCardSeed seed, LoraVariantClassification classification)
+    {
+        IReadOnlyList<LoraVariantDescriptor> variants;
+        if (!string.IsNullOrWhiteSpace(classification.VariantLabel))
+        {
+            variants = new[] { new LoraVariantDescriptor(classification.VariantLabel!, seed.Model) };
+        }
+        else
+        {
+            variants = Array.Empty<LoraVariantDescriptor>();
+        }
+
+        return new LoraCardEntry(seed.Model, seed.SourcePath, seed.FolderPath, seed.TreePath, seed.TreeSegments, variants);
+    }
+
+    private static int GetVariantOrder(string label)
+    {
+        if (string.Equals(label, "High", StringComparison.OrdinalIgnoreCase))
+        {
+            return 0;
+        }
+
+        if (string.Equals(label, "Low", StringComparison.OrdinalIgnoreCase))
+        {
+            return 1;
+        }
+
+        return 2;
+    }
+
+    private readonly struct GroupKey : IEquatable<GroupKey>
+    {
+        private readonly string _normalizedKey;
+        private readonly string _modelId;
+        private readonly string _baseModel;
+
+        public GroupKey(string normalizedKey, string modelId, string baseModel)
+        {
+            _normalizedKey = normalizedKey;
+            _modelId = modelId;
+            _baseModel = baseModel;
+        }
+
+        public bool Equals(GroupKey other) =>
+            string.Equals(_normalizedKey, other._normalizedKey, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(_modelId, other._modelId, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(_baseModel, other._baseModel, StringComparison.OrdinalIgnoreCase);
+
+        public override bool Equals(object? obj) => obj is GroupKey other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            hash.Add(_normalizedKey, StringComparer.OrdinalIgnoreCase);
+            hash.Add(_modelId, StringComparer.OrdinalIgnoreCase);
+            hash.Add(_baseModel, StringComparer.OrdinalIgnoreCase);
+            return hash.ToHashCode();
+        }
+    }
+
+    private sealed class VariantGroup
+    {
+        private readonly LoraCardSeed _seed;
+        private readonly Dictionary<string, ModelClass> _variants = new(LabelComparer);
+
+        public VariantGroup(LoraCardSeed seed)
+        {
+            _seed = seed;
+        }
+
+        public void AddVariant(string label, ModelClass model)
+        {
+            _variants[label] = model;
+        }
+
+        public LoraCardEntry ToEntry()
+        {
+            var ordered = _variants
+                .OrderBy(v => GetVariantOrder(v.Key))
+                .ThenBy(v => v.Key, LabelComparer)
+                .Select(v => new LoraVariantDescriptor(v.Key, v.Value))
+                .ToList();
+
+            var selected = ordered.First();
+            return new LoraCardEntry(selected.Model, _seed.SourcePath, _seed.FolderPath, _seed.TreePath, _seed.TreeSegments, ordered);
+        }
+    }
+}
+
+internal sealed record LoraCardSeed(
+    ModelClass Model,
+    string SourcePath,
+    string? FolderPath,
+    string TreePath,
+    IReadOnlyList<string>? TreeSegments);
+
+internal sealed record LoraVariantDescriptor(string Label, ModelClass Model);
+
+internal sealed record LoraCardEntry(
+    ModelClass Model,
+    string SourcePath,
+    string? FolderPath,
+    string TreePath,
+    IReadOnlyList<string>? TreeSegments,
+    IReadOnlyList<LoraVariantDescriptor> Variants);

--- a/DiffusionNexus.UI/ViewModels/LoraVariantViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraVariantViewModel.cs
@@ -1,0 +1,28 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DiffusionNexus.Service.Classes;
+using System;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+public partial class LoraVariantViewModel : ObservableObject
+{
+    private readonly Action<LoraVariantViewModel> _onSelected;
+
+    public LoraVariantViewModel(string label, ModelClass model, Action<LoraVariantViewModel> onSelected)
+    {
+        Label = label;
+        Model = model;
+        _onSelected = onSelected ?? throw new ArgumentNullException(nameof(onSelected));
+        SelectCommand = new RelayCommand(() => _onSelected(this));
+    }
+
+    public string Label { get; }
+
+    public ModelClass Model { get; }
+
+    [ObservableProperty]
+    private bool isSelected;
+
+    public IRelayCommand SelectCommand { get; }
+}

--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml
@@ -103,6 +103,22 @@
                     <StackPanel>
                       <TextBlock Text="{Binding Model.ModelVersionName}" FontWeight="Bold" Foreground="White" TextWrapping="Wrap"/>
                       <TextBlock Text="{Binding Model.SafeTensorFileName}" FontSize="12" Foreground="#FFCCCCCC" TextWrapping="Wrap"/>
+                      <ItemsControl ItemsSource="{Binding Variants}" Margin="0,4,0,0" IsVisible="{Binding HasVariants}">
+                        <ItemsControl.ItemsPanel>
+                          <ItemsPanelTemplate>
+                            <StackPanel Orientation="Horizontal"/>
+                          </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                          <DataTemplate x:DataType="vm:LoraVariantViewModel">
+                            <ToggleButton Content="{Binding Label}"
+                                          Margin="0,0,4,0"
+                                          MinWidth="60"
+                                          Command="{Binding SelectCommand}"
+                                          IsChecked="{Binding IsSelected, Mode=TwoWay}"/>
+                          </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                      </ItemsControl>
                       <Grid ColumnDefinitions="Auto,*">
                         <!--<Button Content="âœï¸"
                                 Width="36" Height="36" FontSize="16"


### PR DESCRIPTION
## Summary
- add a classifier that infers WAN LoRA high/low variants and produces a normalized grouping key
- merge high/low pairs with matching model id and base model into a single helper card with selectable variants
- update the helper UI to expose variant toggles and cover the new logic with unit tests

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68e4d9386fb083328bbf84af7032b464