### PR TITLE
Add Civitai LoRA download flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Added LoRA downloader flow with URL validation, progress reporting, cancellation, and target persistence.
 - Added busy overlay with progress and cancellation for LoRA sort.
 - Consolidated metadata parsing helpers into internal ModelMetadataUtils.
 - Automatic log expansion during processing.

--- a/DiffusionNexus.Service/Services/CivitaiLinkInfo.cs
+++ b/DiffusionNexus.Service/Services/CivitaiLinkInfo.cs
@@ -1,0 +1,8 @@
+namespace DiffusionNexus.Service.Services;
+
+/// <summary>
+/// Describes the identifiers encoded within a Civitai model URL.
+/// </summary>
+/// <param name="ModelId">The numeric model identifier.</param>
+/// <param name="ModelVersionId">Optional model version identifier.</param>
+public readonly record struct CivitaiLinkInfo(int ModelId, int? ModelVersionId);

--- a/DiffusionNexus.Service/Services/CivitaiLoraDownloader.cs
+++ b/DiffusionNexus.Service/Services/CivitaiLoraDownloader.cs
@@ -1,0 +1,257 @@
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+
+namespace DiffusionNexus.Service.Services;
+
+/// <summary>
+/// Default implementation that resolves download metadata via the Civitai API and streams
+/// the resulting file to disk while reporting progress updates.
+/// </summary>
+public sealed class CivitaiLoraDownloader : ILoraDownloader
+{
+    private static readonly TimeSpan ProgressInterval = TimeSpan.FromMilliseconds(500);
+    private readonly ICivitaiApiClient _apiClient;
+    private readonly HttpClient _httpClient;
+
+    public CivitaiLoraDownloader(ICivitaiApiClient apiClient, HttpClient httpClient)
+    {
+        _apiClient = apiClient ?? throw new ArgumentNullException(nameof(apiClient));
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    }
+
+    public async Task<LoraDownloadPlan> PrepareAsync(int modelId, int? modelVersionId, string? apiKey, CancellationToken cancellationToken)
+    {
+        if (modelId <= 0)
+            throw new ArgumentOutOfRangeException(nameof(modelId), "Model id must be greater than zero.");
+
+        JsonElement versionElement;
+        if (modelVersionId.HasValue)
+        {
+            versionElement = await LoadModelVersionAsync(modelVersionId.Value, apiKey, cancellationToken);
+        }
+        else
+        {
+            versionElement = await ResolveLatestVersionAsync(modelId, apiKey, cancellationToken);
+        }
+
+        var (fileName, downloadUri, totalBytes) = ExtractFileMetadata(versionElement);
+
+        var sanitizedName = SanitizeFileName(fileName);
+        return new LoraDownloadPlan(modelId, versionElement.GetProperty("id").GetInt32(), sanitizedName, downloadUri, totalBytes);
+    }
+
+    public async Task<LoraDownloadResult> DownloadAsync(
+        LoraDownloadPlan plan,
+        string targetFilePath,
+        IProgress<LoraDownloadProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        if (plan is null)
+            throw new ArgumentNullException(nameof(plan));
+
+        if (string.IsNullOrWhiteSpace(targetFilePath))
+            throw new ArgumentException("Target path is required.", nameof(targetFilePath));
+
+        var fullTarget = Path.GetFullPath(targetFilePath);
+        var targetDirectory = Path.GetDirectoryName(fullTarget) ?? throw new InvalidOperationException("Target path must include a directory.");
+        Directory.CreateDirectory(targetDirectory);
+
+        // Prevent path traversal outside of the target directory.
+        var normalizedDirectory = Path.GetFullPath(targetDirectory) + Path.DirectorySeparatorChar;
+        if (!fullTarget.StartsWith(normalizedDirectory, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Invalid target path.");
+        }
+
+        var tempPath = fullTarget + ".partial";
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, plan.DownloadUri);
+        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        await using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        await using var fileStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 81920, useAsync: true);
+
+        var totalBytes = plan.TotalBytes ?? response.Content.Headers.ContentLength;
+        var buffer = new byte[81920];
+        long totalRead = 0;
+        long lastReported = 0;
+        var stopwatch = Stopwatch.StartNew();
+        var lastReportTime = TimeSpan.Zero;
+
+        try
+        {
+            while (true)
+            {
+                var bytesRead = await responseStream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken);
+                if (bytesRead == 0)
+                    break;
+
+                await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken);
+                totalRead += bytesRead;
+
+                var elapsed = stopwatch.Elapsed;
+                if (elapsed - lastReportTime >= ProgressInterval || totalBytes.HasValue && totalRead >= totalBytes.Value)
+                {
+                    var deltaBytes = totalRead - lastReported;
+                    var deltaSeconds = Math.Max((elapsed - lastReportTime).TotalSeconds, 1e-6);
+                    var speedMbps = deltaBytes / deltaSeconds / (1024 * 1024);
+                    double? percent = totalBytes.HasValue && totalBytes.Value > 0 ? totalRead * 100.0 / totalBytes.Value : null;
+
+                    TimeSpan? eta = null;
+                    if (totalBytes.HasValue && speedMbps > 0)
+                    {
+                        var remainingBytes = totalBytes.Value - totalRead;
+                        var secondsRemaining = remainingBytes / (speedMbps * 1024 * 1024);
+                        eta = TimeSpan.FromSeconds(Math.Max(secondsRemaining, 0));
+                    }
+
+                    progress?.Report(new LoraDownloadProgress(totalRead, totalBytes, percent, speedMbps, eta));
+                    lastReportTime = elapsed;
+                    lastReported = totalRead;
+                }
+            }
+
+            await fileStream.FlushAsync(cancellationToken);
+        }
+        catch
+        {
+            // On error or cancellation ensure partial file is cleaned up.
+            await SafeDeleteAsync(tempPath);
+            throw;
+        }
+
+        if (File.Exists(fullTarget))
+        {
+            File.Delete(fullTarget);
+        }
+
+        File.Move(tempPath, fullTarget);
+        progress?.Report(new LoraDownloadProgress(totalRead, totalBytes, 100, 0, TimeSpan.Zero));
+        return new LoraDownloadResult(true, fullTarget);
+    }
+
+    private async Task<JsonElement> LoadModelVersionAsync(int modelVersionId, string? apiKey, CancellationToken cancellationToken)
+    {
+        var json = await _apiClient.GetModelVersionAsync(modelVersionId.ToString(), apiKey ?? string.Empty);
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.Clone();
+    }
+
+    private async Task<JsonElement> ResolveLatestVersionAsync(int modelId, string? apiKey, CancellationToken cancellationToken)
+    {
+        var json = await _apiClient.GetModelAsync(modelId.ToString(), apiKey ?? string.Empty);
+        using var doc = JsonDocument.Parse(json);
+        if (!doc.RootElement.TryGetProperty("modelVersions", out var versions) || versions.ValueKind != JsonValueKind.Array)
+        {
+            throw new InvalidOperationException("No model versions available for this model.");
+        }
+
+        var enumerator = versions.EnumerateArray();
+        if (!enumerator.MoveNext())
+        {
+            throw new InvalidOperationException("No model versions available for this model.");
+        }
+
+        return enumerator.Current.Clone();
+    }
+
+    private static (string FileName, Uri DownloadUri, long? TotalBytes) ExtractFileMetadata(JsonElement versionElement)
+    {
+        if (!versionElement.TryGetProperty("files", out var filesElement) || filesElement.ValueKind != JsonValueKind.Array)
+        {
+            throw new InvalidOperationException("Model version does not contain downloadable files.");
+        }
+
+        JsonElement? selected = null;
+        foreach (var file in filesElement.EnumerateArray())
+        {
+            if (file.TryGetProperty("primary", out var primaryProp) && primaryProp.ValueKind == JsonValueKind.True)
+            {
+                selected = file;
+                break;
+            }
+        }
+
+        selected ??= filesElement.EnumerateArray().FirstOrDefault();
+        if (selected is null)
+        {
+            throw new InvalidOperationException("Model version does not contain downloadable files.");
+        }
+
+        var name = selected.Value.TryGetProperty("name", out var nameProp) && nameProp.ValueKind == JsonValueKind.String
+            ? nameProp.GetString() ?? "model.safetensors"
+            : "model.safetensors";
+
+        if (!selected.Value.TryGetProperty("downloadUrl", out var urlProp) || urlProp.ValueKind != JsonValueKind.String)
+        {
+            throw new InvalidOperationException("Download URL not provided by Civitai.");
+        }
+
+        var downloadUrl = urlProp.GetString();
+        if (string.IsNullOrWhiteSpace(downloadUrl))
+        {
+            throw new InvalidOperationException("Download URL not provided by Civitai.");
+        }
+
+        if (!Uri.TryCreate(downloadUrl, UriKind.Absolute, out var uri))
+        {
+            throw new InvalidOperationException("Download URL is invalid.");
+        }
+
+        long? totalBytes = null;
+        if (selected.Value.TryGetProperty("sizeKB", out var sizeProp))
+        {
+            try
+            {
+                var sizeKb = sizeProp.ValueKind switch
+                {
+                    JsonValueKind.Number => sizeProp.GetDouble(),
+                    JsonValueKind.String when double.TryParse(sizeProp.GetString(), out var parsed) => parsed,
+                    _ => (double?)null
+                };
+
+                if (sizeKb.HasValue)
+                {
+                    totalBytes = (long)Math.Round(sizeKb.Value * 1024);
+                }
+            }
+            catch
+            {
+                totalBytes = null;
+            }
+        }
+
+        return (name, uri, totalBytes);
+    }
+
+    private static string SanitizeFileName(string fileName)
+    {
+        var invalidChars = Path.GetInvalidFileNameChars();
+        var sanitized = new string(fileName.Select(ch => invalidChars.Contains(ch) ? '_' : ch).ToArray());
+        sanitized = sanitized.Replace("..", ".");
+        if (string.IsNullOrWhiteSpace(sanitized))
+        {
+            sanitized = "model.safetensors";
+        }
+
+        return sanitized.Trim();
+    }
+
+    private static async Task SafeDeleteAsync(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch
+        {
+            await Task.CompletedTask;
+        }
+    }
+}

--- a/DiffusionNexus.Service/Services/CivitaiUrlParser.cs
+++ b/DiffusionNexus.Service/Services/CivitaiUrlParser.cs
@@ -1,0 +1,80 @@
+using System.Text.RegularExpressions;
+
+namespace DiffusionNexus.Service.Services;
+
+/// <summary>
+/// Regex-based implementation for parsing Civitai model URLs.
+/// </summary>
+public sealed partial class CivitaiUrlParser : ICivitaiUrlParser
+{
+    private static readonly string[] AllowedHosts = ["civitai.com", "www.civitai.com"];
+
+    /// <inheritdoc />
+    public bool TryParse(string? url, out CivitaiLinkInfo info, out string? normalizedUrl, out string? error)
+    {
+        info = default;
+        normalizedUrl = null;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            error = "URL is required.";
+            return false;
+        }
+
+        if (!Uri.TryCreate(url.Trim(), UriKind.Absolute, out var uri))
+        {
+            error = "Enter a valid URL.";
+            return false;
+        }
+
+        if (!AllowedHosts.Contains(uri.Host, StringComparer.OrdinalIgnoreCase))
+        {
+            error = "Only civitai.com links are supported.";
+            return false;
+        }
+
+        var scheme = uri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase) ? "https" : "https";
+        var builder = new UriBuilder(uri)
+        {
+            Scheme = scheme,
+            Port = scheme.Equals("https", StringComparison.OrdinalIgnoreCase) ? -1 : uri.Port
+        };
+
+        var match = ModelPathRegex().Match(uri.AbsolutePath);
+        if (!match.Success)
+        {
+            error = "URL must be in the form https://civitai.com/models/<id>.";
+            return false;
+        }
+
+        if (!int.TryParse(match.Groups["modelId"].Value, out var modelId))
+        {
+            error = "Model id must be numeric.";
+            return false;
+        }
+
+        int? versionId = null;
+        var versionMatch = VersionRegex().Match(uri.Query);
+        if (versionMatch.Success)
+        {
+            if (!int.TryParse(versionMatch.Groups["versionId"].Value, out var parsedVersion))
+            {
+                error = "Model version id must be numeric.";
+                return false;
+            }
+
+            versionId = parsedVersion;
+        }
+
+        info = new CivitaiLinkInfo(modelId, versionId);
+        normalizedUrl = builder.Uri.ToString();
+        return true;
+    }
+
+    [GeneratedRegex("^/models/(?<modelId>\\d+)(/[^?]+)?$", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+    private static partial Regex ModelPathRegex();
+
+    [GeneratedRegex("(?:[?&])modelVersionId=(?<versionId>\\d+)", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+    private static partial Regex VersionRegex();
+}

--- a/DiffusionNexus.Service/Services/ICivitaiUrlParser.cs
+++ b/DiffusionNexus.Service/Services/ICivitaiUrlParser.cs
@@ -1,0 +1,17 @@
+namespace DiffusionNexus.Service.Services;
+
+/// <summary>
+/// Parses Civitai URLs and extracts model identifiers.
+/// </summary>
+public interface ICivitaiUrlParser
+{
+    /// <summary>
+    /// Attempts to parse the supplied URL.
+    /// </summary>
+    /// <param name="url">The URL provided by the user.</param>
+    /// <param name="info">When successful, contains the extracted identifiers.</param>
+    /// <param name="normalizedUrl">The canonical HTTPS version of the URL.</param>
+    /// <param name="error">An error message describing why parsing failed.</param>
+    /// <returns><c>true</c> when the URL is valid.</returns>
+    bool TryParse(string? url, out CivitaiLinkInfo info, out string? normalizedUrl, out string? error);
+}

--- a/DiffusionNexus.Service/Services/ILoraDownloader.cs
+++ b/DiffusionNexus.Service/Services/ILoraDownloader.cs
@@ -1,0 +1,21 @@
+namespace DiffusionNexus.Service.Services;
+
+/// <summary>
+/// Coordinates preparing and downloading LoRA models from Civitai.
+/// </summary>
+public interface ILoraDownloader
+{
+    /// <summary>
+    /// Resolves the concrete model version and download metadata.
+    /// </summary>
+    Task<LoraDownloadPlan> PrepareAsync(int modelId, int? modelVersionId, string? apiKey, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Downloads the file described by the supplied plan to the given path.
+    /// </summary>
+    Task<LoraDownloadResult> DownloadAsync(
+        LoraDownloadPlan plan,
+        string targetFilePath,
+        IProgress<LoraDownloadProgress>? progress,
+        CancellationToken cancellationToken);
+}

--- a/DiffusionNexus.Service/Services/LoraDownloadPlan.cs
+++ b/DiffusionNexus.Service/Services/LoraDownloadPlan.cs
@@ -1,0 +1,11 @@
+namespace DiffusionNexus.Service.Services;
+
+/// <summary>
+/// Represents a prepared download for a LoRA model version.
+/// </summary>
+/// <param name="ModelId">The Civitai model identifier.</param>
+/// <param name="ModelVersionId">The resolved model version identifier.</param>
+/// <param name="FileName">Sanitised file name suggested by Civitai.</param>
+/// <param name="DownloadUri">Direct download URI.</param>
+/// <param name="TotalBytes">Known file size in bytes (if provided by the API).</param>
+public sealed record LoraDownloadPlan(int ModelId, int ModelVersionId, string FileName, Uri DownloadUri, long? TotalBytes);

--- a/DiffusionNexus.Service/Services/LoraDownloadProgress.cs
+++ b/DiffusionNexus.Service/Services/LoraDownloadProgress.cs
@@ -1,0 +1,17 @@
+namespace DiffusionNexus.Service.Services;
+
+/// <summary>
+/// Represents a progress update for a download operation.
+/// </summary>
+/// <param name="BytesReceived">The cumulative number of bytes written to disk.</param>
+/// <param name="TotalBytes">Optional total size reported by the server.</param>
+/// <param name="Percentage">Optional percentage from 0-100.</param>
+/// <param name="SpeedMbps">Current download speed in megabytes per second.</param>
+/// <param name="EstimatedRemaining">Estimated time remaining.</param>
+public readonly record struct LoraDownloadProgress(
+    long BytesReceived,
+    long? TotalBytes,
+    double? Percentage,
+    double SpeedMbps,
+    TimeSpan? EstimatedRemaining
+);

--- a/DiffusionNexus.Service/Services/LoraDownloadResult.cs
+++ b/DiffusionNexus.Service/Services/LoraDownloadResult.cs
@@ -1,0 +1,8 @@
+namespace DiffusionNexus.Service.Services;
+
+/// <summary>
+/// Result of executing a LoRA download operation.
+/// </summary>
+/// <param name="Succeeded">Indicates whether the download completed successfully.</param>
+/// <param name="FilePath">Absolute path to the downloaded file.</param>
+public sealed record LoraDownloadResult(bool Succeeded, string? FilePath = null);

--- a/DiffusionNexus.Tests/Service/Services/CivitaiUrlParserTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/CivitaiUrlParserTests.cs
@@ -1,0 +1,44 @@
+using DiffusionNexus.Service.Services;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.Service.Services;
+
+public class CivitaiUrlParserTests
+{
+    [Theory]
+    [InlineData("https://civitai.com/models/372465?modelVersionId=914390", 372465, 914390)]
+    [InlineData("https://civitai.com/models/1153088/retro-ghibli-style-porco-rosso", 1153088, null)]
+    public void ParsesValidUrls(string url, int expectedModel, int? expectedVersion)
+    {
+        var parser = new CivitaiUrlParser();
+
+        var success = parser.TryParse(url, out var info, out _, out var error);
+
+        success.Should().BeTrue();
+        error.Should().BeNull();
+        info.ModelId.Should().Be(expectedModel);
+        info.ModelVersionId.Should().Be(expectedVersion);
+    }
+
+    [Fact]
+    public void RejectsNonCivitaiHost()
+    {
+        var parser = new CivitaiUrlParser();
+
+        var success = parser.TryParse("https://example.com/models/123", out _, out _, out var error);
+
+        success.Should().BeFalse();
+        error.Should().Contain("civitai.com");
+    }
+
+    [Fact]
+    public void RejectsInvalidPath()
+    {
+        var parser = new CivitaiUrlParser();
+
+        var success = parser.TryParse("https://civitai.com/foo/123", out _, out _, out var error);
+
+        success.Should().BeFalse();
+        error.Should().Contain("models");
+    }
+}

--- a/DiffusionNexus.Tests/UI/ViewModels/DownloadLoraDialogViewModelTests.cs
+++ b/DiffusionNexus.Tests/UI/ViewModels/DownloadLoraDialogViewModelTests.cs
@@ -1,0 +1,121 @@
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DiffusionNexus.Service.Services;
+using DiffusionNexus.UI.ViewModels;
+using FluentAssertions;
+using Moq;
+
+namespace DiffusionNexus.Tests.UI.ViewModels;
+
+public class DownloadLoraDialogViewModelTests
+{
+    [Fact]
+    public void OkEnabledRequiresValidUrlAndTarget()
+    {
+        var tempDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
+        try
+        {
+            var targets = new[] { new DownloadTargetOption("Test", tempDir.FullName) };
+            var vm = new DownloadLoraDialogViewModel(new CivitaiUrlParser(), Mock.Of<ILoraDownloader>(), targets, null, null, null);
+
+            vm.IsOkEnabled.Should().BeFalse();
+
+            vm.CivitaiUrl = "https://civitai.com/models/1";
+            vm.SelectedTarget = vm.Targets.First();
+
+            vm.IsOkEnabled.Should().BeTrue();
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ExecutesDownloadUsingParsedIdentifiers()
+    {
+        var tempDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
+        try
+        {
+            var parser = new CivitaiUrlParser();
+            var downloader = new Mock<ILoraDownloader>(MockBehavior.Strict);
+            var plan = new LoraDownloadPlan(372465, 914390, "model.safetensors", new Uri("https://example.com"), 1_024);
+
+            downloader
+                .Setup(d => d.PrepareAsync(372465, 914390, null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(plan);
+
+            downloader
+                .Setup(d => d.DownloadAsync(plan, It.IsAny<string>(), It.IsAny<IProgress<LoraDownloadProgress>>(), It.IsAny<CancellationToken>()))
+                .Callback<LoraDownloadPlan, string, IProgress<LoraDownloadProgress>, CancellationToken>((_, _, progress, _) =>
+                {
+                    progress.Report(new LoraDownloadProgress(512, 1_024, 50, 2.5, TimeSpan.FromSeconds(1)));
+                })
+                .ReturnsAsync(new LoraDownloadResult(true, Path.Combine(tempDir.FullName, plan.FileName)));
+
+            string? savedPath = null;
+            var vm = new DownloadLoraDialogViewModel(parser, downloader.Object, [new DownloadTargetOption("Target", tempDir.FullName)], null, null, path =>
+            {
+                savedPath = path;
+                return Task.CompletedTask;
+            });
+
+            vm.SelectedTarget = vm.Targets.First();
+            vm.CivitaiUrl = "https://civitai.com/models/372465?modelVersionId=914390";
+
+            await vm.OkCommand.ExecuteAsync(null);
+
+            vm.WasSuccessful.Should().BeTrue();
+            savedPath.Should().Be(tempDir.FullName);
+
+            downloader.VerifyAll();
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task CancelCommandStopsInFlightDownload()
+    {
+        var tempDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
+        try
+        {
+            var parser = new CivitaiUrlParser();
+            var downloader = new Mock<ILoraDownloader>(MockBehavior.Strict);
+            var plan = new LoraDownloadPlan(1, 2, "model.safetensors", new Uri("https://example.com"), null);
+
+            downloader
+                .Setup(d => d.PrepareAsync(1, 2, null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(plan);
+
+            downloader
+                .Setup(d => d.DownloadAsync(plan, It.IsAny<string>(), It.IsAny<IProgress<LoraDownloadProgress>>(), It.IsAny<CancellationToken>()))
+                .Returns<LoraDownloadPlan, string, IProgress<LoraDownloadProgress>, CancellationToken>(async (p, path, progress, token) =>
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(5), token);
+                    return new LoraDownloadResult(true, path);
+                });
+
+            var vm = new DownloadLoraDialogViewModel(parser, downloader.Object, [new DownloadTargetOption("Target", tempDir.FullName)], null, null, null);
+            vm.SelectedTarget = vm.Targets.First();
+            vm.CivitaiUrl = "https://civitai.com/models/1?modelVersionId=2";
+
+            var execution = vm.OkCommand.ExecuteAsync(null);
+            await Task.Delay(100);
+            vm.CancelCommand.Execute(null);
+
+            await execution;
+
+            vm.WasSuccessful.Should().BeFalse();
+            downloader.Verify(d => d.DownloadAsync(plan, It.IsAny<string>(), It.IsAny<IProgress<LoraDownloadProgress>>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+}

--- a/DiffusionNexus.UI/Classes/SettingsModel.cs
+++ b/DiffusionNexus.UI/Classes/SettingsModel.cs
@@ -19,6 +19,7 @@ namespace DiffusionNexus.UI.Classes
         [ObservableProperty] private bool _showVideoPreview;
         [ObservableProperty] private bool _showNsfw;
         [ObservableProperty] private bool _useForgeStylePrompts = true;
+        [ObservableProperty] private string? _lastDownloadLoraTargetPath;
 
         [JsonIgnore]
         public string? CivitaiApiKey { get; set; }

--- a/DiffusionNexus.UI/Converters/StringNotEmptyToBoolConverter.cs
+++ b/DiffusionNexus.UI/Converters/StringNotEmptyToBoolConverter.cs
@@ -1,0 +1,18 @@
+using Avalonia.Data.Converters;
+using System;
+using System.Globalization;
+
+namespace DiffusionNexus.UI.Converters;
+
+public class StringNotEmptyToBoolConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return value is string s && !string.IsNullOrWhiteSpace(s);
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/DiffusionNexus.UI/ViewModels/DownloadLoraDialogViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/DownloadLoraDialogViewModel.cs
@@ -1,0 +1,472 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DiffusionNexus.Service.Services;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+public partial class DownloadLoraDialogViewModel : ViewModelBase
+{
+    private readonly ICivitaiUrlParser _urlParser;
+    private readonly ILoraDownloader _loraDownloader;
+    private readonly string? _apiKey;
+    private readonly Func<string, Task>? _saveLastTargetAsync;
+    private CancellationTokenSource? _downloadCts;
+    private bool _isUrlValid;
+    private TaskCompletionSource<CollisionResolution>? _collisionTcs;
+    private bool _cancellationRequested;
+
+    public ObservableCollection<DownloadTargetOption> Targets { get; }
+
+    public event EventHandler<bool>? CloseRequested;
+
+    [ObservableProperty]
+    private string? civitaiUrl;
+
+    [ObservableProperty]
+    private DownloadTargetOption? selectedTarget;
+
+    [ObservableProperty]
+    private bool isDownloading;
+
+    [ObservableProperty]
+    private double progress;
+
+    [ObservableProperty]
+    private string progressStatus = string.Empty;
+
+    [ObservableProperty]
+    private double speedMbps;
+
+    [ObservableProperty]
+    private string? etaText;
+
+    [ObservableProperty]
+    private string? urlError;
+
+    [ObservableProperty]
+    private string? errorMessage;
+
+    [ObservableProperty]
+    private bool isCollisionPromptVisible;
+
+    [ObservableProperty]
+    private string? collisionMessage;
+
+    [ObservableProperty]
+    private string? saveAsFileName;
+
+    public bool WasSuccessful { get; private set; }
+
+    public bool IsOkEnabled => _isUrlValid && !IsDownloading && SelectedTarget != null && !IsCollisionPromptVisible;
+
+    public IAsyncRelayCommand OkCommand { get; }
+    public IRelayCommand CancelCommand { get; }
+    public IAsyncRelayCommand PasteFromClipboardCommand { get; }
+    public IRelayCommand OverwriteCommand { get; }
+    public IRelayCommand SkipCommand { get; }
+    public IRelayCommand SaveAsCommand { get; }
+
+    public DownloadLoraDialogViewModel(
+        ICivitaiUrlParser urlParser,
+        ILoraDownloader loraDownloader,
+        IEnumerable<DownloadTargetOption> targets,
+        string? apiKey,
+        string? lastTargetPath,
+        Func<string, Task>? saveLastTargetAsync)
+    {
+        _urlParser = urlParser ?? throw new ArgumentNullException(nameof(urlParser));
+        _loraDownloader = loraDownloader ?? throw new ArgumentNullException(nameof(loraDownloader));
+        _apiKey = apiKey;
+        _saveLastTargetAsync = saveLastTargetAsync;
+
+        Targets = new ObservableCollection<DownloadTargetOption>(targets ?? Enumerable.Empty<DownloadTargetOption>());
+
+        if (!string.IsNullOrWhiteSpace(lastTargetPath))
+        {
+            SelectedTarget = Targets.FirstOrDefault(t => string.Equals(t.FullPath, lastTargetPath, StringComparison.OrdinalIgnoreCase));
+        }
+
+        OkCommand = new AsyncRelayCommand(ExecuteOkAsync, () => IsOkEnabled);
+        CancelCommand = new RelayCommand(OnCancel);
+        PasteFromClipboardCommand = new AsyncRelayCommand(PasteFromClipboardAsync);
+        OverwriteCommand = new RelayCommand(() => ResolveCollision(CollisionResolution.Overwrite), () => IsCollisionPromptVisible);
+        SkipCommand = new RelayCommand(() => ResolveCollision(CollisionResolution.Skip), () => IsCollisionPromptVisible);
+        SaveAsCommand = new RelayCommand(() => ResolveCollision(CollisionResolution.SaveAs), () => IsCollisionPromptVisible);
+    }
+
+    partial void OnCivitaiUrlChanged(string? value)
+    {
+        ValidateUrl(value);
+        OkCommand.NotifyCanExecuteChanged();
+        OnPropertyChanged(nameof(IsOkEnabled));
+    }
+
+    partial void OnSelectedTargetChanged(DownloadTargetOption? value)
+    {
+        OkCommand.NotifyCanExecuteChanged();
+        OnPropertyChanged(nameof(IsOkEnabled));
+    }
+
+    partial void OnIsDownloadingChanged(bool value)
+    {
+        OkCommand.NotifyCanExecuteChanged();
+        CancelCommand.NotifyCanExecuteChangedIfSupported();
+        OnPropertyChanged(nameof(IsOkEnabled));
+    }
+
+    partial void OnIsCollisionPromptVisibleChanged(bool value)
+    {
+        OkCommand.NotifyCanExecuteChanged();
+        OverwriteCommand.NotifyCanExecuteChanged();
+        SkipCommand.NotifyCanExecuteChanged();
+        SaveAsCommand.NotifyCanExecuteChanged();
+        OnPropertyChanged(nameof(IsOkEnabled));
+    }
+
+    public void CancelDownload()
+    {
+        _cancellationRequested = true;
+        _downloadCts?.Cancel();
+    }
+
+    public bool HandleWindowClosing()
+    {
+        if (IsDownloading)
+        {
+            CancelDownload();
+            return true;
+        }
+
+        return false;
+    }
+
+    private async Task ExecuteOkAsync()
+    {
+        ErrorMessage = null;
+
+        if (!_urlParser.TryParse(CivitaiUrl, out var info, out var normalizedUrl, out var parseError))
+        {
+            UrlError = parseError;
+            _isUrlValid = false;
+            return;
+        }
+
+        UrlError = null;
+        _isUrlValid = true;
+        if (!string.IsNullOrWhiteSpace(normalizedUrl) && !string.Equals(CivitaiUrl, normalizedUrl, StringComparison.Ordinal))
+        {
+            CivitaiUrl = normalizedUrl;
+        }
+
+        if (SelectedTarget is null)
+        {
+            ErrorMessage = "Select a target folder.";
+            return;
+        }
+
+        if (!Directory.Exists(SelectedTarget.FullPath))
+        {
+            ErrorMessage = "Target folder no longer exists.";
+            return;
+        }
+
+        if (!IsDirectoryWritable(SelectedTarget.FullPath))
+        {
+            ErrorMessage = "Target folder is not writable.";
+            return;
+        }
+
+        IsDownloading = true;
+        Progress = 0;
+        SpeedMbps = 0;
+        EtaText = null;
+        ProgressStatus = string.Empty;
+        _cancellationRequested = false;
+        _downloadCts = new CancellationTokenSource();
+
+        try
+        {
+            var plan = await _loraDownloader.PrepareAsync(info.ModelId, info.ModelVersionId, _apiKey, _downloadCts.Token);
+            var targetPath = CombineSafe(SelectedTarget.FullPath, plan.FileName);
+
+            if (File.Exists(targetPath))
+            {
+                var resolution = await PromptForCollisionAsync(SelectedTarget.FullPath, plan.FileName, _downloadCts.Token);
+                if (resolution == CollisionResolution.Skip)
+                {
+                    ErrorMessage = "Download skipped.";
+                    return;
+                }
+
+                if (resolution == CollisionResolution.SaveAs)
+                {
+                    targetPath = CombineSafe(SelectedTarget.FullPath, SaveAsFileName ?? plan.FileName);
+                }
+                else if (resolution == CollisionResolution.Overwrite && File.Exists(targetPath))
+                {
+                    File.Delete(targetPath);
+                }
+            }
+
+            var progress = new Progress<LoraDownloadProgress>(UpdateProgress);
+            await _loraDownloader.DownloadAsync(plan, targetPath, progress, _downloadCts.Token);
+
+            if (_saveLastTargetAsync != null)
+            {
+                await _saveLastTargetAsync(SelectedTarget.FullPath);
+            }
+
+            WasSuccessful = true;
+            RequestClose(true);
+        }
+        catch (OperationCanceledException)
+        {
+            if (_cancellationRequested)
+            {
+                RequestClose(false);
+            }
+            else
+            {
+                ErrorMessage = "Download cancelled.";
+            }
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+        }
+        finally
+        {
+            _downloadCts?.Dispose();
+            _downloadCts = null;
+            IsDownloading = false;
+            CancelCollisionPrompt();
+        }
+    }
+
+    private async Task<CollisionResolution> PromptForCollisionAsync(string folder, string fileName, CancellationToken ct)
+    {
+        SaveAsFileName = GenerateSaveAsName(folder, fileName);
+        CollisionMessage = $"The file '{fileName}' already exists.";
+        IsCollisionPromptVisible = true;
+        _collisionTcs = new TaskCompletionSource<CollisionResolution>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using (ct.Register(() => _collisionTcs?.TrySetCanceled()))
+        {
+            try
+            {
+                return await _collisionTcs.Task.ConfigureAwait(false);
+            }
+            finally
+            {
+                IsCollisionPromptVisible = false;
+            }
+        }
+    }
+
+    private void CancelCollisionPrompt()
+    {
+        IsCollisionPromptVisible = false;
+        CollisionMessage = null;
+        SaveAsFileName = null;
+        _collisionTcs?.TrySetCanceled();
+        _collisionTcs = null;
+    }
+
+    private void ResolveCollision(CollisionResolution resolution)
+    {
+        _collisionTcs?.TrySetResult(resolution);
+    }
+
+    private void UpdateProgress(LoraDownloadProgress progress)
+    {
+        RunOnUiThread(() =>
+        {
+            Progress = progress.Percentage ?? 0;
+            SpeedMbps = progress.SpeedMbps;
+            EtaText = progress.EstimatedRemaining.HasValue && progress.EstimatedRemaining > TimeSpan.Zero
+                ? $"ETA ~ {progress.EstimatedRemaining:hh\\:mm\\:ss}"
+                : null;
+
+            ProgressStatus = BuildProgressStatus(progress.BytesReceived, progress.TotalBytes, progress.SpeedMbps);
+        });
+    }
+
+    private static string BuildProgressStatus(long received, long? total, double speed)
+    {
+        var builder = new StringBuilder();
+        builder.Append($"Downloaded {FormatBytes(received)}");
+        if (total.HasValue)
+        {
+            builder.Append($" / {FormatBytes(total.Value)}");
+        }
+
+        builder.Append($" ({speed:F2} MB/s)");
+        return builder.ToString();
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        var sizes = new[] { "B", "KB", "MB", "GB", "TB" };
+        double len = bytes;
+        var order = 0;
+        while (len >= 1024 && order < sizes.Length - 1)
+        {
+            order++;
+            len /= 1024;
+        }
+
+        return $"{len:0.##} {sizes[order]}";
+    }
+
+    private static string CombineSafe(string folder, string fileName)
+    {
+        var fullFolder = Path.GetFullPath(folder);
+        var combined = Path.GetFullPath(Path.Combine(fullFolder, fileName));
+        if (!combined.StartsWith(fullFolder + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) && !combined.Equals(fullFolder, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Attempted to write outside of the target folder.");
+        }
+
+        return combined;
+    }
+
+    private static string GenerateSaveAsName(string folder, string fileName)
+    {
+        var directory = Path.GetFullPath(folder);
+        var baseName = Path.GetFileNameWithoutExtension(fileName);
+        var extension = Path.GetExtension(fileName);
+        var index = 1;
+        string candidate;
+        do
+        {
+            candidate = $"{baseName} ({index}){extension}";
+            index++;
+        }
+        while (File.Exists(Path.Combine(directory, candidate)));
+
+        return candidate;
+    }
+
+    private static bool IsDirectoryWritable(string path)
+    {
+        try
+        {
+            var testFile = Path.Combine(path, Path.GetRandomFileName());
+            using (File.Create(testFile, 1, FileOptions.DeleteOnClose))
+            {
+            }
+
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private void RunOnUiThread(Action action)
+    {
+        if (Dispatcher.UIThread is { } dispatcher)
+        {
+            if (dispatcher.CheckAccess())
+            {
+                action();
+            }
+            else
+            {
+                dispatcher.InvokeAsync(action).GetAwaiter().GetResult();
+            }
+        }
+        else
+        {
+            action();
+        }
+    }
+
+    private void ValidateUrl(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            UrlError = null;
+            _isUrlValid = false;
+            return;
+        }
+
+        if (_urlParser.TryParse(value, out _, out _, out var error))
+        {
+            UrlError = null;
+            _isUrlValid = true;
+        }
+        else
+        {
+            UrlError = error;
+            _isUrlValid = false;
+        }
+
+        OnPropertyChanged(nameof(IsOkEnabled));
+    }
+
+    private async Task PasteFromClipboardAsync()
+    {
+        if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop &&
+            desktop.MainWindow is { Clipboard: { } clipboard })
+        {
+            var text = await clipboard.GetTextAsync();
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                CivitaiUrl = text.Trim();
+            }
+        }
+    }
+
+    private void OnCancel()
+    {
+        if (IsDownloading)
+        {
+            CancelDownload();
+        }
+        else
+        {
+            RequestClose(false);
+        }
+    }
+
+    private void RequestClose(bool result)
+    {
+        CloseRequested?.Invoke(this, result);
+    }
+
+    private enum CollisionResolution
+    {
+        Overwrite,
+        Skip,
+        SaveAs
+    }
+}
+
+internal static class RelayCommandExtensions
+{
+    public static void NotifyCanExecuteChangedIfSupported(this IRelayCommand command)
+    {
+        switch (command)
+        {
+            case RelayCommand relayCommand:
+                relayCommand.NotifyCanExecuteChanged();
+                break;
+            case IAsyncRelayCommand asyncCommand:
+                asyncCommand.NotifyCanExecuteChanged();
+                break;
+        }
+    }
+}

--- a/DiffusionNexus.UI/ViewModels/DownloadTargetOption.cs
+++ b/DiffusionNexus.UI/ViewModels/DownloadTargetOption.cs
@@ -1,0 +1,6 @@
+namespace DiffusionNexus.UI.ViewModels;
+
+public sealed record DownloadTargetOption(string DisplayName, string FullPath)
+{
+    public override string ToString() => DisplayName;
+}

--- a/DiffusionNexus.UI/Views/DownloadLoraDialog.axaml
+++ b/DiffusionNexus.UI/Views/DownloadLoraDialog.axaml
@@ -1,0 +1,96 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:DiffusionNexus.UI.ViewModels"
+        xmlns:conv="using:DiffusionNexus.UI.Converters"
+        x:Class="DiffusionNexus.UI.Views.DownloadLoraDialog"
+        x:DataType="vm:DownloadLoraDialogViewModel"
+        Title="Download LoRA from Civitai"
+        Width="520"
+        MinHeight="420"
+        WindowStartupLocation="CenterOwner">
+  <Window.Resources>
+    <conv:BooleanNotConverter x:Key="BooleanNotConverter" />
+    <conv:StringNotEmptyToBoolConverter x:Key="StringNotEmptyToBoolConverter" />
+  </Window.Resources>
+  <Border Padding="16">
+    <Grid RowDefinitions="Auto,*" ColumnDefinitions="*">
+      <StackPanel Spacing="16">
+        <StackPanel Spacing="4">
+          <TextBlock Text="Civitai Link" FontWeight="Bold" />
+          <StackPanel Orientation="Horizontal" Spacing="8">
+            <TextBox Width="360"
+                     Watermark="https://civitai.com/models/..."
+                     Text="{Binding CivitaiUrl, UpdateSourceTrigger=PropertyChanged}"
+                     IsEnabled="{Binding IsDownloading, Converter={StaticResource BooleanNotConverter}}" />
+            <Button Content="Paste"
+                    Command="{Binding PasteFromClipboardCommand}"
+                    IsEnabled="{Binding IsDownloading, Converter={StaticResource BooleanNotConverter}}" />
+          </StackPanel>
+          <TextBlock Text="Examples:" FontSize="12" Foreground="#AAA" />
+          <StackPanel Spacing="2">
+            <TextBlock Text="https://civitai.com/models/372465?modelVersionId=914390"
+                       FontSize="12"
+                       Foreground="#888" />
+            <TextBlock Text="https://civitai.com/models/1153088/retro-ghibli-style-porco-rosso?modelVersionId=2396443"
+                       FontSize="12"
+                       Foreground="#888" />
+            <TextBlock Text="Note: modelVersionId may be missing for single-version models."
+                       FontSize="12"
+                       Foreground="#888" />
+          </StackPanel>
+          <TextBlock Text="{Binding UrlError}"
+                     Foreground="Red"
+                     FontSize="12"
+                     IsVisible="{Binding UrlError, Converter={StaticResource StringNotEmptyToBoolConverter}}" />
+        </StackPanel>
+
+        <StackPanel Spacing="4">
+          <TextBlock Text="Target Folder" FontWeight="Bold" />
+          <ComboBox ItemsSource="{Binding Targets}"
+                    SelectedItem="{Binding SelectedTarget}"
+                    IsEnabled="{Binding IsDownloading, Converter={StaticResource BooleanNotConverter}}" />
+        </StackPanel>
+
+        <Border Background="#330000" CornerRadius="4" Padding="8" IsVisible="{Binding ErrorMessage, Converter={StaticResource StringNotEmptyToBoolConverter}}">
+          <TextBlock Text="{Binding ErrorMessage}" Foreground="Red" TextWrapping="Wrap" />
+        </Border>
+
+        <Border Background="#223344" CornerRadius="4" Padding="8" IsVisible="{Binding IsCollisionPromptVisible}">
+          <StackPanel Spacing="8">
+            <TextBlock Text="{Binding CollisionMessage}" FontWeight="Bold" TextWrapping="Wrap" />
+            <StackPanel Orientation="Horizontal" Spacing="8">
+              <Button Content="Overwrite"
+                      Command="{Binding OverwriteCommand}" />
+              <Button Content="Skip"
+                      Command="{Binding SkipCommand}" />
+              <Button Command="{Binding SaveAsCommand}">
+                <Button.Content>
+                  <TextBlock Text="{Binding SaveAsFileName, StringFormat='Save as &quot;{0}&quot;'}" />
+                </Button.Content>
+              </Button>
+            </StackPanel>
+          </StackPanel>
+        </Border>
+
+        <StackPanel Spacing="8" IsVisible="{Binding IsDownloading}">
+          <ProgressBar Minimum="0" Maximum="100" Value="{Binding Progress}" Height="16" />
+          <TextBlock Text="{Binding ProgressStatus}" />
+          <TextBlock Text="{Binding EtaText}" Foreground="#AAA" />
+        </StackPanel>
+      </StackPanel>
+
+      <StackPanel Grid.Row="1"
+                  VerticalAlignment="Bottom"
+                  Orientation="Horizontal"
+                  HorizontalAlignment="Right"
+                  Spacing="8"
+                  Margin="0,24,0,0">
+        <Button Content="Cancel" Command="{Binding CancelCommand}" MinWidth="100" />
+        <Button Content="OK"
+                Command="{Binding OkCommand}"
+                IsEnabled="{Binding IsOkEnabled}"
+                MinWidth="100" />
+      </StackPanel>
+    </Grid>
+  </Border>
+</Window>

--- a/DiffusionNexus.UI/Views/DownloadLoraDialog.axaml.cs
+++ b/DiffusionNexus.UI/Views/DownloadLoraDialog.axaml.cs
@@ -1,0 +1,46 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using DiffusionNexus.UI.ViewModels;
+
+namespace DiffusionNexus.UI.Views;
+
+public partial class DownloadLoraDialog : Window
+{
+    private DownloadLoraDialogViewModel? _viewModel;
+
+    public DownloadLoraDialog()
+    {
+        InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+        Closing += OnClosing;
+    }
+
+    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+    private void OnDataContextChanged(object? sender, System.EventArgs e)
+    {
+        if (_viewModel is not null)
+        {
+            _viewModel.CloseRequested -= OnCloseRequested;
+        }
+
+        _viewModel = DataContext as DownloadLoraDialogViewModel;
+        if (_viewModel is not null)
+        {
+            _viewModel.CloseRequested += OnCloseRequested;
+        }
+    }
+
+    private void OnCloseRequested(object? sender, bool result)
+    {
+        Close(result);
+    }
+
+    private void OnClosing(object? sender, WindowClosingEventArgs e)
+    {
+        if (_viewModel is not null && _viewModel.HandleWindowClosing())
+        {
+            e.Cancel = true;
+        }
+    }
+}

--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml
@@ -24,7 +24,7 @@
     </Style>
   </UserControl.Styles>
   <Grid RowDefinitions="Auto,*" ColumnDefinitions="Auto,*" Margin="10">
-    <Grid Grid.ColumnSpan="2" ColumnDefinitions="Auto,1.5*,Auto,Auto,Auto,Auto,Auto,Auto,Auto" Margin="0,0,0,5">
+    <Grid Grid.ColumnSpan="2" ColumnDefinitions="Auto,1.5*,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" Margin="0,0,0,5">
       <Button Grid.Column="0" Content="◀️ Reset Filters" Width="120" Height="36" Command="{Binding ResetFiltersCommand}"/>
       <AutoCompleteBox x:Name="SearchBox"
                       Grid.Column="1"
@@ -51,8 +51,9 @@
       <CheckBox Grid.Column="5" Content="Show NSFW" IsChecked="{Binding ShowNsfw}" VerticalAlignment="Center" Margin="10,0"/>
       <Button Grid.Column="6" Content="🧠 Download Metadata" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Width="200" Height="36" Margin="5,0,0,0"
               Command="{Binding DownloadMissingMetadataCommand}"/>
-      <Button Grid.Column="7" Content="🔄 Refresh" Width="120" Height="36" Margin="5,0,0,0" Command="{Binding RefreshCommand}"/>
-      <Button Grid.Column="8"
+      <Button Grid.Column="7" Content="⬇️ Download LoRA" Width="180" Height="36" Margin="5,0,0,0" Command="{Binding DownloadLoraCommand}"/>
+      <Button Grid.Column="8" Content="🔄 Refresh" Width="120" Height="36" Margin="5,0,0,0" Command="{Binding RefreshCommand}"/>
+      <Button Grid.Column="9"
               Width="48"
               Height="36"
               Margin="5,0,0,0"


### PR DESCRIPTION
## Summary
- add service abstractions and implementations for parsing Civitai URLs and downloading LoRA files with progress reporting and cancellation support
- introduce a Download LoRA dialog with validation, progress UI, collision handling, clipboard paste, and persistence of the last target source
- wire the new dialog into the LoRA helper view and settings, and add unit tests covering the parser and dialog viewmodel behaviour

## Testing
- MSBUILDTERMINALLOGGER=false dotnet test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691438902f608332b6b30ca8d0eaaced)