### PR TITLE
Add per-card metadata download button to Lora helper

### DIFF
--- a/DiffusionNexus.UI/ViewModels/LoraCardViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraCardViewModel.cs
@@ -55,10 +55,13 @@ public partial class LoraCardViewModel : ViewModelBase
     public IAsyncRelayCommand CopyNameCommand { get; }
     public IRelayCommand OpenFolderCommand { get; }
     public IAsyncRelayCommand OpenDetailsCommand { get; }
+    public IAsyncRelayCommand DownloadMetadataCommand { get; }
 
     public ObservableCollection<LoraVariantViewModel> Variants { get; } = new();
 
     public bool HasVariants => Variants.Count > 1;
+
+    public bool ShouldShowDownloadMetadataButton => Model != null && !Model.HasFullMetadata;
 
     public Bitmap? VideoFrame
     {
@@ -90,12 +93,14 @@ public partial class LoraCardViewModel : ViewModelBase
         CopyNameCommand = new AsyncRelayCommand(OnCopyNameAsync);
         OpenFolderCommand = new RelayCommand(OnOpenFolder);
         OpenDetailsCommand = new AsyncRelayCommand(OnOpenDetailsAsync);
+        DownloadMetadataCommand = new AsyncRelayCommand(OnDownloadMetadataAsync);
         Variants.CollectionChanged += OnVariantsCollectionChanged;
     }
 
     partial void OnModelChanged(ModelClass? value)
     {
         _ = LoadPreviewImageAsync();
+        OnPropertyChanged(nameof(ShouldShowDownloadMetadataButton));
     }
 
     partial void OnPreviewImageChanged(Bitmap? value)
@@ -445,6 +450,15 @@ public partial class LoraCardViewModel : ViewModelBase
             return;
 
         await Parent.CopyModelNameAsync(this);
+    }
+
+    private async Task OnDownloadMetadataAsync()
+    {
+        if (Parent == null || Model == null)
+            return;
+
+        await Parent.DownloadMetadataForCardAsync(this);
+        OnPropertyChanged(nameof(ShouldShowDownloadMetadataButton));
     }
 
     private void OnOpenFolder()

--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml
@@ -150,6 +150,13 @@
                                 Margin="0,4,4,0"
                                 Command="{Binding EditCommand}"/>-->
                         <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+                          <Button Content="⬇️"
+                                  Width="36"
+                                  Height="36"
+                                  FontSize="16"
+                                  Margin="0,4,4,0"
+                                  Command="{Binding DownloadMetadataCommand}"
+                                  IsVisible="{Binding ShouldShowDownloadMetadataButton}"/>
                           <Button Content="🌐" Width="36" Height="36" FontSize="16" Margin="0,4,4,0" Command="{Binding OpenWebCommand}"/>
                           <Button Content="📋" Width="36" Height="36" FontSize="16" Margin="0,4,4,0" Command="{Binding CopyCommand}"/>
                           <Button Content="N" Width="36" Height="36" FontSize="16" Margin="0,4,4,0" Command="{Binding CopyNameCommand}"/>


### PR DESCRIPTION
## Summary
- add a per-card metadata download command and visibility flag in `LoraCardViewModel`
- expose a helper method in `LoraHelperViewModel` that downloads metadata for a single card using the existing service
- render a new download button on each card that only appears when metadata is incomplete

## Testing
- dotnet build DiffusionNexus.sln *(fails: MSBUILD : error MSB4017 due to unexpected logger failure)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913ba7c00148332b3a27b07ebf439a8)