### PR TITLE
Add multi-select and delete controls to Generation Gallery

### DIFF
--- a/DiffusionNexus.UI/ViewModels/GenerationGalleryMediaItemViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/GenerationGalleryMediaItemViewModel.cs
@@ -42,6 +42,11 @@ public partial class GenerationGalleryMediaItemViewModel : ObservableObject
     public string FileName => Path.GetFileNameWithoutExtension(FilePath);
 
     /// <summary>
+    /// Full file name with extension.
+    /// </summary>
+    public string FullFileName => Path.GetFileName(FilePath);
+
+    /// <summary>
     /// File extension (lowercase).
     /// </summary>
     public string FileExtension => Path.GetExtension(FilePath).ToLowerInvariant();
@@ -50,6 +55,9 @@ public partial class GenerationGalleryMediaItemViewModel : ObservableObject
     /// Creation timestamp for sorting.
     /// </summary>
     public DateTime CreatedAtUtc { get; }
+
+    [ObservableProperty]
+    private bool _isSelected;
 
     /// <summary>
     /// The loaded thumbnail bitmap. Loads asynchronously on first access.

--- a/DiffusionNexus.UI/Views/GenerationGalleryView.axaml
+++ b/DiffusionNexus.UI/Views/GenerationGalleryView.axaml
@@ -45,15 +45,15 @@
       </Grid>
     </Border>
 
-    <Grid Grid.Row="1">
-      <Border IsVisible="{Binding IsBusy}" Background="#80000000" ZIndex="100">
+    <Grid Grid.Row="1" RowDefinitions="Auto,*">
+      <Border IsVisible="{Binding IsBusy}" Background="#80000000" ZIndex="100" Grid.RowSpan="2">
         <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="8">
           <ProgressBar IsIndeterminate="True" Width="200"/>
           <TextBlock Text="{Binding BusyMessage}" Foreground="White" HorizontalAlignment="Center"/>
         </StackPanel>
       </Border>
 
-      <Border IsVisible="{Binding HasNoMedia}"
+      <Border IsVisible="{Binding HasNoMedia}" Grid.Row="1"
               Background="#1A1A1A" CornerRadius="8" Margin="16" Padding="32"
               HorizontalAlignment="Center" VerticalAlignment="Center">
         <StackPanel Spacing="16" HorizontalAlignment="Center">
@@ -64,7 +64,18 @@
         </StackPanel>
       </Border>
 
-      <ScrollViewer IsVisible="{Binding HasMedia}" Padding="16">
+      <Border Grid.Row="0" Background="#1E1E1E" Padding="12,8" BorderBrush="#333" BorderThickness="0,0,0,1"
+              IsVisible="{Binding HasSelection}">
+        <StackPanel Orientation="Horizontal" Spacing="8">
+          <Button Content="Select All" Command="{Binding SelectAllCommand}" Padding="8,4"/>
+          <Button Content="Clear Selection" Command="{Binding ClearSelectionCommand}" Padding="8,4"/>
+          <Border Width="1" Background="#444" Margin="8,4"/>
+          <Button Content="Delete Selected" Command="{Binding DeleteSelectedCommand}"
+                  Background="#B22222" Padding="12,6"/>
+        </StackPanel>
+      </Border>
+
+      <ScrollViewer Grid.Row="1" IsVisible="{Binding HasMedia}" Padding="16">
         <ItemsControl x:Name="GalleryItems" ItemsSource="{Binding MediaItems}">
           <ItemsControl.ItemsPanel>
             <ItemsPanelTemplate>
@@ -78,8 +89,11 @@
                       Background="#2A2A2A"
                       CornerRadius="8"
                       ClipToBounds="True"
-                      Margin="6">
+                      Margin="6"
+                      PointerPressed="OnMediaCardPointerPressed">
                 <Grid>
+                  <Border CornerRadius="8" BorderBrush="#2196F3" BorderThickness="3" Margin="-1"
+                          IsVisible="{Binding IsSelected}" IsHitTestVisible="False"/>
                   <!-- Loading placeholder shown while thumbnail is null -->
                   <Border Background="#333"
                           IsVisible="{Binding Thumbnail, Converter={x:Static ObjectConverters.IsNull}}">
@@ -93,9 +107,19 @@
                     <TextBlock Text="VIDEO" Foreground="White" FontWeight="Bold"
                                HorizontalAlignment="Center" VerticalAlignment="Center" Opacity="0.7"/>
                   </Border>
+                  <Button Content="X"
+                          Command="{Binding $parent[ItemsControl].((vm:GenerationGalleryViewModel)DataContext).DeleteMediaCommand}"
+                          CommandParameter="{Binding}"
+                          Padding="6,2" FontSize="12" Background="#80444444"
+                          Foreground="#FF6B6B" FontWeight="Bold"
+                          HorizontalAlignment="Right" VerticalAlignment="Top" Margin="6"/>
                   <Border Background="#66000000" CornerRadius="4" Padding="6,2"
-                          HorizontalAlignment="Right" VerticalAlignment="Top" Margin="6">
+                          HorizontalAlignment="Left" VerticalAlignment="Top" Margin="6">
                     <TextBlock Text="{Binding FileExtension}" Foreground="White" FontSize="11" FontWeight="SemiBold"/>
+                  </Border>
+                  <Border Background="#CC1A1A1A" VerticalAlignment="Bottom" Padding="8,6">
+                    <TextBlock Text="{Binding FullFileName}" FontSize="12" Opacity="0.7"
+                               TextTrimming="CharacterEllipsis"/>
                   </Border>
                 </Grid>
               </Border>

--- a/DiffusionNexus.UI/Views/GenerationGalleryView.axaml.cs
+++ b/DiffusionNexus.UI/Views/GenerationGalleryView.axaml.cs
@@ -1,5 +1,9 @@
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Markup.Xaml;
+using Avalonia.VisualTree;
+using DiffusionNexus.UI.ViewModels;
+using System.Linq;
 
 namespace DiffusionNexus.UI.Views;
 
@@ -11,10 +15,51 @@ public partial class GenerationGalleryView : UserControl
     public GenerationGalleryView()
     {
         InitializeComponent();
+        KeyDown += OnKeyDown;
     }
 
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);
+    }
+
+    private void OnMediaCardPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (sender is not Border border) return;
+        if (border.DataContext is not GenerationGalleryMediaItemViewModel item) return;
+        if (DataContext is not GenerationGalleryViewModel vm) return;
+
+        var props = e.GetCurrentPoint(border).Properties;
+        if (!props.IsLeftButtonPressed) return;
+
+        if (e.Source is Control control)
+        {
+            if (control is Button || control.GetVisualAncestors().OfType<Button>().Any())
+            {
+                return;
+            }
+        }
+
+        var isCtrlPressed = e.KeyModifiers.HasFlag(KeyModifiers.Control);
+        var isShiftPressed = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
+
+        vm.SelectWithModifiers(item, isShiftPressed, isCtrlPressed);
+        e.Handled = true;
+    }
+
+    private void OnKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (DataContext is not GenerationGalleryViewModel vm) return;
+
+        if (e.Key == Key.A && e.KeyModifiers.HasFlag(KeyModifiers.Control))
+        {
+            vm.SelectAllCommand.Execute(null);
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Escape && vm.HasSelection)
+        {
+            vm.ClearSelectionCommand.Execute(null);
+            e.Handled = true;
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Bring Generation Gallery selection UX in line with Dataset Management Detail view by supporting multi-select (Ctrl/Shift) and per-item deletion so users can manage generated media directly from the gallery.

### Description
- Add `FullFileName` and an observable `IsSelected` property to `GenerationGalleryMediaItemViewModel` to expose filename text and selection state.
- Implement selection state, selection-count tracking, and commands (`SelectAll`, `ClearSelection`, `DeleteSelected`, `DeleteMedia`) in `GenerationGalleryViewModel`, including Shift-range and Ctrl-toggle selection logic and deletion helpers that remove files from disk and update the collections.
- Update `GenerationGalleryView.axaml` to show a selection toolbar (Select All / Clear / Delete Selected), a blue selection border on tiles, an X button on each tile for single-item deletion, and a filename overlay under each tile.
- Add pointer and keyboard handlers in `GenerationGalleryView.axaml.cs` to route left-click/Ctrl/Shift clicks to the ViewModel and support `Ctrl+A` and `Esc` keyboard shortcuts; avoid interfering with tile buttons.
- Do not add any image rating features (per existing requirement).

### Testing
- No automated tests were executed for this change because it is primarily a UI interaction update and was not covered by existing unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971fc50e2b48332b869adc4c937dcc1)