### PR TITLE
Generation Gallery: add grouping controls (date/folder) and grouping UI

### DIFF
--- a/DiffusionNexus.UI/ViewModels/GenerationGalleryGroupViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/GenerationGalleryGroupViewModel.cs
@@ -1,0 +1,23 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+public partial class GenerationGalleryGroupViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private string _name = string.Empty;
+
+    [ObservableProperty]
+    private string _countText = string.Empty;
+
+    [ObservableProperty]
+    private bool _showHeader;
+
+    public ObservableCollection<GenerationGalleryMediaItemViewModel> Items { get; } = [];
+
+    public void UpdateCountText()
+    {
+        CountText = Items.Count == 1 ? "1 item" : $"{Items.Count} items";
+    }
+}

--- a/DiffusionNexus.UI/ViewModels/GenerationGalleryMediaItemViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/GenerationGalleryMediaItemViewModel.cs
@@ -15,11 +15,12 @@ public partial class GenerationGalleryMediaItemViewModel : ObservableObject
     private bool _isThumbnailLoading;
     private bool _isSelected;
 
-    public GenerationGalleryMediaItemViewModel(string filePath, bool isVideo, DateTime createdAtUtc)
+    public GenerationGalleryMediaItemViewModel(string filePath, bool isVideo, DateTime createdAtUtc, string? sourceRoot = null)
     {
         FilePath = filePath;
         IsVideo = isVideo;
         CreatedAtUtc = createdAtUtc;
+        SourceRoot = sourceRoot;
     }
 
     /// <summary>
@@ -56,6 +57,11 @@ public partial class GenerationGalleryMediaItemViewModel : ObservableObject
     /// Creation timestamp for sorting.
     /// </summary>
     public DateTime CreatedAtUtc { get; }
+
+    /// <summary>
+    /// The gallery root folder this item came from.
+    /// </summary>
+    public string? SourceRoot { get; }
 
     /// <summary>
     /// Whether this item is selected in the gallery.

--- a/DiffusionNexus.UI/Views/GenerationGalleryView.axaml
+++ b/DiffusionNexus.UI/Views/GenerationGalleryView.axaml
@@ -28,6 +28,19 @@
           </StackPanel>
 
           <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+            <TextBlock Text="Group by" VerticalAlignment="Center"/>
+            <ComboBox ItemsSource="{Binding GroupOptions}"
+                      SelectedItem="{Binding SelectedGroupOption}"
+                      Width="170"/>
+          </StackPanel>
+
+          <CheckBox Content="Include sub-folders"
+                    IsChecked="{Binding IncludeSubfolders}"
+                    IsVisible="{Binding IsNameSortSelected}"
+                    IsEnabled="{Binding IsFolderGroupingSelected}"
+                    VerticalAlignment="Center"/>
+
+          <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
             <TextBlock Text="Tile width" VerticalAlignment="Center"/>
             <Slider Minimum="140" Maximum="360" Value="{Binding TileWidth, Mode=TwoWay}" Width="180"/>
             <TextBlock Text="{Binding TileWidth, StringFormat='{}{0:0}px'}" VerticalAlignment="Center"/>
@@ -74,73 +87,92 @@
       </Border>
 
       <ScrollViewer IsVisible="{Binding HasMedia}" Padding="16">
-        <ItemsControl x:Name="GalleryItems" ItemsSource="{Binding MediaItems}">
+        <ItemsControl x:Name="GalleryItems" ItemsSource="{Binding GroupedMediaItems}">
           <ItemsControl.ItemsPanel>
             <ItemsPanelTemplate>
-              <WrapPanel Orientation="Horizontal"/>
+              <StackPanel Orientation="Vertical" Spacing="12"/>
             </ItemsPanelTemplate>
           </ItemsControl.ItemsPanel>
           <ItemsControl.ItemTemplate>
-            <DataTemplate x:DataType="vm:GenerationGalleryMediaItemViewModel">
-              <Border Width="{Binding $parent[ItemsControl].((vm:GenerationGalleryViewModel)DataContext).TileWidth}"
-                      Height="{Binding $parent[ItemsControl].((vm:GenerationGalleryViewModel)DataContext).TileWidth}"
-                      Background="#2A2A2A"
-                      CornerRadius="8"
-                      ClipToBounds="True"
-                      Margin="6"
-                      BorderBrush="#444"
-                      BorderThickness="2"
-                      PointerPressed="OnMediaCardPointerPressed">
-                <Grid>
-                  <!-- Selection overlay border -->
-                  <Border CornerRadius="6" 
-                          BorderBrush="#2196F3" 
-                          BorderThickness="3" 
-                          Margin="-1"
-                          IsVisible="{Binding IsSelected}" 
-                          IsHitTestVisible="False"
-                          ZIndex="10"/>
-
-                  <!-- Loading placeholder shown while thumbnail is null -->
-                  <Border Background="#333"
-                          IsVisible="{Binding Thumbnail, Converter={x:Static ObjectConverters.IsNull}}">
-                    <TextBlock Text="⏳" FontSize="24" Opacity="0.4"
-                               HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                  </Border>
-                  <Image Source="{Binding Thumbnail, TargetNullValue={x:Null}}"
-                         Stretch="UniformToFill"
-                         IsVisible="{Binding IsImage}"/>
-                  <Border Background="Black" IsVisible="{Binding IsVideo}">
-                    <TextBlock Text="VIDEO" Foreground="White" FontWeight="Bold"
-                               HorizontalAlignment="Center" VerticalAlignment="Center" Opacity="0.7"/>
-                  </Border>
-
-                  <!-- File Extension Label (Top Left) -->
-                  <Border Background="#66000000" CornerRadius="4" Padding="6,2"
-                          HorizontalAlignment="Left" VerticalAlignment="Top" Margin="6" ZIndex="5">
-                    <TextBlock Text="{Binding FileExtension}" Foreground="White" FontSize="11" FontWeight="SemiBold"/>
-                  </Border>
-
-                  <!-- Delete Button (Top Right) -->
-                  <Button Content="X"
-                          Command="{Binding $parent[ItemsControl].((vm:GenerationGalleryViewModel)DataContext).DeleteImageCommand}"
-                          CommandParameter="{Binding}"
-                          HorizontalAlignment="Right"
-                          VerticalAlignment="Top"
-                          Margin="6"
-                          Padding="6,2"
-                          Background="#80000000"
-                          CornerRadius="4"
-                          Foreground="#FF6B6B"
-                          FontWeight="Bold"
-                          ZIndex="5"/>
-
-                  <Border Background="#CC1A1A1A" VerticalAlignment="Bottom" Padding="8,6">
-                    <TextBlock Text="{Binding FullFileName}" FontSize="12" Opacity="0.8"
-                               TextTrimming="CharacterEllipsis" MaxLines="1"/>
-                  </Border>
+            <DataTemplate x:DataType="vm:GenerationGalleryGroupViewModel">
+              <StackPanel Spacing="8">
+                <Grid ColumnDefinitions="Auto,8,*,8,Auto" Margin="8,8,8,4"
+                      IsVisible="{Binding ShowHeader}">
+                  <TextBlock Grid.Column="0" Text="{Binding Name}" FontSize="14" FontWeight="SemiBold" Foreground="#888"/>
+                  <Border Grid.Column="2" Height="1" Background="#444" VerticalAlignment="Center"/>
+                  <TextBlock Grid.Column="4" Text="{Binding CountText}" FontSize="12" Foreground="#666"/>
                 </Grid>
-              </Border>
+                <ItemsControl ItemsSource="{Binding Items}">
+                  <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                      <WrapPanel Orientation="Horizontal"/>
+                    </ItemsPanelTemplate>
+                  </ItemsControl.ItemsPanel>
+                  <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="vm:GenerationGalleryMediaItemViewModel">
+                      <Border Width="{Binding $parent[ItemsControl].((vm:GenerationGalleryViewModel)DataContext).TileWidth}"
+                              Height="{Binding $parent[ItemsControl].((vm:GenerationGalleryViewModel)DataContext).TileWidth}"
+                              Background="#2A2A2A"
+                              CornerRadius="8"
+                              ClipToBounds="True"
+                              Margin="6"
+                              BorderBrush="#444"
+                              BorderThickness="2"
+                              PointerPressed="OnMediaCardPointerPressed">
+                        <Grid>
+                          <!-- Selection overlay border -->
+                          <Border CornerRadius="6" 
+                                  BorderBrush="#2196F3" 
+                                  BorderThickness="3" 
+                                  Margin="-1"
+                                  IsVisible="{Binding IsSelected}" 
+                                  IsHitTestVisible="False"
+                                  ZIndex="10"/>
+
+                          <!-- Loading placeholder shown while thumbnail is null -->
+                          <Border Background="#333"
+                                  IsVisible="{Binding Thumbnail, Converter={x:Static ObjectConverters.IsNull}}">
+                            <TextBlock Text="⏳" FontSize="24" Opacity="0.4"
+                                       HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                          </Border>
+                          <Image Source="{Binding Thumbnail, TargetNullValue={x:Null}}"
+                                 Stretch="UniformToFill"
+                                 IsVisible="{Binding IsImage}"/>
+                          <Border Background="Black" IsVisible="{Binding IsVideo}">
+                            <TextBlock Text="VIDEO" Foreground="White" FontWeight="Bold"
+                                       HorizontalAlignment="Center" VerticalAlignment="Center" Opacity="0.7"/>
+                          </Border>
+
+                          <!-- File Extension Label (Top Left) -->
+                          <Border Background="#66000000" CornerRadius="4" Padding="6,2"
+                                  HorizontalAlignment="Left" VerticalAlignment="Top" Margin="6" ZIndex="5">
+                            <TextBlock Text="{Binding FileExtension}" Foreground="White" FontSize="11" FontWeight="SemiBold"/>
+                          </Border>
+
+                          <!-- Delete Button (Top Right) -->
+                          <Button Content="X"
+                                  Command="{Binding $parent[ItemsControl].((vm:GenerationGalleryViewModel)DataContext).DeleteImageCommand}"
+                                  CommandParameter="{Binding}"
+                                  HorizontalAlignment="Right"
+                                  VerticalAlignment="Top"
+                                  Margin="6"
+                                  Padding="6,2"
+                                  Background="#80000000"
+                                  CornerRadius="4"
+                                  Foreground="#FF6B6B"
+                                  FontWeight="Bold"
+                                  ZIndex="5"/>
+
+                          <Border Background="#CC1A1A1A" VerticalAlignment="Bottom" Padding="8,6">
+                            <TextBlock Text="{Binding FullFileName}" FontSize="12" Opacity="0.8"
+                                       TextTrimming="CharacterEllipsis" MaxLines="1"/>
+                          </Border>
+                        </Grid>
+                      </Border>
+                    </DataTemplate>
+                  </ItemsControl.ItemTemplate>
+                </ItemsControl>
+              </StackPanel>
             </DataTemplate>
           </ItemsControl.ItemTemplate>
         </ItemsControl>


### PR DESCRIPTION
### Motivation
- Provide image grouping in the Generation Gallery similar to Dataset Management so users can visually separate items by date ranges or folders. 
- Make grouping options depend on the `Sort by` selection so date-based grouping is available when sorting by date and folder grouping when sorting by name. 
- Allow including sub-folders in folder grouping with an `Include sub-folders` toggle enabled by default to match expected user behavior. 

### Description
- Added a new `GenerationGalleryGroupViewModel` to represent group headers and counts and introduced `GroupedMediaItems` in the gallery VM to drive grouped UI rendering. 
- Extended `GenerationGalleryMediaItemViewModel` with a `SourceRoot` property and updated collection logic to pass the gallery root path into each media item. 
- Implemented grouping state and logic in `GenerationGalleryViewModel`, including `GroupOptions`, `SelectedGroupOption`, `IncludeSubfolders`, `UpdateGroupOptionsForSort()`, `GetGroupingKey()` and folder-relative name handling to support `Day`, `Week`, `Month`, `Year`, `Folder` and `None` group modes. 
- Updated the gallery XAML (`GenerationGalleryView.axaml`) to add a `Group by` `ComboBox`, the `Include sub-folders` `CheckBox`, and to render `GroupedMediaItems` with separation bars and counts similar to the dataset UI. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697250e248ac8332beef6f1d12bed3a8)