### PR TITLE
Add Before/After image comparer UI with tray, filmstrip, and ViewModel tests

### DIFF
--- a/DiffusionNexus.Tests/Viewer/ImageCompareViewModelTests.cs
+++ b/DiffusionNexus.Tests/Viewer/ImageCompareViewModelTests.cs
@@ -1,0 +1,73 @@
+using DiffusionNexus.UI.Controls;
+using DiffusionNexus.UI.ViewModels;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.Viewer;
+
+public class ImageCompareViewModelTests
+{
+    [Fact]
+    public void ResetSlider_SetsSliderBackToHalf()
+    {
+        var viewModel = CreateViewModel();
+        viewModel.SliderValue = 0.9;
+
+        viewModel.ResetSliderCommand.Execute(null);
+
+        viewModel.SliderValue.Should().Be(0.5);
+    }
+
+    [Fact]
+    public void AssignFilmstripItem_AssignsBeforeSelection()
+    {
+        var viewModel = CreateViewModel();
+        var item = viewModel.BeforeDataset!.Items.Last();
+
+        viewModel.AssignTarget = ImageCompareAssignTarget.Before;
+        viewModel.AssignFilmstripItemCommand.Execute(item);
+
+        viewModel.BeforeImagePath.Should().Be(item.ImagePath);
+        viewModel.SelectedBeforeItem.Should().Be(item);
+        item.IsBeforeSelected.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AssignTargetSwitch_UsesAfterDatasetFilmstrip()
+    {
+        var viewModel = CreateViewModel();
+
+        viewModel.AssignTarget = ImageCompareAssignTarget.After;
+
+        viewModel.FilmstripItems.Should().BeEquivalentTo(viewModel.AfterDataset!.Items);
+    }
+
+    [Fact]
+    public void SwapImages_SwapsDatasetsAndSelections()
+    {
+        var viewModel = CreateViewModel();
+        var originalBefore = viewModel.SelectedBeforeItem;
+        var originalAfter = viewModel.SelectedAfterItem;
+        var originalBeforeDataset = viewModel.BeforeDataset;
+        var originalAfterDataset = viewModel.AfterDataset;
+
+        viewModel.SwapImagesCommand.Execute(null);
+
+        viewModel.SelectedBeforeItem.Should().Be(originalAfter);
+        viewModel.SelectedAfterItem.Should().Be(originalBefore);
+        viewModel.BeforeDataset.Should().Be(originalAfterDataset);
+        viewModel.AfterDataset.Should().Be(originalBeforeDataset);
+    }
+
+    private static ImageCompareViewModel CreateViewModel()
+    {
+        var beforeDataset = new ImageCompareDataset("Before",
+            new ImageCompareItem("Before 1", "/tmp/before-1.png"),
+            new ImageCompareItem("Before 2", "/tmp/before-2.png"));
+
+        var afterDataset = new ImageCompareDataset("After",
+            new ImageCompareItem("After 1", "/tmp/after-1.png"),
+            new ImageCompareItem("After 2", "/tmp/after-2.png"));
+
+        return new ImageCompareViewModel(new[] { beforeDataset, afterDataset });
+    }
+}

--- a/DiffusionNexus.UI/Controls/ImageCompareControl.axaml
+++ b/DiffusionNexus.UI/Controls/ImageCompareControl.axaml
@@ -1,0 +1,34 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:converters="clr-namespace:DiffusionNexus.UI.Converters"
+             x:Class="DiffusionNexus.UI.Controls.ImageCompareControl">
+  <UserControl.Resources>
+    <converters:PathToBitmapConverter x:Key="PathToBitmapConverter" />
+  </UserControl.Resources>
+
+  <Grid>
+    <Border Background="#111" CornerRadius="6" ClipToBounds="True">
+      <Grid ClipToBounds="True">
+        <Image x:Name="AfterImageControl"
+               Stretch="Uniform"
+               Source="{Binding AfterImage, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource PathToBitmapConverter}, ConverterParameter=full}" />
+        <Image x:Name="BeforeImageControl"
+               Stretch="Uniform"
+               Source="{Binding BeforeImage, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource PathToBitmapConverter}, ConverterParameter=full}" />
+      </Grid>
+    </Border>
+
+    <Canvas x:Name="SliderCanvas" IsHitTestVisible="False">
+      <Border x:Name="SliderLine" Width="2" Background="#FFFFFF" Opacity="0.9" />
+      <Border x:Name="SliderThumb" Width="18" Height="18" Background="#FFFFFF" CornerRadius="9" BorderBrush="#1E1E1E" BorderThickness="1" />
+    </Canvas>
+
+    <Border x:Name="InputLayer"
+            Background="Transparent"
+            Cursor="SizeWestEast"
+            PointerPressed="OnInputPointerPressed"
+            PointerMoved="OnInputPointerMoved"
+            PointerReleased="OnInputPointerReleased"
+            PointerCaptureLost="OnInputPointerCaptureLost" />
+  </Grid>
+</UserControl>

--- a/DiffusionNexus.UI/Controls/ImageCompareControl.axaml.cs
+++ b/DiffusionNexus.UI/Controls/ImageCompareControl.axaml.cs
@@ -1,0 +1,159 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+
+namespace DiffusionNexus.UI.Controls;
+
+public partial class ImageCompareControl : UserControl
+{
+    public static readonly StyledProperty<string?> BeforeImageProperty =
+        AvaloniaProperty.Register<ImageCompareControl, string?>(nameof(BeforeImage));
+
+    public static readonly StyledProperty<string?> AfterImageProperty =
+        AvaloniaProperty.Register<ImageCompareControl, string?>(nameof(AfterImage));
+
+    public static readonly StyledProperty<double> SliderValueProperty =
+        AvaloniaProperty.Register<ImageCompareControl, double>(nameof(SliderValue), 0.5);
+
+    public static readonly StyledProperty<ImageCompareFitMode> FitModeProperty =
+        AvaloniaProperty.Register<ImageCompareControl, ImageCompareFitMode>(nameof(FitMode), ImageCompareFitMode.Fit);
+
+    private RectangleGeometry? _beforeClip;
+    private bool _isDragging;
+
+    public ImageCompareControl()
+    {
+        InitializeComponent();
+        UpdateFitMode();
+        UpdateSliderVisuals();
+
+        this.GetObservable(SliderValueProperty).Subscribe(_ => UpdateSliderVisuals());
+        this.GetObservable(BoundsProperty).Subscribe(_ => UpdateSliderVisuals());
+        this.GetObservable(FitModeProperty).Subscribe(_ => UpdateFitMode());
+    }
+
+    public string? BeforeImage
+    {
+        get => GetValue(BeforeImageProperty);
+        set => SetValue(BeforeImageProperty, value);
+    }
+
+    public string? AfterImage
+    {
+        get => GetValue(AfterImageProperty);
+        set => SetValue(AfterImageProperty, value);
+    }
+
+    public double SliderValue
+    {
+        get => GetValue(SliderValueProperty);
+        set => SetValue(SliderValueProperty, value);
+    }
+
+    public ImageCompareFitMode FitMode
+    {
+        get => GetValue(FitModeProperty);
+        set => SetValue(FitModeProperty, value);
+    }
+
+    private void UpdateFitMode()
+    {
+        var stretch = FitMode switch
+        {
+            ImageCompareFitMode.Fill => Stretch.UniformToFill,
+            ImageCompareFitMode.OneToOne => Stretch.None,
+            _ => Stretch.Uniform
+        };
+
+        var alignment = FitMode == ImageCompareFitMode.OneToOne ? HorizontalAlignment.Center : HorizontalAlignment.Stretch;
+        var verticalAlignment = FitMode == ImageCompareFitMode.OneToOne ? VerticalAlignment.Center : VerticalAlignment.Stretch;
+
+        BeforeImageControl.Stretch = stretch;
+        BeforeImageControl.HorizontalAlignment = alignment;
+        BeforeImageControl.VerticalAlignment = verticalAlignment;
+
+        AfterImageControl.Stretch = stretch;
+        AfterImageControl.HorizontalAlignment = alignment;
+        AfterImageControl.VerticalAlignment = verticalAlignment;
+    }
+
+    private void UpdateSliderVisuals()
+    {
+        if (SliderCanvas is null || InputLayer is null || BeforeImageControl is null)
+        {
+            return;
+        }
+
+        var width = InputLayer.Bounds.Width;
+        var height = InputLayer.Bounds.Height;
+        if (width <= 0 || height <= 0)
+        {
+            return;
+        }
+
+        var clamped = Math.Clamp(SliderValue, 0, 1);
+        var x = clamped * width;
+
+        if (_beforeClip is null)
+        {
+            _beforeClip = new RectangleGeometry();
+            BeforeImageControl.Clip = _beforeClip;
+        }
+
+        _beforeClip.Rect = new Rect(0, 0, x, height);
+
+        SliderLine.Height = height;
+        Canvas.SetLeft(SliderLine, x - (SliderLine.Width / 2));
+        Canvas.SetTop(SliderLine, 0);
+
+        Canvas.SetLeft(SliderThumb, x - (SliderThumb.Width / 2));
+        Canvas.SetTop(SliderThumb, (height - SliderThumb.Height) / 2);
+    }
+
+    private void UpdateSliderFromPointer(PointerEventArgs e)
+    {
+        if (InputLayer is null)
+        {
+            return;
+        }
+
+        var point = e.GetPosition(InputLayer);
+        var width = InputLayer.Bounds.Width;
+        if (width <= 0)
+        {
+            return;
+        }
+
+        SliderValue = Math.Clamp(point.X / width, 0, 1);
+    }
+
+    private void OnInputPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        _isDragging = true;
+        InputLayer?.CapturePointer(e.Pointer);
+        UpdateSliderFromPointer(e);
+    }
+
+    private void OnInputPointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (!_isDragging)
+        {
+            return;
+        }
+
+        UpdateSliderFromPointer(e);
+    }
+
+    private void OnInputPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        _isDragging = false;
+        InputLayer?.ReleasePointerCapture(e.Pointer);
+    }
+
+    private void OnInputPointerCaptureLost(object? sender, PointerCaptureLostEventArgs e)
+    {
+        _isDragging = false;
+    }
+}

--- a/DiffusionNexus.UI/Controls/ImageCompareEnums.cs
+++ b/DiffusionNexus.UI/Controls/ImageCompareEnums.cs
@@ -1,0 +1,20 @@
+namespace DiffusionNexus.UI.Controls;
+
+/// <summary>
+/// Fit options for the image comparison canvas.
+/// </summary>
+public enum ImageCompareFitMode
+{
+    Fit,
+    Fill,
+    OneToOne
+}
+
+/// <summary>
+/// Target side for assigning filmstrip selections.
+/// </summary>
+public enum ImageCompareAssignTarget
+{
+    Before,
+    After
+}

--- a/DiffusionNexus.UI/ViewModels/ImageCompareViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/ImageCompareViewModel.cs
@@ -1,0 +1,362 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DiffusionNexus.UI.Controls;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+public partial class ImageCompareViewModel : ViewModelBase
+{
+    private const double TrayOpenHeight = 260;
+    private const double TrayClosedHeight = 28;
+    private readonly TimeSpan _trayCloseDelay = TimeSpan.FromMilliseconds(300);
+    private CancellationTokenSource? _trayCloseCts;
+
+    public ObservableCollection<ImageCompareDataset> AvailableDatasets { get; } = [];
+    public ObservableCollection<ImageCompareFitMode> FitModeOptions { get; } = new(Enum.GetValues<ImageCompareFitMode>());
+    public ObservableCollection<ImageCompareItem> FilmstripItems { get; } = [];
+
+    [ObservableProperty]
+    private ImageCompareDataset? _beforeDataset;
+
+    [ObservableProperty]
+    private ImageCompareDataset? _afterDataset;
+
+    [ObservableProperty]
+    private ImageCompareItem? _selectedBeforeItem;
+
+    [ObservableProperty]
+    private ImageCompareItem? _selectedAfterItem;
+
+    [ObservableProperty]
+    private string? _beforeImagePath;
+
+    [ObservableProperty]
+    private string? _afterImagePath;
+
+    [ObservableProperty]
+    private string? _beforeImageLabel;
+
+    [ObservableProperty]
+    private string? _afterImageLabel;
+
+    [ObservableProperty]
+    private ImageCompareAssignTarget _assignTarget = ImageCompareAssignTarget.Before;
+
+    [ObservableProperty]
+    private ImageCompareFitMode _fitMode = ImageCompareFitMode.Fit;
+
+    [ObservableProperty]
+    private double _sliderValue = 0.5;
+
+    [ObservableProperty]
+    private bool _isTrayPinned;
+
+    [ObservableProperty]
+    private bool _isTrayOpen;
+
+    [ObservableProperty]
+    private double _trayHeight = TrayClosedHeight;
+
+    [ObservableProperty]
+    private string? _searchText;
+
+    public ImageCompareViewModel()
+    {
+        LoadDemoData();
+        InitializeDefaults();
+    }
+
+    public ImageCompareViewModel(IEnumerable<ImageCompareDataset> datasets)
+    {
+        foreach (var dataset in datasets)
+        {
+            AvailableDatasets.Add(dataset);
+        }
+
+        InitializeDefaults();
+    }
+
+    public bool IsAssignBefore
+    {
+        get => AssignTarget == ImageCompareAssignTarget.Before;
+        set
+        {
+            if (value)
+            {
+                AssignTarget = ImageCompareAssignTarget.Before;
+            }
+        }
+    }
+
+    public bool IsAssignAfter
+    {
+        get => AssignTarget == ImageCompareAssignTarget.After;
+        set
+        {
+            if (value)
+            {
+                AssignTarget = ImageCompareAssignTarget.After;
+            }
+        }
+    }
+
+    [RelayCommand]
+    private void SwapImages()
+    {
+        var previousBefore = SelectedBeforeItem;
+        var previousAfter = SelectedAfterItem;
+
+        (BeforeImagePath, AfterImagePath) = (AfterImagePath, BeforeImagePath);
+        (BeforeImageLabel, AfterImageLabel) = (AfterImageLabel, BeforeImageLabel);
+        (SelectedBeforeItem, SelectedAfterItem) = (previousAfter, previousBefore);
+        (BeforeDataset, AfterDataset) = (AfterDataset, BeforeDataset);
+
+        if (previousBefore is not null)
+        {
+            previousBefore.IsBeforeSelected = false;
+            previousBefore.IsAfterSelected = true;
+        }
+
+        if (previousAfter is not null)
+        {
+            previousAfter.IsAfterSelected = false;
+            previousAfter.IsBeforeSelected = true;
+        }
+
+        RefreshFilmstrip();
+    }
+
+    [RelayCommand]
+    private void ResetSlider()
+    {
+        SliderValue = 0.5;
+    }
+
+    [RelayCommand]
+    private void SetFitMode(ImageCompareFitMode mode)
+    {
+        FitMode = mode;
+    }
+
+    [RelayCommand]
+    private void AssignFilmstripItem(ImageCompareItem? item)
+    {
+        if (item is null)
+        {
+            return;
+        }
+
+        if (AssignTarget == ImageCompareAssignTarget.Before)
+        {
+            SetBeforeSelection(item);
+        }
+        else
+        {
+            SetAfterSelection(item);
+        }
+    }
+
+    public void RequestTrayOpen()
+    {
+        _trayCloseCts?.Cancel();
+        IsTrayOpen = true;
+    }
+
+    public async Task RequestTrayCloseAsync()
+    {
+        if (IsTrayPinned)
+        {
+            return;
+        }
+
+        _trayCloseCts?.Cancel();
+        var cts = new CancellationTokenSource();
+        _trayCloseCts = cts;
+
+        try
+        {
+            await Task.Delay(_trayCloseDelay, cts.Token);
+            if (!cts.IsCancellationRequested)
+            {
+                IsTrayOpen = false;
+            }
+        }
+        catch (TaskCanceledException)
+        {
+        }
+    }
+
+    partial void OnAssignTargetChanged(ImageCompareAssignTarget value)
+    {
+        OnPropertyChanged(nameof(IsAssignBefore));
+        OnPropertyChanged(nameof(IsAssignAfter));
+        RefreshFilmstrip();
+    }
+
+    partial void OnBeforeDatasetChanged(ImageCompareDataset? value)
+    {
+        if (value is not null && (SelectedBeforeItem is null || !value.Items.Contains(SelectedBeforeItem)))
+        {
+            SetBeforeSelection(value.Items.FirstOrDefault());
+        }
+
+        RefreshFilmstrip();
+    }
+
+    partial void OnAfterDatasetChanged(ImageCompareDataset? value)
+    {
+        if (value is not null && (SelectedAfterItem is null || !value.Items.Contains(SelectedAfterItem)))
+        {
+            SetAfterSelection(value.Items.FirstOrDefault());
+        }
+
+        RefreshFilmstrip();
+    }
+
+    partial void OnIsTrayOpenChanged(bool value)
+    {
+        TrayHeight = value ? TrayOpenHeight : TrayClosedHeight;
+    }
+
+    partial void OnIsTrayPinnedChanged(bool value)
+    {
+        if (value)
+        {
+            IsTrayOpen = true;
+        }
+    }
+
+    partial void OnSearchTextChanged(string? value)
+    {
+        RefreshFilmstrip();
+    }
+
+    private void LoadDemoData()
+    {
+        var demoBefore = new ImageCompareDataset("Dataset A",
+            new ImageCompareItem("Img 014", "C:\\Images\\DatasetA\\img-014.png"),
+            new ImageCompareItem("Img 015", "C:\\Images\\DatasetA\\img-015.png"),
+            new ImageCompareItem("Img 016", "C:\\Images\\DatasetA\\img-016.png"));
+
+        var demoAfter = new ImageCompareDataset("Dataset B",
+            new ImageCompareItem("Img 101", "C:\\Images\\DatasetB\\img-101.png"),
+            new ImageCompareItem("Img 102", "C:\\Images\\DatasetB\\img-102.png"),
+            new ImageCompareItem("Img 103", "C:\\Images\\DatasetB\\img-103.png"));
+
+        AvailableDatasets.Add(demoBefore);
+        AvailableDatasets.Add(demoAfter);
+    }
+
+    private void InitializeDefaults()
+    {
+        BeforeDataset = AvailableDatasets.FirstOrDefault();
+        AfterDataset = AvailableDatasets.Skip(1).FirstOrDefault() ?? BeforeDataset;
+
+        SetBeforeSelection(BeforeDataset?.Items.FirstOrDefault());
+        SetAfterSelection(AfterDataset?.Items.FirstOrDefault());
+
+        RefreshFilmstrip();
+    }
+
+    private void SetBeforeSelection(ImageCompareItem? item)
+    {
+        if (SelectedBeforeItem is not null)
+        {
+            SelectedBeforeItem.IsBeforeSelected = false;
+        }
+
+        SelectedBeforeItem = item;
+        if (item is not null)
+        {
+            item.IsBeforeSelected = true;
+            BeforeImagePath = item.ImagePath;
+            BeforeImageLabel = BuildLabel(BeforeDataset, item);
+        }
+    }
+
+    private void SetAfterSelection(ImageCompareItem? item)
+    {
+        if (SelectedAfterItem is not null)
+        {
+            SelectedAfterItem.IsAfterSelected = false;
+        }
+
+        SelectedAfterItem = item;
+        if (item is not null)
+        {
+            item.IsAfterSelected = true;
+            AfterImagePath = item.ImagePath;
+            AfterImageLabel = BuildLabel(AfterDataset, item);
+        }
+    }
+
+    private void RefreshFilmstrip()
+    {
+        var sourceItems = AssignTarget == ImageCompareAssignTarget.Before
+            ? BeforeDataset?.Items
+            : AfterDataset?.Items;
+
+        FilmstripItems.Clear();
+
+        if (sourceItems is null)
+        {
+            return;
+        }
+
+        var filter = SearchText?.Trim();
+        foreach (var item in sourceItems)
+        {
+            if (!string.IsNullOrWhiteSpace(filter) && !item.DisplayName.Contains(filter, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            FilmstripItems.Add(item);
+        }
+    }
+
+    private static string BuildLabel(ImageCompareDataset? dataset, ImageCompareItem item)
+    {
+        if (dataset is null)
+        {
+            return item.DisplayName;
+        }
+
+        return $"{dataset.Name} / {item.DisplayName}";
+    }
+}
+
+public partial class ImageCompareItem : ObservableObject
+{
+    public ImageCompareItem(string displayName, string imagePath)
+    {
+        DisplayName = displayName;
+        ImagePath = imagePath;
+    }
+
+    public string DisplayName { get; }
+    public string ImagePath { get; }
+
+    [ObservableProperty]
+    private bool _isBeforeSelected;
+
+    [ObservableProperty]
+    private bool _isAfterSelected;
+}
+
+public class ImageCompareDataset
+{
+    public ImageCompareDataset(string name, params ImageCompareItem[] items)
+    {
+        Name = name;
+        Items = new ObservableCollection<ImageCompareItem>(items);
+    }
+
+    public string Name { get; }
+    public ObservableCollection<ImageCompareItem> Items { get; }
+}

--- a/DiffusionNexus.UI/Views/ImageCompareView.axaml
+++ b/DiffusionNexus.UI/Views/ImageCompareView.axaml
@@ -1,0 +1,116 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:DiffusionNexus.UI.ViewModels"
+             xmlns:controls="clr-namespace:DiffusionNexus.UI.Controls"
+             xmlns:converters="clr-namespace:DiffusionNexus.UI.Converters"
+             x:Class="DiffusionNexus.UI.Views.ImageCompareView"
+             x:DataType="vm:ImageCompareViewModel"
+             mc:Ignorable="d">
+  <UserControl.Resources>
+    <converters:PathToBitmapConverter x:Key="PathToBitmapConverter" />
+  </UserControl.Resources>
+
+  <Grid RowDefinitions="Auto,*,Auto" Background="#0E0E0E" ClipToBounds="True">
+    <Border Grid.Row="0" Background="#1A1A1A" Padding="12,8" BorderBrush="#2E2E2E" BorderThickness="0,0,0,1">
+      <DockPanel LastChildFill="False">
+        <TextBlock Text="Compare" FontWeight="SemiBold" FontSize="16" Foreground="White" DockPanel.Dock="Left" />
+        <StackPanel Orientation="Horizontal" Spacing="8" DockPanel.Dock="Right">
+          <Button Content="⇄ Swap" Command="{Binding SwapImagesCommand}" />
+          <Button Content="⟳ Reset" Command="{Binding ResetSliderCommand}" />
+          <ComboBox ItemsSource="{Binding FitModeOptions}" SelectedItem="{Binding FitMode}" MinWidth="120" />
+          <Button Content="1:1" Command="{Binding SetFitModeCommand}" CommandParameter="{x:Static controls:ImageCompareFitMode.OneToOne}" />
+          <Button Content="⋯" IsEnabled="False" />
+        </StackPanel>
+      </DockPanel>
+    </Border>
+
+    <Grid Grid.Row="1">
+      <controls:ImageCompareControl BeforeImage="{Binding BeforeImagePath}"
+                                    AfterImage="{Binding AfterImagePath}"
+                                    SliderValue="{Binding SliderValue, Mode=TwoWay}"
+                                    FitMode="{Binding FitMode}" />
+
+      <Grid Margin="20" RowDefinitions="Auto,*,Auto" IsHitTestVisible="False">
+        <Grid ColumnDefinitions="*,Auto,*">
+          <TextBlock Text="{Binding BeforeImageLabel, TargetNullValue=Before}" Foreground="#D8D8D8" FontWeight="SemiBold" />
+          <TextBlock Grid.Column="2" Text="{Binding AfterImageLabel, TargetNullValue=After}" Foreground="#D8D8D8" FontWeight="SemiBold" HorizontalAlignment="Right" />
+        </Grid>
+        <TextBlock Grid.Row="2" Text="Tip: Click thumbnail → assigns to the side you’ve selected below"
+                   Foreground="#8F8F8F" FontStyle="Italic" HorizontalAlignment="Center" />
+      </Grid>
+    </Grid>
+
+    <Border x:Name="TrayHost"
+            Grid.Row="2"
+            Height="{Binding TrayHeight}"
+            Background="#151515"
+            BorderBrush="#2E2E2E"
+            BorderThickness="1,1,1,0"
+            ClipToBounds="True"
+            PointerEntered="OnTrayPointerEntered"
+            PointerExited="OnTrayPointerExited">
+      <Border.Transitions>
+        <Transitions>
+          <DoubleTransition Property="Height" Duration="0:0:0.25" />
+        </Transitions>
+      </Border.Transitions>
+      <Grid RowDefinitions="Auto,Auto,Auto,Auto" Margin="12,8" RowSpacing="8">
+        <Grid ColumnDefinitions="*,Auto" Height="24">
+          <TextBlock Text="Auto-hide tray" Foreground="#AFAFAF" VerticalAlignment="Center" />
+          <ToggleButton Grid.Column="1" Content="📌" IsChecked="{Binding IsTrayPinned}" />
+        </Grid>
+
+        <WrapPanel Grid.Row="1" Spacing="12" IsVisible="{Binding IsTrayOpen}">
+          <StackPanel Orientation="Vertical" Spacing="4" Width="220">
+            <TextBlock Text="Before dataset" Foreground="#8F8F8F" FontSize="11" />
+            <ComboBox ItemsSource="{Binding AvailableDatasets}" SelectedItem="{Binding BeforeDataset}" DisplayMemberBinding="{Binding Name}" />
+          </StackPanel>
+          <StackPanel Orientation="Vertical" Spacing="4" Width="220">
+            <TextBlock Text="After dataset" Foreground="#8F8F8F" FontSize="11" />
+            <ComboBox ItemsSource="{Binding AvailableDatasets}" SelectedItem="{Binding AfterDataset}" DisplayMemberBinding="{Binding Name}" />
+          </StackPanel>
+        </WrapPanel>
+
+        <WrapPanel Grid.Row="2" Spacing="12" IsVisible="{Binding IsTrayOpen}">
+          <TextBlock Text="Assign on click:" Foreground="#8F8F8F" VerticalAlignment="Center" />
+          <StackPanel Orientation="Horizontal" Spacing="6">
+            <RadioButton Content="Before" GroupName="AssignTarget" IsChecked="{Binding IsAssignBefore}" />
+            <RadioButton Content="After" GroupName="AssignTarget" IsChecked="{Binding IsAssignAfter}" />
+          </StackPanel>
+          <TextBox Width="220" Watermark="Search" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+        </WrapPanel>
+
+        <Border Grid.Row="3" Background="#101010" BorderBrush="#2E2E2E" BorderThickness="1" CornerRadius="6" Padding="8" IsVisible="{Binding IsTrayOpen}">
+          <ListBox ItemsSource="{Binding FilmstripItems}" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Disabled">
+            <ListBox.ItemsPanel>
+              <ItemsPanelTemplate>
+                <VirtualizingStackPanel Orientation="Horizontal" Spacing="6" />
+              </ItemsPanelTemplate>
+            </ListBox.ItemsPanel>
+            <ListBox.ItemTemplate>
+              <DataTemplate>
+                <Button Padding="0" Background="Transparent" BorderThickness="0"
+                        Command="{Binding DataContext.AssignFilmstripItemCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                        CommandParameter="{Binding}">
+                  <Grid Width="96" Height="64">
+                    <Border CornerRadius="4" BorderBrush="#444" BorderThickness="1">
+                      <Image Source="{Binding ImagePath, Converter={StaticResource PathToBitmapConverter}}" Stretch="UniformToFill" />
+                    </Border>
+                    <Border Background="#3A6EA5" CornerRadius="10" Padding="4,2" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="4" IsVisible="{Binding IsBeforeSelected}">
+                      <TextBlock Text="B" Foreground="White" FontSize="10" />
+                    </Border>
+                    <Border Background="#8A3FFC" CornerRadius="10" Padding="4,2" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="4" IsVisible="{Binding IsAfterSelected}">
+                      <TextBlock Text="A" Foreground="White" FontSize="10" />
+                    </Border>
+                  </Grid>
+                </Button>
+              </DataTemplate>
+            </ListBox.ItemTemplate>
+          </ListBox>
+        </Border>
+      </Grid>
+    </Border>
+  </Grid>
+</UserControl>

--- a/DiffusionNexus.UI/Views/ImageCompareView.axaml.cs
+++ b/DiffusionNexus.UI/Views/ImageCompareView.axaml.cs
@@ -1,0 +1,29 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using DiffusionNexus.UI.ViewModels;
+
+namespace DiffusionNexus.UI.Views;
+
+public partial class ImageCompareView : UserControl
+{
+    public ImageCompareView()
+    {
+        InitializeComponent();
+    }
+
+    private void OnTrayPointerEntered(object? sender, PointerEventArgs e)
+    {
+        if (DataContext is ImageCompareViewModel viewModel)
+        {
+            viewModel.RequestTrayOpen();
+        }
+    }
+
+    private async void OnTrayPointerExited(object? sender, PointerEventArgs e)
+    {
+        if (DataContext is ImageCompareViewModel viewModel)
+        {
+            await viewModel.RequestTrayCloseAsync();
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a responsive before/after image comparison view with a draggable slider, dataset-driven filmstrip, and an auto-hiding/pinnable bottom tray to allow swapping and assigning images without closing the comparer.
- Expose a reusable control and MVVM surface so the comparer can be reused across the app and tested in isolation.

### Description
- Added a reusable `ImageCompareControl` (`ImageCompareControl.axaml` + `.axaml.cs`) that layers two `Image` elements and uses a `RectangleGeometry` clip on the top image and a draggable slider to reveal Before/After; supports `ImageCompareFitMode` (`Fit`, `Fill`, `OneToOne`).
- Implemented `ImageCompareViewModel` with bindable properties and commands (`SwapImages`, `ResetSlider`, `SetFitMode`, `AssignFilmstripItem`), dataset/filmstrip management, tray hover/pin logic with a small collapse delay, search filtering, and selection flags for visual badges.
- Added `ImageCompareView` (`.axaml` + `.axaml.cs`) containing the top toolbar (swap/reset/fit), the comparer control bound to the viewmodel, and the bottom auto-hide tray with dataset dropdowns, assign toggles, search box, and a virtualized horizontal filmstrip.
- Introduced small supporting types in `ImageCompareEnums.cs` and lightweight model classes `ImageCompareItem`/`ImageCompareDataset` inside the VM file, and wired the UI to reuse the existing `PathToBitmapConverter` for thumbnail rendering.
- Added unit tests `ImageCompareViewModelTests` covering slider reset, filmstrip assignment, assign-target switching, and swap behavior.

### Testing
- Added unit tests file `DiffusionNexus.Tests/Viewer/ImageCompareViewModelTests.cs` which contains tests for `ResetSlider`, `AssignFilmstripItem`, `AssignTargetSwitch`, and `SwapImages`.
- Attempted to run `dotnet test /workspace/DiffusionNexus/DiffusionNexus.Tests/DiffusionNexus.Tests.csproj --filter ImageCompareViewModelTests`, but the environment lacks the `dotnet` SDK and the test run could not be executed (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973ce81ed388332b9a01a73bdd99c02)