### PR TITLE
Refine LoRA description HTML rendering

### DIFF
--- a/DiffusionNexus.UI/DiffusionNexus.UI.csproj
+++ b/DiffusionNexus.UI/DiffusionNexus.UI.csproj
@@ -34,16 +34,19 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.3.2" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.2" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.2" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.2" />
     <PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.1.5" />
+    <PackageReference Include="Avalonia.Controls.WebView" Version="11.3.11" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.2" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.2" />
+    <PackageReference Include="Avalonia.HtmlRenderer" Version="11.2.0" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.2" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Include="Avalonia.Diagnostics" Version="11.3.2">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="HtmlSanitizer" Version="9.0.886" />
     <PackageReference Include="OpenCvSharp4" Version="4.6.0.20220608" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.7" />

--- a/DiffusionNexus.UI/Utilities/HtmlDescriptionFormatter.cs
+++ b/DiffusionNexus.UI/Utilities/HtmlDescriptionFormatter.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Avalonia.Styling;
+using Ganss.Xss;
+
+namespace DiffusionNexus.UI.Utilities;
+
+internal static class HtmlDescriptionFormatter
+{
+    private const string PlaceholderHtml = "<p class=\"placeholder\">No description provided.</p>";
+
+    private static readonly HtmlSanitizer Sanitizer = CreateSanitizer();
+    private static readonly string LightCss = BuildCss(ThemeVariant.Light);
+    private static readonly string DarkCss = BuildCss(ThemeVariant.Dark);
+
+    public static string? Sanitize(string? html)
+    {
+        if (string.IsNullOrWhiteSpace(html))
+        {
+            return null;
+        }
+
+        var sanitized = Sanitizer.Sanitize(html);
+        return string.IsNullOrWhiteSpace(sanitized) ? null : sanitized.Trim();
+    }
+
+    public static string BuildDocument(string? sanitizedHtml, ThemeVariant themeVariant)
+    {
+        var css = themeVariant == ThemeVariant.Dark ? DarkCss : LightCss;
+        var colorScheme = themeVariant == ThemeVariant.Dark ? "dark" : "light";
+        var bodyContent = string.IsNullOrWhiteSpace(sanitizedHtml)
+            ? PlaceholderHtml
+            : sanitizedHtml;
+
+        var builder = new StringBuilder();
+        builder.AppendLine("<!DOCTYPE html>");
+        builder.AppendLine("<html lang=\"en\">");
+        builder.AppendLine("<head>");
+        builder.AppendLine("  <meta charset=\"utf-8\" />");
+        builder.AppendLine("  <meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'none'; img-src https: data:; style-src 'unsafe-inline';\" />");
+        builder.Append("  <meta name=\"color-scheme\" content=\"").Append(colorScheme).AppendLine("\" />");
+        builder.AppendLine("  <style>");
+        builder.AppendLine(css);
+        builder.AppendLine("  </style>");
+        builder.AppendLine("</head>");
+        builder.AppendLine("<body>");
+        builder.AppendLine("  <main class=\"content\">");
+        builder.AppendLine(bodyContent);
+        builder.AppendLine("  </main>");
+        builder.AppendLine("</body>");
+        builder.AppendLine("</html>");
+        return builder.ToString();
+    }
+
+    public static string GetStylesheet(ThemeVariant themeVariant) => themeVariant == ThemeVariant.Dark ? DarkCss : LightCss;
+
+    private static HtmlSanitizer CreateSanitizer()
+    {
+        var sanitizer = new HtmlSanitizer();
+        sanitizer.AllowedSchemes.Clear();
+        sanitizer.AllowedSchemes.Add("https");
+        sanitizer.AllowedSchemes.Add("http");
+
+        sanitizer.AllowedTags.Clear();
+        foreach (var tag in AllowedTags)
+        {
+            sanitizer.AllowedTags.Add(tag);
+        }
+
+        sanitizer.AllowedAttributes.Clear();
+        foreach (var attribute in AllowedAttributes)
+        {
+            sanitizer.AllowedAttributes.Add(attribute);
+        }
+
+        sanitizer.AllowedCssProperties.Clear();
+        foreach (var property in AllowedCssProperties)
+        {
+            sanitizer.AllowedCssProperties.Add(property);
+        }
+
+        sanitizer.AllowDataAttributes = false;
+        sanitizer.AllowCssCustomProperties = false;
+        sanitizer.FilterUrl += OnFilterUrl;
+        return sanitizer;
+    }
+
+    private static void OnFilterUrl(object? sender, FilterUrlEventArgs e)
+    {
+        var url = e.SanitizedUrl ?? e.OriginalUrl;
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            e.SanitizedUrl = null;
+            return;
+        }
+
+        var tagName = e.Tag?.TagName?.ToLowerInvariant();
+        if (tagName == "img")
+        {
+            if (!url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            {
+                e.SanitizedUrl = null;
+            }
+
+            return;
+        }
+
+        if (tagName == "a")
+        {
+            if (url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+                url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            {
+                e.SanitizedUrl = url;
+            }
+            else
+            {
+                e.SanitizedUrl = null;
+            }
+
+            return;
+        }
+
+        e.SanitizedUrl = null;
+    }
+
+    private static string BuildCss(ThemeVariant themeVariant)
+    {
+        var isDark = themeVariant == ThemeVariant.Dark;
+        var background = isDark ? "#1B1D1F" : "#FFFFFF";
+        var foreground = isDark ? "#E6E8EA" : "#1B1D1F";
+        var secondary = isDark ? "#C0C5CC" : "#3C4043";
+        var border = isDark ? "#2F3336" : "#D0D7DE";
+        var link = isDark ? "#8AB4F8" : "#1A73E8";
+        var codeBackground = isDark ? "#2A2D31" : "#F5F7FA";
+
+        var builder = new StringBuilder();
+        builder.AppendLine(":root { font-family: 'Inter', 'Segoe UI', sans-serif; }");
+        builder.AppendLine("body { margin: 0; padding: 0; background: " + background + "; color: " + foreground + "; font-size: 14px; line-height: 1.55; }");
+        builder.AppendLine(".content { padding: 0.75rem 1rem; background: " + background + "; color: inherit; }");
+        builder.AppendLine("h1, h2, h3, h4 { margin: 1.2rem 0 0.5rem; font-weight: 600; line-height: 1.25; }");
+        builder.AppendLine("p { margin: 0 0 0.75rem; color: inherit; }");
+        builder.AppendLine("ul, ol { margin: 0 0 0.75rem 1.35rem; padding: 0; }");
+        builder.AppendLine("li { margin-bottom: 0.35rem; }");
+        builder.AppendLine("a { color: " + link + "; text-decoration: none; }");
+        builder.AppendLine("a:hover, a:focus { text-decoration: underline; }");
+        builder.AppendLine("img { max-width: 100%; border-radius: 6px; margin: 0.5rem 0; }");
+        builder.AppendLine("table { border-collapse: collapse; width: 100%; margin-bottom: 1rem; }");
+        builder.AppendLine("th, td { border: 1px solid " + border + "; padding: 0.5rem; text-align: left; vertical-align: top; }");
+        builder.AppendLine("blockquote { margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid " + border + "; color: " + secondary + "; }");
+        builder.AppendLine("code { background: " + codeBackground + "; padding: 0.15rem 0.4rem; border-radius: 4px; font-family: 'Cascadia Code', 'Consolas', monospace; font-size: 0.95em; }");
+        builder.AppendLine("pre { background: " + codeBackground + "; padding: 0.75rem; border-radius: 6px; overflow-x: auto; }");
+        builder.AppendLine("pre code { background: transparent; padding: 0; }");
+        builder.AppendLine(".placeholder { color: " + secondary + "; font-style: italic; text-align: center; margin: 3rem 0; }");
+        return builder.ToString();
+    }
+
+    private static readonly IReadOnlyCollection<string> AllowedTags = new[]
+    {
+        "a", "abbr", "b", "blockquote", "br", "code", "div", "em", "h1", "h2", "h3", "h4",
+        "hr", "i", "img", "li", "ol", "p", "pre", "span", "strong", "sub", "sup", "table",
+        "tbody", "td", "th", "thead", "tr", "u", "ul"
+    };
+
+    private static readonly IReadOnlyCollection<string> AllowedAttributes = new[]
+    {
+        "href", "src", "alt", "title", "style", "class", "width", "height", "colspan", "rowspan", "align"
+    };
+
+    private static readonly IReadOnlyCollection<string> AllowedCssProperties = new[]
+    {
+        "color", "background-color", "font-style", "font-weight", "text-decoration", "text-align",
+        "line-height", "font-size",
+        "margin", "margin-left", "margin-right", "margin-top", "margin-bottom",
+        "padding", "padding-left", "padding-right", "padding-top", "padding-bottom",
+        "border", "border-left", "border-right", "border-top", "border-bottom",
+        "border-color", "border-width", "border-style", "border-radius",
+        "display", "list-style", "list-style-type", "vertical-align", "width", "height",
+        "max-width", "max-height", "min-width", "min-height", "float"
+    };
+}

--- a/DiffusionNexus.UI/ViewModels/LoraDetailViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraDetailViewModel.cs
@@ -9,6 +9,7 @@ using Avalonia.Media.Imaging;
 using Avalonia.Platform;
 using Avalonia.Threading;
 using DiffusionNexus.Service.Classes;
+using DiffusionNexus.UI.Utilities;
 using OpenCvSharp;
 
 namespace DiffusionNexus.UI.ViewModels;
@@ -20,6 +21,7 @@ public class LoraDetailViewModel : ViewModelBase, IDisposable
     private string? _modelVersionId;
     private string? _description;
     private string? _previewMediaPath;
+    private string? _descriptionHtml;
     private VideoCapture? _videoCapture;
     private DispatcherTimer? _videoTimer;
     private Bitmap? _videoFrame;
@@ -57,9 +59,11 @@ public class LoraDetailViewModel : ViewModelBase, IDisposable
         _ => Card.Model!.ModelType.ToString()
     };
 
-    public string Description => string.IsNullOrWhiteSpace(_description)
-        ? "No description available."
-        : _description!;
+    public string Description => _description ?? string.Empty;
+
+    public string? DescriptionHtml => _descriptionHtml;
+
+    public bool HasDescriptionHtml => !string.IsNullOrWhiteSpace(_descriptionHtml);
 
     public Bitmap? VideoFrame
     {
@@ -118,7 +122,10 @@ public class LoraDetailViewModel : ViewModelBase, IDisposable
 
         var description = TryLoadDescription();
         SetProperty(ref _description, description, nameof(Description));
+        var sanitizedHtml = HtmlDescriptionFormatter.Sanitize(description);
+        SetProperty(ref _descriptionHtml, sanitizedHtml, nameof(DescriptionHtml));
         OnPropertyChanged(nameof(Description));
+        OnPropertyChanged(nameof(HasDescriptionHtml));
     }
 
     private void UpdatePreviewMediaPath()

--- a/DiffusionNexus.UI/Views/Controls/HtmlDescriptionView.axaml
+++ b/DiffusionNexus.UI/Views/Controls/HtmlDescriptionView.axaml
@@ -1,0 +1,48 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:html="clr-namespace:TheArtOfDev.HtmlRenderer.Avalonia;assembly=Avalonia.HtmlRenderer"
+             xmlns:wv="clr-namespace:Avalonia.Controls;assembly=Avalonia.Controls.WebView"
+             x:Class="DiffusionNexus.UI.Views.Controls.HtmlDescriptionView">
+  <Grid RowDefinitions="Auto,*">
+    <Border x:Name="FallbackBanner"
+            Background="#312A2A"
+            BorderBrush="#5A3F3F"
+            BorderThickness="0,0,0,1"
+            Padding="12"
+            IsVisible="False">
+      <TextBlock Text="HTML viewer unavailable (WebView runtime missing). Using basic renderer."
+                 TextWrapping="Wrap"/>
+    </Border>
+    <Grid Grid.Row="1">
+      <wv:NativeWebView x:Name="WebView"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Stretch"
+                        Focusable="False"
+                        IsVisible="False"/>
+      <ScrollViewer x:Name="HtmlScroll"
+                    IsVisible="False"
+                    Padding="12">
+        <html:HtmlPanel x:Name="HtmlPanel"
+                        Background="Transparent"
+                        BorderThickness="0"
+                        Padding="0"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Stretch"/>
+      </ScrollViewer>
+      <ScrollViewer x:Name="PlainTextScroll"
+                    IsVisible="False"
+                    Padding="12">
+        <TextBlock x:Name="PlainTextBlock"
+                   TextWrapping="Wrap"/>
+      </ScrollViewer>
+      <TextBlock x:Name="Placeholder"
+                 Text="No description provided."
+                 FontStyle="Italic"
+                 Foreground="#AAAAAA"
+                 HorizontalAlignment="Center"
+                 VerticalAlignment="Center"
+                 IsVisible="False"
+                 Margin="12"/>
+    </Grid>
+  </Grid>
+</UserControl>

--- a/DiffusionNexus.UI/Views/Controls/HtmlDescriptionView.axaml.cs
+++ b/DiffusionNexus.UI/Views/Controls/HtmlDescriptionView.axaml.cs
@@ -1,0 +1,285 @@
+using System;
+using System.Diagnostics;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Styling;
+using DiffusionNexus.UI.Utilities;
+using TheArtOfDev.HtmlRenderer.Avalonia;
+using TheArtOfDev.HtmlRenderer.Core.Entities;
+using SystemUri = System.Uri;
+
+namespace DiffusionNexus.UI.Views.Controls;
+
+public partial class HtmlDescriptionView : UserControl
+{
+    public static readonly StyledProperty<string?> HtmlProperty =
+        AvaloniaProperty.Register<HtmlDescriptionView, string?>(nameof(Html));
+
+    public static readonly StyledProperty<string?> PlainTextProperty =
+        AvaloniaProperty.Register<HtmlDescriptionView, string?>(nameof(PlainText));
+
+    public static readonly StyledProperty<bool> EnableWebViewProperty =
+        AvaloniaProperty.Register<HtmlDescriptionView, bool>(nameof(EnableWebView), true);
+
+    private NativeWebView? _webView;
+    private ScrollViewer? _htmlScroll;
+    private HtmlPanel? _htmlPanel;
+    private ScrollViewer? _plainTextScroll;
+    private TextBlock? _plainTextBlock;
+    private TextBlock? _placeholder;
+    private Border? _fallbackBanner;
+    private bool _webViewFailed;
+    private bool _suppressNavigation;
+
+    public HtmlDescriptionView()
+    {
+        InitializeComponent();
+        ActualThemeVariantChanged += OnActualThemeVariantChanged;
+        DetachedFromVisualTree += OnDetachedFromVisualTree;
+        Loaded += OnLoaded;
+    }
+
+    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+    public string? Html
+    {
+        get => GetValue(HtmlProperty);
+        set => SetValue(HtmlProperty, value);
+    }
+
+    public string? PlainText
+    {
+        get => GetValue(PlainTextProperty);
+        set => SetValue(PlainTextProperty, value);
+    }
+
+    public bool EnableWebView
+    {
+        get => GetValue(EnableWebViewProperty);
+        set => SetValue(EnableWebViewProperty, value);
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == EnableWebViewProperty && change.GetNewValue<bool>())
+        {
+            _webViewFailed = false;
+        }
+
+        if (change.Property == HtmlProperty ||
+            change.Property == PlainTextProperty ||
+            change.Property == EnableWebViewProperty)
+        {
+            UpdatePresentation();
+        }
+    }
+
+    private void OnLoaded(object? sender, RoutedEventArgs e)
+    {
+        Loaded -= OnLoaded;
+
+        _webView = this.FindControl<NativeWebView>("WebView");
+        _htmlScroll = this.FindControl<ScrollViewer>("HtmlScroll");
+        _htmlPanel = this.FindControl<HtmlPanel>("HtmlPanel");
+        _plainTextScroll = this.FindControl<ScrollViewer>("PlainTextScroll");
+        _plainTextBlock = this.FindControl<TextBlock>("PlainTextBlock");
+        _placeholder = this.FindControl<TextBlock>("Placeholder");
+        _fallbackBanner = this.FindControl<Border>("FallbackBanner");
+
+        if (_webView != null)
+        {
+            _webView.NavigationStarted += OnWebViewNavigationStarted;
+            _webView.NavigationCompleted += OnWebViewNavigationCompleted;
+            _webView.NewWindowRequested += OnWebViewNewWindowRequested;
+        }
+
+        if (_htmlPanel != null)
+        {
+            _htmlPanel.LinkClicked += OnHtmlPanelLinkClicked;
+        }
+
+        UpdatePresentation();
+    }
+
+    private void OnDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
+    {
+        if (_webView != null)
+        {
+            _webView.NavigationStarted -= OnWebViewNavigationStarted;
+            _webView.NavigationCompleted -= OnWebViewNavigationCompleted;
+            _webView.NewWindowRequested -= OnWebViewNewWindowRequested;
+        }
+
+        if (_htmlPanel != null)
+        {
+            _htmlPanel.LinkClicked -= OnHtmlPanelLinkClicked;
+        }
+
+        ActualThemeVariantChanged -= OnActualThemeVariantChanged;
+        DetachedFromVisualTree -= OnDetachedFromVisualTree;
+    }
+
+    private void OnActualThemeVariantChanged(object? sender, EventArgs e) => UpdatePresentation();
+
+    private void UpdatePresentation()
+    {
+        if (_webView == null &&
+            _htmlPanel == null &&
+            _htmlScroll == null &&
+            _plainTextScroll == null &&
+            _placeholder == null &&
+            _fallbackBanner == null)
+        {
+            return;
+        }
+
+        var html = Html;
+        var plainText = PlainText;
+        var theme = ActualThemeVariant ?? ThemeVariant.Dark;
+
+        if (!string.IsNullOrWhiteSpace(html))
+        {
+            var document = HtmlDescriptionFormatter.BuildDocument(html, theme);
+
+            if (_webView != null && EnableWebView && !_webViewFailed)
+            {
+                try
+                {
+                    _suppressNavigation = true;
+                    _webView.NavigateToString(document);
+                    SetMode(HtmlDescriptionMode.WebView);
+                    return;
+                }
+                catch (Exception ex) when (ex is InvalidOperationException or PlatformNotSupportedException)
+                {
+                    _webViewFailed = true;
+                }
+                finally
+                {
+                    if (_webViewFailed)
+                    {
+                        _suppressNavigation = false;
+                    }
+                }
+            }
+
+            if (_htmlPanel != null && _htmlScroll != null)
+            {
+                _htmlPanel.BaseStylesheet = HtmlDescriptionFormatter.GetStylesheet(theme);
+                _htmlPanel.Text = html;
+                SetMode(HtmlDescriptionMode.HtmlPanel);
+                return;
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(plainText))
+        {
+            if (_plainTextBlock != null)
+            {
+                _plainTextBlock.Text = plainText;
+            }
+
+            SetMode(HtmlDescriptionMode.PlainText);
+        }
+        else
+        {
+            SetMode(HtmlDescriptionMode.Placeholder);
+        }
+    }
+
+    private void SetMode(HtmlDescriptionMode mode)
+    {
+        if (_webView != null)
+        {
+            _webView.IsVisible = mode == HtmlDescriptionMode.WebView;
+        }
+
+        if (_htmlScroll != null)
+        {
+            _htmlScroll.IsVisible = mode == HtmlDescriptionMode.HtmlPanel;
+        }
+
+        if (_plainTextScroll != null)
+        {
+            _plainTextScroll.IsVisible = mode == HtmlDescriptionMode.PlainText;
+        }
+
+        if (_placeholder != null)
+        {
+            _placeholder.IsVisible = mode == HtmlDescriptionMode.Placeholder;
+        }
+
+        if (_fallbackBanner != null)
+        {
+            var shouldShowBanner = EnableWebView && _webViewFailed && !string.IsNullOrWhiteSpace(Html);
+            _fallbackBanner.IsVisible = shouldShowBanner;
+        }
+    }
+
+    private void OnWebViewNavigationStarted(object? sender, WebViewNavigationStartingEventArgs e)
+    {
+        if (_suppressNavigation)
+        {
+            return;
+        }
+
+        var requestUri = e.Request?.ToString();
+        if (requestUri != null &&
+            SystemUri.TryCreate(requestUri, UriKind.Absolute, out var uri) &&
+            (uri.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase) ||
+             uri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase)))
+        {
+            e.Cancel = true;
+            OpenExternalLink(uri);
+        }
+    }
+
+    private void OnWebViewNavigationCompleted(object? sender, WebViewNavigationCompletedEventArgs e)
+    {
+        _suppressNavigation = false;
+    }
+
+    private void OnWebViewNewWindowRequested(object? sender, WebViewNewWindowRequestedEventArgs e)
+    {
+        var uriString = e.Request?.ToString();
+        if (uriString != null && SystemUri.TryCreate(uriString, UriKind.Absolute, out var uri))
+        {
+            OpenExternalLink(uri);
+        }
+
+        e.Handled = true;
+    }
+
+    private void OnHtmlPanelLinkClicked(object? sender, HtmlRendererRoutedEventArgs<HtmlLinkClickedEventArgs> e)
+    {
+        if (e.Event?.Link is { Length: > 0 } link && SystemUri.TryCreate(link, UriKind.Absolute, out var uri))
+        {
+            OpenExternalLink(uri);
+            e.Event.Handled = true;
+        }
+    }
+
+    private static void OpenExternalLink(SystemUri uri)
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo(uri.ToString()) { UseShellExecute = true });
+        }
+        catch
+        {
+            // ignored
+        }
+    }
+
+    private enum HtmlDescriptionMode
+    {
+        WebView,
+        HtmlPanel,
+        PlainText,
+        Placeholder
+    }
+}

--- a/DiffusionNexus.UI/Views/LoraDetailWindow.axaml
+++ b/DiffusionNexus.UI/Views/LoraDetailWindow.axaml
@@ -1,6 +1,7 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:DiffusionNexus.UI.ViewModels"
+        xmlns:controls="using:DiffusionNexus.UI.Views.Controls"
         x:Class="DiffusionNexus.UI.Views.LoraDetailWindow"
         x:DataType="vm:LoraDetailViewModel"
         Width="900"
@@ -92,17 +93,17 @@
       </Border>
     </Grid>
 
-    <StackPanel Grid.Row="3" Spacing="6">
+    <Grid Grid.Row="3" RowDefinitions="Auto,*" RowSpacing="6">
       <TextBlock Text="Description" FontWeight="SemiBold" FontSize="16"/>
-      <Border Background="#1E1E1E"
+      <Border Grid.Row="1"
+              Background="#1E1E1E"
               CornerRadius="8"
-              Padding="12">
-        <ScrollViewer MaxHeight="180">
-          <TextBlock Text="{Binding Description}"
-                     TextWrapping="Wrap"/>
-        </ScrollViewer>
+              Padding="0"
+              ClipToBounds="True">
+        <controls:HtmlDescriptionView Html="{Binding DescriptionHtml}"
+                                      PlainText="{Binding Description}"/>
       </Border>
-    </StackPanel>
+    </Grid>
 
     <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
       <Button Content="🌐" Width="44" Height="44" FontSize="18" Command="{Binding Card.OpenWebCommand}"/>


### PR DESCRIPTION
## Summary
- add a reusable `HtmlDescriptionView` control that renders sanitized LoRA descriptions with NativeWebView plus HtmlRenderer/plain-text fallbacks and theme-aware styling
- tighten HTML sanitization and CSS generation to respect the app theme while allowing common formatting and safe external links
- simplify `LoraDetailWindow` to host the new control and expose raw description text for placeholder handling

## Testing
- dotnet build DiffusionNexus.sln *(fails: AvaloniaUI license key missing)*

------
https://chatgpt.com/codex/tasks/task_e_68f21d90bea4833294acb05c47e7a802