### PR TITLE
Add hover highlight to Lora helper cards

### DIFF
--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml
@@ -88,7 +88,12 @@
           </items:ItemsRepeater.Layout>
           <items:ItemsRepeater.ItemTemplate>
             <DataTemplate x:DataType="vm:LoraCardViewModel">
-              <Border Background="#333333" Padding="5" Margin="5" Width="250" Height="300">
+              <Border Background="#333333" Padding="5" Margin="5" Width="250" Height="300" BorderBrush="Transparent" BorderThickness="2">
+                <Border.Styles>
+                  <Style Selector="Border:pointerover">
+                    <Setter Property="BorderBrush" Value="#0078D4"/>
+                  </Style>
+                </Border.Styles>
                 <Grid>
                   <Image Source="{Binding PreviewImage}" Stretch="UniformToFill"/>
                   <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Top">


### PR DESCRIPTION
## Summary
- add a pointer-over style to LoRA helper cards so the active card shows a blue border

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f0a24372788332a94e7b9fc899716f