### PR TITLE
Add detail window for LoRA cards with video previews

### DIFF
--- a/DiffusionNexus.UI/DiffusionNexus.UI.csproj
+++ b/DiffusionNexus.UI/DiffusionNexus.UI.csproj
@@ -7,6 +7,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     <WarningLevel>3</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Base version prefix. Build number will be appended automatically. -->
     <VersionPrefix>0.5.1</VersionPrefix>
     <Version>$(VersionPrefix).0</Version>
@@ -43,10 +44,16 @@
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="OpenCvSharp4" Version="4.6.0.20220608" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.7" />
     <PackageReference Include="Xabe.FFmpeg" Version="6.0.1" />
     <PackageReference Include="Xabe.FFmpeg.Downloader" Version="6.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.6.0.20220608" />
+    <PackageReference Include="OpenCvSharp4.runtime.ubuntu.20.04-x64" Version="4.6.0.20220608" />
   </ItemGroup>
 
   <!-- Automatically read, increment and save build number on each build -->

--- a/DiffusionNexus.UI/ViewModels/LoraCardViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraCardViewModel.cs
@@ -44,6 +44,7 @@ public partial class LoraCardViewModel : ViewModelBase
     public IAsyncRelayCommand CopyCommand { get; }
     public IAsyncRelayCommand CopyNameCommand { get; }
     public IRelayCommand OpenFolderCommand { get; }
+    public IAsyncRelayCommand OpenDetailsCommand { get; }
 
     public ObservableCollection<LoraVariantViewModel> Variants { get; } = new();
 
@@ -59,6 +60,7 @@ public partial class LoraCardViewModel : ViewModelBase
         CopyCommand = new AsyncRelayCommand(OnCopyAsync);
         CopyNameCommand = new AsyncRelayCommand(OnCopyNameAsync);
         OpenFolderCommand = new RelayCommand(OnOpenFolder);
+        OpenDetailsCommand = new AsyncRelayCommand(OnOpenDetailsAsync);
         Variants.CollectionChanged += OnVariantsCollectionChanged;
     }
 
@@ -177,10 +179,10 @@ public partial class LoraCardViewModel : ViewModelBase
         return null;
     }
 
-    private string? GetPreviewMediaPath()
+    public string? GetPreviewMediaPath()
     {
         if (Model == null) return null;
-        
+
 
         foreach (var ext in SupportedTypes.VideoTypesByPriority)
         {
@@ -197,6 +199,11 @@ public partial class LoraCardViewModel : ViewModelBase
     private Task OnDeleteAsync()
     {
         return Parent?.DeleteCardAsync(this) ?? Task.CompletedTask;
+    }
+
+    private Task OnOpenDetailsAsync()
+    {
+        return Parent?.ShowDetailsAsync(this) ?? Task.CompletedTask;
     }
 
     private async Task OnOpenWebAsync()

--- a/DiffusionNexus.UI/ViewModels/LoraDetailViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraDetailViewModel.cs
@@ -1,0 +1,369 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Avalonia;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+using Avalonia.Threading;
+using DiffusionNexus.Service.Classes;
+using OpenCvSharp;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+public class LoraDetailViewModel : ViewModelBase, IDisposable
+{
+    private static readonly string[] ModelFileExtensions = [".safetensors", ".pt", ".ckpt", ".pth"];
+    private readonly object _videoLock = new();
+    private string? _modelVersionId;
+    private string? _description;
+    private string? _previewMediaPath;
+    private VideoCapture? _videoCapture;
+    private DispatcherTimer? _videoTimer;
+    private Bitmap? _videoFrame;
+
+    public LoraDetailViewModel(LoraCardViewModel card)
+    {
+        Card = card;
+        Card.PropertyChanged += OnCardPropertyChanged;
+        UpdateMetadata();
+        UpdatePreviewMediaPath();
+    }
+
+    public LoraCardViewModel Card { get; }
+
+    public string ModelName => Card.Model?.ModelVersionName ?? Card.Model?.SafeTensorFileName ?? "Unknown Model";
+
+    public IEnumerable<string> Tags => Card.Model?.Tags ?? Enumerable.Empty<string>();
+
+    public bool HasTags => Tags.Any();
+
+    public string ModelId => string.IsNullOrWhiteSpace(Card.Model?.ModelId) ? "Unknown" : Card.Model!.ModelId!;
+
+    public string ModelVersionId => string.IsNullOrWhiteSpace(_modelVersionId) ? "Unknown" : _modelVersionId!;
+
+    public string BaseModel => string.IsNullOrWhiteSpace(Card.Model?.DiffusionBaseModel)
+        ? "Unknown"
+        : Card.Model!.DiffusionBaseModel;
+
+    public string FileName => GetModelFileName() ?? Card.Model?.SafeTensorFileName ?? "Unknown";
+
+    public string ModelType => Card.Model?.ModelType switch
+    {
+        null => "Unknown",
+        DiffusionTypes.UNASSIGNED => "Unknown",
+        _ => Card.Model!.ModelType.ToString()
+    };
+
+    public string Description => string.IsNullOrWhiteSpace(_description)
+        ? "No description available."
+        : _description!;
+
+    public Bitmap? VideoFrame
+    {
+        get => _videoFrame;
+        private set
+        {
+            if (ReferenceEquals(_videoFrame, value))
+                return;
+
+            _videoFrame?.Dispose();
+            SetProperty(ref _videoFrame, value, nameof(VideoFrame));
+        }
+    }
+
+    public bool HasVideo => _videoCapture != null;
+
+    public bool HasImage => Card.PreviewImage != null;
+
+    public bool ShouldShowImage => !HasVideo && HasImage;
+
+    public bool ShowPlaceholder => !HasVideo && !HasImage;
+
+    public void Dispose()
+    {
+        Card.PropertyChanged -= OnCardPropertyChanged;
+        StopVideoPlayback();
+        VideoFrame = null;
+    }
+
+    private void OnCardPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(LoraCardViewModel.Model))
+        {
+            OnPropertyChanged(nameof(ModelName));
+            OnPropertyChanged(nameof(ModelId));
+            OnPropertyChanged(nameof(BaseModel));
+            OnPropertyChanged(nameof(FileName));
+            OnPropertyChanged(nameof(ModelType));
+            OnPropertyChanged(nameof(Tags));
+            OnPropertyChanged(nameof(HasTags));
+            UpdateMetadata();
+            UpdatePreviewMediaPath();
+        }
+        else if (e.PropertyName == nameof(LoraCardViewModel.PreviewImage))
+        {
+            OnPropertyChanged(nameof(HasImage));
+            OnPropertyChanged(nameof(ShouldShowImage));
+            OnPropertyChanged(nameof(ShowPlaceholder));
+        }
+    }
+
+    private void UpdateMetadata()
+    {
+        var versionId = TryLoadModelVersionId();
+        SetProperty(ref _modelVersionId, versionId, nameof(ModelVersionId));
+
+        var description = TryLoadDescription();
+        SetProperty(ref _description, description, nameof(Description));
+        OnPropertyChanged(nameof(Description));
+    }
+
+    private void UpdatePreviewMediaPath()
+    {
+        _previewMediaPath = Card.GetPreviewMediaPath();
+        RestartVideoPlayback();
+        OnPropertyChanged(nameof(HasVideo));
+        OnPropertyChanged(nameof(ShouldShowImage));
+        OnPropertyChanged(nameof(ShowPlaceholder));
+    }
+
+    private void RestartVideoPlayback()
+    {
+        StopVideoPlayback();
+        if (string.IsNullOrWhiteSpace(_previewMediaPath) || !File.Exists(_previewMediaPath))
+            return;
+
+        try
+        {
+            var capture = new VideoCapture(_previewMediaPath);
+            if (!capture.IsOpened())
+            {
+                capture.Dispose();
+                return;
+            }
+
+            _videoCapture = capture;
+            var fps = capture.Fps;
+            if (fps <= 0 || double.IsNaN(fps) || double.IsInfinity(fps))
+            {
+                fps = 24;
+            }
+
+            _videoTimer = new DispatcherTimer
+            {
+                Interval = TimeSpan.FromMilliseconds(Math.Max(15, 1000.0 / fps))
+            };
+            _videoTimer.Tick += OnVideoTick;
+            _videoTimer.Start();
+            OnPropertyChanged(nameof(HasVideo));
+            OnPropertyChanged(nameof(ShouldShowImage));
+            OnPropertyChanged(nameof(ShowPlaceholder));
+            OnVideoTick(this, EventArgs.Empty);
+        }
+        catch (Exception ex)
+        {
+            Log($"Failed to start video playback: {ex.Message}", LogSeverity.Warning);
+            StopVideoPlayback();
+        }
+    }
+
+    private void StopVideoPlayback()
+    {
+        if (_videoTimer != null)
+        {
+            _videoTimer.Stop();
+            _videoTimer.Tick -= OnVideoTick;
+            _videoTimer = null;
+        }
+
+        if (_videoCapture != null)
+        {
+            try
+            {
+                _videoCapture.Release();
+            }
+            catch
+            {
+                // ignored
+            }
+            _videoCapture.Dispose();
+            _videoCapture = null;
+        }
+
+        VideoFrame = null;
+        OnPropertyChanged(nameof(HasVideo));
+        OnPropertyChanged(nameof(ShouldShowImage));
+        OnPropertyChanged(nameof(ShowPlaceholder));
+    }
+
+    private unsafe void OnVideoTick(object? sender, EventArgs e)
+    {
+        if (_videoCapture == null)
+            return;
+
+        lock (_videoLock)
+        {
+            try
+            {
+                using var frame = new Mat();
+                if (!_videoCapture.Read(frame) || frame.Empty())
+                {
+                    _videoCapture.Set(VideoCaptureProperties.PosFrames, 0);
+                    if (!_videoCapture.Read(frame) || frame.Empty())
+                    {
+                        return;
+                    }
+                }
+
+                using var converted = new Mat();
+                Cv2.CvtColor(frame, converted, ColorConversionCodes.BGR2BGRA);
+
+                var size = new PixelSize(converted.Width, converted.Height);
+                var bitmap = new WriteableBitmap(size, new Vector(96, 96), PixelFormat.Bgra8888, AlphaFormat.Premul);
+                using (var fb = bitmap.Lock())
+                {
+                    var sourceStride = (int)converted.Step();
+                    var targetStride = fb.RowBytes;
+                    var rows = converted.Height;
+                    var srcPtr = (byte*)converted.DataPointer;
+                    var dstPtr = (byte*)fb.Address;
+
+                    for (var y = 0; y < rows; y++)
+                    {
+                        var srcOffset = y * sourceStride;
+                        var dstOffset = y * targetStride;
+                        Buffer.MemoryCopy(srcPtr + srcOffset, dstPtr + dstOffset, targetStride, sourceStride);
+                    }
+                }
+
+                VideoFrame = bitmap;
+            }
+            catch (Exception ex)
+            {
+                Log($"Error updating video frame: {ex.Message}", LogSeverity.Warning);
+            }
+        }
+    }
+
+    private string? TryLoadModelVersionId()
+    {
+        try
+        {
+            var infoFile = Card.Model?.AssociatedFilesInfo
+                .FirstOrDefault(f => f.Name.EndsWith(".civitai.info", StringComparison.OrdinalIgnoreCase));
+            if (infoFile == null || !File.Exists(infoFile.FullName))
+                return null;
+
+            using var stream = File.OpenRead(infoFile.FullName);
+            using var doc = JsonDocument.Parse(stream);
+            var root = doc.RootElement;
+
+            if (root.TryGetProperty("modelVersionId", out var mvId))
+            {
+                return mvId.ValueKind switch
+                {
+                    JsonValueKind.String => mvId.GetString(),
+                    JsonValueKind.Number => mvId.GetInt64().ToString(),
+                    _ => null
+                };
+            }
+
+            if (root.TryGetProperty("id", out var id))
+            {
+                return id.ValueKind switch
+                {
+                    JsonValueKind.String => id.GetString(),
+                    JsonValueKind.Number => id.GetInt64().ToString(),
+                    _ => null
+                };
+            }
+        }
+        catch (Exception ex)
+        {
+            Log($"Failed to parse model version id: {ex.Message}", LogSeverity.Warning);
+        }
+
+        return null;
+    }
+
+    private string? TryLoadDescription()
+    {
+        try
+        {
+            var model = Card.Model;
+            if (model == null)
+                return null;
+
+            var jsonFile = model.AssociatedFilesInfo
+                .FirstOrDefault(f =>
+                    f.Extension.Equals(".json", StringComparison.OrdinalIgnoreCase) &&
+                    !f.Name.EndsWith(".civitai.info", StringComparison.OrdinalIgnoreCase));
+
+            if (jsonFile != null && File.Exists(jsonFile.FullName))
+            {
+                var text = File.ReadAllText(jsonFile.FullName);
+                using var doc = JsonDocument.Parse(text);
+                var root = doc.RootElement;
+
+                if (root.TryGetProperty("description", out var description) && description.ValueKind == JsonValueKind.String)
+                {
+                    return NormalizeDescription(description.GetString());
+                }
+
+                if (root.TryGetProperty("modelVersions", out var versions) && versions.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var version in versions.EnumerateArray())
+                    {
+                        if (version.TryGetProperty("description", out var versionDescription) &&
+                            versionDescription.ValueKind == JsonValueKind.String)
+                        {
+                            return NormalizeDescription(versionDescription.GetString());
+                        }
+                    }
+                }
+            }
+
+            var infoFile = model.AssociatedFilesInfo
+                .FirstOrDefault(f => f.Name.EndsWith(".civitai.info", StringComparison.OrdinalIgnoreCase));
+            if (infoFile != null && File.Exists(infoFile.FullName))
+            {
+                using var stream = File.OpenRead(infoFile.FullName);
+                using var doc = JsonDocument.Parse(stream);
+                var root = doc.RootElement;
+                if (root.TryGetProperty("description", out var infoDescription) &&
+                    infoDescription.ValueKind == JsonValueKind.String)
+                {
+                    return NormalizeDescription(infoDescription.GetString());
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Log($"Failed to load description: {ex.Message}", LogSeverity.Warning);
+        }
+
+        return null;
+    }
+
+    private static string? NormalizeDescription(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        return value.Replace("\r\n", "\n").Trim();
+    }
+
+    private string? GetModelFileName()
+    {
+        var model = Card.Model;
+        if (model == null)
+            return null;
+
+        var file = model.AssociatedFilesInfo
+            .FirstOrDefault(f => ModelFileExtensions.Contains(f.Extension, StringComparer.OrdinalIgnoreCase));
+        return file?.Name;
+    }
+}

--- a/DiffusionNexus.UI/ViewModels/LoraHelperViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraHelperViewModel.cs
@@ -7,6 +7,7 @@ using DiffusionNexus.Service.Classes;
 using DiffusionNexus.Service.Search;
 using DiffusionNexus.Service.Services;
 using DiffusionNexus.UI.Classes;
+using DiffusionNexus.UI.Views;
 using Avalonia.Controls;
 using Avalonia.Platform.Storage;
 using System.Diagnostics;
@@ -493,6 +494,19 @@ public partial class LoraHelperViewModel : ViewModelBase
         _allCards.Remove(card);
         Cards.Remove(card);
         StartIndexing();
+    }
+
+    public Task ShowDetailsAsync(LoraCardViewModel card)
+    {
+        if (_window is null)
+            return Task.CompletedTask;
+
+        var detailWindow = new LoraDetailWindow
+        {
+            DataContext = new LoraDetailViewModel(card)
+        };
+
+        return detailWindow.ShowDialog(_window);
     }
 
     public async Task OpenWebForCardAsync(LoraCardViewModel card)

--- a/DiffusionNexus.UI/Views/LoraDetailWindow.axaml
+++ b/DiffusionNexus.UI/Views/LoraDetailWindow.axaml
@@ -1,0 +1,115 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:DiffusionNexus.UI.ViewModels"
+        x:Class="DiffusionNexus.UI.Views.LoraDetailWindow"
+        x:DataType="vm:LoraDetailViewModel"
+        Width="900"
+        Height="650"
+        Title="LoRA Details"
+        WindowStartupLocation="CenterOwner">
+  <Window.Styles>
+    <Style Selector="Button.tag-pill">
+      <Setter Property="Background" Value="#2B2B2B"/>
+      <Setter Property="BorderBrush" Value="#3F3F3F"/>
+      <Setter Property="BorderThickness" Value="1"/>
+      <Setter Property="CornerRadius" Value="6"/>
+      <Setter Property="Foreground" Value="#E0E0E0"/>
+      <Setter Property="Padding" Value="6,4"/>
+      <Setter Property="FontSize" Value="12"/>
+      <Setter Property="Margin" Value="0,0,6,6"/>
+      <Setter Property="IsHitTestVisible" Value="False"/>
+    </Style>
+
+    <Style Selector="TextBlock.meta-label">
+      <Setter Property="FontWeight" Value="SemiBold"/>
+      <Setter Property="Foreground" Value="#B0B0B0"/>
+      <Setter Property="Margin" Value="0,0,12,0"/>
+    </Style>
+  </Window.Styles>
+
+  <Grid Margin="20" RowDefinitions="Auto,Auto,*,Auto,Auto" RowSpacing="18">
+    <TextBlock Grid.Row="0"
+               Text="{Binding ModelName}"
+               FontSize="28"
+               FontWeight="Bold"
+               TextWrapping="Wrap"/>
+
+    <ItemsControl Grid.Row="1"
+                  ItemsSource="{Binding Tags}"
+                  IsVisible="{Binding HasTags}">
+      <ItemsControl.ItemsPanel>
+        <ItemsPanelTemplate>
+          <WrapPanel />
+        </ItemsPanelTemplate>
+      </ItemsControl.ItemsPanel>
+      <ItemsControl.ItemTemplate>
+        <DataTemplate>
+          <Button Classes="tag-pill" Content="{Binding .}" />
+        </DataTemplate>
+      </ItemsControl.ItemTemplate>
+    </ItemsControl>
+
+    <Grid Grid.Row="2" ColumnDefinitions="2*,3*" ColumnSpacing="18">
+      <Border Background="#1E1E1E"
+              CornerRadius="10"
+              Padding="10">
+        <Grid>
+          <Image Source="{Binding VideoFrame}"
+                 Stretch="Uniform"
+                 IsVisible="{Binding HasVideo}"/>
+          <Image Source="{Binding Card.PreviewImage}"
+                 Stretch="Uniform"
+                 IsVisible="{Binding ShouldShowImage}"/>
+          <TextBlock Text="No preview available"
+                     HorizontalAlignment="Center"
+                     VerticalAlignment="Center"
+                     FontStyle="Italic"
+                     Foreground="#AAAAAA"
+                     IsVisible="{Binding ShowPlaceholder}"/>
+        </Grid>
+      </Border>
+
+      <Border Grid.Column="1"
+              Background="#1E1E1E"
+              CornerRadius="10"
+              Padding="16">
+        <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto" RowSpacing="12" ColumnDefinitions="Auto,*">
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="Model ID:" Classes="meta-label"/>
+          <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding ModelId}" TextWrapping="Wrap"/>
+
+          <TextBlock Grid.Row="1" Grid.Column="0" Text="Version ID:" Classes="meta-label"/>
+          <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding ModelVersionId}" TextWrapping="Wrap"/>
+
+          <TextBlock Grid.Row="2" Grid.Column="0" Text="Base Model:" Classes="meta-label"/>
+          <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding BaseModel}" TextWrapping="Wrap"/>
+
+          <TextBlock Grid.Row="3" Grid.Column="0" Text="File:" Classes="meta-label"/>
+          <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding FileName}" TextWrapping="Wrap"/>
+
+          <TextBlock Grid.Row="4" Grid.Column="0" Text="Type:" Classes="meta-label"/>
+          <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding ModelType}" TextWrapping="Wrap"/>
+        </Grid>
+      </Border>
+    </Grid>
+
+    <StackPanel Grid.Row="3" Spacing="6">
+      <TextBlock Text="Description" FontWeight="SemiBold" FontSize="16"/>
+      <Border Background="#1E1E1E"
+              CornerRadius="8"
+              Padding="12">
+        <ScrollViewer MaxHeight="180">
+          <TextBlock Text="{Binding Description}"
+                     TextWrapping="Wrap"/>
+        </ScrollViewer>
+      </Border>
+    </StackPanel>
+
+    <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+      <Button Content="🌐" Width="44" Height="44" FontSize="18" Command="{Binding Card.OpenWebCommand}"/>
+      <Button Content="📋" Width="44" Height="44" FontSize="18" Command="{Binding Card.CopyCommand}"/>
+      <Button Content="N" Width="44" Height="44" FontSize="18" Command="{Binding Card.CopyNameCommand}"/>
+      <Button Content="📂" Width="44" Height="44" FontSize="18" Command="{Binding Card.OpenFolderCommand}"/>
+      <Button Content="❌" Width="44" Height="44" FontSize="18" Command="{Binding Card.DeleteCommand}"/>
+    </StackPanel>
+  </Grid>
+</Window>

--- a/DiffusionNexus.UI/Views/LoraDetailWindow.axaml.cs
+++ b/DiffusionNexus.UI/Views/LoraDetailWindow.axaml.cs
@@ -1,0 +1,26 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace DiffusionNexus.UI.Views;
+
+public partial class LoraDetailWindow : Window
+{
+    public LoraDetailWindow()
+    {
+        InitializeComponent();
+        Closed += OnClosed;
+    }
+
+    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+    private void OnClosed(object? sender, EventArgs e)
+    {
+        if (DataContext is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+
+        Closed -= OnClosed;
+    }
+}

--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml
@@ -97,7 +97,14 @@
           </items:ItemsRepeater.Layout>
           <items:ItemsRepeater.ItemTemplate>
             <DataTemplate x:DataType="vm:LoraCardViewModel">
-              <Border Background="#333333" Padding="5" Margin="5" Width="250" Height="300" Classes="lora-card">
+              <Border Background="#333333"
+                      Padding="5"
+                      Margin="5"
+                      Width="250"
+                      Height="300"
+                      Classes="lora-card"
+                      Cursor="Hand"
+                      PointerReleased="OnCardPointerReleased">
                 <Grid>
                   <Image Source="{Binding PreviewImage}" Stretch="UniformToFill"/>
                   <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Top">

--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml.cs
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml.cs
@@ -1,6 +1,9 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
 using Avalonia.Markup.Xaml;
+using CommunityToolkit.Mvvm.Input;
 using DiffusionNexus.UI.ViewModels;
 using DiffusionNexus.UI.Classes;
 
@@ -53,5 +56,31 @@ public partial class LoraHelperView : UserControl
                 await vm.LoadNextPageAsync();
             }
         }
+    }
+
+    private async void OnCardPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (e.InitialPressMouseButton != MouseButton.Left)
+            return;
+
+        if (sender is not Border border)
+            return;
+
+        if (e.Source is Button || e.Source is ToggleButton)
+            return;
+
+        if (border.DataContext is not LoraCardViewModel card)
+            return;
+
+        if (card.OpenDetailsCommand is IAsyncRelayCommand asyncCommand)
+        {
+            await asyncCommand.ExecuteAsync(null);
+        }
+        else
+        {
+            card.OpenDetailsCommand.Execute(null);
+        }
+
+        e.Handled = true;
     }
 }


### PR DESCRIPTION
## Summary
- add a dedicated LoRA detail window that shows model metadata, tags, description, and the existing card actions
- stream MP4 previews via OpenCvSharp when available while falling back to images or a placeholder
- wire card clicks to open the new detail window and include required dependencies

## Testing
- dotnet build DiffusionNexus.sln

------
https://chatgpt.com/codex/tasks/task_e_68f0e0b86e40833291760d61b02d2c55