### PR TITLE
ci: stop publish.ps1 and release.yml from double-bumping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Publish (single-file zip)
       shell: pwsh
-      run: .\publish.ps1 -SkipDatabasePrompt
+      run: .\publish.ps1 -SkipDatabasePrompt -NoBump
       env:
         GITHUB_PACKAGES_TOKEN: ${{ secrets.PACKAGES_PAT }}
 

--- a/publish.ps1
+++ b/publish.ps1
@@ -9,7 +9,8 @@
 param(
     [switch]$SkipDatabasePrompt,
     [switch]$IncludeDatabase,
-    [switch]$NoZip
+    [switch]$NoZip,
+    [switch]$NoBump
 )
 
 $ErrorActionPreference = "Stop"
@@ -101,11 +102,15 @@ if (-not $Version) {
 
 Write-Host "Old Version: $Version" -ForegroundColor Yellow
 
-# Increment the version
-$Version = Increment-Version -VersionString $Version
+if ($NoBump) {
+    Write-Host "Skipping version bump (-NoBump). Using version from Directory.Build.props." -ForegroundColor Yellow
+} else {
+    # Increment the version
+    $Version = Increment-Version -VersionString $Version
 
-# Update the Directory.Build.Props file
-Update-PropsFileVersion -NewVersion $Version
+    # Update the Directory.Build.Props file
+    Update-PropsFileVersion -NewVersion $Version
+}
 
 Write-Host "Current Version: $Version" -ForegroundColor Green
 Write-Host ""


### PR DESCRIPTION
## Summary
- Adds a `-NoBump` switch to `publish.ps1` that skips its self-increment.
- `release.yml` passes `-NoBump` so the version stamped by the workflow (`GITHUB_RUN_NUMBER`) is what ends up in the zip name — fixes the upload-step 404 from the previous run.
- Local `publish.ps1` invocations without the switch keep the existing auto-bump behaviour for dev workflows.

## Test plan
- [ ] Merge this PR; the merge commit on `main` should re-trigger `release.yml`.
- [ ] Confirm the publish step prints "Skipping version bump (-NoBump)".
- [ ] Confirm `diffusion_nexus.V0.9.10.<run#>.zip` appears as an artifact on the run page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)