### PR TITLE
Stabilize download dialog progress test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Added busy overlay with progress and cancellation for LoRA sort.
+- Added Civitai-powered "Download LoRA" flow with validation, progress feedback, and conflict handling in LoRA Helper.
 - Consolidated metadata parsing helpers into internal ModelMetadataUtils.
 - Automatic log expansion during processing.
 - Added path validation, disk space check and progress reporting.

--- a/DiffusionNexus.Service/Services/CivitaiLoraDownloader.cs
+++ b/DiffusionNexus.Service/Services/CivitaiLoraDownloader.cs
@@ -1,0 +1,232 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DiffusionNexus.Service.Services;
+
+public class CivitaiLoraDownloader : ILoraDownloader
+{
+    private readonly ICivitaiApiClient _apiClient;
+    private readonly HttpClient _httpClient;
+
+    public CivitaiLoraDownloader(ICivitaiApiClient apiClient, HttpClient httpClient)
+    {
+        _apiClient = apiClient ?? throw new ArgumentNullException(nameof(apiClient));
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    }
+
+    public async Task<LoraDownloadResult> DownloadAsync(LoraDownloadRequest request, IProgress<LoraDownloadProgress>? progress, CancellationToken cancellationToken)
+    {
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+
+        if (string.IsNullOrWhiteSpace(request.TargetDirectory))
+            throw new ArgumentException("Target directory must be provided.", nameof(request));
+
+        Directory.CreateDirectory(request.TargetDirectory);
+
+        var version = await ResolveVersionAsync(request, cancellationToken).ConfigureAwait(false);
+        var file = SelectFile(version);
+
+        if (file == null)
+            throw new InvalidOperationException("No downloadable file was found for this model version.");
+
+        var fileName = SanitizeFileName(file.Name, request.ModelId, version.Id);
+        var targetPath = EnsureTargetWithinDirectory(Path.Combine(request.TargetDirectory, fileName), request.TargetDirectory);
+
+        var tempPath = targetPath + ".partial";
+
+        if (File.Exists(targetPath))
+        {
+            var resolution = request.ConflictResolver != null
+                ? await request.ConflictResolver(new LoraDownloadConflictContext(targetPath, fileName, new FileInfo(targetPath).Length)).ConfigureAwait(false)
+                : new LoraDownloadConflictResolution(LoraDownloadConflictResolutionType.Skip);
+
+            switch (resolution.Type)
+            {
+                case LoraDownloadConflictResolutionType.Skip:
+                    return new LoraDownloadResult(LoraDownloadResultStatus.Skipped, targetPath);
+                case LoraDownloadConflictResolutionType.Rename:
+                    if (string.IsNullOrWhiteSpace(resolution.FileName))
+                        throw new InvalidOperationException("A file name must be supplied when renaming.");
+                    fileName = SanitizeFileName(resolution.FileName, request.ModelId, version.Id);
+                    targetPath = EnsureTargetWithinDirectory(Path.Combine(request.TargetDirectory, fileName), request.TargetDirectory);
+                    tempPath = targetPath + ".partial";
+                    break;
+                case LoraDownloadConflictResolutionType.Overwrite:
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        progress?.Report(new LoraDownloadProgress(0, file.TotalBytes));
+
+        var requestMessage = new HttpRequestMessage(HttpMethod.Get, file.DownloadUrl);
+        if (!string.IsNullOrWhiteSpace(request.ApiKey))
+        {
+            requestMessage.Headers.Authorization = new AuthenticationHeaderValue("ApiKey", request.ApiKey);
+        }
+
+        using var response = await _httpClient.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var totalBytes = response.Content.Headers.ContentLength ?? file.TotalBytes;
+
+        await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        await using var fileStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 81920, useAsync: true);
+
+        var buffer = ArrayPool<byte>.Shared.Rent(81920);
+        try
+        {
+            long totalRead = 0;
+            while (true)
+            {
+                var read = await contentStream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false);
+                if (read == 0)
+                    break;
+
+                await fileStream.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+                totalRead += read;
+                progress?.Report(new LoraDownloadProgress(totalRead, totalBytes));
+            }
+
+            await fileStream.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            if (File.Exists(tempPath))
+            {
+                File.Delete(tempPath);
+            }
+            throw;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+
+        if (File.Exists(targetPath))
+        {
+            File.Delete(targetPath);
+        }
+
+        File.Move(tempPath, targetPath, overwrite: true);
+
+        return new LoraDownloadResult(LoraDownloadResultStatus.Completed, targetPath);
+    }
+
+    private async Task<ModelVersionDto> ResolveVersionAsync(LoraDownloadRequest request, CancellationToken cancellationToken)
+    {
+        if (request.ModelVersionId.HasValue)
+        {
+            var json = await _apiClient.GetModelVersionAsync(request.ModelVersionId.Value.ToString(CultureInfo.InvariantCulture), request.ApiKey ?? string.Empty).ConfigureAwait(false);
+            return ParseVersion(JsonDocument.Parse(json).RootElement);
+        }
+
+        var modelJson = await _apiClient.GetModelAsync(request.ModelId.ToString(CultureInfo.InvariantCulture), request.ApiKey ?? string.Empty).ConfigureAwait(false);
+        using var doc = JsonDocument.Parse(modelJson);
+        if (doc.RootElement.TryGetProperty("modelVersions", out var versions) && versions.ValueKind == JsonValueKind.Array)
+        {
+            var first = versions.EnumerateArray().OrderByDescending(v => v.TryGetProperty("createdAt", out var created) && created.ValueKind == JsonValueKind.String ? DateTime.TryParse(created.GetString(), out var dt) ? dt : DateTime.MinValue : DateTime.MinValue).FirstOrDefault();
+            if (first.ValueKind != JsonValueKind.Undefined)
+            {
+                return ParseVersion(first);
+            }
+        }
+
+        throw new InvalidOperationException("No model versions were found for this model.");
+    }
+
+    private static ModelVersionDto ParseVersion(JsonElement element)
+    {
+        if (!element.TryGetProperty("id", out var idEl) || idEl.ValueKind != JsonValueKind.Number)
+            throw new InvalidOperationException("Invalid model version payload.");
+
+        var id = idEl.GetInt32();
+        var files = element.TryGetProperty("files", out var filesEl) && filesEl.ValueKind == JsonValueKind.Array
+            ? filesEl.EnumerateArray().Select(ParseFile).Where(f => f != null).Cast<ModelFileDto>().ToList()
+            : new List<ModelFileDto>();
+
+        return new ModelVersionDto(id, files);
+    }
+
+    private static ModelFileDto? ParseFile(JsonElement element)
+    {
+        if (!element.TryGetProperty("downloadUrl", out var urlEl) || urlEl.ValueKind != JsonValueKind.String)
+            return null;
+
+        var name = element.TryGetProperty("name", out var nameEl) && nameEl.ValueKind == JsonValueKind.String
+            ? nameEl.GetString()
+            : null;
+
+        long? size = null;
+        if (element.TryGetProperty("sizeKB", out var sizeEl) && sizeEl.ValueKind is JsonValueKind.Number)
+        {
+            var kb = sizeEl.GetDouble();
+            size = (long)(kb * 1024);
+        }
+
+        string? format = null;
+        if (element.TryGetProperty("metadata", out var metadataEl) && metadataEl.ValueKind == JsonValueKind.Object && metadataEl.TryGetProperty("format", out var formatEl) && formatEl.ValueKind == JsonValueKind.String)
+        {
+            format = formatEl.GetString();
+        }
+
+        var type = element.TryGetProperty("type", out var typeEl) && typeEl.ValueKind == JsonValueKind.String
+            ? typeEl.GetString()
+            : null;
+
+        return new ModelFileDto(name, urlEl.GetString()!, size, type, format);
+    }
+
+    private static ModelFileDto? SelectFile(ModelVersionDto version)
+    {
+        static bool IsPreferred(ModelFileDto file) =>
+            string.Equals(file.Format, "safetensor", StringComparison.OrdinalIgnoreCase) ||
+            (string.Equals(file.Type, "model", StringComparison.OrdinalIgnoreCase) &&
+             file.Name != null && file.Name.EndsWith(".safetensors", StringComparison.OrdinalIgnoreCase));
+
+        return version.Files.FirstOrDefault(IsPreferred) ?? version.Files.FirstOrDefault();
+    }
+
+    private static string SanitizeFileName(string? name, int modelId, int versionId)
+    {
+        var candidate = string.IsNullOrWhiteSpace(name)
+            ? $"model-{modelId}-{versionId}.safetensors"
+            : Path.GetFileName(name);
+
+        if (string.IsNullOrWhiteSpace(candidate))
+        {
+            candidate = $"model-{modelId}-{versionId}.safetensors";
+        }
+
+        foreach (var invalid in Path.GetInvalidFileNameChars())
+        {
+            candidate = candidate.Replace(invalid, '_');
+        }
+
+        return candidate;
+    }
+
+    private static string EnsureTargetWithinDirectory(string targetPath, string baseDirectory)
+    {
+        var fullTarget = Path.GetFullPath(targetPath);
+        var fullBase = Path.GetFullPath(baseDirectory);
+        if (!fullTarget.StartsWith(fullBase, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException("Resolved file path escapes the target directory.");
+        return fullTarget;
+    }
+
+    private sealed record ModelVersionDto(int Id, List<ModelFileDto> Files);
+
+    private sealed record ModelFileDto(string? Name, string DownloadUrl, long? TotalBytes, string? Type, string? Format);
+}

--- a/DiffusionNexus.Service/Services/ILoraDownloader.cs
+++ b/DiffusionNexus.Service/Services/ILoraDownloader.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DiffusionNexus.Service.Services;
+
+public interface ILoraDownloader
+{
+    Task<LoraDownloadResult> DownloadAsync(LoraDownloadRequest request, IProgress<LoraDownloadProgress>? progress, CancellationToken cancellationToken);
+}
+
+public record LoraDownloadRequest
+{
+    public required int ModelId { get; init; }
+    public int? ModelVersionId { get; init; }
+    public required string TargetDirectory { get; init; }
+    public string? ApiKey { get; init; }
+    public Func<LoraDownloadConflictContext, Task<LoraDownloadConflictResolution>>? ConflictResolver { get; init; }
+}
+
+public record LoraDownloadProgress(long BytesReceived, long? TotalBytes);
+
+public enum LoraDownloadResultStatus
+{
+    Completed,
+    Skipped
+}
+
+public record LoraDownloadResult(LoraDownloadResultStatus Status, string? FilePath = null);
+
+public enum LoraDownloadConflictResolutionType
+{
+    Overwrite,
+    Skip,
+    Rename
+}
+
+public record LoraDownloadConflictContext(string ExistingFilePath, string SuggestedFileName, long? ExistingFileSize);
+
+public record LoraDownloadConflictResolution(LoraDownloadConflictResolutionType Type, string? FileName = null);

--- a/DiffusionNexus.Tests/UI/Classes/CivitaiUrlParserTests.cs
+++ b/DiffusionNexus.Tests/UI/Classes/CivitaiUrlParserTests.cs
@@ -1,0 +1,63 @@
+using DiffusionNexus.UI.Classes;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.UI.Classes;
+
+public class CivitaiUrlParserTests
+{
+    private readonly CivitaiUrlParser _parser = new();
+
+    [Theory]
+    [InlineData("https://civitai.com/models/372465?modelVersionId=914390", 372465, 914390)]
+    [InlineData("https://civitai.com/models/1153088/retro-ghibli-style-porco-rosso?modelVersionId=2396443", 1153088, 2396443)]
+    public void Parses_Model_And_Version(string url, int expectedModel, int expectedVersion)
+    {
+        var result = _parser.TryParse(url, out var info, out var error);
+
+        result.Should().BeTrue();
+        info.Should().NotBeNull();
+        info!.ModelId.Should().Be(expectedModel);
+        info.ModelVersionId.Should().Be(expectedVersion);
+        error.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parses_Model_With_Slug_Without_Version()
+    {
+        var url = "https://civitai.com/models/1153088/retro-ghibli-style-porco-rosso";
+
+        var result = _parser.TryParse(url, out var info, out var error);
+
+        result.Should().BeTrue();
+        info.Should().NotBeNull();
+        info!.ModelId.Should().Be(1153088);
+        info.ModelVersionId.Should().BeNull();
+        error.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("https://notcivitai.com/models/123")]
+    [InlineData("https://civitai.com/foo/123")]
+    public void Rejects_Invalid_Urls(string url)
+    {
+        var result = _parser.TryParse(url, out var info, out var error);
+
+        result.Should().BeFalse();
+        info.Should().BeNull();
+        error.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Handles_Extra_Query_Parameters()
+    {
+        var url = "https://civitai.com/models/372465?modelVersionId=914390&foo=bar";
+
+        var result = _parser.TryParse(url, out var info, out var error);
+
+        result.Should().BeTrue();
+        info.Should().NotBeNull();
+        info!.ModelId.Should().Be(372465);
+        info.ModelVersionId.Should().Be(914390);
+        error.Should().BeNull();
+    }
+}

--- a/DiffusionNexus.Tests/UI/ViewModels/DownloadLoraDialogViewModelTests.cs
+++ b/DiffusionNexus.Tests/UI/ViewModels/DownloadLoraDialogViewModelTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using DiffusionNexus.Service.Services;
+using DiffusionNexus.UI.Classes;
+using DiffusionNexus.UI.ViewModels;
+using FluentAssertions;
+using Moq;
+
+namespace DiffusionNexus.Tests.UI.ViewModels;
+
+public class DownloadLoraDialogViewModelTests : IDisposable
+{
+    private readonly string _tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+    public DownloadLoraDialogViewModelTests()
+    {
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    [Fact]
+    public async Task Ok_Is_Enabled_When_Url_And_Target_Selected()
+    {
+        var downloader = new Mock<ILoraDownloader>(MockBehavior.Strict);
+        downloader.Setup(d => d.DownloadAsync(It.IsAny<LoraDownloadRequest>(), It.IsAny<IProgress<LoraDownloadProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LoraDownloadResult(LoraDownloadResultStatus.Completed, Path.Combine(_tempDirectory, "file")));
+
+        var sourcesProvider = new Mock<ILoraSourcesProvider>();
+        sourcesProvider.Setup(p => p.GetSourcesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<LoraSourceInfo> { new("Temp", _tempDirectory) });
+
+        var userSettings = new Mock<IUserSettings>();
+        userSettings.Setup(s => s.GetLastDownloadLoraTargetAsync()).ReturnsAsync((string?)null);
+        userSettings.Setup(s => s.SetLastDownloadLoraTargetAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
+
+        var vm = new DownloadLoraDialogViewModel(new CivitaiUrlParser(), downloader.Object, sourcesProvider.Object, userSettings.Object, string.Empty);
+        await vm.InitializeAsync();
+
+        vm.CivitaiUrl = "https://civitai.com/models/372465?modelVersionId=914390";
+
+        vm.IsOkEnabled.Should().BeTrue();
+
+        await vm.OkCommand.ExecuteAsync(null);
+        await Task.Delay(50);
+
+        downloader.Verify(d => d.DownloadAsync(It.Is<LoraDownloadRequest>(r => r.ModelId == 372465 && r.ModelVersionId == 914390), It.IsAny<IProgress<LoraDownloadProgress>>(), It.IsAny<CancellationToken>()), Times.Once);
+        userSettings.Verify(s => s.SetLastDownloadLoraTargetAsync(_tempDirectory), Times.Once);
+    }
+
+    [Fact]
+    public async Task Invalid_Url_Shows_Error()
+    {
+        var downloader = new Mock<ILoraDownloader>(MockBehavior.Strict);
+        var sourcesProvider = new Mock<ILoraSourcesProvider>();
+        sourcesProvider.Setup(p => p.GetSourcesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<LoraSourceInfo> { new("Temp", _tempDirectory) });
+
+        var userSettings = new Mock<IUserSettings>();
+        userSettings.Setup(s => s.GetLastDownloadLoraTargetAsync()).ReturnsAsync((string?)null);
+
+        var vm = new DownloadLoraDialogViewModel(new CivitaiUrlParser(), downloader.Object, sourcesProvider.Object, userSettings.Object, string.Empty);
+        await vm.InitializeAsync();
+
+        vm.CivitaiUrl = "https://notcivitai.com/foo";
+
+        vm.ErrorMessage.Should().NotBeNull();
+        vm.IsOkEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Progress_Updates_Set_Speed_And_Eta()
+    {
+        var previousContext = SynchronizationContext.Current;
+        SynchronizationContext.SetSynchronizationContext(new ImmediateSynchronizationContext());
+        try
+        {
+            var downloader = new Mock<ILoraDownloader>();
+            downloader.Setup(d => d.DownloadAsync(It.IsAny<LoraDownloadRequest>(), It.IsAny<IProgress<LoraDownloadProgress>>(), It.IsAny<CancellationToken>()))
+                .Returns<LoraDownloadRequest, IProgress<LoraDownloadProgress>, CancellationToken>(async (req, progress, _) =>
+                {
+                    progress.Report(new LoraDownloadProgress(512 * 1024, 1024 * 1024));
+                    await Task.Delay(10);
+                    progress.Report(new LoraDownloadProgress(1024 * 1024, 1024 * 1024));
+                    return new LoraDownloadResult(LoraDownloadResultStatus.Completed, Path.Combine(_tempDirectory, "file"));
+                });
+
+            var sourcesProvider = new Mock<ILoraSourcesProvider>();
+            sourcesProvider.Setup(p => p.GetSourcesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<LoraSourceInfo> { new("Temp", _tempDirectory) });
+
+            var userSettings = new Mock<IUserSettings>();
+            userSettings.Setup(s => s.GetLastDownloadLoraTargetAsync()).ReturnsAsync((string?)null);
+            userSettings.Setup(s => s.SetLastDownloadLoraTargetAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
+
+            var timestamps = new Queue<DateTimeOffset>(new[]
+            {
+                DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow.AddSeconds(1)
+            });
+
+            var vm = new DownloadLoraDialogViewModel(new CivitaiUrlParser(), downloader.Object, sourcesProvider.Object, userSettings.Object, string.Empty, () => timestamps.Count > 0 ? timestamps.Dequeue() : DateTimeOffset.UtcNow);
+            await vm.InitializeAsync();
+            vm.CivitaiUrl = "https://civitai.com/models/372465?modelVersionId=914390";
+
+            await vm.OkCommand.ExecuteAsync(null);
+
+            vm.Progress.Should().BeApproximately(100d, 0.1);
+            vm.ProgressText.Should().Contain("1.00 MB");
+            SpinWait.SpinUntil(() => !string.IsNullOrEmpty(vm.SpeedText), TimeSpan.FromSeconds(1)).Should().BeTrue();
+            vm.SpeedText.Should().NotBeNullOrEmpty();
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(previousContext);
+        }
+    }
+
+    private sealed class ImmediateSynchronizationContext : SynchronizationContext
+    {
+        public override void Post(SendOrPostCallback d, object? state)
+        {
+            d(state);
+        }
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDirectory))
+            {
+                Directory.Delete(_tempDirectory, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+}

--- a/DiffusionNexus.UI/Classes/CivitaiUrlParser.cs
+++ b/DiffusionNexus.UI/Classes/CivitaiUrlParser.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace DiffusionNexus.UI.Classes;
+
+public class CivitaiUrlParser : ICivitaiUrlParser
+{
+    private static readonly Regex PathRegex = new(
+        "^https?://(?:www\\.)?civitai\\.com/models/(?<modelId>\\d+)(?:/[^?]+)?",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private static readonly Regex VersionRegex = new(
+        "(?:[?&])modelVersionId=(?<versionId>\\d+)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    public bool TryParse(string? url, out CivitaiLinkInfo? info, out string? errorMessage)
+    {
+        info = null;
+        errorMessage = null;
+
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            errorMessage = "Please enter a Civitai URL.";
+            return false;
+        }
+
+        if (!url.StartsWith("https://", StringComparison.OrdinalIgnoreCase) &&
+            url.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+        {
+            url = "https://" + url.Substring("http://".Length);
+        }
+
+        var match = PathRegex.Match(url);
+        if (!match.Success)
+        {
+            errorMessage = "Enter a valid civitai.com/models link.";
+            return false;
+        }
+
+        if (!int.TryParse(match.Groups["modelId"].Value, out var modelId))
+        {
+            errorMessage = "Model ID must be numeric.";
+            return false;
+        }
+
+        int? versionId = null;
+        var versionMatch = VersionRegex.Match(url);
+        if (versionMatch.Success &&
+            int.TryParse(versionMatch.Groups["versionId"].Value, out var parsedVersion))
+        {
+            versionId = parsedVersion;
+        }
+
+        info = new CivitaiLinkInfo(modelId, versionId);
+        return true;
+    }
+}

--- a/DiffusionNexus.UI/Classes/ICivitaiUrlParser.cs
+++ b/DiffusionNexus.UI/Classes/ICivitaiUrlParser.cs
@@ -1,0 +1,8 @@
+namespace DiffusionNexus.UI.Classes;
+
+public interface ICivitaiUrlParser
+{
+    bool TryParse(string? url, out CivitaiLinkInfo? info, out string? errorMessage);
+}
+
+public record CivitaiLinkInfo(int ModelId, int? ModelVersionId);

--- a/DiffusionNexus.UI/Classes/ILoraSourcesProvider.cs
+++ b/DiffusionNexus.UI/Classes/ILoraSourcesProvider.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DiffusionNexus.UI.Classes;
+
+public interface ILoraSourcesProvider
+{
+    Task<IReadOnlyList<LoraSourceInfo>> GetSourcesAsync(CancellationToken cancellationToken);
+}
+
+public record LoraSourceInfo(string DisplayName, string Path);

--- a/DiffusionNexus.UI/Classes/IUserSettings.cs
+++ b/DiffusionNexus.UI/Classes/IUserSettings.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace DiffusionNexus.UI.Classes;
+
+public interface IUserSettings
+{
+    Task<string?> GetLastDownloadLoraTargetAsync();
+    Task SetLastDownloadLoraTargetAsync(string? path);
+}

--- a/DiffusionNexus.UI/Classes/SettingsLoraSourcesProvider.cs
+++ b/DiffusionNexus.UI/Classes/SettingsLoraSourcesProvider.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DiffusionNexus.UI.Classes;
+
+public class SettingsLoraSourcesProvider : ILoraSourcesProvider
+{
+    private readonly ISettingsService _settingsService;
+
+    public SettingsLoraSourcesProvider(ISettingsService settingsService)
+    {
+        _settingsService = settingsService ?? throw new ArgumentNullException(nameof(settingsService));
+    }
+
+    public async Task<IReadOnlyList<LoraSourceInfo>> GetSourcesAsync(CancellationToken cancellationToken)
+    {
+        var settings = await _settingsService.LoadAsync();
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var sources = settings.LoraHelperSources
+            .Where(s => s.IsEnabled && !string.IsNullOrWhiteSpace(s.FolderPath))
+            .Select(s => s.FolderPath!.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(path =>
+            {
+                var trimmed = path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                var name = Path.GetFileName(trimmed);
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    name = trimmed;
+                }
+
+                return new LoraSourceInfo(name, trimmed);
+            })
+            .ToList();
+
+        return sources;
+    }
+}

--- a/DiffusionNexus.UI/Classes/SettingsModel.cs
+++ b/DiffusionNexus.UI/Classes/SettingsModel.cs
@@ -18,7 +18,8 @@ namespace DiffusionNexus.UI.Classes
         [ObservableProperty] private bool _generateVideoThumbnails = true;
         [ObservableProperty] private bool _showVideoPreview;
         [ObservableProperty] private bool _showNsfw;
-        [ObservableProperty] private bool _useForgeStylePrompts = true;
+    [ObservableProperty] private bool _useForgeStylePrompts = true;
+    [ObservableProperty] private string? _lastDownloadLoraTarget;
 
         [JsonIgnore]
         public string? CivitaiApiKey { get; set; }

--- a/DiffusionNexus.UI/Classes/SettingsUserSettings.cs
+++ b/DiffusionNexus.UI/Classes/SettingsUserSettings.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading.Tasks;
+
+namespace DiffusionNexus.UI.Classes;
+
+public class SettingsUserSettings : IUserSettings
+{
+    private readonly ISettingsService _settingsService;
+
+    public SettingsUserSettings(ISettingsService settingsService)
+    {
+        _settingsService = settingsService ?? throw new ArgumentNullException(nameof(settingsService));
+    }
+
+    public async Task<string?> GetLastDownloadLoraTargetAsync()
+    {
+        var settings = await _settingsService.LoadAsync();
+        return settings.LastDownloadLoraTarget;
+    }
+
+    public async Task SetLastDownloadLoraTargetAsync(string? path)
+    {
+        var settings = await _settingsService.LoadAsync();
+        settings.LastDownloadLoraTarget = path;
+        await _settingsService.SaveAsync(settings);
+    }
+}

--- a/DiffusionNexus.UI/Converters/StringNotNullOrEmptyConverter.cs
+++ b/DiffusionNexus.UI/Converters/StringNotNullOrEmptyConverter.cs
@@ -1,0 +1,15 @@
+using Avalonia.Data.Converters;
+using System;
+using System.Globalization;
+
+namespace DiffusionNexus.UI.Converters;
+
+public class StringNotNullOrEmptyConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return value is string s && !string.IsNullOrWhiteSpace(s);
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => throw new NotSupportedException();
+}

--- a/DiffusionNexus.UI/ViewModels/DownloadLoraDialogViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/DownloadLoraDialogViewModel.cs
@@ -1,0 +1,498 @@
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DiffusionNexus.Service.Services;
+using DiffusionNexus.UI.Classes;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+public partial class DownloadLoraDialogViewModel : ViewModelBase
+{
+    private readonly ICivitaiUrlParser _urlParser;
+    private readonly ILoraDownloader _downloader;
+    private readonly ILoraSourcesProvider _sourcesProvider;
+    private readonly IUserSettings _userSettings;
+    private readonly string _apiKey;
+    private readonly Func<DateTimeOffset> _clock;
+    private CancellationTokenSource? _downloadCts;
+    private CivitaiLinkInfo? _currentLink;
+    private Window? _window;
+    private DateTimeOffset? _lastProgressTimestamp;
+    private long _lastProgressBytes;
+    private bool _isClosing;
+
+    public DownloadLoraDialogViewModel(
+        ICivitaiUrlParser urlParser,
+        ILoraDownloader downloader,
+        ILoraSourcesProvider sourcesProvider,
+        IUserSettings userSettings,
+        string apiKey,
+        Func<DateTimeOffset>? clock = null)
+    {
+        _urlParser = urlParser ?? throw new ArgumentNullException(nameof(urlParser));
+        _downloader = downloader ?? throw new ArgumentNullException(nameof(downloader));
+        _sourcesProvider = sourcesProvider ?? throw new ArgumentNullException(nameof(sourcesProvider));
+        _userSettings = userSettings ?? throw new ArgumentNullException(nameof(userSettings));
+        _apiKey = apiKey ?? string.Empty;
+        _clock = clock ?? (() => DateTimeOffset.UtcNow);
+
+        OkCommand = new AsyncRelayCommand(StartDownloadAsync, () => !IsDownloading);
+        CancelCommand = new RelayCommand(Cancel);
+        PasteFromClipboardCommand = new AsyncRelayCommand(PasteFromClipboardAsync);
+    }
+
+    public ObservableCollection<LoraDownloadTargetOption> Targets { get; } = new();
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(OkCommand))]
+    private bool isDownloading;
+
+    [ObservableProperty]
+    private string? civitaiUrl;
+
+    [ObservableProperty]
+    private LoraDownloadTargetOption? selectedTarget;
+
+    [ObservableProperty]
+    private double progress;
+
+    [ObservableProperty]
+    private string progressText = string.Empty;
+
+    [ObservableProperty]
+    private string speedText = string.Empty;
+
+    [ObservableProperty]
+    private string etaText = string.Empty;
+
+    [ObservableProperty]
+    private string? errorMessage;
+
+    [ObservableProperty]
+    private bool isOkEnabled;
+
+    [ObservableProperty]
+    private bool showProgress;
+
+    public IDialogService? DialogService { get; set; }
+
+    public IAsyncRelayCommand OkCommand { get; }
+    public IRelayCommand CancelCommand { get; }
+    public IAsyncRelayCommand PasteFromClipboardCommand { get; }
+
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        var sources = await _sourcesProvider.GetSourcesAsync(cancellationToken).ConfigureAwait(false);
+
+        Targets.Clear();
+        foreach (var source in sources)
+        {
+            Targets.Add(new LoraDownloadTargetOption(source.DisplayName, source.Path));
+        }
+
+        var last = await _userSettings.GetLastDownloadLoraTargetAsync().ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(last))
+        {
+            SelectedTarget = Targets.FirstOrDefault(t => string.Equals(t.Path, last, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (SelectedTarget == null && Targets.Count > 0)
+        {
+            SelectedTarget = Targets[0];
+        }
+
+        UpdateValidation();
+    }
+
+    partial void OnCivitaiUrlChanged(string? value) => UpdateValidation();
+
+    partial void OnSelectedTargetChanged(LoraDownloadTargetOption? value) => UpdateValidation();
+
+    partial void OnIsDownloadingChanged(bool value)
+    {
+        UpdateIsOkEnabled();
+        if (!value)
+        {
+            ShowProgress = false;
+        }
+    }
+
+    private void UpdateValidation()
+    {
+        _currentLink = null;
+        ErrorMessage = null;
+
+        if (!_urlParser.TryParse(CivitaiUrl, out var info, out var message))
+        {
+            if (!string.IsNullOrWhiteSpace(CivitaiUrl))
+            {
+                ErrorMessage = message;
+            }
+        }
+        else
+        {
+            _currentLink = info;
+        }
+
+        if (SelectedTarget == null)
+        {
+            ErrorMessage ??= "Select a target folder.";
+        }
+
+        UpdateIsOkEnabled();
+    }
+
+    private void UpdateIsOkEnabled()
+    {
+        IsOkEnabled = _currentLink != null && SelectedTarget != null && !IsDownloading && string.IsNullOrWhiteSpace(ErrorMessage);
+    }
+
+    private async Task StartDownloadAsync()
+    {
+        if (_currentLink == null || SelectedTarget == null)
+        {
+            UpdateValidation();
+            return;
+        }
+
+        var link = _currentLink!;
+
+        if (!Directory.Exists(SelectedTarget.Path))
+        {
+            ErrorMessage = "Selected folder does not exist.";
+            UpdateIsOkEnabled();
+            return;
+        }
+
+        try
+        {
+            var testPath = Path.Combine(SelectedTarget.Path, Path.GetRandomFileName());
+            await using (File.Create(testPath, 1, FileOptions.DeleteOnClose))
+            {
+            }
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = $"Cannot write to the selected folder: {ex.Message}";
+            UpdateIsOkEnabled();
+            return;
+        }
+
+        _downloadCts = new CancellationTokenSource();
+        IsDownloading = true;
+        ShowProgress = true;
+        ErrorMessage = null;
+        Progress = 0;
+        ProgressText = string.Empty;
+        SpeedText = string.Empty;
+        EtaText = string.Empty;
+        _lastProgressTimestamp = null;
+        _lastProgressBytes = 0;
+
+        var progress = new Progress<LoraDownloadProgress>(ReportProgress);
+
+        try
+        {
+            var result = await _downloader.DownloadAsync(new LoraDownloadRequest
+            {
+                ModelId = link.ModelId,
+                ModelVersionId = link.ModelVersionId,
+                TargetDirectory = SelectedTarget.Path,
+                ApiKey = _apiKey,
+                ConflictResolver = HandleConflictAsync
+            }, progress, _downloadCts.Token).ConfigureAwait(false);
+
+            if (result.Status == LoraDownloadResultStatus.Skipped)
+            {
+                ErrorMessage = "Download skipped.";
+                IsDownloading = false;
+                return;
+            }
+
+            await _userSettings.SetLastDownloadLoraTargetAsync(SelectedTarget.Path).ConfigureAwait(false);
+            _window?.Close(true);
+        }
+        catch (OperationCanceledException)
+        {
+            if (!_isClosing)
+            {
+                _window?.Close(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+            IsDownloading = false;
+        }
+    }
+
+    private void ReportProgress(LoraDownloadProgress update)
+    {
+        if (update.TotalBytes.HasValue && update.TotalBytes.Value > 0)
+        {
+            Progress = Math.Clamp(update.BytesReceived / (double)update.TotalBytes.Value * 100d, 0d, 100d);
+            ProgressText = $"{FormatSize(update.BytesReceived)} / {FormatSize(update.TotalBytes.Value)}";
+        }
+        else
+        {
+            Progress = 0;
+            ProgressText = FormatSize(update.BytesReceived);
+            EtaText = string.Empty;
+        }
+
+        var now = _clock();
+        if (_lastProgressTimestamp is { } previous)
+        {
+            var elapsed = (now - previous).TotalSeconds;
+            if (elapsed > 0)
+            {
+                var deltaBytes = update.BytesReceived - _lastProgressBytes;
+                var bytesPerSecond = deltaBytes / elapsed;
+                if (bytesPerSecond > 0)
+                {
+                    SpeedText = $"{bytesPerSecond / (1024 * 1024):F2} MB/s";
+                    if (update.TotalBytes.HasValue)
+                    {
+                        var remaining = update.TotalBytes.Value - update.BytesReceived;
+                        if (remaining > 0)
+                        {
+                            var etaSeconds = remaining / bytesPerSecond;
+                            var eta = TimeSpan.FromSeconds(etaSeconds);
+                            EtaText = $"ETA ~ {eta:mm\\:ss}";
+                        }
+                        else
+                        {
+                            EtaText = string.Empty;
+                        }
+                    }
+                }
+                else if (!update.TotalBytes.HasValue)
+                {
+                    EtaText = string.Empty;
+                }
+            }
+        }
+
+        _lastProgressTimestamp = now;
+        _lastProgressBytes = update.BytesReceived;
+    }
+
+    private void Cancel()
+    {
+        if (IsDownloading)
+        {
+            _downloadCts?.Cancel();
+        }
+        else
+        {
+            _window?.Close(false);
+        }
+    }
+
+    private async Task PasteFromClipboardAsync()
+    {
+        if (_window?.Clipboard is { } clipboard)
+        {
+            var text = await clipboard.GetTextAsync();
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                CivitaiUrl = text.Trim();
+            }
+        }
+    }
+
+    private async Task<LoraDownloadConflictResolution> HandleConflictAsync(LoraDownloadConflictContext context)
+    {
+        if (_window is null)
+        {
+            return new LoraDownloadConflictResolution(LoraDownloadConflictResolutionType.Skip);
+        }
+
+        var tcs = new TaskCompletionSource<LoraDownloadConflictResolution>();
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            var dialog = new Window
+            {
+                Width = 420,
+                Height = 210,
+                Title = "File already exists",
+                WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                CanResize = false
+            };
+
+            var overwriteButton = new Button { Content = "Overwrite", Width = 110 };
+            var skipButton = new Button { Content = "Skip", Width = 110 };
+            var saveAsButton = new Button { Content = "Save As", Width = 110 };
+
+            void Complete(LoraDownloadConflictResolution resolution)
+            {
+                if (!tcs.TrySetResult(resolution))
+                    return;
+                dialog.Close();
+            }
+
+            overwriteButton.Click += (_, _) => Complete(new LoraDownloadConflictResolution(LoraDownloadConflictResolutionType.Overwrite));
+            skipButton.Click += (_, _) => Complete(new LoraDownloadConflictResolution(LoraDownloadConflictResolutionType.Skip));
+            saveAsButton.Click += async (_, _) =>
+            {
+                string? newName = null;
+                if (DialogService != null)
+                {
+                    newName = await DialogService.ShowInputAsync("Choose a new file name", context.SuggestedFileName);
+                }
+                else
+                {
+                    newName = await ShowInputDialogAsync(context.SuggestedFileName);
+                }
+
+                if (string.IsNullOrWhiteSpace(newName))
+                {
+                    return;
+                }
+
+                Complete(new LoraDownloadConflictResolution(LoraDownloadConflictResolutionType.Rename, newName.Trim()));
+            };
+
+            dialog.Closed += (_, _) =>
+            {
+                if (!tcs.Task.IsCompleted)
+                {
+                    tcs.TrySetResult(new LoraDownloadConflictResolution(LoraDownloadConflictResolutionType.Skip));
+                }
+            };
+
+            var text = new TextBlock
+            {
+                Text = $"'{Path.GetFileName(context.ExistingFilePath)}' already exists in the target folder.",
+                TextWrapping = Avalonia.Media.TextWrapping.Wrap
+            };
+
+            dialog.Content = new StackPanel
+            {
+                Margin = new Thickness(16),
+                Spacing = 12,
+                Children =
+                {
+                    text,
+                    new TextBlock { Text = "Choose what to do:", FontWeight = FontWeight.SemiBold },
+                    new StackPanel
+                    {
+                        Orientation = Orientation.Horizontal,
+                        HorizontalAlignment = HorizontalAlignment.Right,
+                        Spacing = 8,
+                        Children = { overwriteButton, skipButton, saveAsButton }
+                    }
+                }
+            };
+
+            _ = dialog.ShowDialog(_window);
+        });
+
+        return await tcs.Task.ConfigureAwait(false);
+    }
+
+    private async Task<string?> ShowInputDialogAsync(string suggestedFileName)
+    {
+        var localTcs = new TaskCompletionSource<string?>();
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            if (_window is null)
+            {
+                localTcs.TrySetResult(null);
+                return;
+            }
+
+            var dialog = new Window
+            {
+                Width = 360,
+                Height = 170,
+                Title = "Save As",
+                WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                CanResize = false
+            };
+
+            var textBox = new TextBox { Text = suggestedFileName };
+            var okButton = new Button { Content = "OK", Width = 90 };
+            var cancelButton = new Button { Content = "Cancel", Width = 90 };
+
+            okButton.Click += (_, _) =>
+            {
+                localTcs.TrySetResult(textBox.Text);
+                dialog.Close();
+            };
+
+            cancelButton.Click += (_, _) =>
+            {
+                localTcs.TrySetResult(null);
+                dialog.Close();
+            };
+
+            dialog.Content = new StackPanel
+            {
+                Margin = new Thickness(16),
+                Spacing = 12,
+                Children =
+                {
+                    new TextBlock { Text = "Enter a new file name", FontWeight = FontWeight.SemiBold },
+                    textBox,
+                    new StackPanel
+                    {
+                        Orientation = Orientation.Horizontal,
+                        HorizontalAlignment = HorizontalAlignment.Right,
+                        Spacing = 8,
+                        Children = { okButton, cancelButton }
+                    }
+                }
+            };
+
+            _ = dialog.ShowDialog(_window);
+        });
+
+        return await localTcs.Task.ConfigureAwait(false);
+    }
+
+    private static string FormatSize(long bytes)
+    {
+        double value = bytes;
+        string[] units = { "B", "KB", "MB", "GB" };
+        var unitIndex = 0;
+        while (value >= 1024 && unitIndex < units.Length - 1)
+        {
+            value /= 1024;
+            unitIndex++;
+        }
+
+        return $"{value:F2} {units[unitIndex]}";
+    }
+
+    public void SetWindow(Window window)
+    {
+        _window = window;
+    }
+
+    public void OnWindowClosing()
+    {
+        _isClosing = true;
+        if (IsDownloading)
+        {
+            _downloadCts?.Cancel();
+        }
+    }
+}
+
+public record LoraDownloadTargetOption(string DisplayName, string Path)
+{
+    public override string ToString() => DisplayName;
+}

--- a/DiffusionNexus.UI/Views/DownloadLoraDialog.axaml
+++ b/DiffusionNexus.UI/Views/DownloadLoraDialog.axaml
@@ -1,0 +1,84 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="using:DiffusionNexus.UI.ViewModels"
+        xmlns:conv="using:DiffusionNexus.UI.Converters"
+        x:Class="DiffusionNexus.UI.Views.DownloadLoraDialog"
+        Width="520"
+        Height="420"
+        Title="Download LoRA from Civitai"
+        CanResize="False"
+        WindowStartupLocation="CenterOwner"
+        x:DataType="vm:DownloadLoraDialogViewModel"
+        mc:Ignorable="d">
+  <Window.Resources>
+    <conv:BooleanNotConverter x:Key="BooleanNotConverter" />
+    <conv:StringNotNullOrEmptyConverter x:Key="StringNotNullOrEmptyConverter" />
+  </Window.Resources>
+  <Grid RowDefinitions="Auto,Auto,Auto,*,Auto" Margin="16" RowSpacing="12">
+    <StackPanel Orientation="Vertical" Spacing="6">
+      <TextBlock Text="Civitai Link" FontWeight="Bold"/>
+      <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+        <TextBox Text="{Binding CivitaiUrl, UpdateSourceTrigger=PropertyChanged}"
+                 Watermark="https://civitai.com/models/{id}?modelVersionId={version}"
+                 IsEnabled="{Binding IsDownloading, Converter={StaticResource BooleanNotConverter}}"/>
+        <Button Grid.Column="1"
+                Content="Paste"
+                MinWidth="70"
+                IsEnabled="{Binding IsDownloading, Converter={StaticResource BooleanNotConverter}}"
+                Command="{Binding PasteFromClipboardCommand}"/>
+      </Grid>
+      <StackPanel Spacing="2">
+        <TextBlock Text="Examples:" FontStyle="Italic" />
+        <TextBlock Text="https://civitai.com/models/372465?modelVersionId=914390"
+                   FontSize="12"
+                   Foreground="#AAA"/>
+        <TextBlock Text="https://civitai.com/models/1153088/retro-ghibli-style-porco-rosso"
+                   FontSize="12"
+                   Foreground="#AAA"/>
+        <TextBlock Text="Note: modelVersionId may be missing for single-version models."
+                   FontSize="12"
+                   Foreground="#AAA"/>
+      </StackPanel>
+    </StackPanel>
+
+    <StackPanel Grid.Row="1" Orientation="Vertical" Spacing="6">
+      <TextBlock Text="Target Folder" FontWeight="Bold"/>
+      <ComboBox ItemsSource="{Binding Targets}"
+                SelectedItem="{Binding SelectedTarget}"
+                IsEnabled="{Binding IsDownloading, Converter={StaticResource BooleanNotConverter}}"
+                PlaceholderText="Select a configured LoRA source"/>
+    </StackPanel>
+
+    <TextBlock Grid.Row="2"
+               Foreground="#FFCC3333"
+               TextWrapping="Wrap"
+               Text="{Binding ErrorMessage}"
+               IsVisible="{Binding ErrorMessage, Converter={StaticResource StringNotNullOrEmptyConverter}}"/>
+
+    <StackPanel Grid.Row="3" Spacing="8">
+      <ProgressBar Minimum="0"
+                   Maximum="100"
+                   Height="20"
+                   Value="{Binding Progress}"
+                   IsVisible="{Binding ShowProgress}"/>
+      <StackPanel Orientation="Horizontal"
+                  Spacing="12"
+                  IsVisible="{Binding ShowProgress}">
+        <TextBlock Text="{Binding ProgressText}"/>
+        <TextBlock Text="{Binding SpeedText}"/>
+        <TextBlock Text="{Binding EtaText}"/>
+      </StackPanel>
+    </StackPanel>
+
+    <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+      <Button Content="Cancel"
+              Command="{Binding CancelCommand}"/>
+      <Button Content="OK"
+              Command="{Binding OkCommand}"
+              IsEnabled="{Binding IsOkEnabled}"
+              IsDefault="True"/>
+    </StackPanel>
+  </Grid>
+</Window>

--- a/DiffusionNexus.UI/Views/DownloadLoraDialog.axaml.cs
+++ b/DiffusionNexus.UI/Views/DownloadLoraDialog.axaml.cs
@@ -1,0 +1,35 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using DiffusionNexus.UI.Classes;
+using DiffusionNexus.UI.ViewModels;
+
+namespace DiffusionNexus.UI.Views;
+
+public partial class DownloadLoraDialog : Window
+{
+    public DownloadLoraDialog()
+    {
+        InitializeComponent();
+        Opened += OnOpened;
+        Closing += OnClosing;
+    }
+
+    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+    private void OnOpened(object? sender, System.EventArgs e)
+    {
+        if (DataContext is DownloadLoraDialogViewModel vm)
+        {
+            vm.SetWindow(this);
+            vm.DialogService ??= new DialogService(this);
+        }
+    }
+
+    private void OnClosing(object? sender, WindowClosingEventArgs e)
+    {
+        if (DataContext is DownloadLoraDialogViewModel vm)
+        {
+            vm.OnWindowClosing();
+        }
+    }
+}

--- a/DiffusionNexus.UI/Views/LoraHelperView.axaml
+++ b/DiffusionNexus.UI/Views/LoraHelperView.axaml
@@ -24,7 +24,7 @@
     </Style>
   </UserControl.Styles>
   <Grid RowDefinitions="Auto,*" ColumnDefinitions="Auto,*" Margin="10">
-    <Grid Grid.ColumnSpan="2" ColumnDefinitions="Auto,1.5*,Auto,Auto,Auto,Auto,Auto,Auto,Auto" Margin="0,0,0,5">
+    <Grid Grid.ColumnSpan="2" ColumnDefinitions="Auto,1.5*,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" Margin="0,0,0,5">
       <Button Grid.Column="0" Content="◀️ Reset Filters" Width="120" Height="36" Command="{Binding ResetFiltersCommand}"/>
       <AutoCompleteBox x:Name="SearchBox"
                       Grid.Column="1"
@@ -49,10 +49,18 @@
         </StackPanel>
       </Border>
       <CheckBox Grid.Column="5" Content="Show NSFW" IsChecked="{Binding ShowNsfw}" VerticalAlignment="Center" Margin="10,0"/>
-      <Button Grid.Column="6" Content="🧠 Download Metadata" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Width="200" Height="36" Margin="5,0,0,0"
+      <Button Grid.Column="6"
+              Content="⬇️ Download LoRA"
+              VerticalContentAlignment="Center"
+              HorizontalContentAlignment="Center"
+              Width="200"
+              Height="36"
+              Margin="5,0,0,0"
+              Command="{Binding DownloadLoraCommand}"/>
+      <Button Grid.Column="7" Content="🧠 Download Metadata" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Width="200" Height="36" Margin="5,0,0,0"
               Command="{Binding DownloadMissingMetadataCommand}"/>
-      <Button Grid.Column="7" Content="🔄 Refresh" Width="120" Height="36" Margin="5,0,0,0" Command="{Binding RefreshCommand}"/>
-      <Button Grid.Column="8"
+      <Button Grid.Column="8" Content="🔄 Refresh" Width="120" Height="36" Margin="5,0,0,0" Command="{Binding RefreshCommand}"/>
+      <Button Grid.Column="9"
               Width="48"
               Height="36"
               Margin="5,0,0,0"


### PR DESCRIPTION
## Summary
- execute the download progress unit test inside an immediate synchronization context so progress callbacks run deterministically
- wait for the speed text to populate before asserting and restore the original synchronization context afterwards

## Testing
- TERM=dumb dotnet test DiffusionNexus.Tests/DiffusionNexus.Tests.csproj --nologo -p:UseTerminalLogger=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691438902f608332b6b30ca8d0eaaced)