### PR TITLE
Improve Civitai integration and clipboard UX

### DIFF
--- a/DiffusionNexus.Service/Classes/CivitaiModelMetadataBase.cs
+++ b/DiffusionNexus.Service/Classes/CivitaiModelMetadataBase.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+
+namespace DiffusionNexus.Service.Classes;
+
+/// <summary>
+/// Common properties shared between metadata models sourced from Civitai.
+/// </summary>
+public abstract class CivitaiModelMetadataBase
+{
+    private string modelVersionName = string.Empty;
+    private string? baseModel;
+    private List<string> trainedWords = new();
+
+    /// <summary>
+    /// Display name of the model version.
+    /// </summary>
+    public virtual string ModelVersionName
+    {
+        get => modelVersionName;
+        set => modelVersionName = value ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Base diffusion model that the asset targets.
+    /// </summary>
+    public virtual string? BaseModel
+    {
+        get => baseModel;
+        set => baseModel = value;
+    }
+
+    /// <summary>
+    /// Tags supplied by the author to describe how the model was trained.
+    /// </summary>
+    public IReadOnlyList<string> TrainedWords => trainedWords;
+
+    /// <summary>
+    /// Optional long form description of the model version.
+    /// </summary>
+    public virtual string? Description { get; set; }
+
+    /// <summary>
+    /// Provides derived classes with mutable access to the trained word list.
+    /// </summary>
+    protected List<string> MutableTrainedWords
+    {
+        get => trainedWords;
+        set => trainedWords = value ?? new List<string>();
+    }
+}

--- a/DiffusionNexus.Service/Classes/CivitaiModelVersionInfo.cs
+++ b/DiffusionNexus.Service/Classes/CivitaiModelVersionInfo.cs
@@ -1,14 +1,55 @@
+using System.Collections.Generic;
+using System.Linq;
+
 namespace DiffusionNexus.Service.Classes;
 
 /// <summary>
 /// Represents the metadata for a specific Civitai model version.
 /// </summary>
-public record CivitaiModelVersionInfo(
-    int ModelId,
-    int VersionId,
-    string VersionName,
-    string? BaseModel,
-    string? ModelType,
-    IReadOnlyList<string> TrainedWords,
-    IReadOnlyList<CivitaiModelFileInfo> Files,
-    string? Description);
+public class CivitaiModelVersionInfo : CivitaiModelMetadataBase
+{
+    public CivitaiModelVersionInfo(
+        int modelId,
+        int versionId,
+        string versionName,
+        string? baseModel,
+        string? modelType,
+        IReadOnlyList<string> trainedWords,
+        IReadOnlyList<CivitaiModelFileInfo> files,
+        string? description)
+    {
+        ModelId = modelId;
+        VersionId = versionId;
+        ModelVersionName = versionName;
+        BaseModel = baseModel;
+        ModelType = modelType;
+        Description = description;
+        MutableTrainedWords = trainedWords?.ToList() ?? new List<string>();
+        Files = files?.ToList() ?? new List<CivitaiModelFileInfo>();
+    }
+
+    /// <summary>
+    /// Identifier of the parent model.
+    /// </summary>
+    public int ModelId { get; }
+
+    /// <summary>
+    /// Identifier of the specific model version.
+    /// </summary>
+    public int VersionId { get; }
+
+    /// <summary>
+    /// Convenience alias matching the original record API.
+    /// </summary>
+    public string VersionName => ModelVersionName;
+
+    /// <summary>
+    /// Classification of the asset as reported by Civitai.
+    /// </summary>
+    public string? ModelType { get; }
+
+    /// <summary>
+    /// Files published for this model version.
+    /// </summary>
+    public IReadOnlyList<CivitaiModelFileInfo> Files { get; }
+}

--- a/DiffusionNexus.Service/Classes/ModelClass.cs
+++ b/DiffusionNexus.Service/Classes/ModelClass.cs
@@ -4,11 +4,12 @@
 */
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace DiffusionNexus.Service.Classes
 {
-    public class ModelClass
+    public class ModelClass : CivitaiModelMetadataBase
     {
         private const string Unknown = "UNKNOWN";
 
@@ -18,19 +19,48 @@ namespace DiffusionNexus.Service.Classes
         public string DiffusionBaseModel
         {
             get => diffusionBaseModel;
-            set => diffusionBaseModel = value == "SDXL 1.0" ? "SDXL" : value;
+            set
+            {
+                var normalised = value switch
+                {
+                    null or "" => Unknown,
+                    "SDXL 1.0" => "SDXL",
+                    _ => value
+                };
+                diffusionBaseModel = normalised;
+                base.BaseModel = normalised;
+            }
         }
 
-        [MetadataField] public string SafeTensorFileName { get; set; }
-        [MetadataField] public string ModelVersionName { get; set; }
+        public override string? BaseModel
+        {
+            get => DiffusionBaseModel;
+            set => DiffusionBaseModel = value ?? Unknown;
+        }
+
+        [MetadataField] public string SafeTensorFileName { get; set; } = string.Empty;
+
+        [MetadataField]
+        public override string ModelVersionName
+        {
+            get => base.ModelVersionName;
+            set => base.ModelVersionName = value;
+        }
+
         [MetadataField] public string? ModelId { get; set; }
         public string? SHA256Hash { get; set; }
         [MetadataField] public DiffusionTypes ModelType { get; set; } = DiffusionTypes.UNASSIGNED;
-        public List<FileInfo> AssociatedFilesInfo { get; set; }
+        public List<FileInfo> AssociatedFilesInfo { get; set; } = new();
         [MetadataField] public List<string> Tags { get; set; } = new();
         [MetadataField] public CivitaiBaseCategories CivitaiCategory { get; set; } = CivitaiBaseCategories.UNASSIGNED;
-        [MetadataField] public List<string> TrainedWords { get; set; } = new();
+        [MetadataField]
+        public new List<string> TrainedWords
+        {
+            get => MutableTrainedWords;
+            set => MutableTrainedWords = value ?? new List<string>();
+        }
         [MetadataField] public bool? Nsfw { get; set; }
+        public override string? Description { get; set; }
 
         // status flags
         public bool NoMetaData { get; set; } = true;

--- a/DiffusionNexus.Service/Services/CivitaiApiClient.cs
+++ b/DiffusionNexus.Service/Services/CivitaiApiClient.cs
@@ -26,7 +26,7 @@ namespace DiffusionNexus.Service.Services
             var request = new HttpRequestMessage(HttpMethod.Get, url);
             if (!string.IsNullOrWhiteSpace(apiKey))
             {
-                request.Headers.Authorization = new AuthenticationHeaderValue("ApiKey", apiKey);
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
             }
 
             HttpResponseMessage response = await _httpClient.SendAsync(request);

--- a/DiffusionNexus.Service/Services/CivitaiMetaDataService.cs
+++ b/DiffusionNexus.Service/Services/CivitaiMetaDataService.cs
@@ -103,9 +103,9 @@ namespace DiffusionNexus.Service.Services
             return string.Empty;
         }
 
-        private static string ParseModelId(string civitaiUrl)
+        internal static string ParseModelId(string civitaiUrl)
         {
-            var match = Regex.Match(civitaiUrl, @"civitai\.com/models/(\d+)", RegexOptions.IgnoreCase);
+            var match = Regex.Match(civitaiUrl, @"civitai\.com/(?:api/download/)?models/(\d+)", RegexOptions.IgnoreCase);
             if (!match.Success)
             {
                 throw new InvalidOperationException("Failed to extract model id from the Civitai URL.");

--- a/DiffusionNexus.Service/Services/CivitaiModelDownloadService.cs
+++ b/DiffusionNexus.Service/Services/CivitaiModelDownloadService.cs
@@ -72,7 +72,7 @@ public class CivitaiModelDownloadService
         try
         {
             var uri = new Uri(file.DownloadUrl);
-            await _fileDownloader.DownloadAsync(uri, destinationPath, progress, cancellationToken);
+            await _fileDownloader.DownloadAsync(uri, destinationPath, apiKey, progress, cancellationToken);
             return new CivitaiModelDownloadResult(ModelDownloadResultType.Success, destinationPath, versionInfo, file);
         }
         catch (OperationCanceledException)

--- a/DiffusionNexus.Tests/LoraSort/Services/CivitaiFileDownloaderTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/Services/CivitaiFileDownloaderTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using DiffusionNexus.Service.Services;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.LoraSort.Services;
+
+public class CivitaiFileDownloaderTests
+{
+    [Fact]
+    public async Task DownloadAsync_ShouldSendBearerTokenWhenApiKeyProvided()
+    {
+        string? authorizationHeader = null;
+        using var handler = new TestHandler(request =>
+        {
+            authorizationHeader = request.Headers.Authorization?.ToString();
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(new byte[] { 1, 2, 3 })
+            };
+            response.Content.Headers.ContentLength = 3;
+            return response;
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var downloader = new CivitaiFileDownloader(httpClient);
+        var tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".bin");
+
+        try
+        {
+            await downloader.DownloadAsync(new Uri("https://example.com/model"), tempFile, "secret", null, CancellationToken.None);
+
+            authorizationHeader.Should().Be("Bearer secret");
+            File.Exists(tempFile).Should().BeTrue();
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+            {
+                File.Delete(tempFile);
+            }
+        }
+    }
+
+    private sealed class TestHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+
+        public TestHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
+        {
+            _handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_handler(request));
+        }
+    }
+}

--- a/DiffusionNexus.Tests/LoraSort/Services/CivitaiMetaDataServiceTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/Services/CivitaiMetaDataServiceTests.cs
@@ -154,5 +154,14 @@ public class CivitaiMetaDataServiceTests
             // Assert
             result.Should().Be("12345");
         }
+
+        [Theory]
+        [InlineData("https://civitai.com/models/2108995", "2108995")]
+        [InlineData("https://civitai.com/models/2108995?modelVersionId=2385870", "2108995")]
+        [InlineData("https://civitai.com/api/download/models/2108995?type=Model&format=SafeTensor", "2108995")]
+        public void ParseModelId_ShouldSupportModernCivitaiUrls(string url, string expected)
+        {
+            CivitaiMetaDataService.ParseModelId(url).Should().Be(expected);
+        }
     }
 

--- a/DiffusionNexus.Tests/LoraSort/Services/CivitaiModelDownloadServiceTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/Services/CivitaiModelDownloadServiceTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using DiffusionNexus.Service.Classes;
+using DiffusionNexus.Service.Services;
+using FluentAssertions;
+using Moq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DiffusionNexus.Tests.LoraSort.Services;
+
+public class CivitaiModelDownloadServiceTests
+{
+    [Fact]
+    public async Task DownloadModelAsync_ShouldPassApiKeyToFileDownloader()
+    {
+        const string apiKey = "api-key";
+        var mockApiClient = new Mock<ICivitaiApiClient>();
+        var modelService = new CivitaiModelService(mockApiClient.Object);
+        var downloader = new TestFileDownloader();
+        var service = new CivitaiModelDownloadService(modelService, downloader);
+
+        var versionJson = """
+{
+  "id": 2385870,
+  "modelId": 2108995,
+  "name": "Test Version",
+  "baseModel": "SDXL",
+  "model": { "type": "LORA" },
+  "trainedWords": ["pony", "qwen"],
+  "files": [
+    {
+      "downloadUrl": "https://example.com/model.safetensors",
+      "name": "model.safetensors",
+      "type": "Model",
+      "format": "SafeTensor",
+      "sizeKB": 1,
+      "hashes": { "SHA256": "abc" },
+      "primary": true
+    }
+  ]
+}
+""";
+
+        mockApiClient.Setup(c => c.GetModelVersionAsync("2385870", apiKey))
+                     .ReturnsAsync(versionJson);
+
+        var targetFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(targetFolder);
+
+        try
+        {
+            var result = await service.DownloadModelAsync(
+                "https://civitai.com/models/2108995/qwen-x-pony?modelVersionId=2385870",
+                targetFolder,
+                apiKey,
+                progress: null,
+                CancellationToken.None);
+
+            result.ResultType.Should().Be(ModelDownloadResultType.Success);
+            downloader.ReceivedApiKey.Should().Be(apiKey);
+            downloader.WrittenFile.Should().NotBeNull();
+            File.Exists(downloader.WrittenFile!).Should().BeTrue();
+        }
+        finally
+        {
+            if (Directory.Exists(targetFolder))
+            {
+                Directory.Delete(targetFolder, recursive: true);
+            }
+        }
+    }
+
+    private sealed class TestFileDownloader : CivitaiFileDownloader
+    {
+        public string? ReceivedApiKey { get; private set; }
+        public string? WrittenFile { get; private set; }
+
+        public override Task DownloadAsync(Uri downloadUri, string destinationFilePath, string? apiKey, IProgress<ModelDownloadProgress>? progress, CancellationToken cancellationToken)
+        {
+            ReceivedApiKey = apiKey;
+            WrittenFile = destinationFilePath;
+            File.WriteAllText(destinationFilePath, "dummy");
+            progress?.Report(new ModelDownloadProgress(5, 5, null));
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/DiffusionNexus.Tests/LoraSort/Services/CivitaiModelServiceTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/Services/CivitaiModelServiceTests.cs
@@ -1,0 +1,24 @@
+using DiffusionNexus.Service.Services;
+using DiffusionNexus.Service.Classes;
+using FluentAssertions;
+using Moq;
+
+namespace DiffusionNexus.Tests.LoraSort.Services;
+
+public class CivitaiModelServiceTests
+{
+    [Fact]
+    public void TryParseModelUrl_ShouldHandleSluggedModelLinkWithVersionQuery()
+    {
+        var apiClient = new Mock<ICivitaiApiClient>();
+        var service = new CivitaiModelService(apiClient.Object);
+
+        var url = "https://civitai.com/models/2108995/qwen-x-pony?modelVersionId=2385870";
+
+        var result = service.TryParseModelUrl(url, out var reference);
+
+        result.Should().BeTrue();
+        reference.ModelId.Should().Be(2108995);
+        reference.ModelVersionId.Should().Be(2385870);
+    }
+}

--- a/DiffusionNexus.UI/Views/LoraDownloadWindow.axaml
+++ b/DiffusionNexus.UI/Views/LoraDownloadWindow.axaml
@@ -14,9 +14,16 @@
   <Grid Margin="20" RowDefinitions="Auto,Auto,Auto,*,Auto" RowSpacing="16">
     <StackPanel Grid.Row="0" Spacing="6">
       <TextBlock Text="Civitai Link" FontWeight="SemiBold"/>
-      <TextBox Text="{Binding CivitaiUrl, Mode=TwoWay}"
-               MinWidth="400"
-               IsEnabled="{Binding IsDownloading, Converter={StaticResource BooleanNotConverter}}"/>
+      <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+        <TextBox Grid.Column="0"
+                 Text="{Binding CivitaiUrl, Mode=TwoWay}"
+                 MinWidth="400"
+                 IsEnabled="{Binding IsDownloading, Converter={StaticResource BooleanNotConverter}}"/>
+        <Button Grid.Column="1"
+                Content="Paste"
+                Command="{Binding PasteFromClipboardCommand}"
+                IsEnabled="{Binding IsDownloading, Converter={StaticResource BooleanNotConverter}}"/>
+      </Grid>
     </StackPanel>
 
     <StackPanel Grid.Row="1" Spacing="6">


### PR DESCRIPTION
## Summary
- introduce a shared metadata base class and update the Civitai model/domain types to use it
- send the API key with Civitai HTTP/file downloads while improving URL parsing for metadata lookups
- add a clipboard paste control in the download dialog and cover the new behaviour with unit tests

## Testing
- MSBUILDTERMINALLOGGER=false dotnet test -nologo

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914a891fecc83329802216ed23e2ab3)