### PR TITLE
Add 'Add Selected to Dataset' dialog and import flow to Generation Gallery

### DIFF
--- a/DiffusionNexus.UI/Services/DialogService.cs
+++ b/DiffusionNexus.UI/Services/DialogService.cs
@@ -181,6 +181,18 @@ public class DialogService : IDialogService
         return dialog.Result ?? CreateDatasetResult.Cancelled();
     }
 
+    public async Task<AddToDatasetResult> ShowAddToDatasetDialogAsync(
+        int selectionCount,
+        IEnumerable<DatasetCardViewModel> availableDatasets,
+        IEnumerable<DatasetCategoryViewModel> availableCategories)
+    {
+        var dialog = new AddToDatasetDialog()
+            .WithOptions(selectionCount, availableDatasets, availableCategories);
+
+        await dialog.ShowDialog(_window);
+        return dialog.Result ?? AddToDatasetResult.Cancelled();
+    }
+
     public async Task ShowImageViewerDialogAsync(
         ObservableCollection<DatasetImageViewModel> images,
         int startIndex,

--- a/DiffusionNexus.UI/Services/IDialogService.cs
+++ b/DiffusionNexus.UI/Services/IDialogService.cs
@@ -125,6 +125,18 @@ public interface IDialogService
     Task<CreateDatasetResult> ShowCreateDatasetDialogAsync(IEnumerable<DatasetCategoryViewModel> availableCategories);
 
     /// <summary>
+    /// Shows the add-to-dataset dialog for moving or copying files into a dataset.
+    /// </summary>
+    /// <param name="selectionCount">Number of selected files.</param>
+    /// <param name="availableDatasets">List of available datasets.</param>
+    /// <param name="availableCategories">Categories for new dataset creation.</param>
+    /// <returns>Result with transfer and target settings, or cancelled result.</returns>
+    Task<AddToDatasetResult> ShowAddToDatasetDialogAsync(
+        int selectionCount,
+        IEnumerable<DatasetCardViewModel> availableDatasets,
+        IEnumerable<DatasetCategoryViewModel> availableCategories);
+
+    /// <summary>
     /// Shows the full-screen image viewer dialog for browsing dataset images.
     /// Integrates with the event aggregator for cross-component state synchronization.
     /// </summary>

--- a/DiffusionNexus.UI/Utilities/DatasetCreationHelper.cs
+++ b/DiffusionNexus.UI/Utilities/DatasetCreationHelper.cs
@@ -1,0 +1,100 @@
+using DiffusionNexus.Domain.Services;
+using DiffusionNexus.UI.ViewModels;
+
+namespace DiffusionNexus.UI.Utilities;
+
+public sealed class DatasetCreationOutcome
+{
+    public bool Success { get; init; }
+    public bool StorageConfigured { get; init; }
+    public string? ErrorMessage { get; init; }
+    public DatasetCardViewModel? Dataset { get; init; }
+
+    public static DatasetCreationOutcome Failed(string message, bool storageConfigured)
+    {
+        return new DatasetCreationOutcome
+        {
+            Success = false,
+            StorageConfigured = storageConfigured,
+            ErrorMessage = message
+        };
+    }
+
+    public static DatasetCreationOutcome Created(DatasetCardViewModel dataset)
+    {
+        return new DatasetCreationOutcome
+        {
+            Success = true,
+            StorageConfigured = true,
+            Dataset = dataset
+        };
+    }
+}
+
+public static class DatasetCreationHelper
+{
+    public static async Task<DatasetCreationOutcome> TryCreateDatasetAsync(
+        IAppSettingsService settingsService,
+        CreateDatasetResult result)
+    {
+        var settings = await settingsService.GetSettingsAsync();
+
+        if (string.IsNullOrWhiteSpace(settings.DatasetStoragePath))
+        {
+            return DatasetCreationOutcome.Failed(
+                "Please configure the Dataset Storage Path in Settings first.",
+                storageConfigured: false);
+        }
+
+        if (!Directory.Exists(settings.DatasetStoragePath))
+        {
+            return DatasetCreationOutcome.Failed(
+                "The configured Dataset Storage Path does not exist. Please update it in Settings.",
+                storageConfigured: false);
+        }
+
+        var sanitizedName = result.Name;
+        var datasetPath = Path.Combine(settings.DatasetStoragePath, sanitizedName);
+
+        if (Directory.Exists(datasetPath))
+        {
+            return DatasetCreationOutcome.Failed(
+                $"A dataset named '{sanitizedName}' already exists.",
+                storageConfigured: true);
+        }
+
+        try
+        {
+            Directory.CreateDirectory(datasetPath);
+            var v1Path = Path.Combine(datasetPath, "V1");
+            Directory.CreateDirectory(v1Path);
+
+            var newDataset = new DatasetCardViewModel
+            {
+                Name = sanitizedName,
+                FolderPath = datasetPath,
+                IsVersionedStructure = true,
+                CurrentVersion = 1,
+                TotalVersions = 1,
+                ImageCount = 0,
+                VideoCount = 0,
+                CategoryId = result.CategoryId,
+                CategoryOrder = result.CategoryOrder,
+                CategoryName = result.CategoryName,
+                Type = result.Type,
+                IsNsfw = result.IsNsfw
+            };
+
+            newDataset.VersionNsfwFlags[1] = result.IsNsfw;
+            newDataset.SaveMetadata();
+
+            return DatasetCreationOutcome.Created(newDataset);
+        }
+        catch (Exception ex)
+        {
+            return DatasetCreationOutcome.Failed(
+                $"Failed to create dataset: {ex.Message}",
+                storageConfigured: true);
+        }
+    }
+}

--- a/DiffusionNexus.UI/Utilities/DatasetImportHelper.cs
+++ b/DiffusionNexus.UI/Utilities/DatasetImportHelper.cs
@@ -1,0 +1,192 @@
+using DiffusionNexus.UI.Services;
+using DiffusionNexus.UI.ViewModels;
+
+namespace DiffusionNexus.UI.Utilities;
+
+public sealed class DatasetImportSummary
+{
+    public bool Cancelled { get; init; }
+    public int Copied { get; init; }
+    public int Overridden { get; init; }
+    public int Renamed { get; init; }
+    public int Ignored { get; init; }
+    public IReadOnlyList<string> ProcessedSourceFiles { get; init; } = [];
+
+    public int TotalAdded => Copied + Overridden + Renamed;
+
+    public static DatasetImportSummary CancelledResult() => new() { Cancelled = true };
+}
+
+public static class DatasetImportHelper
+{
+    public static async Task<DatasetImportSummary> ImportFilesAsync(
+        IDialogService dialogService,
+        string destinationFolder,
+        IEnumerable<string> sourceFiles,
+        bool moveFiles)
+    {
+        var files = sourceFiles
+            .Where(File.Exists)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (files.Count == 0)
+        {
+            return new DatasetImportSummary();
+        }
+
+        Directory.CreateDirectory(destinationFolder);
+
+        var existingFileNames = Directory.Exists(destinationFolder)
+            ? Directory.EnumerateFiles(destinationFolder)
+                .Select(Path.GetFileName)
+                .Where(n => !string.IsNullOrEmpty(n))
+                .Cast<string>()
+                .ToHashSet(StringComparer.OrdinalIgnoreCase)
+            : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        var detection = FileConflictDetector.DetectConflicts(files, existingFileNames, destinationFolder);
+        var resolution = new FileConflictResolutionResult { Confirmed = true, Conflicts = [] };
+
+        if (detection.Conflicts.Count > 0)
+        {
+            resolution = await dialogService.ShowFileConflictDialogAsync(
+                detection.Conflicts,
+                detection.NonConflictingFiles);
+
+            if (!resolution.Confirmed)
+            {
+                return DatasetImportSummary.CancelledResult();
+            }
+        }
+
+        return ApplyResolution(
+            destinationFolder,
+            detection.NonConflictingFiles,
+            resolution,
+            moveFiles);
+    }
+
+    private static DatasetImportSummary ApplyResolution(
+        string destinationFolder,
+        List<string> nonConflictingFiles,
+        FileConflictResolutionResult resolution,
+        bool moveFiles)
+    {
+        var copied = 0;
+        var overridden = 0;
+        var renamed = 0;
+        var ignored = 0;
+        var processedSources = new List<string>();
+        var renamedPairs = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var sourceFile in nonConflictingFiles)
+        {
+            var fileName = Path.GetFileName(sourceFile);
+            var destPath = Path.Combine(destinationFolder, fileName);
+            TransferFile(sourceFile, destPath, moveFiles, overwrite: false);
+            processedSources.Add(sourceFile);
+            copied++;
+        }
+
+        foreach (var conflict in resolution.Conflicts)
+        {
+            switch (conflict.Resolution)
+            {
+                case FileConflictResolution.Override:
+                    if (File.Exists(conflict.ExistingFilePath))
+                    {
+                        File.Delete(conflict.ExistingFilePath);
+                    }
+                    TransferFile(conflict.NewFilePath, conflict.ExistingFilePath, moveFiles, overwrite: true);
+                    processedSources.Add(conflict.NewFilePath);
+
+                    if (conflict.HasPairedCaption && conflict.PairedCaptionPath is not null)
+                    {
+                        var captionFileName = Path.GetFileName(conflict.PairedCaptionPath);
+                        var destCaptionPath = Path.Combine(destinationFolder, captionFileName);
+                        if (File.Exists(destCaptionPath))
+                        {
+                            File.Delete(destCaptionPath);
+                        }
+                        TransferFile(conflict.PairedCaptionPath, destCaptionPath, moveFiles, overwrite: true);
+                        processedSources.Add(conflict.PairedCaptionPath);
+                    }
+
+                    overridden++;
+                    break;
+
+                case FileConflictResolution.Rename:
+                    var baseName = Path.GetFileNameWithoutExtension(conflict.ConflictingName);
+                    if (!renamedPairs.TryGetValue(baseName, out var newBaseName))
+                    {
+                        var uniquePath = GenerateUniqueFileName(destinationFolder, conflict.ConflictingName);
+                        newBaseName = Path.GetFileNameWithoutExtension(uniquePath);
+                        renamedPairs[baseName] = newBaseName;
+                    }
+
+                    var extension = Path.GetExtension(conflict.ConflictingName);
+                    var finalName = newBaseName + extension;
+                    var finalPath = Path.Combine(destinationFolder, finalName);
+                    TransferFile(conflict.NewFilePath, finalPath, moveFiles, overwrite: false);
+                    processedSources.Add(conflict.NewFilePath);
+
+                    if (conflict.HasPairedCaption && conflict.PairedCaptionPath is not null)
+                    {
+                        var captionExtension = Path.GetExtension(conflict.PairedCaptionPath);
+                        var captionPath = Path.Combine(destinationFolder, newBaseName + captionExtension);
+                        TransferFile(conflict.PairedCaptionPath, captionPath, moveFiles, overwrite: false);
+                        processedSources.Add(conflict.PairedCaptionPath);
+                    }
+
+                    renamed++;
+                    break;
+
+                case FileConflictResolution.Ignore:
+                    ignored++;
+                    break;
+            }
+        }
+
+        return new DatasetImportSummary
+        {
+            Copied = copied,
+            Overridden = overridden,
+            Renamed = renamed,
+            Ignored = ignored,
+            ProcessedSourceFiles = processedSources
+        };
+    }
+
+    private static void TransferFile(string sourcePath, string destinationPath, bool moveFile, bool overwrite)
+    {
+        if (moveFile)
+        {
+            if (overwrite && File.Exists(destinationPath))
+            {
+                File.Delete(destinationPath);
+            }
+            File.Move(sourcePath, destinationPath);
+            return;
+        }
+
+        File.Copy(sourcePath, destinationPath, overwrite);
+    }
+
+    private static string GenerateUniqueFileName(string folderPath, string fileName)
+    {
+        var nameWithoutExt = Path.GetFileNameWithoutExtension(fileName);
+        var extension = Path.GetExtension(fileName);
+        var counter = 1;
+        string newPath;
+
+        do
+        {
+            var newName = $"{nameWithoutExt}_{counter}{extension}";
+            newPath = Path.Combine(folderPath, newName);
+            counter++;
+        } while (File.Exists(newPath));
+
+        return newPath;
+    }
+}

--- a/DiffusionNexus.UI/Utilities/DatasetVersionHelper.cs
+++ b/DiffusionNexus.UI/Utilities/DatasetVersionHelper.cs
@@ -1,0 +1,38 @@
+using DiffusionNexus.UI.ViewModels;
+
+namespace DiffusionNexus.UI.Utilities;
+
+public static class DatasetVersionHelper
+{
+    public static Task MigrateLegacyToVersionedAsync(DatasetCardViewModel dataset)
+    {
+        var rootPath = dataset.FolderPath;
+        var v1Path = dataset.GetVersionFolderPath(1);
+
+        Directory.CreateDirectory(v1Path);
+
+        var filesToMove = Directory.EnumerateFiles(rootPath)
+            .Where(f =>
+            {
+                var ext = Path.GetExtension(f).ToLowerInvariant();
+                var fileName = Path.GetFileName(f);
+                if (fileName.StartsWith(".")) return false;
+                return MediaFileExtensions.MediaExtensions.Contains(ext) || ext == ".txt";
+            })
+            .ToList();
+
+        foreach (var sourceFile in filesToMove)
+        {
+            var fileName = Path.GetFileName(sourceFile);
+            var destFile = Path.Combine(v1Path, fileName);
+            File.Move(sourceFile, destFile);
+        }
+
+        dataset.IsVersionedStructure = true;
+        dataset.CurrentVersion = 1;
+        dataset.TotalVersions = 1;
+        dataset.SaveMetadata();
+
+        return Task.CompletedTask;
+    }
+}

--- a/DiffusionNexus.UI/ViewModels/AddToDatasetDialogViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/AddToDatasetDialogViewModel.cs
@@ -1,0 +1,258 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+public enum FileTransferMode
+{
+    Copy,
+    Move
+}
+
+public enum DatasetTargetMode
+{
+    CreateNew,
+    Existing
+}
+
+public enum DatasetVersionMode
+{
+    ExistingVersion,
+    NewVersion
+}
+
+public sealed class AddToDatasetResult
+{
+    public bool Confirmed { get; init; }
+    public FileTransferMode TransferMode { get; init; }
+    public DatasetTargetMode TargetMode { get; init; }
+    public DatasetVersionMode VersionMode { get; init; }
+    public int? TargetVersion { get; init; }
+    public DatasetCardViewModel? SelectedDataset { get; init; }
+    public CreateDatasetResult? NewDataset { get; init; }
+
+    public static AddToDatasetResult Cancelled() => new() { Confirmed = false };
+}
+
+public partial class AddToDatasetDialogViewModel : ObservableObject
+{
+    private readonly ObservableCollection<int> _availableVersions = [];
+
+    public AddToDatasetDialogViewModel(
+        int selectionCount,
+        IEnumerable<DatasetCardViewModel> availableDatasets,
+        IEnumerable<DatasetCategoryViewModel> availableCategories)
+    {
+        SelectionCount = selectionCount;
+        AvailableDatasets = new ObservableCollection<DatasetCardViewModel>(
+            availableDatasets.OrderBy(d => d.Name, StringComparer.OrdinalIgnoreCase));
+        CreateDatasetModel = new CreateDatasetDialogViewModel(availableCategories);
+        CreateDatasetModel.PropertyChanged += (_, _) => UpdateCanConfirm();
+
+        IsCopy = true;
+        IsCreateNewDataset = AvailableDatasets.Count == 0;
+        IsAddToExistingDataset = AvailableDatasets.Count > 0;
+
+        if (AvailableDatasets.Count > 0)
+        {
+            SelectedDataset = AvailableDatasets[0];
+        }
+
+        UseExistingVersion = true;
+        CreateNewVersion = false;
+
+        UpdateCanConfirm();
+    }
+
+    public int SelectionCount { get; }
+
+    public string SelectionSummary => SelectionCount == 1
+        ? "1 file selected"
+        : $"{SelectionCount} files selected";
+
+    public ObservableCollection<DatasetCardViewModel> AvailableDatasets { get; }
+
+    public CreateDatasetDialogViewModel CreateDatasetModel { get; }
+
+    public ObservableCollection<int> AvailableVersions => _availableVersions;
+
+    [ObservableProperty]
+    private bool _isCopy;
+
+    [ObservableProperty]
+    private bool _isMove;
+
+    [ObservableProperty]
+    private bool _isCreateNewDataset;
+
+    [ObservableProperty]
+    private bool _isAddToExistingDataset;
+
+    [ObservableProperty]
+    private DatasetCardViewModel? _selectedDataset;
+
+    [ObservableProperty]
+    private int? _selectedVersion;
+
+    [ObservableProperty]
+    private bool _useExistingVersion;
+
+    [ObservableProperty]
+    private bool _createNewVersion;
+
+    [ObservableProperty]
+    private int _nextVersionNumber;
+
+    [ObservableProperty]
+    private bool _canConfirm;
+
+    public bool HasExistingDatasets => AvailableDatasets.Count > 0;
+
+    public AddToDatasetResult ToResult()
+    {
+        var transferMode = IsMove ? FileTransferMode.Move : FileTransferMode.Copy;
+        var targetMode = IsCreateNewDataset ? DatasetTargetMode.CreateNew : DatasetTargetMode.Existing;
+        var versionMode = CreateNewVersion ? DatasetVersionMode.NewVersion : DatasetVersionMode.ExistingVersion;
+
+        return new AddToDatasetResult
+        {
+            Confirmed = true,
+            TransferMode = transferMode,
+            TargetMode = targetMode,
+            VersionMode = versionMode,
+            TargetVersion = SelectedVersion,
+            SelectedDataset = SelectedDataset,
+            NewDataset = targetMode == DatasetTargetMode.CreateNew
+                ? new CreateDatasetResult
+                {
+                    Confirmed = true,
+                    Name = CreateDatasetModel.GetSanitizedName(),
+                    CategoryId = CreateDatasetModel.SelectedCategory?.Id,
+                    CategoryOrder = CreateDatasetModel.SelectedCategory?.Order,
+                    CategoryName = CreateDatasetModel.SelectedCategory?.Name,
+                    Type = CreateDatasetModel.SelectedType,
+                    IsNsfw = CreateDatasetModel.IsNsfw
+                }
+                : null
+        };
+    }
+
+    partial void OnIsCopyChanged(bool value)
+    {
+        if (value)
+        {
+            IsMove = false;
+        }
+        UpdateCanConfirm();
+    }
+
+    partial void OnIsMoveChanged(bool value)
+    {
+        if (value)
+        {
+            IsCopy = false;
+        }
+        UpdateCanConfirm();
+    }
+
+    partial void OnIsCreateNewDatasetChanged(bool value)
+    {
+        if (value)
+        {
+            IsAddToExistingDataset = false;
+        }
+        UpdateCanConfirm();
+    }
+
+    partial void OnIsAddToExistingDatasetChanged(bool value)
+    {
+        if (value)
+        {
+            IsCreateNewDataset = false;
+        }
+        UpdateCanConfirm();
+    }
+
+    partial void OnSelectedDatasetChanged(DatasetCardViewModel? value)
+    {
+        _availableVersions.Clear();
+        if (value is null)
+        {
+            SelectedVersion = null;
+            NextVersionNumber = 0;
+            UpdateCanConfirm();
+            return;
+        }
+
+        foreach (var version in value.GetAllVersionNumbers())
+        {
+            _availableVersions.Add(version);
+        }
+
+        SelectedVersion = value.CurrentVersion > 0
+            ? value.CurrentVersion
+            : _availableVersions.FirstOrDefault();
+        NextVersionNumber = value.GetNextVersionNumber();
+        UpdateCanConfirm();
+    }
+
+    partial void OnSelectedVersionChanged(int? value)
+    {
+        UpdateCanConfirm();
+    }
+
+    partial void OnUseExistingVersionChanged(bool value)
+    {
+        if (value)
+        {
+            CreateNewVersion = false;
+        }
+        UpdateCanConfirm();
+    }
+
+    partial void OnCreateNewVersionChanged(bool value)
+    {
+        if (value)
+        {
+            UseExistingVersion = false;
+        }
+        UpdateCanConfirm();
+    }
+
+    private void UpdateCanConfirm()
+    {
+        var isTransferSelected = IsCopy || IsMove;
+
+        if (!isTransferSelected)
+        {
+            CanConfirm = false;
+            return;
+        }
+
+        if (IsCreateNewDataset)
+        {
+            CanConfirm = CreateDatasetModel.IsValid;
+            return;
+        }
+
+        if (!IsAddToExistingDataset)
+        {
+            CanConfirm = false;
+            return;
+        }
+
+        if (SelectedDataset is null)
+        {
+            CanConfirm = false;
+            return;
+        }
+
+        if (CreateNewVersion)
+        {
+            CanConfirm = true;
+            return;
+        }
+
+        CanConfirm = UseExistingVersion && SelectedVersion.HasValue;
+    }
+}

--- a/DiffusionNexus.UI/Views/Dialogs/AddToDatasetDialog.axaml
+++ b/DiffusionNexus.UI/Views/Dialogs/AddToDatasetDialog.axaml
@@ -1,0 +1,148 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:DiffusionNexus.UI.ViewModels"
+        xmlns:converters="using:DiffusionNexus.UI.Converters"
+        xmlns:local="using:DiffusionNexus.UI.Views.Dialogs"
+        xmlns:enums="using:DiffusionNexus.Domain.Enums"
+        x:Class="DiffusionNexus.UI.Views.Dialogs.AddToDatasetDialog"
+        x:DataType="vm:AddToDatasetDialogViewModel"
+        Width="900"
+        SizeToContent="Height"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        Background="#252526">
+
+  <Grid Margin="24" RowDefinitions="Auto,*,Auto">
+    <StackPanel Grid.Row="0" Margin="0,0,0,20" Spacing="6">
+      <TextBlock Text="Add Selected to Dataset"
+                 FontSize="18"
+                 FontWeight="SemiBold"
+                 Foreground="#4CAF50"/>
+      <TextBlock Text="{Binding SelectionSummary}" Opacity="0.7"/>
+    </StackPanel>
+
+    <StackPanel Grid.Row="1" Spacing="16">
+      <Border Background="#1A1A1A"
+              CornerRadius="8"
+              Padding="16"
+              BorderThickness="2"
+              BorderBrush="{Binding IsCopy, Converter={x:Static converters:BoolConverters.ToAccentBorder}}">
+        <StackPanel Spacing="10">
+          <TextBlock Text="Transfer Mode" FontWeight="SemiBold"/>
+          <StackPanel Orientation="Horizontal" Spacing="16">
+            <StackPanel Orientation="Horizontal" Spacing="8">
+              <RadioButton GroupName="TransferMode" IsChecked="{Binding IsCopy, Mode=TwoWay}"/>
+              <TextBlock Text="Copy (keep originals)" VerticalAlignment="Center"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Spacing="8">
+              <RadioButton GroupName="TransferMode" IsChecked="{Binding IsMove, Mode=TwoWay}"/>
+              <TextBlock Text="Move (remove originals)" VerticalAlignment="Center"/>
+            </StackPanel>
+          </StackPanel>
+        </StackPanel>
+      </Border>
+
+      <Grid ColumnDefinitions="*,24,*">
+        <Border Background="#1A1A1A"
+                CornerRadius="8"
+                Padding="16"
+                BorderThickness="2"
+                BorderBrush="{Binding IsCreateNewDataset, Converter={x:Static converters:BoolConverters.ToAccentBorder}}">
+          <StackPanel Spacing="12">
+            <StackPanel Orientation="Horizontal" Spacing="8">
+              <RadioButton GroupName="DatasetTarget" IsChecked="{Binding IsCreateNewDataset, Mode=TwoWay}"/>
+              <TextBlock Text="Create New Dataset" FontWeight="SemiBold"/>
+            </StackPanel>
+
+            <StackPanel IsEnabled="{Binding IsCreateNewDataset}" Spacing="8">
+              <TextBlock Text="Dataset Name"/>
+              <TextBox Text="{Binding CreateDatasetModel.Name, Mode=TwoWay}"/>
+              <TextBlock Text="{Binding CreateDatasetModel.NameError}" Foreground="#FF6B6B" FontSize="11"/>
+
+              <TextBlock Text="Category"/>
+              <ComboBox ItemsSource="{Binding CreateDatasetModel.AvailableCategories}"
+                        SelectedItem="{Binding CreateDatasetModel.SelectedCategory, Mode=TwoWay}">
+                <ComboBox.ItemTemplate>
+                  <DataTemplate x:DataType="vm:DatasetCategoryViewModel">
+                    <TextBlock Text="{Binding Name}"/>
+                  </DataTemplate>
+                </ComboBox.ItemTemplate>
+              </ComboBox>
+
+              <TextBlock Text="Type"/>
+              <ComboBox ItemsSource="{Binding CreateDatasetModel.AvailableTypes}"
+                        SelectedItem="{Binding CreateDatasetModel.SelectedType, Mode=TwoWay}">
+                <ComboBox.ItemTemplate>
+                  <DataTemplate x:DataType="enums:DatasetType">
+                    <TextBlock Text="{Binding Converter={x:Static local:DatasetTypeConverter.Instance}}"/>
+                  </DataTemplate>
+                </ComboBox.ItemTemplate>
+              </ComboBox>
+
+              <CheckBox IsChecked="{Binding CreateDatasetModel.IsNsfw, Mode=TwoWay}">
+                <TextBlock Text="Mark as NSFW"/>
+              </CheckBox>
+            </StackPanel>
+          </StackPanel>
+        </Border>
+
+        <Border Background="#1A1A1A"
+                CornerRadius="8"
+                Padding="16"
+                BorderThickness="2"
+                BorderBrush="{Binding IsAddToExistingDataset, Converter={x:Static converters:BoolConverters.ToAccentBorder}}"
+                Grid.Column="2">
+          <StackPanel Spacing="12" IsEnabled="{Binding HasExistingDatasets}">
+            <StackPanel Orientation="Horizontal" Spacing="8">
+              <RadioButton GroupName="DatasetTarget" IsChecked="{Binding IsAddToExistingDataset, Mode=TwoWay}"/>
+              <TextBlock Text="Add to Existing Dataset" FontWeight="SemiBold"/>
+            </StackPanel>
+
+            <StackPanel IsEnabled="{Binding IsAddToExistingDataset}" Spacing="8">
+              <TextBlock Text="Select Dataset"/>
+              <ComboBox ItemsSource="{Binding AvailableDatasets}" SelectedItem="{Binding SelectedDataset}">
+                <ComboBox.ItemTemplate>
+                  <DataTemplate x:DataType="vm:DatasetCardViewModel">
+                    <TextBlock Text="{Binding Name}"/>
+                  </DataTemplate>
+                </ComboBox.ItemTemplate>
+              </ComboBox>
+
+              <TextBlock Text="Version"/>
+              <StackPanel Spacing="8">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                  <RadioButton GroupName="VersionTarget" IsChecked="{Binding UseExistingVersion, Mode=TwoWay}"/>
+                  <TextBlock Text="Use existing version" VerticalAlignment="Center"/>
+                </StackPanel>
+                <ComboBox ItemsSource="{Binding AvailableVersions}"
+                          SelectedItem="{Binding SelectedVersion, Mode=TwoWay}"
+                          IsEnabled="{Binding UseExistingVersion}"
+                          MinWidth="120">
+                  <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                      <TextBlock Text="{Binding StringFormat='V{0}'}"/>
+                    </DataTemplate>
+                  </ComboBox.ItemTemplate>
+                </ComboBox>
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                  <RadioButton GroupName="VersionTarget" IsChecked="{Binding CreateNewVersion, Mode=TwoWay}"/>
+                  <TextBlock Text="{Binding NextVersionNumber, StringFormat='Create new version (V{0})'}" VerticalAlignment="Center"/>
+                </StackPanel>
+              </StackPanel>
+            </StackPanel>
+          </StackPanel>
+        </Border>
+      </Grid>
+    </StackPanel>
+
+    <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+      <Button Content="Cancel" Click="OnCancelClick" Padding="16,6"/>
+      <Button Content="Add to Dataset"
+              Click="OnConfirmClick"
+              IsEnabled="{Binding CanConfirm}"
+              Background="#4CAF50"
+              Foreground="White"
+              Padding="16,6"/>
+    </StackPanel>
+  </Grid>
+</Window>

--- a/DiffusionNexus.UI/Views/Dialogs/AddToDatasetDialog.axaml.cs
+++ b/DiffusionNexus.UI/Views/Dialogs/AddToDatasetDialog.axaml.cs
@@ -1,0 +1,52 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using DiffusionNexus.UI.ViewModels;
+
+namespace DiffusionNexus.UI.Views.Dialogs;
+
+public partial class AddToDatasetDialog : Window
+{
+    private AddToDatasetDialogViewModel? _viewModel;
+
+    public AddToDatasetDialog()
+    {
+        InitializeComponent();
+    }
+
+    public AddToDatasetResult? Result { get; private set; }
+
+    public AddToDatasetDialog WithOptions(
+        int selectionCount,
+        IEnumerable<DatasetCardViewModel> availableDatasets,
+        IEnumerable<DatasetCategoryViewModel> availableCategories)
+    {
+        _viewModel = new AddToDatasetDialogViewModel(selectionCount, availableDatasets, availableCategories);
+        DataContext = _viewModel;
+        return this;
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private void OnConfirmClick(object? sender, RoutedEventArgs e)
+    {
+        if (_viewModel is null || !_viewModel.CanConfirm)
+        {
+            Result = AddToDatasetResult.Cancelled();
+            Close(false);
+            return;
+        }
+
+        Result = _viewModel.ToResult();
+        Close(true);
+    }
+
+    private void OnCancelClick(object? sender, RoutedEventArgs e)
+    {
+        Result = AddToDatasetResult.Cancelled();
+        Close(false);
+    }
+}

--- a/DiffusionNexus.UI/Views/GenerationGalleryView.axaml
+++ b/DiffusionNexus.UI/Views/GenerationGalleryView.axaml
@@ -38,7 +38,7 @@
 
     <Border Grid.Row="1" Background="#1E1E1E" Padding="12,8" BorderBrush="#333" BorderThickness="0,0,0,1"
             IsVisible="{Binding HasSelection}">
-      <Grid ColumnDefinitions="Auto,Auto,*,Auto">
+      <Grid ColumnDefinitions="Auto,Auto,*,Auto,Auto">
         <Border Grid.Column="0" Background="#4CAF50" CornerRadius="4" Padding="8,4">
           <TextBlock Text="{Binding SelectionText}" FontWeight="SemiBold" Foreground="White"/>
         </Border>
@@ -47,7 +47,9 @@
           <Button Content="Clear Selection" Command="{Binding ClearSelectionCommand}" Padding="8,4"/>
         </StackPanel>
         <Border Grid.Column="2"/>
-        <Button Grid.Column="3" Content="Delete Selected" Command="{Binding DeleteSelectedCommand}"
+        <Button Grid.Column="3" Content="Add Selected to Dataset" Command="{Binding AddSelectedToDatasetCommand}"
+                Padding="12,6"/>
+        <Button Grid.Column="4" Content="Delete Selected" Command="{Binding DeleteSelectedCommand}"
                 Background="#B22222" Padding="12,6"/>
       </Grid>
     </Border>


### PR DESCRIPTION
### Motivation
- Provide a single-click way to copy or move selected gallery items into datasets from the Generation Gallery UI. 
- Reuse existing dataset manager logic for dataset creation, versioning and conflict resolution to avoid duplication and keep behavior consistent.

### Description
- Added a new dialog `AddToDatasetDialog` (`.axaml` + code-behind) and `AddToDatasetDialogViewModel` to let the user choose copy vs move, create new dataset vs add to existing, and existing vs new version (reuses `CreateDatasetDialogViewModel` for new dataset fields). 
- Exposed the new dialog via `IDialogService.ShowAddToDatasetDialogAsync` and implemented it in `DialogService`. 
- Implemented shared helpers `DatasetCreationHelper`, `DatasetImportHelper`, and `DatasetVersionHelper` to centralize dataset creation, file import (with conflict detection/resolution), and legacy->version migration logic (reusing the existing file conflict UI and logic). 
- Wired `GenerationGalleryView`/`GenerationGalleryViewModel` to show the dialog with an `Add Selected to Dataset` button/command, resolve the chosen dataset/version, and perform the import (copy/move), removing moved items from the gallery and publishing `ImageAdded`/`VersionCreated` events as appropriate. 
- Refactored `DatasetManagementViewModel` to use `DatasetCreationHelper` and `DatasetVersionHelper` and to reload datasets when external creations happen (`DatasetCreated` subscription), keeping behavior consistent with the Dataset Manager. 
- Small UI update to `GenerationGalleryView.axaml` to add the new button and selection bar layout. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69721c2a2ad0833285794aec129afd87)