### PR TITLE
Add hover highlight to Lora helper cards

### DIFF
--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml
@@ -14,6 +14,15 @@
     <conv:EnumToBooleanConverter x:Key="EnumToBooleanConverter" />
     <conv:BooleanNotConverter x:Key="BooleanNotConverter"/>
   </UserControl.Resources>
+  <UserControl.Styles>
+    <Style Selector="Border.lora-card">
+      <Setter Property="BorderThickness" Value="0"/>
+    </Style>
+    <Style Selector="Border.lora-card:pointerover">
+      <Setter Property="BorderThickness" Value="2"/>
+      <Setter Property="BorderBrush" Value="#4A90E2"/>
+    </Style>
+  </UserControl.Styles>
   <Grid RowDefinitions="Auto,*" ColumnDefinitions="Auto,*" Margin="10">
     <Grid Grid.ColumnSpan="2" ColumnDefinitions="Auto,1.5*,Auto,Auto,Auto,Auto,Auto,Auto,Auto" Margin="0,0,0,5">
       <Button Grid.Column="0" Content="◀️ Reset Filters" Width="120" Height="36" Command="{Binding ResetFiltersCommand}"/>
@@ -88,7 +97,7 @@
           </items:ItemsRepeater.Layout>
           <items:ItemsRepeater.ItemTemplate>
             <DataTemplate x:DataType="vm:LoraCardViewModel">
-              <Border Background="#333333" Padding="5" Margin="5" Width="250" Height="300">
+              <Border Background="#333333" Padding="5" Margin="5" Width="250" Height="300" Classes="lora-card">
                 <Grid>
                   <Image Source="{Binding PreviewImage}" Stretch="UniformToFill"/>
                   <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Top">


### PR DESCRIPTION
## Summary
- add hover styling for Lora helper cards
- apply blue border when a card is hovered

## Testing
- dotnet build DiffusionNexus.sln

------
https://chatgpt.com/codex/tasks/task_e_68f0ab4695288332a2578db906deee92