### PR TITLE
Add detailed LoRA preview window

### DIFF
--- a/DiffusionNexus.Service/Classes/ModelClass.cs
+++ b/DiffusionNexus.Service/Classes/ModelClass.cs
@@ -24,6 +24,7 @@ namespace DiffusionNexus.Service.Classes
         [MetadataField] public string SafeTensorFileName { get; set; }
         [MetadataField] public string ModelVersionName { get; set; }
         [MetadataField] public string? ModelId { get; set; }
+        [MetadataField] public string? ModelVersionId { get; set; }
         public string? SHA256Hash { get; set; }
         [MetadataField] public DiffusionTypes ModelType { get; set; } = DiffusionTypes.UNASSIGNED;
         public List<FileInfo> AssociatedFilesInfo { get; set; }
@@ -31,6 +32,7 @@ namespace DiffusionNexus.Service.Classes
         [MetadataField] public CivitaiBaseCategories CivitaiCategory { get; set; } = CivitaiBaseCategories.UNASSIGNED;
         [MetadataField] public List<string> TrainedWords { get; set; } = new();
         [MetadataField] public bool? Nsfw { get; set; }
+        [MetadataField] public string? Description { get; set; }
 
         // status flags
         public bool NoMetaData { get; set; } = true;

--- a/DiffusionNexus.Service/Services/JsonInfoFileReaderService.cs
+++ b/DiffusionNexus.Service/Services/JsonInfoFileReaderService.cs
@@ -2,6 +2,12 @@ using DiffusionNexus.Service.Classes;
 using DiffusionNexus.Service.Helper;
 using ModelMover.Core.Metadata;
 using Serilog;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace DiffusionNexus.Service.Services;
 
@@ -41,12 +47,14 @@ public class JsonInfoFileReaderService
                 progress?.Report(new ProgressReport { StatusMessage = $"Processing metadata for {safetensors.Name}", LogLevel = LogSeverity.Info });
                 ModelClass meta = await _metadataFetcher(safetensors.FullName, progress, cancellationToken);
                 model.ModelId = meta.ModelId;
+                model.ModelVersionId = meta.ModelVersionId;
                 model.DiffusionBaseModel = meta.DiffusionBaseModel;
                 model.ModelType = meta.ModelType;
                 model.ModelVersionName = string.IsNullOrWhiteSpace(meta.ModelVersionName) ? model.SafeTensorFileName : meta.ModelVersionName;
                 model.Tags = meta.Tags;
                 model.Nsfw = meta.Nsfw;
                 model.TrainedWords = meta.TrainedWords;
+                model.Description = meta.Description;
                 model.CivitaiCategory = MetaDataUtilService.GetCategoryFromTags(model.Tags);
                 var completeness = meta.HasFullMetadata ? "complete" : meta.HasAnyMetadata ? "partial" : "none";
                 var level = meta.HasFullMetadata ? LogSeverity.Success : LogSeverity.Warning;

--- a/DiffusionNexus.Tests/Service/Services/LoraMetadataDownloadServiceTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/LoraMetadataDownloadServiceTests.cs
@@ -11,9 +11,11 @@ public class LoraMetadataDownloadServiceTests
     public void ParseInfoJson_ReturnsExpectedValues()
     {
         var json = "{\"modelId\":123,\"images\":[{\"url\":\"http://example.com/a.jpg\"}],\"trainedWords\":[\"foo\"],\"model\":{\"nsfw\":true}}";
-        var (url, id, words, nsfw) = LoraMetadataDownloadService.ParseInfoJson(json);
+        var (url, id, versionId, description, words, nsfw) = LoraMetadataDownloadService.ParseInfoJson(json);
         id.Should().Be("123");
+        versionId.Should().BeNull();
         url.Should().Be("http://example.com/a.jpg");
+        description.Should().BeNull();
         words.Should().ContainSingle().Which.Should().Be("foo");
         nsfw.Should().BeTrue();
     }

--- a/DiffusionNexus.UI/DiffusionNexus.UI.csproj
+++ b/DiffusionNexus.UI/DiffusionNexus.UI.csproj
@@ -47,6 +47,8 @@
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.7" />
     <PackageReference Include="Xabe.FFmpeg" Version="6.0.1" />
     <PackageReference Include="Xabe.FFmpeg.Downloader" Version="6.0.1" />
+    <PackageReference Include="LibVLCSharp.Avalonia" Version="3.7.0" />
+    <PackageReference Include="LibVLCSharp" Version="3.7.0" />
   </ItemGroup>
 
   <!-- Automatically read, increment and save build number on each build -->

--- a/DiffusionNexus.UI/ViewModels/LoraCardViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraCardViewModel.cs
@@ -44,6 +44,7 @@ public partial class LoraCardViewModel : ViewModelBase
     public IAsyncRelayCommand CopyCommand { get; }
     public IAsyncRelayCommand CopyNameCommand { get; }
     public IRelayCommand OpenFolderCommand { get; }
+    public IAsyncRelayCommand OpenDetailsCommand { get; }
 
     public ObservableCollection<LoraVariantViewModel> Variants { get; } = new();
 
@@ -59,12 +60,14 @@ public partial class LoraCardViewModel : ViewModelBase
         CopyCommand = new AsyncRelayCommand(OnCopyAsync);
         CopyNameCommand = new AsyncRelayCommand(OnCopyNameAsync);
         OpenFolderCommand = new RelayCommand(OnOpenFolder);
+        OpenDetailsCommand = new AsyncRelayCommand(OnOpenDetailsAsync);
         Variants.CollectionChanged += OnVariantsCollectionChanged;
     }
 
     partial void OnModelChanged(ModelClass? value)
     {
         _ = LoadPreviewImageAsync();
+        Description = value?.Description;
     }
 
     internal void SetVariants(IReadOnlyList<LoraVariantDescriptor> variants)
@@ -177,7 +180,7 @@ public partial class LoraCardViewModel : ViewModelBase
         return null;
     }
 
-    private string? GetPreviewMediaPath()
+    public string? GetPreviewMediaPath()
     {
         if (Model == null) return null;
         
@@ -190,6 +193,11 @@ public partial class LoraCardViewModel : ViewModelBase
         }
 
         return null;
+    }
+
+    private Task OnOpenDetailsAsync()
+    {
+        return Parent?.ShowDetailsAsync(this) ?? Task.CompletedTask;
     }
 
     private void OnEdit() => Log($"Edit {Model.SafeTensorFileName}", LogSeverity.Info);

--- a/DiffusionNexus.UI/ViewModels/LoraDetailViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraDetailViewModel.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Avalonia.Media.Imaging;
+using DiffusionNexus.Service.Classes;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+public class LoraDetailViewModel : ViewModelBase
+{
+    private readonly LoraCardViewModel _card;
+    private readonly Uri? _previewMediaUri;
+    private readonly string? _previewMediaPath;
+
+    public LoraDetailViewModel(LoraCardViewModel card)
+    {
+        _card = card;
+        var mediaPath = card.GetPreviewMediaPath();
+        if (!string.IsNullOrWhiteSpace(mediaPath) && File.Exists(mediaPath))
+        {
+            _previewMediaPath = mediaPath;
+            _previewMediaUri = new Uri(mediaPath);
+        }
+    }
+
+    public LoraCardViewModel Card => _card;
+
+    public string ModelName => _card.Model?.ModelVersionName
+        ?? _card.Model?.SafeTensorFileName
+        ?? "Unknown Model";
+
+    public IReadOnlyList<string> Tags => (IReadOnlyList<string>?)_card.Model?.Tags ?? Array.Empty<string>();
+
+    public bool HasTags => _card.Model?.Tags?.Count > 0;
+
+    public Bitmap? PreviewImage => _card.PreviewImage;
+
+    public bool HasPreviewVideo => _previewMediaUri != null;
+
+    public Uri? PreviewMediaSource => _previewMediaUri;
+
+    public string? PreviewMediaPath => _previewMediaPath;
+
+    public string ModelIdDisplay => string.IsNullOrWhiteSpace(_card.Model?.ModelId)
+        ? "Not available"
+        : _card.Model!.ModelId!;
+
+    public string ModelVersionIdDisplay => string.IsNullOrWhiteSpace(_card.Model?.ModelVersionId)
+        ? "Not available"
+        : _card.Model!.ModelVersionId!;
+
+    public string BaseModelDisplay => string.IsNullOrWhiteSpace(_card.Model?.DiffusionBaseModel)
+        ? "Unknown"
+        : _card.Model!.DiffusionBaseModel;
+
+    public string FileNameWithExtension
+    {
+        get
+        {
+            var model = _card.Model;
+            if (model == null)
+            {
+                return "Not available";
+            }
+
+            var file = model.AssociatedFilesInfo
+                .FirstOrDefault(f => SupportedTypes.ModelTypesByPriority.Any(ext =>
+                    f.Extension.Equals(ext, StringComparison.OrdinalIgnoreCase)));
+
+            if (file != null)
+            {
+                return file.Name;
+            }
+
+            if (!string.IsNullOrWhiteSpace(model.SafeTensorFileName))
+            {
+                return model.SafeTensorFileName.EndsWith(".safetensors", StringComparison.OrdinalIgnoreCase)
+                    ? model.SafeTensorFileName
+                    : model.SafeTensorFileName + ".safetensors";
+            }
+
+            return "Not available";
+        }
+    }
+
+    public string ModelTypeDisplay => _card.Model?.ModelType.ToString() ?? "Unknown";
+
+    public string Description => string.IsNullOrWhiteSpace(_card.Model?.Description)
+        ? "No description available."
+        : _card.Model!.Description!;
+
+    public bool HasDescription => !string.IsNullOrWhiteSpace(_card.Model?.Description);
+}

--- a/DiffusionNexus.UI/ViewModels/LoraHelperViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraHelperViewModel.cs
@@ -7,6 +7,7 @@ using DiffusionNexus.Service.Classes;
 using DiffusionNexus.Service.Search;
 using DiffusionNexus.Service.Services;
 using DiffusionNexus.UI.Classes;
+using DiffusionNexus.UI.Views;
 using Avalonia.Controls;
 using Avalonia.Platform.Storage;
 using System.Diagnostics;
@@ -558,6 +559,23 @@ public partial class LoraHelperViewModel : ViewModelBase
                 Log($"failed to copy: {ex.Message}", LogSeverity.Error);
             }
         }
+    }
+
+    public async Task ShowDetailsAsync(LoraCardViewModel card)
+    {
+        if (card.Model == null || _window == null)
+            return;
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            var detailVm = new LoraDetailViewModel(card);
+            var window = new LoraDetailWindow
+            {
+                DataContext = detailVm
+            };
+
+            window.Show(_window);
+        });
     }
 
     private static IEnumerable<char> GetLoraNameShort(LoraCardViewModel card)

--- a/DiffusionNexus.UI/Views/LoraDetailWindow.axaml
+++ b/DiffusionNexus.UI/Views/LoraDetailWindow.axaml
@@ -1,0 +1,93 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:DiffusionNexus.UI.ViewModels"
+        xmlns:conv="using:DiffusionNexus.UI.Converters"
+        xmlns:vlc="clr-namespace:LibVLCSharp.Avalonia;assembly=LibVLCSharp.Avalonia"
+        x:Class="DiffusionNexus.UI.Views.LoraDetailWindow"
+        x:DataType="vm:LoraDetailViewModel"
+        Width="900"
+        Height="620"
+        Title="{Binding ModelName}"
+        WindowStartupLocation="CenterOwner">
+  <Window.Resources>
+    <conv:BooleanNotConverter x:Key="BooleanNotConverter" />
+  </Window.Resources>
+  <Window.Styles>
+    <Style Selector="Button.tag-chip">
+      <Setter Property="Background" Value="#2C2C2C"/>
+      <Setter Property="BorderBrush" Value="#3F3F3F"/>
+      <Setter Property="BorderThickness" Value="1"/>
+      <Setter Property="CornerRadius" Value="6"/>
+      <Setter Property="Foreground" Value="#F0F0F0"/>
+      <Setter Property="Padding" Value="10,4"/>
+      <Setter Property="FontSize" Value="12"/>
+      <Setter Property="IsEnabled" Value="False"/>
+    </Style>
+  </Window.Styles>
+  <ScrollViewer HorizontalScrollBarVisibility="Disabled">
+    <StackPanel Margin="20" Spacing="16">
+      <TextBlock Text="{Binding ModelName}" FontSize="26" FontWeight="Bold" TextWrapping="Wrap"/>
+      <ItemsControl ItemsSource="{Binding Tags}" IsVisible="{Binding HasTags}">
+        <ItemsControl.ItemsPanel>
+          <ItemsPanelTemplate>
+            <WrapPanel ItemSpacing="8"/>
+          </ItemsPanelTemplate>
+        </ItemsControl.ItemsPanel>
+        <ItemsControl.ItemTemplate>
+          <DataTemplate>
+            <Button Classes="tag-chip" Content="{Binding .}"/>
+          </DataTemplate>
+        </ItemsControl.ItemTemplate>
+      </ItemsControl>
+
+      <Grid ColumnDefinitions="3*,2*" ColumnSpacing="20">
+        <Border Background="#1E1E1E" CornerRadius="10" Padding="12" MinHeight="320">
+          <Grid>
+            <Image x:Name="PreviewImageControl"
+                   Source="{Binding PreviewImage}" Stretch="Uniform"/>
+            <vlc:VideoView x:Name="PreviewVideo" IsVisible="False"/>
+            <TextBlock x:Name="PreviewPlaceholder"
+                       Text="No preview available"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Center"/>
+          </Grid>
+        </Border>
+        <Border Background="#1E1E1E" CornerRadius="10" Padding="16">
+          <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="Auto,*" RowSpacing="12" ColumnSpacing="16">
+            <TextBlock Text="Model ID" FontWeight="SemiBold"/>
+            <TextBlock Grid.Column="1" Text="{Binding ModelIdDisplay}" TextWrapping="Wrap"/>
+
+            <TextBlock Grid.Row="1" Text="Model Version ID" FontWeight="SemiBold"/>
+            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding ModelVersionIdDisplay}" TextWrapping="Wrap"/>
+
+            <TextBlock Grid.Row="2" Text="Base Model" FontWeight="SemiBold"/>
+            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding BaseModelDisplay}" TextWrapping="Wrap"/>
+
+            <TextBlock Grid.Row="3" Text="File" FontWeight="SemiBold"/>
+            <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding FileNameWithExtension}" TextWrapping="Wrap"/>
+
+            <TextBlock Grid.Row="4" Text="Model Type" FontWeight="SemiBold"/>
+            <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding ModelTypeDisplay}" TextWrapping="Wrap"/>
+          </Grid>
+        </Border>
+      </Grid>
+
+      <StackPanel>
+        <TextBlock Text="Description" FontWeight="SemiBold" FontSize="16"/>
+        <Border Background="#1E1E1E" CornerRadius="10" Padding="16" MinHeight="120">
+          <ScrollViewer MaxHeight="240" VerticalScrollBarVisibility="Auto">
+            <TextBlock Text="{Binding Description}" TextWrapping="Wrap"/>
+          </ScrollViewer>
+        </Border>
+      </StackPanel>
+
+      <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+        <Button Content="🌐" Width="44" Height="44" Command="{Binding Card.OpenWebCommand}" ToolTip.Tip="Open on Civitai"/>
+        <Button Content="📋" Width="44" Height="44" Command="{Binding Card.CopyCommand}" ToolTip.Tip="Copy trigger words"/>
+        <Button Content="N" Width="44" Height="44" Command="{Binding Card.CopyNameCommand}" ToolTip.Tip="Copy model name"/>
+        <Button Content="📂" Width="44" Height="44" Command="{Binding Card.OpenFolderCommand}" ToolTip.Tip="Open containing folder"/>
+        <Button Content="❌" Width="44" Height="44" Command="{Binding Card.DeleteCommand}" ToolTip.Tip="Delete this model"/>
+      </StackPanel>
+    </StackPanel>
+  </ScrollViewer>
+</Window>

--- a/DiffusionNexus.UI/Views/LoraDetailWindow.axaml.cs
+++ b/DiffusionNexus.UI/Views/LoraDetailWindow.axaml.cs
@@ -1,0 +1,154 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using LibVLCSharp.Avalonia;
+using LibVLCSharp.Shared;
+
+namespace DiffusionNexus.UI.Views;
+
+public partial class LoraDetailWindow : Window
+{
+    private VideoView? _videoView;
+    private Image? _previewImage;
+    private TextBlock? _placeholder;
+    private LibVLC? _libVlc;
+    private MediaPlayer? _mediaPlayer;
+    private bool _videoInitialized;
+    private string? _currentMediaPath;
+    private Media? _media;
+
+    public LoraDetailWindow()
+    {
+        InitializeComponent();
+        _videoView = this.FindControl<VideoView>("PreviewVideo");
+        _previewImage = this.FindControl<Image>("PreviewImageControl");
+        _placeholder = this.FindControl<TextBlock>("PreviewPlaceholder");
+
+        DataContextChanged += OnDataContextChanged;
+
+        TryInitializeVideo();
+        UpdatePreviewVisibility();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        TryInitializeVideo();
+        UpdatePreviewVisibility();
+    }
+
+    private void TryInitializeVideo()
+    {
+        CleanupVideo();
+
+        if (_videoView == null)
+        {
+            _videoInitialized = false;
+            return;
+        }
+
+        if (DataContext is not ViewModels.LoraDetailViewModel vm || string.IsNullOrWhiteSpace(vm.PreviewMediaPath))
+        {
+            _videoInitialized = false;
+            return;
+        }
+
+        try
+        {
+            Core.Initialize();
+            _libVlc = new LibVLC();
+            _mediaPlayer = new MediaPlayer(_libVlc)
+            {
+                EnableHardwareDecoding = true
+            };
+
+            _mediaPlayer.EndReached += OnMediaEnded;
+
+            _videoView.MediaPlayer = _mediaPlayer;
+            _currentMediaPath = vm.PreviewMediaPath;
+            _media = new Media(_libVlc, _currentMediaPath, FromType.FromPath);
+            if (_mediaPlayer.Play(_media))
+            {
+                _videoInitialized = true;
+            }
+            else
+            {
+                CleanupVideo();
+            }
+        }
+        catch
+        {
+            CleanupVideo();
+            _videoInitialized = false;
+        }
+    }
+
+    private void UpdatePreviewVisibility()
+    {
+        if (_previewImage == null || _placeholder == null)
+        {
+            return;
+        }
+
+        bool hasImage = DataContext is ViewModels.LoraDetailViewModel vm && vm.PreviewImage != null;
+
+        if (_videoView != null)
+        {
+            _videoView.IsVisible = _videoInitialized;
+        }
+
+        _previewImage.IsVisible = !_videoInitialized && hasImage;
+        _placeholder.IsVisible = !_videoInitialized && !hasImage;
+    }
+
+    private void CleanupVideo()
+    {
+        if (_videoView != null)
+        {
+            _videoView.MediaPlayer = null;
+        }
+
+        if (_mediaPlayer != null)
+        {
+            _mediaPlayer.EndReached -= OnMediaEnded;
+            _mediaPlayer.Dispose();
+        }
+        _mediaPlayer = null;
+        _media?.Dispose();
+        _media = null;
+        _libVlc?.Dispose();
+        _libVlc = null;
+        _videoInitialized = false;
+        _currentMediaPath = null;
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        base.OnClosed(e);
+        DataContextChanged -= OnDataContextChanged;
+        CleanupVideo();
+    }
+
+    private void OnMediaEnded(object? sender, EventArgs e)
+    {
+        if (_mediaPlayer == null || _libVlc == null || string.IsNullOrWhiteSpace(_currentMediaPath))
+        {
+            return;
+        }
+
+        try
+        {
+            _media?.Dispose();
+            _media = new Media(_libVlc, _currentMediaPath, FromType.FromPath);
+            _mediaPlayer.Play(_media);
+        }
+        catch
+        {
+            // Ignore playback restart failures; the image fallback remains visible.
+        }
+    }
+}

--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml
@@ -97,7 +97,8 @@
           </items:ItemsRepeater.Layout>
           <items:ItemsRepeater.ItemTemplate>
             <DataTemplate x:DataType="vm:LoraCardViewModel">
-              <Border Background="#333333" Padding="5" Margin="5" Width="250" Height="300" Classes="lora-card">
+              <Border Background="#333333" Padding="5" Margin="5" Width="250" Height="300" Classes="lora-card"
+                      PointerPressed="OnCardPointerPressed">
                 <Grid>
                   <Image Source="{Binding PreviewImage}" Stretch="UniformToFill"/>
                   <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Top">

--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml.cs
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml.cs
@@ -3,6 +3,8 @@ using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using DiffusionNexus.UI.ViewModels;
 using DiffusionNexus.UI.Classes;
+using Avalonia.Input;
+using Avalonia.Controls.Primitives;
 
 namespace DiffusionNexus.UI.Views;
 
@@ -52,6 +54,30 @@ public partial class LoraHelperView : UserControl
             {
                 await vm.LoadNextPageAsync();
             }
+        }
+    }
+
+    private void OnCardPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (sender is not Border { DataContext: LoraCardViewModel card })
+        {
+            return;
+        }
+
+        if (!e.GetCurrentPoint(null).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+
+        if (e.Source is Control control && control != sender && (control is Button || control is ToggleButton))
+        {
+            return;
+        }
+
+        if (card.OpenDetailsCommand.CanExecute(null))
+        {
+            card.OpenDetailsCommand.Execute(null);
+            e.Handled = true;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a dedicated LoRA detail window with tag chips, preview/video area, metadata grid, description, and action buttons
- wire card selection to launch the detail window and expose preview information through a new view model
- enrich metadata ingestion with model version IDs and descriptions while updating dependencies and tests

## Testing
- dotnet build DiffusionNexus.sln

------
https://chatgpt.com/codex/tasks/task_e_68f0e0b86e40833291760d61b02d2c55