### PR TITLE
Add optional video previews to Lora Helper cards

### DIFF
--- a/DiffusionNexus.UI/Classes/SettingsModel.cs
+++ b/DiffusionNexus.UI/Classes/SettingsModel.cs
@@ -16,6 +16,7 @@ namespace DiffusionNexus.UI.Classes
         [ObservableProperty] private bool _mergeLoraHelperSources;
         [ObservableProperty] private bool _deleteEmptySourceFolders;
         [ObservableProperty] private bool _generateVideoThumbnails = true;
+        [ObservableProperty] private bool _showVideoPreview;
         [ObservableProperty] private bool _showNsfw;
         [ObservableProperty] private bool _useForgeStylePrompts = true;
 

--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml
@@ -106,7 +106,16 @@
                       Cursor="Hand"
                       PointerReleased="OnCardPointerReleased">
                 <Grid>
-                  <Image Source="{Binding PreviewImage}" Stretch="UniformToFill"/>
+                  <Grid>
+                    <Image Source="{Binding VideoFrame}" Stretch="UniformToFill" IsVisible="{Binding ShouldShowVideo}"/>
+                    <Image Source="{Binding PreviewImage}" Stretch="UniformToFill" IsVisible="{Binding ShouldShowImage}"/>
+                    <TextBlock Text="No preview available"
+                               HorizontalAlignment="Center"
+                               VerticalAlignment="Center"
+                               FontStyle="Italic"
+                               Foreground="#AAAAAA"
+                               IsVisible="{Binding ShowPlaceholder}"/>
+                  </Grid>
                   <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Top">
                     <Border BorderBrush="White" BorderThickness="2" Padding="2" Margin="2" Background="Black">
                       <TextBlock Text="{Binding DiffusionTypes, Converter={StaticResource TagsDisplayConverter}}" FontSize="12"/>

--- a/DiffusionNexus.UI/Views/SettingsView.axaml
+++ b/DiffusionNexus.UI/Views/SettingsView.axaml
@@ -65,6 +65,9 @@
           <CheckBox Content="Automatic thumbnail generation from videos"
                    IsChecked="{Binding Settings.GenerateVideoThumbnails, Mode=TwoWay}"
                    Margin="0,5,0,0"/>
+          <CheckBox Content="Show Video Preview (experimental / slow)"
+                   IsChecked="{Binding Settings.ShowVideoPreview, Mode=TwoWay}"
+                   Margin="0,5,0,0"/>
           <CheckBox Content="Show NSFW by default"
                    IsChecked="{Binding Settings.ShowNsfw, Mode=TwoWay}"
                    Margin="0,5,0,0"/>


### PR DESCRIPTION
## Summary
- add a "Show Video Preview (experimental / slow)" toggle to the Lora Helper settings
- update Lora Helper cards to play their video previews when the option is enabled and fall back to images otherwise
- dispose card video resources when refreshing or deleting entries to avoid leaks

## Testing
- dotnet build DiffusionNexus.sln

------
https://chatgpt.com/codex/tasks/task_e_68f0f864a0248332ab941c9e36e3413a