### PR TITLE
Add Viewer mosaic gallery module

### DIFF
--- a/DiffusionNexus.Tests/Viewer/ViewModels/ViewerViewModelTests.cs
+++ b/DiffusionNexus.Tests/Viewer/ViewModels/ViewerViewModelTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using DiffusionNexus.Domain.Entities;
+using DiffusionNexus.Domain.Enums;
+using DiffusionNexus.Domain.Services;
+using DiffusionNexus.UI.ViewModels;
+using FluentAssertions;
+using Moq;
+
+namespace DiffusionNexus.Tests.Viewer.ViewModels;
+
+public class ViewerViewModelTests
+{
+    [Fact]
+    public async Task RefreshAsync_LoadsMediaFromEnabledGalleriesAndSubfolders()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var nested = Path.Combine(tempRoot, "nested");
+        Directory.CreateDirectory(nested);
+
+        var imagePath = Path.Combine(tempRoot, "sample.png");
+        var videoPath = Path.Combine(nested, "clip.mp4");
+        File.WriteAllText(imagePath, "fake");
+        File.WriteAllText(videoPath, "fake");
+
+        var disabledRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(disabledRoot);
+        var disabledImage = Path.Combine(disabledRoot, "disabled.png");
+        File.WriteAllText(disabledImage, "fake");
+
+        try
+        {
+            var settings = new AppSettings
+            {
+                ImageGalleries =
+                [
+                    new ImageGallery { FolderPath = tempRoot, IsEnabled = true },
+                    new ImageGallery { FolderPath = disabledRoot, IsEnabled = false }
+                ]
+            };
+
+            var settingsService = new Mock<IAppSettingsService>();
+            settingsService.Setup(service => service.GetSettingsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(settings);
+
+            var viewModel = new ViewerViewModel(settingsService.Object);
+
+            await viewModel.RefreshCommand.ExecuteAsync(null);
+
+            viewModel.MediaItems.Should().HaveCount(2);
+            viewModel.MediaItems.Select(item => item.FilePath).Should().Contain(imagePath);
+            viewModel.MediaItems.Select(item => item.FilePath).Should().Contain(videoPath);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, true);
+            Directory.Delete(disabledRoot, true);
+        }
+    }
+
+    [Fact]
+    public async Task RefreshAsync_AssignsFormatTagsForImageAndVideo()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+
+        var imagePath = Path.Combine(tempRoot, "sample.png");
+        var videoPath = Path.Combine(tempRoot, "clip.mp4");
+        File.WriteAllText(imagePath, "fake");
+        File.WriteAllText(videoPath, "fake");
+
+        try
+        {
+            var settings = new AppSettings
+            {
+                ImageGalleries =
+                [
+                    new ImageGallery { FolderPath = tempRoot, IsEnabled = true }
+                ]
+            };
+
+            var settingsService = new Mock<IAppSettingsService>();
+            settingsService.Setup(service => service.GetSettingsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(settings);
+
+            var viewModel = new ViewerViewModel(settingsService.Object);
+
+            await viewModel.RefreshCommand.ExecuteAsync(null);
+
+            var imageItem = viewModel.MediaItems.Single(item => item.FilePath == imagePath);
+            var videoItem = viewModel.MediaItems.Single(item => item.FilePath == videoPath);
+
+            imageItem.FormatTag.Should().Be(SupportedMediaTypes.ImageExtensionsDisplay);
+            videoItem.FormatTag.Should().Be(SupportedMediaTypes.VideoExtensionsDisplay);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, true);
+        }
+    }
+}

--- a/DiffusionNexus.UI/App.axaml.cs
+++ b/DiffusionNexus.UI/App.axaml.cs
@@ -231,6 +231,7 @@ public partial class App : Application
             sp.GetService<IActivityLogService>()));
         
         services.AddScoped<LoraViewerViewModel>();
+        services.AddScoped<ViewerViewModel>();
         
         // LoraDatasetHelperViewModel - use factory to inject all required services
         services.AddScoped<LoraDatasetHelperViewModel>(sp => new LoraDatasetHelperViewModel(
@@ -265,6 +266,15 @@ public partial class App : Application
             "avares://DiffusionNexus.UI/Assets/LoraSort.png",
             loraViewerView));
 
+        // Viewer module
+        var viewerVm = Services!.GetRequiredService<ViewerViewModel>();
+        var viewerView = new ViewerView { DataContext = viewerVm };
+
+        mainViewModel.RegisterModule(new ModuleItem(
+            "Viewer",
+            string.Empty,
+            viewerView));
+
         // Settings module
         var settingsVm = Services!.GetRequiredService<SettingsViewModel>();
         var settingsView = new SettingsView { DataContext = settingsVm };
@@ -288,6 +298,9 @@ public partial class App : Application
 
         // Load models on startup
         loraViewerVm.RefreshCommand.Execute(null);
+
+        // Load media on startup
+        viewerVm.RefreshCommand.Execute(null);
     }
 
     private void DisableAvaloniaDataAnnotationValidation()

--- a/DiffusionNexus.UI/ViewModels/ViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/ViewerViewModel.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.IO;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DiffusionNexus.Domain.Enums;
+using DiffusionNexus.Domain.Services;
+using DiffusionNexus.UI.Services;
+using DiffusionNexus.UI.Utilities;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+public enum ViewerSortOption
+{
+    Name,
+    CreationDate
+}
+
+public sealed record ViewerSortOptionItem(ViewerSortOption Option, string DisplayName);
+
+public partial class ViewerMediaItemViewModel : ObservableObject
+{
+    public ViewerMediaItemViewModel(string filePath, bool isVideo, DateTime createdAt, string formatTag)
+    {
+        FilePath = filePath;
+        IsVideo = isVideo;
+        CreatedAt = createdAt;
+        FormatTag = formatTag;
+    }
+
+    public string FilePath { get; }
+
+    public string FileName => Path.GetFileName(FilePath);
+
+    public bool IsVideo { get; }
+
+    public bool IsImage => !IsVideo;
+
+    public DateTime CreatedAt { get; }
+
+    public string FormatTag { get; }
+}
+
+public partial class ViewerViewModel : ViewModelBase
+{
+    private readonly IAppSettingsService _settingsService;
+    private readonly IDatasetEventAggregator? _eventAggregator;
+    private readonly List<ViewerMediaItemViewModel> _allItems = [];
+
+    public ObservableCollection<ViewerMediaItemViewModel> MediaItems { get; } = [];
+
+    public IReadOnlyList<ViewerSortOptionItem> SortOptions { get; } =
+    [
+        new(ViewerSortOption.Name, "Name"),
+        new(ViewerSortOption.CreationDate, "Creation Date")
+    ];
+
+    [ObservableProperty]
+    private ViewerSortOptionItem? _selectedSortOption;
+
+    [ObservableProperty]
+    private double _tileWidth = 220;
+
+    public bool HasMedia => MediaItems.Count > 0;
+
+    public ViewerViewModel(IAppSettingsService settingsService, IDatasetEventAggregator? eventAggregator = null)
+    {
+        _settingsService = settingsService;
+        _eventAggregator = eventAggregator;
+
+        SelectedSortOption = SortOptions.First();
+        MediaItems.CollectionChanged += OnMediaItemsChanged;
+    }
+
+    public ViewerViewModel()
+    {
+        _settingsService = null!;
+        _eventAggregator = null;
+
+        SelectedSortOption = SortOptions.First();
+        MediaItems.CollectionChanged += OnMediaItemsChanged;
+    }
+
+    private void OnMediaItemsChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        OnPropertyChanged(nameof(HasMedia));
+    }
+
+    [RelayCommand]
+    private async Task RefreshAsync()
+    {
+        if (_settingsService is null)
+            return;
+
+        var settings = await _settingsService.GetSettingsAsync();
+        var enabledGalleries = settings.ImageGalleries
+            .Where(gallery => gallery.IsEnabled)
+            .Select(gallery => gallery.FolderPath)
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var items = await Task.Run(() => LoadMediaItems(enabledGalleries));
+
+        _allItems.Clear();
+        _allItems.AddRange(items);
+
+        ApplySorting();
+    }
+
+    [RelayCommand]
+    private void OpenSettings()
+    {
+        _eventAggregator?.PublishNavigateToSettings(new NavigateToSettingsEventArgs());
+    }
+
+    private static IReadOnlyList<ViewerMediaItemViewModel> LoadMediaItems(IEnumerable<string> galleryPaths)
+    {
+        var items = new List<ViewerMediaItemViewModel>();
+
+        foreach (var rootPath in galleryPaths)
+        {
+            if (string.IsNullOrWhiteSpace(rootPath) || !Directory.Exists(rootPath))
+                continue;
+
+            IEnumerable<string> files;
+            try
+            {
+                files = Directory.EnumerateFiles(rootPath, "*.*", SearchOption.AllDirectories);
+            }
+            catch
+            {
+                continue;
+            }
+
+            try
+            {
+                foreach (var file in files)
+                {
+                    if (!MediaFileExtensions.IsDisplayableMediaFile(file))
+                        continue;
+
+                    var isVideo = MediaFileExtensions.IsVideoFile(file);
+                    var createdAt = File.GetCreationTime(file);
+                    var formatTag = isVideo
+                        ? SupportedMediaTypes.VideoExtensionsDisplay
+                        : SupportedMediaTypes.ImageExtensionsDisplay;
+
+                    items.Add(new ViewerMediaItemViewModel(file, isVideo, createdAt, formatTag));
+                }
+            }
+            catch
+            {
+                // Skip unreadable paths
+            }
+        }
+
+        return items;
+    }
+
+    partial void OnSelectedSortOptionChanged(ViewerSortOptionItem? value)
+    {
+        ApplySorting();
+    }
+
+    private void ApplySorting()
+    {
+        var sorted = SelectedSortOption?.Option switch
+        {
+            ViewerSortOption.CreationDate => _allItems
+                .OrderBy(item => item.CreatedAt)
+                .ThenBy(item => item.FileName, StringComparer.OrdinalIgnoreCase),
+            _ => _allItems
+                .OrderBy(item => item.FileName, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(item => item.CreatedAt)
+        };
+
+        MediaItems.Clear();
+        foreach (var item in sorted)
+        {
+            MediaItems.Add(item);
+        }
+    }
+}

--- a/DiffusionNexus.UI/Views/ViewerView.axaml
+++ b/DiffusionNexus.UI/Views/ViewerView.axaml
@@ -1,0 +1,117 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:DiffusionNexus.UI.ViewModels"
+             xmlns:converters="using:DiffusionNexus.UI.Converters"
+             mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
+             x:Class="DiffusionNexus.UI.Views.ViewerView"
+             x:DataType="vm:ViewerViewModel">
+
+  <Design.DataContext>
+    <vm:ViewerViewModel/>
+  </Design.DataContext>
+
+  <UserControl.Resources>
+    <converters:PathToBitmapConverter x:Key="PathToBitmapConverter"/>
+  </UserControl.Resources>
+
+  <Grid RowDefinitions="Auto,*">
+
+    <!-- Toolbar -->
+    <Border Grid.Row="0"
+            Background="#1E1E1E"
+            Padding="16,12"
+            BorderBrush="#333"
+            BorderThickness="0,0,0,1">
+      <Grid ColumnDefinitions="Auto,Auto,*,Auto" RowDefinitions="Auto">
+        <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
+          <TextBlock Text="Tile Size" VerticalAlignment="Center"/>
+          <Slider Width="200"
+                  Minimum="120"
+                  Maximum="360"
+                  Value="{Binding TileWidth, Mode=TwoWay}"/>
+          <TextBlock Text="{Binding TileWidth, StringFormat={}{0:0}px}" VerticalAlignment="Center"/>
+        </StackPanel>
+
+        <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center" Margin="24,0,0,0">
+          <TextBlock Text="Sort by" VerticalAlignment="Center"/>
+          <ComboBox ItemsSource="{Binding SortOptions}"
+                    SelectedItem="{Binding SelectedSortOption, Mode=TwoWay}"
+                    DisplayMemberPath="DisplayName"
+                    Width="180"/>
+        </StackPanel>
+
+        <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right">
+          <Button Content="Refresh" Command="{Binding RefreshCommand}"/>
+        </StackPanel>
+      </Grid>
+    </Border>
+
+    <Grid Grid.Row="1">
+      <ScrollViewer Padding="16" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+        <ItemsControl ItemsSource="{Binding MediaItems}">
+          <ItemsControl.ItemsPanel>
+            <ItemsPanelTemplate>
+              <WrapPanel Orientation="Horizontal"/>
+            </ItemsPanelTemplate>
+          </ItemsControl.ItemsPanel>
+          <ItemsControl.ItemTemplate>
+            <DataTemplate x:DataType="vm:ViewerMediaItemViewModel">
+              <Border Margin="8"
+                      Width="{Binding DataContext.TileWidth, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                      Height="{Binding DataContext.TileWidth, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                      Background="#1A1A1A"
+                      BorderBrush="#333"
+                      BorderThickness="1"
+                      CornerRadius="8"
+                      ClipToBounds="True">
+                <Grid>
+                  <Image Source="{Binding FilePath, Converter={StaticResource PathToBitmapConverter}}"
+                         Stretch="UniformToFill"
+                         IsVisible="{Binding IsImage}"/>
+
+                  <Border Background="Black" IsVisible="{Binding IsVideo}">
+                    <Viewbox Stretch="Uniform">
+                      <TextBlock Text="Video" Foreground="White" FontSize="24"/>
+                    </Viewbox>
+                  </Border>
+
+                  <Border Background="#80000000"
+                          CornerRadius="4"
+                          Padding="6,2"
+                          HorizontalAlignment="Right"
+                          VerticalAlignment="Top"
+                          Margin="6">
+                    <TextBlock Text="{Binding FormatTag}" FontSize="10" Foreground="White"/>
+                  </Border>
+                </Grid>
+              </Border>
+            </DataTemplate>
+          </ItemsControl.ItemTemplate>
+        </ItemsControl>
+      </ScrollViewer>
+
+      <Border IsVisible="{Binding !HasMedia}"
+              Background="#1A1A1A"
+              CornerRadius="8"
+              Margin="16"
+              Padding="32"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center">
+        <StackPanel Spacing="16" HorizontalAlignment="Center">
+          <TextBlock Text="🖼️" FontSize="64" HorizontalAlignment="Center" Opacity="0.4"/>
+          <TextBlock Text="No Images Found" FontSize="20" FontWeight="SemiBold" HorizontalAlignment="Center"/>
+          <TextBlock Text="Add Image Gallery folders in Settings to view your images and videos." Opacity="0.6" HorizontalAlignment="Center"/>
+          <Button Content="Open Settings"
+                  Command="{Binding OpenSettingsCommand}"
+                  HorizontalAlignment="Center"
+                  Padding="16,10"
+                  FontSize="14"
+                  Background="#4CAF50"
+                  Foreground="White"/>
+        </StackPanel>
+      </Border>
+    </Grid>
+  </Grid>
+</UserControl>

--- a/DiffusionNexus.UI/Views/ViewerView.axaml.cs
+++ b/DiffusionNexus.UI/Views/ViewerView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace DiffusionNexus.UI.Views;
+
+public partial class ViewerView : UserControl
+{
+    public ViewerView()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
### Motivation
- Add a new `Viewer` module reachable from the app menu that shows all images/videos from configured image gallery folders as a mosaic gallery with adjustable tile width.  
- Only include gallery folders from `ImageGalleries` that are `IsEnabled`, recurse subfolders, and provide sorting and simple video placeholders.  
- Surface supported file-format tags using `SupportedMediaTypes.ImageExtensionsDisplay` and `SupportedMediaTypes.VideoExtensionsDisplay` and show a guidance empty-state linking to Settings when no media is found.

### Description
- Added a new ViewModel `ViewerViewModel` (`DiffusionNexus.UI/ViewModels/ViewerViewModel.cs`) which loads media from enabled `ImageGalleries`, exposes `MediaItems`, `SortOptions`, `TileWidth`, `RefreshCommand`, and `OpenSettingsCommand`.  
- Created the UI `ViewerView.axaml` and code-behind `ViewerView.axaml.cs` implementing a mosaic (`WrapPanel`) layout, a slider bound to `TileWidth`, a sort `ComboBox`, refresh button, format tag overlay, and an empty-state with an `Open Settings` action.  
- Registered `ViewerViewModel` in DI and added the `Viewer` module to the main module list in `App.axaml.cs` and trigger `viewerVm.RefreshCommand` on startup so media is initially loaded.  
- Implementation details: uses `MediaFileExtensions.IsDisplayableMediaFile` and `MediaFileExtensions.IsVideoFile`, sets `FormatTag` from `SupportedMediaTypes.*Display`, enumerates files recursively with exception safety, and binds image display via the existing `PathToBitmapConverter` for thumbnails.

### Testing
- Added unit tests `DiffusionNexus.Tests/Viewer/ViewModels/ViewerViewModelTests.cs` which create temporary folders/files and assert that `RefreshCommand` picks up media from enabled galleries and assigns `FormatTag` values.  
- Attempted to run `dotnet test /workspace/DiffusionNexus/DiffusionNexus.Tests/DiffusionNexus.Tests.csproj -c Release` but the test runner could not be executed in this environment because `dotnet` is not available, so the new tests were added but not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970b8f4e7808332bc619d1f18b3aad1)