### PR TITLE
Add LoRA download workflow

### DIFF
--- a/DiffusionNexus.Service/Classes/CivitaiLinkInfo.cs
+++ b/DiffusionNexus.Service/Classes/CivitaiLinkInfo.cs
@@ -1,0 +1,3 @@
+namespace DiffusionNexus.Service.Classes;
+
+public record CivitaiLinkInfo(string ModelId, string? ModelVersionId);

--- a/DiffusionNexus.Service/Classes/CivitaiModelInfo.cs
+++ b/DiffusionNexus.Service/Classes/CivitaiModelInfo.cs
@@ -1,0 +1,10 @@
+namespace DiffusionNexus.Service.Classes;
+
+public record CivitaiModelInfo(
+    string ModelId,
+    string ModelVersionId,
+    string FileName,
+    string DownloadUrl,
+    string VersionJson,
+    string ModelJson,
+    string? PreviewImageUrl);

--- a/DiffusionNexus.Service/Classes/LoraDownloadProgress.cs
+++ b/DiffusionNexus.Service/Classes/LoraDownloadProgress.cs
@@ -1,0 +1,8 @@
+namespace DiffusionNexus.Service.Classes;
+
+public record LoraDownloadProgress(long BytesReceived, long? TotalBytes, double? BytesPerSecond)
+{
+    public double? Percentage => TotalBytes.HasValue && TotalBytes.Value > 0
+        ? BytesReceived * 100d / TotalBytes.Value
+        : null;
+}

--- a/DiffusionNexus.Service/Classes/LoraDownloadResult.cs
+++ b/DiffusionNexus.Service/Classes/LoraDownloadResult.cs
@@ -1,0 +1,6 @@
+namespace DiffusionNexus.Service.Classes;
+
+public record LoraDownloadResult(
+    string FilePath,
+    string ModelId,
+    string ModelVersionId);

--- a/DiffusionNexus.Service/Services/CivitaiLinkParser.cs
+++ b/DiffusionNexus.Service/Services/CivitaiLinkParser.cs
@@ -1,0 +1,109 @@
+using System.Text.RegularExpressions;
+using DiffusionNexus.Service.Classes;
+
+namespace DiffusionNexus.Service.Services;
+
+public static class CivitaiLinkParser
+{
+    private static readonly Regex DigitRegex = new("\\d+", RegexOptions.Compiled);
+
+    public static bool TryParse(string? link, out CivitaiLinkInfo? info)
+    {
+        info = null;
+        if (string.IsNullOrWhiteSpace(link))
+        {
+            return false;
+        }
+
+        if (!Uri.TryCreate(link.Trim(), UriKind.Absolute, out var uri))
+        {
+            return false;
+        }
+
+        if (!uri.Host.Contains("civitai.com", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var path = uri.AbsolutePath.Trim('/');
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return false;
+        }
+
+        var segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (segments.Length == 0 || !segments[0].Equals("models", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        string? modelId = null;
+        string? versionId = null;
+
+        if (segments.Length >= 2)
+        {
+            modelId = ExtractFirstNumber(segments[1]);
+        }
+
+        if (segments.Length >= 4 && segments[2].StartsWith("model", StringComparison.OrdinalIgnoreCase))
+        {
+            versionId = ExtractFirstNumber(segments[3]);
+        }
+
+        versionId ??= TryGetQueryValue(uri, "modelVersionId");
+
+        if (string.IsNullOrWhiteSpace(modelId))
+        {
+            return false;
+        }
+
+        info = new CivitaiLinkInfo(modelId, versionId);
+        return true;
+    }
+
+    private static string? TryGetQueryValue(Uri uri, string key)
+    {
+        var query = uri.Query;
+        if (string.IsNullOrEmpty(query))
+        {
+            return null;
+        }
+
+        var trimmed = query.TrimStart('?');
+        var pairs = trimmed.Split('&', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        foreach (var pair in pairs)
+        {
+            var kvp = pair.Split('=', 2, StringSplitOptions.TrimEntries);
+            if (kvp.Length == 0)
+            {
+                continue;
+            }
+
+            if (!kvp[0].Equals(key, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (kvp.Length == 1)
+            {
+                return string.Empty;
+            }
+
+            var value = Uri.UnescapeDataString(kvp[1]);
+            return ExtractFirstNumber(value);
+        }
+
+        return null;
+    }
+
+    private static string? ExtractFirstNumber(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return null;
+        }
+
+        var match = DigitRegex.Match(input);
+        return match.Success ? match.Value : null;
+    }
+}

--- a/DiffusionNexus.Service/Services/LoraDownloadService.cs
+++ b/DiffusionNexus.Service/Services/LoraDownloadService.cs
@@ -1,0 +1,279 @@
+using System.Diagnostics;
+using System.IO;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using DiffusionNexus.Service.Classes;
+
+namespace DiffusionNexus.Service.Services;
+
+public class LoraDownloadService
+{
+    private readonly ICivitaiApiClient _apiClient;
+    private readonly HttpClient _httpClient;
+
+    public LoraDownloadService(ICivitaiApiClient apiClient, HttpClient? httpClient = null)
+    {
+        _apiClient = apiClient ?? throw new ArgumentNullException(nameof(apiClient));
+        _httpClient = httpClient ?? new HttpClient();
+    }
+
+    public async Task<CivitaiModelInfo> ResolveAsync(string civitaiLink, string apiKey, CancellationToken cancellationToken = default)
+    {
+        if (!CivitaiLinkParser.TryParse(civitaiLink, out var linkInfo) || linkInfo is null)
+        {
+            throw new ArgumentException("Invalid Civitai link", nameof(civitaiLink));
+        }
+
+        var modelJson = await _apiClient.GetModelAsync(linkInfo.ModelId, apiKey);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var versionId = linkInfo.ModelVersionId ?? ExtractPreferredVersionId(modelJson)
+            ?? throw new InvalidOperationException("Unable to determine model version id from Civitai response.");
+
+        var versionJson = await _apiClient.GetModelVersionAsync(versionId, apiKey);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var file = ExtractPreferredFile(versionJson)
+            ?? throw new InvalidOperationException("The selected version does not contain any downloadable files.");
+
+        var downloadUrl = TryGetString(file, "downloadUrl")
+            ?? throw new InvalidOperationException("Unable to determine download URL for the selected file.");
+        var fileName = TryGetString(file, "name")
+            ?? throw new InvalidOperationException("Unable to determine file name for the selected file.");
+
+        var previewUrl = ExtractPreviewImage(versionJson);
+
+        return new CivitaiModelInfo(linkInfo.ModelId, versionId, fileName, downloadUrl, versionJson, modelJson, previewUrl);
+    }
+
+    public async Task<LoraDownloadResult> DownloadAsync(
+        CivitaiModelInfo modelInfo,
+        string targetDirectory,
+        IProgress<LoraDownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (modelInfo is null)
+        {
+            throw new ArgumentNullException(nameof(modelInfo));
+        }
+
+        if (string.IsNullOrWhiteSpace(targetDirectory))
+        {
+            throw new ArgumentException("Target directory is required", nameof(targetDirectory));
+        }
+
+        Directory.CreateDirectory(targetDirectory);
+
+        var destinationFile = Path.Combine(targetDirectory, modelInfo.FileName);
+        if (File.Exists(destinationFile))
+        {
+            File.Delete(destinationFile);
+        }
+        await DownloadFileAsync(modelInfo.DownloadUrl, destinationFile, progress, cancellationToken);
+
+        var baseName = Path.GetFileNameWithoutExtension(modelInfo.FileName);
+        await WriteMetadataAsync(modelInfo, targetDirectory, baseName, cancellationToken);
+
+        return new LoraDownloadResult(destinationFile, modelInfo.ModelId, modelInfo.ModelVersionId);
+    }
+
+    private async Task DownloadFileAsync(
+        string downloadUrl,
+        string destination,
+        IProgress<LoraDownloadProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, downloadUrl);
+        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var totalBytes = response.Content.Headers.ContentLength;
+        await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        await using var fileStream = File.Create(destination);
+
+        var buffer = new byte[81920];
+        long totalRead = 0;
+        var stopwatch = Stopwatch.StartNew();
+
+        while (true)
+        {
+            var read = await contentStream.ReadAsync(buffer, cancellationToken);
+            if (read == 0)
+            {
+                break;
+            }
+
+            await fileStream.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
+            totalRead += read;
+
+            double? speed = null;
+            if (stopwatch.Elapsed.TotalSeconds > 0)
+            {
+                speed = totalRead / stopwatch.Elapsed.TotalSeconds;
+            }
+
+            progress?.Report(new LoraDownloadProgress(totalRead, totalBytes, speed));
+        }
+
+        progress?.Report(new LoraDownloadProgress(totalRead, totalBytes, null));
+    }
+
+    private async Task WriteMetadataAsync(
+        CivitaiModelInfo modelInfo,
+        string folder,
+        string baseName,
+        CancellationToken cancellationToken)
+    {
+        var infoPath = Path.Combine(folder, baseName + ".civitai.info");
+        if (File.Exists(infoPath))
+        {
+            File.Delete(infoPath);
+        }
+        await File.WriteAllTextAsync(infoPath, modelInfo.VersionJson, cancellationToken);
+
+        if (!string.IsNullOrWhiteSpace(modelInfo.PreviewImageUrl))
+        {
+            try
+            {
+                var uri = new Uri(modelInfo.PreviewImageUrl);
+                var ext = Path.GetExtension(uri.AbsolutePath);
+                if (!string.IsNullOrWhiteSpace(ext))
+                {
+                    var imagePath = Path.Combine(folder, baseName + ext);
+                    if (File.Exists(imagePath))
+                    {
+                        File.Delete(imagePath);
+                    }
+                    using var previewRequest = new HttpRequestMessage(HttpMethod.Get, modelInfo.PreviewImageUrl);
+                    using var previewResponse = await _httpClient.SendAsync(previewRequest, cancellationToken);
+                    previewResponse.EnsureSuccessStatusCode();
+                    await using var imageStream = await previewResponse.Content.ReadAsStreamAsync(cancellationToken);
+                    await using var imageFile = File.Create(imagePath);
+                    await imageStream.CopyToAsync(imageFile, cancellationToken);
+                }
+            }
+            catch
+            {
+                // Ignore preview failures but keep metadata files.
+            }
+        }
+
+        var modelJsonPath = Path.Combine(folder, baseName + ".json");
+        if (File.Exists(modelJsonPath))
+        {
+            File.Delete(modelJsonPath);
+        }
+        await File.WriteAllTextAsync(modelJsonPath, modelInfo.ModelJson, cancellationToken);
+    }
+
+    private static JsonElement? ExtractPreferredFile(string versionJson)
+    {
+        using var doc = JsonDocument.Parse(versionJson);
+        var root = doc.RootElement;
+        if (!root.TryGetProperty("files", out var files) || files.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        JsonElement? primary = null;
+        JsonElement? safetensors = null;
+        JsonElement? first = null;
+
+        foreach (var file in files.EnumerateArray())
+        {
+            if (file.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            first ??= file;
+
+            if (file.TryGetProperty("primary", out var primaryProp) && primaryProp.ValueKind == JsonValueKind.True)
+            {
+                primary = file;
+                break;
+            }
+
+            var name = TryGetString(file, "name");
+            if (safetensors == null && name != null && name.EndsWith(".safetensors", StringComparison.OrdinalIgnoreCase))
+            {
+                safetensors = file;
+            }
+        }
+
+        return primary ?? safetensors ?? first;
+    }
+
+    private static string? ExtractPreferredVersionId(string modelJson)
+    {
+        using var doc = JsonDocument.Parse(modelJson);
+        var root = doc.RootElement;
+        if (!root.TryGetProperty("modelVersions", out var versions) || versions.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        foreach (var version in versions.EnumerateArray())
+        {
+            if (version.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            if (version.TryGetProperty("id", out var idElement))
+            {
+                return idElement.ValueKind switch
+                {
+                    JsonValueKind.Number => idElement.GetInt64().ToString(),
+                    JsonValueKind.String => idElement.GetString(),
+                    _ => null
+                };
+            }
+        }
+
+        return null;
+    }
+
+    private static string? ExtractPreviewImage(string versionJson)
+    {
+        using var doc = JsonDocument.Parse(versionJson);
+        var root = doc.RootElement;
+        if (!root.TryGetProperty("images", out var images) || images.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        foreach (var image in images.EnumerateArray())
+        {
+            if (image.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            var url = TryGetString(image, "url");
+            if (!string.IsNullOrWhiteSpace(url))
+            {
+                return url;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? TryGetString(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var value))
+        {
+            return null;
+        }
+
+        return value.ValueKind switch
+        {
+            JsonValueKind.String => value.GetString(),
+            JsonValueKind.Number => value.GetInt64().ToString(),
+            _ => null
+        };
+    }
+}

--- a/DiffusionNexus.Tests/Service/Services/CivitaiLinkParserTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/CivitaiLinkParserTests.cs
@@ -1,0 +1,37 @@
+using DiffusionNexus.Service.Classes;
+using DiffusionNexus.Service.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace DiffusionNexus.Tests.Service.Services;
+
+public class CivitaiLinkParserTests
+{
+    [Theory]
+    [InlineData("https://civitai.com/models/372465?modelVersionId=914390", "372465", "914390")]
+    [InlineData("https://civitai.com/models/372465/model-versions/914390", "372465", "914390")]
+    [InlineData("https://civitai.com/models/372465", "372465", null)]
+    [InlineData("https://civitai.com/models/372465/wild-hair", "372465", null)]
+    public void TryParse_ValidLinks_ReturnsExpected(string link, string modelId, string? versionId)
+    {
+        var result = CivitaiLinkParser.TryParse(link, out CivitaiLinkInfo? info);
+
+        result.Should().BeTrue();
+        info.Should().NotBeNull();
+        info!.ModelId.Should().Be(modelId);
+        info.ModelVersionId.Should().Be(versionId);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("https://example.com/models/123")] 
+    [InlineData("https://civitai.com/users/1")] 
+    public void TryParse_InvalidLinks_ReturnsFalse(string? link)
+    {
+        var result = CivitaiLinkParser.TryParse(link, out var info);
+
+        result.Should().BeFalse();
+        info.Should().BeNull();
+    }
+}

--- a/DiffusionNexus.UI/ViewModels/DownloadLoraViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/DownloadLoraViewModel.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DiffusionNexus.Service.Classes;
+using DiffusionNexus.Service.Services;
+using DiffusionNexus.UI.Classes;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+public partial class DownloadLoraViewModel : ViewModelBase
+{
+    private readonly ISettingsService _settingsService;
+    private readonly LoraDownloadService _downloadService;
+
+    private Window? _window;
+    private CancellationTokenSource? _downloadCts;
+
+    [ObservableProperty]
+    private string? civitaiLink;
+
+    [ObservableProperty]
+    private string? selectedFolder;
+
+    [ObservableProperty]
+    private bool isDownloading;
+
+    [ObservableProperty]
+    private double progress;
+
+    [ObservableProperty]
+    private string? speedDisplay;
+
+    [ObservableProperty]
+    private string? statusMessage;
+
+    [ObservableProperty]
+    private bool isResolveInProgress;
+
+    public ObservableCollection<string> SourceFolders { get; } = new();
+
+    public IAsyncRelayCommand DownloadCommand { get; }
+    public IRelayCommand CancelCommand { get; }
+
+    public event EventHandler<bool>? CloseRequested;
+
+    public DownloadLoraViewModel()
+        : this(new SettingsService(), new LoraDownloadService(new CivitaiApiClient(new HttpClient())))
+    {
+    }
+
+    public DownloadLoraViewModel(ISettingsService settingsService, LoraDownloadService downloadService)
+    {
+        _settingsService = settingsService;
+        _downloadService = downloadService;
+        DownloadCommand = new AsyncRelayCommand(DownloadAsync, CanDownload);
+        CancelCommand = new RelayCommand(Cancel);
+    }
+
+    public async Task InitializeAsync()
+    {
+        var settings = await _settingsService.LoadAsync();
+        SourceFolders.Clear();
+        foreach (var source in settings.LoraHelperSources)
+        {
+            if (!source.IsEnabled || string.IsNullOrWhiteSpace(source.FolderPath))
+            {
+                continue;
+            }
+
+            if (!SourceFolders.Contains(source.FolderPath))
+            {
+                SourceFolders.Add(source.FolderPath);
+            }
+        }
+
+        if (SourceFolders.Count > 0 && SelectedFolder == null)
+        {
+            SelectedFolder = SourceFolders[0];
+        }
+        else if (SourceFolders.Count == 0)
+        {
+            StatusMessage = "No enabled LoRA source folders configured.";
+        }
+    }
+
+    public void SetWindow(Window window)
+    {
+        _window = window;
+    }
+
+    private bool CanDownload()
+    {
+        return !IsDownloading
+            && !IsResolveInProgress
+            && !string.IsNullOrWhiteSpace(CivitaiLink)
+            && !string.IsNullOrWhiteSpace(SelectedFolder);
+    }
+
+    partial void OnCivitaiLinkChanged(string? value)
+    {
+        DownloadCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnSelectedFolderChanged(string? value)
+    {
+        DownloadCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnIsResolveInProgressChanged(bool value)
+    {
+        DownloadCommand.NotifyCanExecuteChanged();
+    }
+
+    private async Task DownloadAsync()
+    {
+        if (!CanDownload())
+        {
+            return;
+        }
+
+        IsResolveInProgress = true;
+        StatusMessage = "Resolving Civitai link...";
+        Progress = 0;
+        SpeedDisplay = null;
+
+        CivitaiModelInfo modelInfo;
+        try
+        {
+            var settings = await _settingsService.LoadAsync();
+            var apiKey = settings.CivitaiApiKey ?? string.Empty;
+            modelInfo = await _downloadService.ResolveAsync(CivitaiLink!, apiKey);
+        }
+        catch (Exception ex)
+        {
+            Log($"Failed to resolve Civitai link: {ex.Message}", LogSeverity.Error);
+            StatusMessage = $"Failed to resolve link: {ex.Message}";
+            IsResolveInProgress = false;
+            DownloadCommand.NotifyCanExecuteChanged();
+            return;
+        }
+        finally
+        {
+            IsResolveInProgress = false;
+        }
+
+        if (SelectedFolder is null)
+        {
+            StatusMessage = "Please choose a target folder.";
+            DownloadCommand.NotifyCanExecuteChanged();
+            return;
+        }
+
+        var destinationPath = Path.Combine(SelectedFolder, modelInfo.FileName);
+        if (File.Exists(destinationPath))
+        {
+            StatusMessage = $"File '{modelInfo.FileName}' already exists.";
+            DownloadCommand.NotifyCanExecuteChanged();
+            return;
+        }
+
+        _downloadCts = new CancellationTokenSource();
+        IsDownloading = true;
+        StatusMessage = "Downloading LoRA...";
+        DownloadCommand.NotifyCanExecuteChanged();
+
+        var progress = new Progress<LoraDownloadProgress>(p =>
+        {
+            if (p.Percentage.HasValue)
+            {
+                Progress = Math.Round(p.Percentage.Value, 2);
+            }
+
+            if (p.BytesPerSecond.HasValue && p.BytesPerSecond.Value > 0)
+            {
+                SpeedDisplay = FormatSpeed(p.BytesPerSecond.Value);
+            }
+        });
+
+        try
+        {
+            var result = await _downloadService.DownloadAsync(modelInfo, SelectedFolder, progress, _downloadCts.Token);
+            StatusMessage = "Download completed.";
+            Log($"Downloaded LoRA model {result.ModelId} (version {result.ModelVersionId})", LogSeverity.Success);
+            CloseRequested?.Invoke(this, true);
+            _window?.Close(true);
+        }
+        catch (OperationCanceledException)
+        {
+            StatusMessage = "Download cancelled.";
+            Log("LoRA download cancelled", LogSeverity.Warning);
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Download failed: {ex.Message}";
+            Log($"LoRA download failed: {ex.Message}", LogSeverity.Error);
+        }
+        finally
+        {
+            _downloadCts?.Dispose();
+            _downloadCts = null;
+            IsDownloading = false;
+            Progress = 0;
+            SpeedDisplay = null;
+            DownloadCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    private void Cancel()
+    {
+        if (IsDownloading)
+        {
+            _downloadCts?.Cancel();
+            return;
+        }
+
+        _window?.Close(false);
+    }
+
+    private static string FormatSpeed(double bytesPerSecond)
+    {
+        const double kb = 1024d;
+        const double mb = kb * 1024d;
+        const double gb = mb * 1024d;
+
+        return bytesPerSecond switch
+        {
+            >= gb => string.Format(CultureInfo.InvariantCulture, "{0:F2} GB/s", bytesPerSecond / gb),
+            >= mb => string.Format(CultureInfo.InvariantCulture, "{0:F2} MB/s", bytesPerSecond / mb),
+            >= kb => string.Format(CultureInfo.InvariantCulture, "{0:F2} KB/s", bytesPerSecond / kb),
+            _ => string.Format(CultureInfo.InvariantCulture, "{0:F0} B/s", bytesPerSecond)
+        };
+    }
+}

--- a/DiffusionNexus.UI/Views/DownloadLoraWindow.axaml
+++ b/DiffusionNexus.UI/Views/DownloadLoraWindow.axaml
@@ -1,0 +1,29 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:DiffusionNexus.UI.ViewModels"
+        xmlns:conv="using:DiffusionNexus.UI.Converters"
+        x:Class="DiffusionNexus.UI.Views.DownloadLoraWindow"
+        x:DataType="vm:DownloadLoraViewModel"
+        Width="500"
+        Height="320"
+        WindowStartupLocation="CenterOwner"
+        Title="Download LoRA">
+  <Window.Resources>
+    <conv:BooleanNotConverter x:Key="BooleanNotConverter" />
+  </Window.Resources>
+  <Grid RowDefinitions="Auto,*" Margin="16">
+    <StackPanel Spacing="12">
+      <TextBlock Text="Civitai Link"/>
+      <TextBox Text="{Binding CivitaiLink, Mode=TwoWay}" IsEnabled="{Binding IsDownloading, Converter={StaticResource BooleanNotConverter}}"/>
+      <TextBlock Text="Target Folder" Margin="0,8,0,0"/>
+      <ComboBox ItemsSource="{Binding SourceFolders}" SelectedItem="{Binding SelectedFolder, Mode=TwoWay}" IsEnabled="{Binding IsDownloading, Converter={StaticResource BooleanNotConverter}}"/>
+      <TextBlock Text="{Binding StatusMessage}" Foreground="#FFCCCCCC" TextWrapping="Wrap"/>
+      <ProgressBar Minimum="0" Maximum="100" Height="18" Value="{Binding Progress}" IsVisible="{Binding IsDownloading}"/>
+      <TextBlock Text="{Binding SpeedDisplay}" IsVisible="{Binding IsDownloading}"/>
+    </StackPanel>
+    <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10" Margin="0,16,0,0">
+      <Button Content="Cancel" Width="100" Command="{Binding CancelCommand}"/>
+      <Button Content="Download" Width="120" Command="{Binding DownloadCommand}"/>
+    </StackPanel>
+  </Grid>
+</Window>

--- a/DiffusionNexus.UI/Views/DownloadLoraWindow.axaml.cs
+++ b/DiffusionNexus.UI/Views/DownloadLoraWindow.axaml.cs
@@ -1,0 +1,29 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using DiffusionNexus.UI.ViewModels;
+
+namespace DiffusionNexus.UI.Views;
+
+public partial class DownloadLoraWindow : Window
+{
+    public DownloadLoraWindow()
+    {
+        InitializeComponent();
+        this.AttachedToVisualTree += OnAttachedToVisualTree;
+    }
+
+    private async void OnAttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
+    {
+        if (DataContext is DownloadLoraViewModel vm)
+        {
+            vm.SetWindow(this);
+            await vm.InitializeAsync();
+        }
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml
@@ -24,7 +24,7 @@
     </Style>
   </UserControl.Styles>
   <Grid RowDefinitions="Auto,*" ColumnDefinitions="Auto,*" Margin="10">
-    <Grid Grid.ColumnSpan="2" ColumnDefinitions="Auto,1.5*,Auto,Auto,Auto,Auto,Auto,Auto,Auto" Margin="0,0,0,5">
+    <Grid Grid.ColumnSpan="2" ColumnDefinitions="Auto,1.5*,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" Margin="0,0,0,5">
       <Button Grid.Column="0" Content="◀️ Reset Filters" Width="120" Height="36" Command="{Binding ResetFiltersCommand}"/>
       <AutoCompleteBox x:Name="SearchBox"
                       Grid.Column="1"
@@ -49,10 +49,12 @@
         </StackPanel>
       </Border>
       <CheckBox Grid.Column="5" Content="Show NSFW" IsChecked="{Binding ShowNsfw}" VerticalAlignment="Center" Margin="10,0"/>
-      <Button Grid.Column="6" Content="🧠 Download Metadata" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Width="200" Height="36" Margin="5,0,0,0"
+      <Button Grid.Column="6" Content="⬇️ Download LoRA" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Width="200" Height="36" Margin="5,0,0,0"
+              Command="{Binding OpenDownloadLoraCommand}"/>
+      <Button Grid.Column="7" Content="🧠 Download Metadata" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Width="200" Height="36" Margin="5,0,0,0"
               Command="{Binding DownloadMissingMetadataCommand}"/>
-      <Button Grid.Column="7" Content="🔄 Refresh" Width="120" Height="36" Margin="5,0,0,0" Command="{Binding RefreshCommand}"/>
-      <Button Grid.Column="8"
+      <Button Grid.Column="8" Content="🔄 Refresh" Width="120" Height="36" Margin="5,0,0,0" Command="{Binding RefreshCommand}"/>
+      <Button Grid.Column="9"
               Width="48"
               Height="36"
               Margin="5,0,0,0"


### PR DESCRIPTION
## Summary
- add reusable Civitai link parser and LoRA download service that saves metadata and preview assets
- introduce a Download LoRA dialog in Lora Helper to collect the link, target source folder, and show progress/speed feedback
- wire the new command into the toolbar and add unit coverage for the link parser

## Testing
- `dotnet test` *(fails: MSBuild TerminalLogger crashes on existing nullable warnings in ModelClass)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913c96ff34c8332b31f725ada9f00f1)