### PR TITLE
Sync readiness-checker hotfix from main into develop (resolves #359 conflicts)

### DIFF
--- a/DiffusionNexus.Domain/Models/ComfyUIFeatureRequirements.cs
+++ b/DiffusionNexus.Domain/Models/ComfyUIFeatureRequirements.cs
@@ -15,12 +15,20 @@ namespace DiffusionNexus.Domain.Models;
 /// Models the feature needs. Each entry pairs a node type + input name (used to query
 /// <c>/object_info</c>) with the expected model substring.
 /// An empty list means no model verification is needed (or the model auto-downloads).
+/// Only consulted when <see cref="WorkloadConfigurationId"/> is <c>null</c>.
+/// </param>
+/// <param name="WorkloadConfigurationId">
+/// Optional SDK <c>InstallationConfiguration.Id</c> backing this feature. When set, the
+/// readiness service consults the disk-based workload checker (matching what the
+/// Installer Manager workload dialog reports) instead of the legacy <c>/object_info</c>
+/// model query. The legacy <see cref="RequiredModels"/> entries are ignored in that case.
 /// </param>
 public sealed record ComfyUIFeatureRequirements(
     Enums.ComfyUIFeature Feature,
     string DisplayName,
     IReadOnlyList<string> RequiredNodeTypes,
-    IReadOnlyList<ModelRequirement> RequiredModels);
+    IReadOnlyList<ModelRequirement> RequiredModels,
+    Guid? WorkloadConfigurationId = null);
 
 /// <summary>
 /// Describes a single model that must be present on the ComfyUI server for a feature to work.

--- a/DiffusionNexus.Domain/Models/WorkloadCheckSummary.cs
+++ b/DiffusionNexus.Domain/Models/WorkloadCheckSummary.cs
@@ -1,0 +1,35 @@
+namespace DiffusionNexus.Domain.Models;
+
+/// <summary>
+/// Disk-state summary for a single SDK workload, produced by
+/// <see cref="Services.IWorkloadInstallationChecker"/>.
+/// Mirrors what the Installer Manager workload dialog reports for the same workload.
+/// </summary>
+public sealed record WorkloadCheckSummary
+{
+    /// <summary>The workload's SDK configuration id that was checked.</summary>
+    public required Guid WorkloadId { get; init; }
+
+    /// <summary>Workload name (for log/UI messages).</summary>
+    public required string WorkloadName { get; init; }
+
+    /// <summary>
+    /// <c>true</c> when every required custom node and model for the workload is present
+    /// on disk (placeholders count as present). Equivalent to the Installer Manager's
+    /// "Full" status.
+    /// </summary>
+    public required bool IsFullyInstalled { get; init; }
+
+    /// <summary>
+    /// Human-readable descriptions of items that are not installed
+    /// (custom node folder missing, model file absent, etc.). Empty when
+    /// <see cref="IsFullyInstalled"/> is <c>true</c>.
+    /// </summary>
+    public required IReadOnlyList<string> MissingItems { get; init; }
+
+    /// <summary>
+    /// Disk path against which the check was performed (the resolved ComfyUI root).
+    /// <c>null</c> when no ComfyUI installation could be located.
+    /// </summary>
+    public string? CheckedAgainstPath { get; init; }
+}

--- a/DiffusionNexus.Domain/Services/IWorkloadInstallationChecker.cs
+++ b/DiffusionNexus.Domain/Services/IWorkloadInstallationChecker.cs
@@ -1,0 +1,40 @@
+using DiffusionNexus.Domain.Models;
+
+namespace DiffusionNexus.Domain.Services;
+
+/// <summary>
+/// Disk-based installation check for an SDK workload.
+///
+/// <para>
+/// Bridges feature readiness (Image Editor / Captioning / Batch Upscale) to the same
+/// truth source the Installer Manager dialog uses — the SDK <c>InstallationConfiguration</c>
+/// walked against the configured ComfyUI installation. When the Installer Manager would
+/// show a workload as "Partial" or "None", this checker reports
+/// <see cref="WorkloadCheckSummary.IsFullyInstalled"/> = <c>false</c>.
+/// </para>
+///
+/// <para>
+/// The implementation lives in the UI assembly (because it depends on the Installer SDK
+/// types and on the user's installer-package repository); the interface lives in Domain so
+/// the service layer can consume it without taking an SDK package reference.
+/// </para>
+/// </summary>
+public interface IWorkloadInstallationChecker
+{
+    /// <summary>
+    /// Runs the configuration checker for the given workload against the registered
+    /// ComfyUI installation (the one flagged <c>IsDefault</c>, or the first ComfyUI install
+    /// when none is marked default).
+    /// </summary>
+    /// <param name="workloadId">SDK <c>InstallationConfiguration.Id</c> to check.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// A summary describing whether the workload is fully installed on disk plus the list
+    /// of missing items. When the check could not run at all (workload not in the SDK DB,
+    /// no ComfyUI installation registered, or the check threw), the returned summary has
+    /// <see cref="WorkloadCheckSummary.IsFullyInstalled"/> = <c>false</c> and a single
+    /// human-readable entry in <see cref="WorkloadCheckSummary.MissingItems"/> describing
+    /// the reason — callers can treat these uniformly as "not ready".
+    /// </returns>
+    Task<WorkloadCheckSummary> CheckAsync(Guid workloadId, CancellationToken cancellationToken = default);
+}

--- a/DiffusionNexus.Service/Services/ComfyUIFeatureRegistry.cs
+++ b/DiffusionNexus.Service/Services/ComfyUIFeatureRegistry.cs
@@ -19,6 +19,18 @@ namespace DiffusionNexus.Service.Services;
 /// </summary>
 public static class ComfyUIFeatureRegistry
 {
+    // SDK workload ids backing each feature. The readiness service uses these to delegate to
+    // IWorkloadInstallationChecker (same source the Installer Manager workload dialog uses)
+    // instead of the legacy /object_info-based model probe.
+    //
+    // IMPORTANT: these must be declared BEFORE the Registry field below — static field
+    // initializers run in textual order, and Registry's BuildRegistry() call references
+    // these values. If they're declared afterwards they read as Guid.Empty.
+    private static readonly Guid CaptioningWorkloadId      = new("701DA214-2B25-44B4-A904-E4B036621564"); // Captioning-Qwen-3-VL
+    private static readonly Guid InpaintingWorkloadId      = new("4C486765-A4C1-4E94-ACC2-BBAC0E405B6A"); // Inpainting-Qwen 2512
+    private static readonly Guid OutpaintWorkloadId        = new("137929E4-5C05-4304-80D4-5D785D45FD3F"); // Outpainting-Qwen 2512 (covers Vision variant — same workload installs Qwen3-VL nodes)
+    private static readonly Guid BatchUpscaleWorkloadId    = new("B853EB7C-0A0E-48A6-985E-E32B2F8848F5"); // Upscaling-Z-Image-Turbo (covers Vision variant)
+
     private static readonly Dictionary<ComfyUIFeature, ComfyUIFeatureRequirements> Registry = BuildRegistry();
 
     /// <summary>
@@ -52,7 +64,8 @@ public static class ComfyUIFeatureRegistry
                     DisplayName: "Qwen3-VL-4B-Instruct-FP8",
                     ApproximateSizeDescription: "~8 GB",
                     AutoDownloads: true)
-            ]);
+            ],
+            WorkloadConfigurationId: CaptioningWorkloadId);
 
         // ── Inpainting (Inpaint-Qwen-2512.json) ────────────────────────────
         // Custom nodes: UnetLoaderGGUF, ControlNetInpaintingAliMamaApply
@@ -71,7 +84,8 @@ public static class ComfyUIFeatureRegistry
                     DisplayName: "Qwen-Image-2512 GGUF",
                     ApproximateSizeDescription: "~8 GB",
                     AutoDownloads: true)
-            ]);
+            ],
+            WorkloadConfigurationId: InpaintingWorkloadId);
 
         // ── Batch Upscale (Z-Image-Turbo-Upscale.json) ─────────────────────
         // Custom nodes: UltimateSDUpscale, Power Lora Loader (rgthree)
@@ -81,7 +95,8 @@ public static class ComfyUIFeatureRegistry
             ComfyUIFeature.BatchUpscale,
             "Batch Upscale",
             RequiredNodeTypes: ["UltimateSDUpscale", "Power Lora Loader (rgthree)"],
-            RequiredModels: []);
+            RequiredModels: [],
+            WorkloadConfigurationId: BatchUpscaleWorkloadId);
 
         // ── Batch Upscale + Vision (Vision-Z-Image-Turbo-Upscale.json) ──────
         // Same as BatchUpscale plus Qwen3_VQA and SomethingToString for auto-prompt.
@@ -98,7 +113,8 @@ public static class ComfyUIFeatureRegistry
                     DisplayName: "Qwen3-VL-4B-Instruct-FP8",
                     ApproximateSizeDescription: "~8 GB",
                     AutoDownloads: true)
-            ]);
+            ],
+            WorkloadConfigurationId: BatchUpscaleWorkloadId);
 
         // ── Outpaint (Qwen-Image-2512-outpaint-nonVision.json) ──────────────
         // Custom nodes: UnetLoaderGGUF, ControlNetInpaintingAliMamaApply,
@@ -125,10 +141,14 @@ public static class ComfyUIFeatureRegistry
                     DisplayName: "Qwen-Image-InstantX-ControlNet-Inpainting",
                     ApproximateSizeDescription: "~2 GB",
                     AutoDownloads: true)
-            ]);
+            ],
+            WorkloadConfigurationId: OutpaintWorkloadId);
 
         // ── Outpaint Vision (Qwen-Image-2512-outpaint-Vision.json) ──────────
         // Same as Outpaint plus Qwen3_VQA + SomethingToString for auto-prompt.
+        // The Outpainting-Qwen 2512 SDK workload already includes the Qwen3-VL Instruct
+        // custom node + the Qwen 3 VL placeholder model, so both Vision and nonVision
+        // map to the same workload id.
         registry[ComfyUIFeature.OutpaintVision] = new ComfyUIFeatureRequirements(
             ComfyUIFeature.OutpaintVision,
             "Outpaint (Vision Auto-Prompt)",
@@ -156,7 +176,8 @@ public static class ComfyUIFeatureRegistry
                     DisplayName: "Qwen3-VL-4B-Instruct-FP8",
                     ApproximateSizeDescription: "~8 GB",
                     AutoDownloads: true)
-            ]);
+            ],
+            WorkloadConfigurationId: OutpaintWorkloadId);
 
         return registry;
     }

--- a/DiffusionNexus.Service/Services/ComfyUIReadinessService.cs
+++ b/DiffusionNexus.Service/Services/ComfyUIReadinessService.cs
@@ -1,37 +1,84 @@
 using DiffusionNexus.Domain.Enums;
 using DiffusionNexus.Domain.Models;
 using DiffusionNexus.Domain.Services;
+using DiffusionNexus.Domain.Services.UnifiedLogging;
 using Serilog;
+using SerilogILogger = Serilog.ILogger;
 
 namespace DiffusionNexus.Service.Services;
 
 /// <summary>
 /// Unified implementation that checks ComfyUI server connectivity, custom node availability,
 /// and model presence for any registered <see cref="ComfyUIFeature"/>.
-/// 
+///
 /// <para>
-/// Delegates to <see cref="IComfyUIWrapperService"/> for live queries (<c>/system_stats</c>,
-/// <c>/object_info</c>) and reads the feature requirements from <see cref="ComfyUIFeatureRegistry"/>.
+/// When a feature's <see cref="ComfyUIFeatureRequirements.WorkloadConfigurationId"/> is set,
+/// the model/node check is delegated to <see cref="IWorkloadInstallationChecker"/> — the same
+/// disk-walking logic the Installer Manager workload dialog uses. This keeps "Ready" in the
+/// feature panel consistent with the workload status the user sees in the Installer Manager.
+/// </para>
+///
+/// <para>
+/// Features without a workload id fall back to the legacy <c>/object_info</c>-driven check.
 /// </para>
 /// </summary>
 public sealed class ComfyUIReadinessService : IComfyUIReadinessService
 {
-    private static readonly ILogger Logger = Log.ForContext<ComfyUIReadinessService>();
+    private const string LogSource = "Readiness";
+    private static readonly SerilogILogger SerilogLogger = Log.ForContext<ComfyUIReadinessService>();
 
     private readonly IComfyUIWrapperService _comfyUi;
     private readonly IAppSettingsService _settingsService;
+    private readonly IWorkloadInstallationChecker? _workloadChecker;
+    private readonly IUnifiedLogger? _unifiedLogger;
 
     /// <summary>
     /// Creates a new instance.
     /// </summary>
     /// <param name="comfyUi">The ComfyUI wrapper for HTTP/WebSocket communication.</param>
     /// <param name="settingsService">Reads the configured ComfyUI server URL.</param>
-    public ComfyUIReadinessService(IComfyUIWrapperService comfyUi, IAppSettingsService settingsService)
+    /// <param name="workloadChecker">
+    /// Optional disk-based workload checker. When supplied, features that declare a
+    /// <see cref="ComfyUIFeatureRequirements.WorkloadConfigurationId"/> use it as the
+    /// authoritative source for node/model presence. When <c>null</c>, every feature falls back
+    /// to the legacy <c>/object_info</c> probe (tests / standalone consumers).
+    /// </param>
+    /// <param name="unifiedLogger">
+    /// Optional unified logger. When supplied, the readiness decision is also routed to the
+    /// in-app console so the user can see which gate is failing without exporting the
+    /// on-disk log file.
+    /// </param>
+    public ComfyUIReadinessService(
+        IComfyUIWrapperService comfyUi,
+        IAppSettingsService settingsService,
+        IWorkloadInstallationChecker? workloadChecker = null,
+        IUnifiedLogger? unifiedLogger = null)
     {
         ArgumentNullException.ThrowIfNull(comfyUi);
         ArgumentNullException.ThrowIfNull(settingsService);
         _comfyUi = comfyUi;
         _settingsService = settingsService;
+        _workloadChecker = workloadChecker;
+        _unifiedLogger = unifiedLogger;
+    }
+
+    /// <summary>Emits to both Serilog (file) and the in-app unified console when available.</summary>
+    private void LogInfo(string message)
+    {
+        SerilogLogger.Information(message);
+        _unifiedLogger?.Info(LogCategory.Configuration, LogSource, message);
+    }
+
+    private void LogDebug(string message)
+    {
+        SerilogLogger.Debug(message);
+        _unifiedLogger?.Debug(LogCategory.Configuration, LogSource, message);
+    }
+
+    private void LogWarn(string message)
+    {
+        SerilogLogger.Warning(message);
+        _unifiedLogger?.Warn(LogCategory.Configuration, LogSource, message);
     }
 
     /// <inheritdoc />
@@ -59,9 +106,11 @@ public sealed class ComfyUIReadinessService : IComfyUIReadinessService
     {
         var requirements = ComfyUIFeatureRegistry.GetRequirements(feature);
 
+        LogInfo($"CheckFeatureAsync({feature}) — start");
+
         if (requirements is null)
         {
-            Logger.Warning("No requirements registered for feature {Feature}", feature);
+            LogWarn($"No requirements registered for feature {feature}");
             return new FeatureReadinessResult
             {
                 Feature = feature,
@@ -80,11 +129,12 @@ public sealed class ComfyUIReadinessService : IComfyUIReadinessService
         }
         catch (Exception ex)
         {
-            Logger.Debug(ex, "Failed to resolve ComfyUI server URL for feature {Feature}", feature);
+            SerilogLogger.Debug(ex, "Failed to resolve ComfyUI server URL for feature {Feature}", feature);
+            LogWarn($"{feature}: failed to resolve ComfyUI server URL — {ex.Message}");
             return FeatureReadinessResult.ServerOffline(feature, "(unknown)");
         }
 
-        // 1. Health check
+        // 1. Health check — same regardless of which check strategy we use below.
         bool isOnline;
         try
         {
@@ -99,11 +149,80 @@ public sealed class ComfyUIReadinessService : IComfyUIReadinessService
 
         if (!isOnline)
         {
-            Logger.Debug("ComfyUI server offline at {Url} for feature {Feature}", serverUrl, feature);
+            LogWarn($"{feature}: ComfyUI server offline at {serverUrl}");
             return FeatureReadinessResult.ServerOffline(feature, serverUrl);
         }
 
-        // 2. Check custom nodes
+        // 2. Pick the check strategy. When the feature is backed by an SDK workload AND we
+        // have a workload checker, use the same disk-walking logic the Installer Manager
+        // uses so both views agree. Guid.Empty is treated as "no workload set" — it would
+        // never match a real SDK row, and a confusing "workload not found" error is worse
+        // than falling back to the legacy probe.
+        if (requirements.WorkloadConfigurationId is { } workloadId
+            && workloadId != Guid.Empty
+            && _workloadChecker is not null)
+        {
+            return await CheckViaWorkloadAsync(feature, requirements, workloadId, serverUrl, ct);
+        }
+
+        return await CheckViaObjectInfoAsync(feature, requirements, serverUrl, ct);
+    }
+
+    /// <summary>
+    /// Disk-based check via <see cref="IWorkloadInstallationChecker"/>. Maps the workload's
+    /// installation status (Full / Partial / None, in Installer-Manager terms) onto the
+    /// feature readiness model. Anything short of "fully installed" is reported as blocking.
+    /// </summary>
+    private async Task<FeatureReadinessResult> CheckViaWorkloadAsync(
+        ComfyUIFeature feature,
+        ComfyUIFeatureRequirements requirements,
+        Guid workloadId,
+        string serverUrl,
+        CancellationToken ct)
+    {
+        var summary = await _workloadChecker!.CheckAsync(workloadId, ct);
+
+        var missingReqs = new List<string>();
+
+        if (!summary.IsFullyInstalled)
+        {
+            missingReqs.AddRange(summary.MissingItems);
+
+            // Action hint — the workload dialog is where the user installs missing pieces.
+            missingReqs.Add(
+                $"Open Installer Manager → '{summary.WorkloadName}' to install the missing items.");
+        }
+
+        var result = new FeatureReadinessResult
+        {
+            Feature = feature,
+            IsServerOnline = true,
+            // The workload check is holistic: it covers both nodes and models in one disk
+            // walk, so AllNodesInstalled and AllModelsPresent move together.
+            AllNodesInstalled = summary.IsFullyInstalled,
+            AllModelsPresent = summary.IsFullyInstalled,
+            MissingRequirements = missingReqs,
+            Warnings = [],
+            ServerUrl = serverUrl
+        };
+
+        LogInfo(
+            $"Readiness check for {feature} (workload {workloadId} @ {summary.CheckedAgainstPath ?? "(unresolved)"}): " +
+            $"Ready={result.IsReady}, MissingCount={missingReqs.Count}");
+
+        return result;
+    }
+
+    /// <summary>
+    /// Legacy <c>/object_info</c>-driven check, kept for features that don't yet have an
+    /// SDK workload id and for tests that don't wire <see cref="IWorkloadInstallationChecker"/>.
+    /// </summary>
+    private async Task<FeatureReadinessResult> CheckViaObjectInfoAsync(
+        ComfyUIFeature feature,
+        ComfyUIFeatureRequirements requirements,
+        string serverUrl,
+        CancellationToken ct)
+    {
         var missingReqs = new List<string>();
         var allNodesInstalled = true;
 
@@ -121,13 +240,10 @@ public sealed class ComfyUIReadinessService : IComfyUIReadinessService
 
                 missingReqs.Add("Install via ComfyUI Manager or place into the custom_nodes folder, then restart ComfyUI.");
 
-                Logger.Warning(
-                    "Feature {Feature}: missing custom nodes: {MissingNodes}",
-                    feature, string.Join(", ", missingNodes));
+                LogWarn($"{feature}: missing custom nodes: {string.Join(", ", missingNodes)}");
             }
         }
 
-        // 3. Check models
         var allBlockingModelsPresent = true;
         var warnings = new List<string>();
 
@@ -140,10 +256,9 @@ public sealed class ComfyUIReadinessService : IComfyUIReadinessService
                 var availableOptions = await _comfyUi.GetNodeInputOptionsAsync(
                     model.NodeType, model.InputName, ct);
 
-                Logger.Debug(
-                    "Feature {Feature}: {NodeType}.{Input} has {Count} option(s): {Options}",
-                    feature, model.NodeType, model.InputName,
-                    availableOptions.Count, string.Join(", ", availableOptions));
+                LogDebug(
+                    $"{feature}: {model.NodeType}.{model.InputName} has {availableOptions.Count} option(s): " +
+                    $"{string.Join(", ", availableOptions)}");
 
                 var isPresent = availableOptions.Any(
                     o => o.Contains(model.ExpectedModelSubstring, StringComparison.OrdinalIgnoreCase));
@@ -169,11 +284,11 @@ public sealed class ComfyUIReadinessService : IComfyUIReadinessService
             }
             catch (Exception ex)
             {
-                Logger.Warning(ex,
+                SerilogLogger.Warning(ex,
                     "Feature {Feature}: failed to query model info for {NodeType}.{Input}",
                     feature, model.NodeType, model.InputName);
+                LogWarn($"{feature}: failed to query model info for {model.NodeType}.{model.InputName} — {ex.Message}");
 
-                // Treat query failure as non-blocking if the model auto-downloads
                 if (model.AutoDownloads)
                 {
                     warnings.Add($"Could not verify model '{model.DisplayName}' — it may download automatically on first run.");
@@ -197,9 +312,9 @@ public sealed class ComfyUIReadinessService : IComfyUIReadinessService
             ServerUrl = serverUrl
         };
 
-        Logger.Information(
-            "Readiness check for {Feature}: Ready={IsReady}, MissingReqs={MissingCount}, Warnings={WarnCount}",
-            feature, result.IsReady, missingReqs.Count, warnings.Count);
+        LogInfo(
+            $"Readiness check for {feature} (legacy /object_info path): " +
+            $"Ready={result.IsReady}, MissingReqs={missingReqs.Count}, Warnings={warnings.Count}");
 
         return result;
     }

--- a/DiffusionNexus.Tests/Service/Services/ComfyUIFeatureRegistryTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/ComfyUIFeatureRegistryTests.cs
@@ -1,0 +1,32 @@
+using DiffusionNexus.Domain.Enums;
+using DiffusionNexus.Service.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace DiffusionNexus.Tests.Service.Services;
+
+/// <summary>
+/// Pins the SDK workload-id bindings on each feature so the order-of-initialization bug
+/// (Guid.Empty leaking into the registry because the *WorkloadId fields were declared
+/// AFTER the Registry field) can't silently regress.
+/// </summary>
+public class ComfyUIFeatureRegistryTests
+{
+    [Theory]
+    [InlineData(ComfyUIFeature.Captioning,         "701DA214-2B25-44B4-A904-E4B036621564")]
+    [InlineData(ComfyUIFeature.Inpainting,         "4C486765-A4C1-4E94-ACC2-BBAC0E405B6A")]
+    [InlineData(ComfyUIFeature.BatchUpscale,       "B853EB7C-0A0E-48A6-985E-E32B2F8848F5")]
+    [InlineData(ComfyUIFeature.BatchUpscaleVision, "B853EB7C-0A0E-48A6-985E-E32B2F8848F5")]
+    [InlineData(ComfyUIFeature.Outpaint,           "137929E4-5C05-4304-80D4-5D785D45FD3F")]
+    [InlineData(ComfyUIFeature.OutpaintVision,     "137929E4-5C05-4304-80D4-5D785D45FD3F")]
+    public void EachFeature_BindsToExpectedSdkWorkload(ComfyUIFeature feature, string expectedGuid)
+    {
+        var requirements = ComfyUIFeatureRegistry.GetRequirements(feature);
+
+        requirements.Should().NotBeNull();
+        requirements!.WorkloadConfigurationId
+            .Should().Be(Guid.Parse(expectedGuid),
+                $"feature '{feature}' is supposed to be backed by SDK workload {expectedGuid}; "
+                + "a Guid.Empty here means the static initializer order is wrong again.");
+    }
+}

--- a/DiffusionNexus.UI/App.axaml.cs
+++ b/DiffusionNexus.UI/App.axaml.cs
@@ -788,6 +788,16 @@ public partial class App : Application
         // Configuration checker (singleton - accessible across the entire application)
         services.AddSingleton<IConfigurationCheckerService, ConfigurationCheckerService>();
 
+        // Workload installation checker — bridges feature readiness to the same disk-walking
+        // logic the Installer Manager workload dialog uses. Singleton; resolves scoped
+        // dependencies per call via IServiceProvider. Also gets the unified logger so the
+        // per-install check results land in the in-app console.
+        services.AddSingleton<Domain.Services.IWorkloadInstallationChecker>(sp =>
+            new WorkloadInstallationCheckerAdapter(
+                sp,
+                sp.GetRequiredService<IConfigurationCheckerService>(),
+                sp.GetService<Domain.Services.UnifiedLogging.IUnifiedLogger>()));
+
         // Workload installer (singleton - clones custom nodes + downloads models)
         services.AddSingleton<IWorkloadInstallService>(sp =>
             new WorkloadInstallService(
@@ -818,11 +828,16 @@ public partial class App : Application
             return new ComfyUIWrapperService();
         });
 
-        // Unified ComfyUI readiness service (singleton - checks server, nodes, models per feature)
+        // Unified ComfyUI readiness service (singleton - checks server, nodes, models per feature).
+        // The workload checker bridges to the same disk-walking logic the Installer Manager uses,
+        // so a feature reports "Ready" iff its backing workload would show as "Full" in the dialog.
+        // The unified logger plumb-through makes readiness decisions visible in the in-app console.
         services.AddSingleton<IComfyUIReadinessService>(sp =>
             new ComfyUIReadinessService(
                 sp.GetRequiredService<IComfyUIWrapperService>(),
-                sp.GetRequiredService<IAppSettingsService>()));
+                sp.GetRequiredService<IAppSettingsService>(),
+                sp.GetService<Domain.Services.IWorkloadInstallationChecker>(),
+                sp.GetService<Domain.Services.UnifiedLogging.IUnifiedLogger>()));
 
         // Civitai API client (singleton - maintains HttpClient)
         services.AddSingleton<Civitai.ICivitaiClient, Civitai.CivitaiClient>();
@@ -961,7 +976,8 @@ public partial class App : Application
             sp.GetService<AnalysisRunStore>(),
             sp.GetService<DuplicateDetector>(),
             sp.GetService<ColorDistributionAnalyzer>(),
-            sp.GetService<IDownloadCoordinator>()));
+            sp.GetService<IDownloadCoordinator>(),
+            sp.GetService<Domain.Services.UnifiedLogging.IUnifiedLogger>()));
     }
 
     /// <summary>

--- a/DiffusionNexus.UI/Converters/LogCategoryDisplayConverter.cs
+++ b/DiffusionNexus.UI/Converters/LogCategoryDisplayConverter.cs
@@ -1,0 +1,30 @@
+using Avalonia.Data.Converters;
+using DiffusionNexus.Domain.Services.UnifiedLogging;
+using System.Globalization;
+
+namespace DiffusionNexus.UI.Converters;
+
+/// <summary>
+/// Renders a <see cref="LogCategory"/>? combo-box item. The <c>null</c> value represents
+/// "no category filter" and is shown as "All Categories" so the user can explicitly pick
+/// it from the dropdown — the placeholder text alone is invisible once any other category
+/// has been selected (e.g. when launching a ComfyUI instance auto-filters to
+/// <see cref="LogCategory.InstanceManagement"/>).
+/// </summary>
+public sealed class LogCategoryDisplayConverter : IValueConverter
+{
+    public static readonly LogCategoryDisplayConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return value switch
+        {
+            null              => "All Categories",
+            LogCategory enumValue => enumValue.ToString(),
+            _                 => value.ToString()
+        };
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}

--- a/DiffusionNexus.UI/Markup/SafeAssetExtension.cs
+++ b/DiffusionNexus.UI/Markup/SafeAssetExtension.cs
@@ -1,0 +1,24 @@
+using Avalonia.Markup.Xaml;
+using DiffusionNexus.UI.Services;
+
+namespace DiffusionNexus.UI.Markup;
+
+/// <summary>
+/// XAML markup extension that resolves an avares:// URI through
+/// <see cref="SafeAssetBitmap"/>. A failed load returns <c>null</c>
+/// (Image renders blank) instead of throwing — see issue #351.
+/// </summary>
+public sealed class SafeAssetExtension : MarkupExtension
+{
+    public SafeAssetExtension() { }
+
+    public SafeAssetExtension(string uri)
+    {
+        Uri = uri;
+    }
+
+    public string Uri { get; set; } = string.Empty;
+
+    public override object ProvideValue(IServiceProvider serviceProvider)
+        => SafeAssetBitmap.Load(Uri)!;
+}

--- a/DiffusionNexus.UI/Services/ConfigurationChecker/WorkloadInstallationCheckerAdapter.cs
+++ b/DiffusionNexus.UI/Services/ConfigurationChecker/WorkloadInstallationCheckerAdapter.cs
@@ -1,0 +1,241 @@
+using DiffusionNexus.DataAccess.UnitOfWork;
+using DiffusionNexus.Domain.Enums;
+using DiffusionNexus.Domain.Models;
+using DiffusionNexus.Domain.Services;
+using DiffusionNexus.Domain.Services.UnifiedLogging;
+using DiffusionNexus.Installer.SDK.DataAccess;
+using DiffusionNexus.UI.Services.ConfigurationChecker.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+using SerilogILogger = Serilog.ILogger;
+
+namespace DiffusionNexus.UI.Services.ConfigurationChecker;
+
+/// <summary>
+/// Bridges <see cref="IWorkloadInstallationChecker"/> (consumed by the Service layer) to the
+/// existing UI-side <see cref="IConfigurationCheckerService"/> + Installer SDK repositories.
+///
+/// <para>
+/// Walks every registered ComfyUI installation and reports a node/model as installed if it's
+/// present in <em>any</em> of them. Users frequently keep multiple ComfyUI installs side by
+/// side (each with its own <c>extra_model_paths.yaml</c>), so checking only the
+/// <c>IsDefault</c> install would mark workloads as Partial whenever the running install
+/// isn't the one flagged default.
+/// </para>
+///
+/// <para>
+/// Implemented as a singleton that resolves scoped dependencies (<see cref="IUnitOfWork"/>,
+/// <see cref="IConfigurationRepository"/>) per call via <see cref="IServiceProvider"/>.
+/// </para>
+/// </summary>
+public sealed class WorkloadInstallationCheckerAdapter : IWorkloadInstallationChecker
+{
+    private const string LogSource = "WorkloadCheck";
+    private static readonly SerilogILogger SerilogLogger = Log.ForContext<WorkloadInstallationCheckerAdapter>();
+
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IConfigurationCheckerService _configurationChecker;
+    private readonly IUnifiedLogger? _unifiedLogger;
+
+    public WorkloadInstallationCheckerAdapter(
+        IServiceProvider serviceProvider,
+        IConfigurationCheckerService configurationChecker,
+        IUnifiedLogger? unifiedLogger = null)
+    {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+        ArgumentNullException.ThrowIfNull(configurationChecker);
+        _serviceProvider = serviceProvider;
+        _configurationChecker = configurationChecker;
+        _unifiedLogger = unifiedLogger;
+    }
+
+    private void LogInfo(string message)
+    {
+        SerilogLogger.Information(message);
+        _unifiedLogger?.Info(LogCategory.Configuration, LogSource, message);
+    }
+
+    private void LogDebug(string message)
+    {
+        SerilogLogger.Debug(message);
+        _unifiedLogger?.Debug(LogCategory.Configuration, LogSource, message);
+    }
+
+    private void LogWarn(string message)
+    {
+        SerilogLogger.Warning(message);
+        _unifiedLogger?.Warn(LogCategory.Configuration, LogSource, message);
+    }
+
+    private void LogError(string message, Exception? ex = null)
+    {
+        if (ex is null) SerilogLogger.Error(message);
+        else SerilogLogger.Error(ex, message);
+        _unifiedLogger?.Error(LogCategory.Configuration, LogSource, message, ex);
+    }
+
+    /// <inheritdoc />
+    public async Task<WorkloadCheckSummary> CheckAsync(Guid workloadId, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var sp = scope.ServiceProvider;
+
+            var configurationRepository = sp.GetRequiredService<IConfigurationRepository>();
+            var configuration = await configurationRepository.GetByIdAsync(workloadId, cancellationToken);
+
+            if (configuration is null)
+            {
+                LogWarn($"Workload {workloadId} not found in SDK database");
+                return new WorkloadCheckSummary
+                {
+                    WorkloadId = workloadId,
+                    WorkloadName = workloadId.ToString(),
+                    IsFullyInstalled = false,
+                    MissingItems = [$"Workload {workloadId} is not in the Installer SDK database."],
+                };
+            }
+
+            var comfyInstallPaths = await ResolveAllComfyUIRootPathsAsync(sp, cancellationToken);
+            if (comfyInstallPaths.Count == 0)
+            {
+                LogWarn($"No ComfyUI installation registered — cannot check workload '{configuration.Name}'");
+                return new WorkloadCheckSummary
+                {
+                    WorkloadId = workloadId,
+                    WorkloadName = configuration.Name,
+                    IsFullyInstalled = false,
+                    MissingItems = [
+                        "No ComfyUI installation is registered. Add one in Installer Manager so workloads can be checked against disk."
+                    ],
+                };
+            }
+
+            // Run the disk check against every ComfyUI install in turn and OR the per-item
+            // results — a model that lives in one install but not another still counts as
+            // installed for the user's purposes.
+            var nodeInstalled = new Dictionary<Guid, (bool installed, string name)>();
+            var modelInstalled = new Dictionary<Guid, (bool installed, string name)>();
+
+            LogInfo(
+                $"Workload '{configuration.Name}': checking against {comfyInstallPaths.Count} ComfyUI install(s): " +
+                $"{string.Join(" | ", comfyInstallPaths)}");
+
+            foreach (var path in comfyInstallPaths)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                ConfigurationCheckResult result;
+                try
+                {
+                    result = await _configurationChecker.CheckConfigurationAsync(
+                        configuration, path, options: null, cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    LogWarn(
+                        $"Workload '{configuration.Name}' check against {path} failed " +
+                        $"({ex.Message}); continuing with remaining installs");
+                    continue;
+                }
+
+                LogInfo(
+                    $"Workload '{configuration.Name}' @ {path}: status={result.OverallStatus} " +
+                    $"({result.InstalledCustomNodes}/{result.TotalCustomNodes} nodes, " +
+                    $"{result.InstalledModels}/{result.TotalModels} models)");
+
+                foreach (var node in result.CustomNodeResults)
+                {
+                    LogDebug($"  node '{node.Name}' installed={node.IsInstalled} at {node.ExpectedPath}");
+                    if (!nodeInstalled.TryGetValue(node.Id, out var prev) || !prev.installed)
+                    {
+                        nodeInstalled[node.Id] = (node.IsInstalled, node.Name);
+                    }
+                }
+
+                foreach (var model in result.ModelResults)
+                {
+                    LogDebug(
+                        $"  model '{model.Name}' installed={model.IsInstalled} " +
+                        $"placeholder={model.IsPlaceholder} " +
+                        $"foundAt={(string.IsNullOrEmpty(model.FoundAtPath) ? "(not found)" : model.FoundAtPath)}");
+                    if (!modelInstalled.TryGetValue(model.Id, out var prev) || !prev.installed)
+                    {
+                        // model.IsInstalled is already true for placeholders
+                        // (see ConfigurationCheckerService — IsInstalled = IsPlaceholder || file-found)
+                        modelInstalled[model.Id] = (model.IsInstalled, model.Name);
+                    }
+                }
+            }
+
+            var missingItems = new List<string>();
+            foreach (var (installed, name) in nodeInstalled.Values)
+            {
+                if (!installed) missingItems.Add($"Missing custom node: {name}");
+            }
+            foreach (var (installed, name) in modelInstalled.Values)
+            {
+                if (!installed) missingItems.Add($"Missing model: {name}");
+            }
+
+            var isFullyInstalled = missingItems.Count == 0;
+            LogInfo(
+                $"Workload '{configuration.Name}' check: Full={isFullyInstalled}, " +
+                $"checked {comfyInstallPaths.Count} install(s): {string.Join(" | ", comfyInstallPaths)}");
+
+            return new WorkloadCheckSummary
+            {
+                WorkloadId = workloadId,
+                WorkloadName = configuration.Name,
+                IsFullyInstalled = isFullyInstalled,
+                MissingItems = missingItems,
+                CheckedAgainstPath = string.Join(" | ", comfyInstallPaths)
+            };
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogError($"Workload installation check failed for {workloadId}", ex);
+            return new WorkloadCheckSummary
+            {
+                WorkloadId = workloadId,
+                WorkloadName = workloadId.ToString(),
+                IsFullyInstalled = false,
+                MissingItems = [$"Workload check failed: {ex.Message}"],
+            };
+        }
+    }
+
+    /// <summary>
+    /// Returns every registered ComfyUI installation path, default(s) first.
+    /// The list is deduplicated case-insensitively so symlinked or repeated entries don't
+    /// double-walk the same folder.
+    /// </summary>
+    private static async Task<IReadOnlyList<string>> ResolveAllComfyUIRootPathsAsync(
+        IServiceProvider sp,
+        CancellationToken ct)
+    {
+        var unitOfWork = sp.GetRequiredService<IUnitOfWork>();
+        var packages = await unitOfWork.InstallerPackages.GetAllAsync(ct);
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var paths = new List<string>();
+
+        foreach (var pkg in packages
+            .Where(p => p.Type == InstallerType.ComfyUI && !string.IsNullOrWhiteSpace(p.InstallationPath))
+            .OrderByDescending(p => p.IsDefault)
+            .ThenBy(p => p.Name))
+        {
+            if (seen.Add(pkg.InstallationPath))
+            {
+                paths.Add(pkg.InstallationPath);
+            }
+        }
+
+        return paths;
+    }
+}

--- a/DiffusionNexus.UI/Services/SafeAssetBitmap.cs
+++ b/DiffusionNexus.UI/Services/SafeAssetBitmap.cs
@@ -1,0 +1,73 @@
+using System.Collections.Concurrent;
+using Avalonia.Controls;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+
+namespace DiffusionNexus.UI.Services;
+
+/// <summary>
+/// Loads avares:// bitmap assets with full-buffer copy, retry, and cache.
+/// All avares:// loads in the app must go through this helper — see issue #351.
+/// </summary>
+public static class SafeAssetBitmap
+{
+    private static readonly ConcurrentDictionary<string, Bitmap?> _cache = new();
+
+    public static Bitmap? Load(string avaresUri)
+    {
+        if (string.IsNullOrEmpty(avaresUri))
+            return null;
+
+        if (_cache.TryGetValue(avaresUri, out var cached))
+            return cached;
+
+        Bitmap? result = null;
+        Exception? lastEx = null;
+
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                using var src = AssetLoader.Open(new Uri(avaresUri));
+                if (src is null)
+                {
+                    Serilog.Log.Warning("SafeAssetBitmap: asset not found {Uri}", avaresUri);
+                    break;
+                }
+
+                using var ms = new MemoryStream();
+                src.CopyTo(ms);
+                if (ms.Length == 0)
+                {
+                    lastEx = new InvalidDataException($"Empty stream for {avaresUri}");
+                    if (attempt < 2) Thread.Sleep(10);
+                    continue;
+                }
+
+                ms.Position = 0;
+                result = new Bitmap(ms);
+                break;
+            }
+            catch (Exception ex)
+            {
+                lastEx = ex;
+                if (attempt < 2) Thread.Sleep(10);
+            }
+        }
+
+        if (result is null && lastEx is not null)
+        {
+            Serilog.Log.Error(lastEx,
+                "SafeAssetBitmap: failed after retries for {Uri}", avaresUri);
+        }
+
+        _cache[avaresUri] = result;
+        return result;
+    }
+
+    public static WindowIcon? LoadWindowIcon(string avaresUri)
+    {
+        var bmp = Load(avaresUri);
+        return bmp is null ? null : new WindowIcon(bmp);
+    }
+}

--- a/DiffusionNexus.UI/ViewModels/DiffusionNexusMainWindowViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/DiffusionNexusMainWindowViewModel.cs
@@ -46,28 +46,7 @@ public partial class ModuleItem : ObservableObject
         _name = name;
         _view = view;
         _isVisible = isVisible;
-        
-        if (string.IsNullOrEmpty(iconPath))
-            return;
-
-        try
-        {
-            using var stream = AssetLoader.Open(new Uri(iconPath));
-            if (stream is null)
-            {
-                Serilog.Log.Warning("Asset not found: {IconPath}", iconPath);
-                return;
-            }
-
-            _icon = new Bitmap(stream);
-        }
-        catch (Exception ex)
-        {
-            Serilog.Log.Error(ex,
-                "Module icon decode failed for {IconPath}. Skia cannot decode .ico; use PNG/JPEG/WebP.",
-                iconPath);
-            _icon = null;
-        }
+        _icon = SafeAssetBitmap.Load(iconPath);
     }
 }
 

--- a/DiffusionNexus.UI/ViewModels/ImageEditorViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/ImageEditorViewModel.cs
@@ -176,7 +176,7 @@ public partial class ImageEditorViewModel : ObservableObject
     }
 
     /// <summary>Formatted image dimensions for display.</summary>
-    public string ImageDimensions => HasImage ? $"{ImageWidth} × {ImageHeight}" : string.Empty;
+    public string ImageDimensions => HasImage ? $"{ImageWidth} ï¿½ {ImageHeight}" : string.Empty;
 
     /// <summary>Whether the crop tool is currently active.</summary>
     public bool IsCropToolActive
@@ -273,7 +273,7 @@ public partial class ImageEditorViewModel : ObservableObject
 
     /// <summary>Combined image info for display.</summary>
     public string ImageInfo => HasImage
-        ? $"Size: {ImageWidth} × {ImageHeight} px\nResolution: {ImageDpi} DPI\nFile: {FileSizeText}"
+        ? $"Size: {ImageWidth} ï¿½ {ImageHeight} px\nResolution: {ImageDpi} DPI\nFile: {FileSizeText}"
         : string.Empty;
 
     #endregion
@@ -345,7 +345,8 @@ public partial class ImageEditorViewModel : ObservableObject
         IBackgroundRemovalService? backgroundRemovalService = null,
         IComfyUIWrapperService? comfyUiService = null,
         EditorServices? services = null,
-        IComfyUIReadinessService? readinessService = null)
+        IComfyUIReadinessService? readinessService = null,
+        Domain.Services.UnifiedLogging.IUnifiedLogger? unifiedLogger = null)
     {
         _eventAggregator = eventAggregator;
         _services = services ?? EditorServiceFactory.Create();
@@ -358,7 +359,7 @@ public partial class ImageEditorViewModel : ObservableObject
         BackgroundRemoval = new BackgroundRemovalViewModel(() => HasImage, DeactivateOtherTools, backgroundRemovalService);
         BackgroundFill = new BackgroundFillViewModel(() => HasImage, DeactivateOtherTools);
         Inpainting = new InpaintingViewModel(() => HasImage, DeactivateOtherTools, comfyUiService, eventAggregator, readinessService);
-        Outpainting = new OutpaintingViewModel(() => HasImage, () => ImageWidth, () => ImageHeight, DeactivateOtherTools, comfyUiService, readinessService);
+        Outpainting = new OutpaintingViewModel(() => HasImage, () => ImageWidth, () => ImageHeight, DeactivateOtherTools, comfyUiService, readinessService, unifiedLogger);
         Rating = new RatingViewModel(() => HasImage, eventAggregator);
 
         WireSubViewModelEvents();

--- a/DiffusionNexus.UI/ViewModels/InpaintingViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/InpaintingViewModel.cs
@@ -94,13 +94,54 @@ public partial class InpaintingViewModel : ObservableObject
             () => _hasImage() && IsPanelOpen);
         GenerateCommand = new AsyncRelayCommand(
             ExecuteGenerateAsync,
-            () => _hasImage() && IsPanelOpen && !IsBusy);
+            () => _hasImage() && IsPanelOpen && !IsBusy && IsReadinessClickable(Readiness));
         GenerateAndCompareCommand = new AsyncRelayCommand(
             ExecuteGenerateAndCompareAsync,
-            () => _hasImage() && IsPanelOpen && !IsBusy);
+            () => _hasImage() && IsPanelOpen && !IsBusy && IsReadinessClickable(Readiness));
         UseCurrentAsBaseCommand = new RelayCommand(
             () => SetBaseRequested?.Invoke(this, EventArgs.Empty),
             () => _hasImage() && IsPanelOpen);
+
+        // Re-evaluate Generate CanExecute when readiness flips, so the buttons grey out
+        // automatically once the workload reports as not fully installed (matching what
+        // the Installer Manager workload dialog would show).
+        Readiness.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName is nameof(ComfyUIReadinessViewModel.IsReady)
+                                  or nameof(ComfyUIReadinessViewModel.HasChecked))
+            {
+                GenerateCommand.NotifyCanExecuteChanged();
+                GenerateAndCompareCommand.NotifyCanExecuteChanged();
+            }
+        };
+    }
+
+    /// <summary>
+    /// A feature is clickable once readiness either reports ready, or readiness has never
+    /// been checked yet (initial state — the button shouldn't be disabled before we know).
+    /// As soon as the first check completes with <c>IsReady=false</c>, the button greys out.
+    /// </summary>
+    private static bool IsReadinessClickable(ComfyUIReadinessViewModel readiness) =>
+        !readiness.HasChecked || readiness.IsReady;
+
+    /// <summary>
+    /// Runs the inpainting readiness check. Fired automatically when the panel opens so the
+    /// Generate buttons reflect installation state without the user having to press "Check".
+    /// </summary>
+    private async Task RunReadinessCheckAsync()
+    {
+        try
+        {
+            await Readiness.CheckReadinessAsync();
+        }
+        catch (OperationCanceledException)
+        {
+            // Cancellation during panel close — nothing to do.
+        }
+        catch (Exception ex)
+        {
+            Logger.Warning(ex, "Inpaint readiness check failed");
+        }
     }
 
     /// <summary>Unified readiness check for the Inpainting feature (server, nodes, models).</summary>
@@ -120,6 +161,7 @@ public partial class InpaintingViewModel : ObservableObject
                 {
                     _deactivateOtherTools(ImageEditor.Services.ToolIds.Inpainting);
                     StatusMessageChanged?.Invoke(this, "Inpaint: Paint over areas to mark them for AI regeneration.");
+                    _ = RunReadinessCheckAsync();
 
                     if (!HasBase)
                         SetBaseRequested?.Invoke(this, EventArgs.Empty);
@@ -520,6 +562,8 @@ public partial class InpaintingViewModel : ObservableObject
 
     private async Task ExecuteGenerateAsync()
     {
+        if (!CheckReadinessOrReport()) return;
+
         if (string.IsNullOrWhiteSpace(_positivePrompt))
         {
             StatusMessageChanged?.Invoke(this, "Please enter a prompt describing what to generate.");
@@ -545,6 +589,8 @@ public partial class InpaintingViewModel : ObservableObject
 
     private async Task ExecuteGenerateAndCompareAsync()
     {
+        if (!CheckReadinessOrReport()) return;
+
         if (string.IsNullOrWhiteSpace(_positivePrompt))
         {
             StatusMessageChanged?.Invoke(this, "Please enter a prompt describing what to generate.");
@@ -566,6 +612,25 @@ public partial class InpaintingViewModel : ObservableObject
         GenerateRequested?.Invoke(this, EventArgs.Empty);
 
         await Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Surfaces a clear status message and returns <c>false</c> when readiness has already
+    /// reported the workload as not fully installed, so the click is short-circuited before
+    /// any image-export or upload work happens.
+    /// </summary>
+    private bool CheckReadinessOrReport()
+    {
+        if (Readiness.HasChecked && !Readiness.IsReady)
+        {
+            var detail = Readiness.MissingRequirements.Count > 0
+                ? Readiness.MissingRequirements[0]
+                : "Required nodes or models are missing.";
+            StatusMessageChanged?.Invoke(this, detail);
+            return false;
+        }
+
+        return true;
     }
 
     private void OnFinished()

--- a/DiffusionNexus.UI/ViewModels/InstallerPackageCardViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/InstallerPackageCardViewModel.cs
@@ -255,19 +255,7 @@ public partial class InstallerPackageCardViewModel : ViewModelBase
             _ => "avares://DiffusionNexus.UI/Assets/Installer.png"
         };
 
-        try
-        {
-            using var assetStream = AssetLoader.Open(new Uri(assetPath));
-            var ms = new MemoryStream();
-            assetStream.CopyTo(ms);
-            ms.Position = 0;
-            return new Bitmap(ms);
-        }
-        catch (Exception ex)
-        {
-            Serilog.Log.Warning(ex, "Failed to load installer logo from {AssetPath}", assetPath);
-            return null;
-        }
+        return SafeAssetBitmap.Load(assetPath);
     }
 
     /// <summary>

--- a/DiffusionNexus.UI/ViewModels/InstanceTabItem.cs
+++ b/DiffusionNexus.UI/ViewModels/InstanceTabItem.cs
@@ -1,7 +1,7 @@
 using Avalonia.Media.Imaging;
-using Avalonia.Platform;
 using CommunityToolkit.Mvvm.ComponentModel;
 using DiffusionNexus.Domain.Enums;
+using DiffusionNexus.UI.Services;
 
 namespace DiffusionNexus.UI.ViewModels;
 
@@ -115,17 +115,6 @@ public partial class InstanceTabItem : ObservableObject
             _ => "avares://DiffusionNexus.UI/Assets/Installer.png"
         };
 
-        try
-        {
-            using var assetStream = AssetLoader.Open(new Uri(assetPath));
-            var ms = new MemoryStream();
-            assetStream.CopyTo(ms);
-            ms.Position = 0;
-            return new Bitmap(ms);
-        }
-        catch
-        {
-            return null;
-        }
+        return SafeAssetBitmap.Load(assetPath);
     }
 }

--- a/DiffusionNexus.UI/ViewModels/LoraDatasetHelperViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraDatasetHelperViewModel.cs
@@ -179,7 +179,8 @@ public partial class LoraDatasetHelperViewModel : ViewModelBase, IDialogServiceA
         AnalysisRunStore? analysisRunStore = null,
         DuplicateDetector? duplicateDetector = null,
         ColorDistributionAnalyzer? colorDistributionAnalyzer = null,
-        IDownloadCoordinator? downloadCoordinator = null)
+        IDownloadCoordinator? downloadCoordinator = null,
+        Domain.Services.UnifiedLogging.IUnifiedLogger? unifiedLogger = null)
     {
         _eventAggregator = eventAggregator ?? throw new ArgumentNullException(nameof(eventAggregator));
         _state = state ?? throw new ArgumentNullException(nameof(state));
@@ -206,7 +207,7 @@ public partial class LoraDatasetHelperViewModel : ViewModelBase, IDialogServiceA
             analysisRunStore,
             duplicateDetector,
             colorDistributionAnalyzer);
-        ImageEdit = new ImageEditTabViewModel(eventAggregator, state, backgroundRemovalService, comfyUiService, thumbnailOrchestrator, readinessService);
+        ImageEdit = new ImageEditTabViewModel(eventAggregator, state, backgroundRemovalService, comfyUiService, thumbnailOrchestrator, readinessService, unifiedLogger);
         BatchCropScale = new BatchCropScaleTabViewModel(state, eventAggregator, settingsService);
         Captioning = new CaptioningTabViewModel(eventAggregator, state, captioningService, captioningBackends, settingsService, readinessService, downloadCoordinator);
         BatchUpscale = new BatchUpscaleTabViewModel(eventAggregator, state, comfyUiService, settingsService, readinessService);

--- a/DiffusionNexus.UI/ViewModels/OutpaintingViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/OutpaintingViewModel.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DiffusionNexus.Domain.Enums;
 using DiffusionNexus.Domain.Services;
+using DiffusionNexus.Domain.Services.UnifiedLogging;
 using DiffusionNexus.UI.ImageEditor.Services;
 using Serilog;
 
@@ -94,13 +95,17 @@ public partial class OutpaintingViewModel : ObservableObject
     private string? _progressDisplayText;
     private int _lastDisplayTextIndex = -1;
 
+    private readonly IUnifiedLogger? _unifiedLogger;
+    private const string LogSource = "Outpaint";
+
     public OutpaintingViewModel(
         Func<bool> hasImage,
         Func<int> getImageWidth,
         Func<int> getImageHeight,
         Action<string> deactivateOtherTools,
         IComfyUIWrapperService? comfyUiService = null,
-        IComfyUIReadinessService? readinessService = null)
+        IComfyUIReadinessService? readinessService = null,
+        IUnifiedLogger? unifiedLogger = null)
     {
         ArgumentNullException.ThrowIfNull(hasImage);
         ArgumentNullException.ThrowIfNull(getImageWidth);
@@ -112,6 +117,7 @@ public partial class OutpaintingViewModel : ObservableObject
         _getImageHeight = getImageHeight;
         _deactivateOtherTools = deactivateOtherTools;
         _comfyUiService = comfyUiService;
+        _unifiedLogger = unifiedLogger;
 
         Readiness = new ComfyUIReadinessViewModel(readinessService, ComfyUIFeature.Outpaint);
         VisionReadiness = new ComfyUIReadinessViewModel(readinessService, ComfyUIFeature.OutpaintVision);
@@ -122,10 +128,104 @@ public partial class OutpaintingViewModel : ObservableObject
         SetAspectRatioCommand = new RelayCommand<string>(ExecuteSetAspectRatio, _ => _hasImage() && IsPanelOpen);
         GenerateCommand = new AsyncRelayCommand(
             () => ExecuteGenerateAsync(useVision: false),
-            () => _hasImage() && IsPanelOpen && !IsBusy && HasExtension);
+            () => _hasImage() && IsPanelOpen && !IsBusy && HasExtension && IsReadinessClickable(Readiness));
         GenerateVisionCommand = new AsyncRelayCommand(
             () => ExecuteGenerateAsync(useVision: true),
-            () => _hasImage() && IsPanelOpen && !IsBusy && HasExtension);
+            () => _hasImage() && IsPanelOpen && !IsBusy && HasExtension && IsReadinessClickable(VisionReadiness));
+
+        // Re-evaluate Generate / Generate (Vision) CanExecute whenever the matching readiness
+        // view-model finishes a check — otherwise the buttons stay enabled after the workload
+        // status flips from Full → Partial (or vice versa) without a user-driven property change.
+        Readiness.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName is nameof(ComfyUIReadinessViewModel.IsReady)
+                                  or nameof(ComfyUIReadinessViewModel.HasChecked))
+            {
+                GenerateCommand.NotifyCanExecuteChanged();
+                LogCanExecuteState($"after Readiness.{args.PropertyName}");
+            }
+
+            // The reusable readiness panel's "Check" button only triggers Readiness — not
+            // VisionReadiness. Both back the same SDK workload, so when Readiness finishes a
+            // check we also re-run Vision so its state doesn't go stale (e.g. left as
+            // ServerOffline from a prior run before ComfyUI was started).
+            if (args.PropertyName == nameof(ComfyUIReadinessViewModel.IsChecking)
+                && !Readiness.IsChecking
+                && !VisionReadiness.IsChecking)
+            {
+                _ = VisionReadiness.CheckReadinessAsync();
+            }
+        };
+        VisionReadiness.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName is nameof(ComfyUIReadinessViewModel.IsReady)
+                                  or nameof(ComfyUIReadinessViewModel.HasChecked))
+            {
+                GenerateVisionCommand.NotifyCanExecuteChanged();
+                LogCanExecuteState($"after VisionReadiness.{args.PropertyName}");
+            }
+        };
+    }
+
+    /// <summary>
+    /// A feature is clickable once readiness either reports ready, or readiness has never
+    /// been checked yet (initial state — the button shouldn't be disabled before we know).
+    /// As soon as the first check completes with <c>IsReady=false</c>, the button greys out.
+    /// </summary>
+    private static bool IsReadinessClickable(ComfyUIReadinessViewModel readiness) =>
+        !readiness.HasChecked || readiness.IsReady;
+
+    /// <summary>
+    /// Runs both readiness checks in parallel. Fired automatically when the panel opens
+    /// so the Generate / Generate (Vision) buttons reflect installation state without the
+    /// user having to press the "Check" button. Outpaint and OutpaintVision share an SDK
+    /// workload, so both checks resolve against the same disk state.
+    /// </summary>
+    private async Task RunReadinessChecksAsync()
+    {
+        try
+        {
+            EmitInfo("starting readiness checks (Outpaint + OutpaintVision)");
+            await Task.WhenAll(
+                Readiness.CheckReadinessAsync(),
+                VisionReadiness.CheckReadinessAsync());
+            LogCanExecuteState("after readiness check");
+        }
+        catch (OperationCanceledException)
+        {
+            // Cancellation during panel close — nothing to do.
+        }
+        catch (Exception ex)
+        {
+            Logger.Warning(ex, "Outpaint readiness checks failed");
+            _unifiedLogger?.Warn(LogCategory.Configuration, LogSource,
+                $"Readiness checks failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Logs the value of every CanExecute gate for Generate and Generate (Vision), so when
+    /// a user reports "the button is disabled" the log clearly says which gate is blocking.
+    /// Cheap (just bool reads + one log line) and only fires on readiness completion and on
+    /// generate-button clicks, not on every WPF CanExecute poll.
+    /// </summary>
+    private void LogCanExecuteState(string context)
+    {
+        var message =
+            $"CanExecute ({context}): hasImage={_hasImage()}, panelOpen={IsPanelOpen}, " +
+            $"isBusy={IsBusy}, hasExtension={HasExtension}, " +
+            $"outpaintReady={Readiness.IsReady} (checked={Readiness.HasChecked}), " +
+            $"visionReady={VisionReadiness.IsReady} (checked={VisionReadiness.HasChecked}) " +
+            $"→ Generate={GenerateCommand.CanExecute(null)}, " +
+            $"GenerateVision={GenerateVisionCommand.CanExecute(null)}";
+        EmitInfo(message);
+    }
+
+    /// <summary>Emits to both Serilog (file) and the in-app unified console when available.</summary>
+    private void EmitInfo(string message)
+    {
+        Logger.Information("Outpaint: {Message}", message);
+        _unifiedLogger?.Info(LogCategory.Configuration, LogSource, message);
     }
 
     /// <summary>Readiness check for the prompt-driven Outpaint workflow.</summary>
@@ -149,6 +249,7 @@ public partial class OutpaintingViewModel : ObservableObject
                     _deactivateOtherTools(ToolIds.Outpainting);
                     OutpaintToolActivated?.Invoke(this, EventArgs.Empty);
                     StatusMessageChanged?.Invoke(this, "Outpaint: Drag arrows to extend the canvas. Use aspect ratio presets on the right.");
+                    _ = RunReadinessChecksAsync();
                 }
                 else
                 {
@@ -182,7 +283,10 @@ public partial class OutpaintingViewModel : ObservableObject
         private set
         {
             if (SetProperty(ref _hasExtension, value))
+            {
+                EmitInfo($"HasExtension → {value}");
                 NotifyGenerateCommandsCanExecuteChanged();
+            }
         }
     }
 
@@ -480,9 +584,24 @@ public partial class OutpaintingViewModel : ObservableObject
 
     private async Task ExecuteGenerateAsync(bool useVision)
     {
+        LogCanExecuteState(useVision ? "click Generate (Vision)" : "click Generate");
+
         // Clear any stale error display from a previous attempt before validating,
         // so the user always gets visual feedback that the click registered.
         ResetErrorState();
+
+        // Short-circuit before any IO when the backing workload isn't fully installed.
+        // Same source of truth as the Installer Manager — if the workload would show as
+        // Partial/None there, no Generate attempt should reach the upload step.
+        var readiness = useVision ? VisionReadiness : Readiness;
+        if (readiness.HasChecked && !readiness.IsReady)
+        {
+            var detail = readiness.MissingRequirements.Count > 0
+                ? readiness.MissingRequirements[0]
+                : "Required nodes or models are missing.";
+            ReportValidationError(detail);
+            return;
+        }
 
         if (!useVision && string.IsNullOrWhiteSpace(_positivePrompt))
         {

--- a/DiffusionNexus.UI/ViewModels/Tabs/BatchUpscaleTabViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/Tabs/BatchUpscaleTabViewModel.cs
@@ -740,6 +740,18 @@ public partial class BatchUpscaleTabViewModel : ViewModelBase, IDialogServiceAwa
             return;
         }
 
+        // Defensive short-circuit: if readiness has flipped to "not ready" between the
+        // CanExecute check and the click, surface the same message the readiness panel
+        // shows so the user isn't left wondering why nothing happens.
+        var requiredReadiness = PromptMode == UpscalePromptMode.VisionAutoPrompt ? VisionReadiness : Readiness;
+        if (requiredReadiness.HasChecked && !requiredReadiness.IsReady)
+        {
+            CurrentProcessingStatus = requiredReadiness.MissingRequirements.Count > 0
+                ? requiredReadiness.MissingRequirements[0]
+                : "Required nodes or models are missing.";
+            return;
+        }
+
         // --- Single Image Mode ---
         if (IsSingleImageMode)
         {

--- a/DiffusionNexus.UI/ViewModels/Tabs/ImageEditTabViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/Tabs/ImageEditTabViewModel.cs
@@ -266,7 +266,8 @@ public partial class ImageEditTabViewModel : ObservableObject, IDialogServiceAwa
         IBackgroundRemovalService? backgroundRemovalService = null,
         IComfyUIWrapperService? comfyUiService = null,
         IThumbnailOrchestrator? thumbnailOrchestrator = null,
-        IComfyUIReadinessService? readinessService = null)
+        IComfyUIReadinessService? readinessService = null,
+        Domain.Services.UnifiedLogging.IUnifiedLogger? unifiedLogger = null)
     {
         _eventAggregator = eventAggregator ?? throw new ArgumentNullException(nameof(eventAggregator));
         _state = state ?? throw new ArgumentNullException(nameof(state));
@@ -276,7 +277,7 @@ public partial class ImageEditTabViewModel : ObservableObject, IDialogServiceAwa
         _readinessService = readinessService;
 
         // Create the image editor with background removal service
-        ImageEditor = new ImageEditorViewModel(_eventAggregator, _backgroundRemovalService, _comfyUiService, readinessService: _readinessService);
+        ImageEditor = new ImageEditorViewModel(_eventAggregator, _backgroundRemovalService, _comfyUiService, readinessService: _readinessService, unifiedLogger: unifiedLogger);
 
         // Subscribe to events
         _eventAggregator.NavigateToImageEditorRequested += OnNavigateToImageEditorRequested;

--- a/DiffusionNexus.UI/ViewModels/UnifiedConsoleViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/UnifiedConsoleViewModel.cs
@@ -294,7 +294,22 @@ public partial class UnifiedConsoleViewModel : ViewModelBase, IDisposable
     partial void OnShowInfoChanged(bool value) => ApplyFilters();
     partial void OnShowWarningChanged(bool value) => ApplyFilters();
     partial void OnShowErrorChanged(bool value) => ApplyFilters();
-    partial void OnCategoryFilterChanged(LogCategory? value) => ApplyFilters();
+    partial void OnCategoryFilterChanged(LogCategory? value)
+    {
+        // When the user explicitly switches the category away from InstanceManagement
+        // (e.g. picks "All Categories"), also drop the instance-tab selection so
+        // app-level entries — which carry their own source contexts, not the instance
+        // name/id — become visible again. Without this the user picks "All Categories"
+        // but ShouldInclude still demands a matching SelectedInstance source.
+        if (value != LogCategory.InstanceManagement && SelectedInstance is not null)
+        {
+            foreach (var t in InstanceTabs) t.IsSelected = false;
+            SelectedInstance = null; // ApplyFilters will run via OnSelectedInstanceChanged
+            return;
+        }
+
+        ApplyFilters();
+    }
     partial void OnTaskIdFilterChanged(string? value) => ApplyFilters();
     partial void OnSearchTextChanged(string? value) => ApplyFilters();
     partial void OnSelectedInstanceChanged(InstanceTabItem? value) => ApplyFilters();

--- a/DiffusionNexus.UI/Views/Controls/UnifiedConsoleView.axaml
+++ b/DiffusionNexus.UI/Views/Controls/UnifiedConsoleView.axaml
@@ -2,6 +2,7 @@
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
   xmlns:vm="using:DiffusionNexus.UI.ViewModels"
   xmlns:ul="using:DiffusionNexus.Domain.Services.UnifiedLogging"
+  xmlns:converters="using:DiffusionNexus.UI.Converters"
   x:Class="DiffusionNexus.UI.Views.Controls.UnifiedConsoleView"
   x:DataType="vm:UnifiedConsoleViewModel">
   <UserControl.Styles>
@@ -102,7 +103,13 @@
             <ToggleButton Classes="level-toggle" Content="WRN" IsChecked="{Binding ShowWarning}"/>
             <ToggleButton Classes="level-toggle" Content="ERR" IsChecked="{Binding ShowError}"/>
             <Border Width="1" Background="#3C3C3C" Margin="8,0"/>
-            <ComboBox ItemsSource="{Binding AvailableCategories}" SelectedItem="{Binding CategoryFilter}" PlaceholderText="All Categories" MinWidth="130" FontSize="12"/>
+            <ComboBox ItemsSource="{Binding AvailableCategories}" SelectedItem="{Binding CategoryFilter}" PlaceholderText="All Categories" MinWidth="130" FontSize="12">
+              <ComboBox.ItemTemplate>
+                <DataTemplate>
+                  <TextBlock Text="{Binding Converter={x:Static converters:LogCategoryDisplayConverter.Instance}}"/>
+                </DataTemplate>
+              </ComboBox.ItemTemplate>
+            </ComboBox>
             <Border Width="1" Background="#3C3C3C" Margin="8,0"/>
             <TextBox Text="{Binding SearchText}" Watermark="Search..." MinWidth="150" FontSize="12"/>
           </StackPanel>

--- a/DiffusionNexus.UI/Views/Dialogs/ReplaceDialog.axaml
+++ b/DiffusionNexus.UI/Views/Dialogs/ReplaceDialog.axaml
@@ -8,8 +8,7 @@
         WindowStartupLocation="CenterOwner"
         CanResize="False"
         Background="#252526"
-        Title="Replace Image"
-        Icon="avares://DiffusionNexus.UI/Assets/AIKnowledgeIcon.png">
+        Title="Replace Image">
   
   <Grid RowDefinitions="Auto,*,Auto">
       <StackPanel>

--- a/DiffusionNexus.UI/Views/Dialogs/ReplaceDialog.axaml.cs
+++ b/DiffusionNexus.UI/Views/Dialogs/ReplaceDialog.axaml.cs
@@ -3,6 +3,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Avalonia.Platform.Storage;
+using DiffusionNexus.UI.Services;
 using DiffusionNexus.UI.ViewModels;
 
 namespace DiffusionNexus.UI.Views.Dialogs;
@@ -12,7 +13,8 @@ public partial class ReplaceDialog : Window, IDialogCloseable
     public ReplaceDialog()
     {
         InitializeComponent();
-        
+        Icon = SafeAssetBitmap.LoadWindowIcon("avares://DiffusionNexus.UI/Assets/AIKnowledgeIcon.png");
+
         AddHandler(DragDrop.DropEvent, OnDrop);
         AddHandler(DragDrop.DragEnterEvent, OnDragEnter);
         AddHandler(DragDrop.DragLeaveEvent, OnDragLeave);

--- a/DiffusionNexus.UI/Views/DiffusionNexusMainWindow.axaml
+++ b/DiffusionNexus.UI/Views/DiffusionNexusMainWindow.axaml
@@ -2,13 +2,13 @@
 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 xmlns:vm="using:DiffusionNexus.UI.ViewModels"
 xmlns:controls="using:DiffusionNexus.UI.Views.Controls"
+xmlns:m="using:DiffusionNexus.UI.Markup"
 x:Class="DiffusionNexus.UI.Views.DiffusionNexusMainWindow"
 x:DataType="vm:DiffusionNexusMainWindowViewModel"
 Title="{Binding AppVersion, StringFormat='Diffusion Nexus v{0}'}"
 MinWidth="1300" MinHeight="800"
 Width="1400" Height="900"
 WindowStartupLocation="CenterScreen"
-Icon="avares://DiffusionNexus.UI/Assets/AIKnowledgeIcon.png"
 x:Name="MainWin">
     
     <Design.DataContext>
@@ -56,7 +56,7 @@ x:Name="MainWin">
                                         Command="{Binding OpenYoutubeCommand}"
                                         HorizontalContentAlignment="Left">
                                     <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <Image Source="avares://DiffusionNexus.UI/Assets/yt.png" Width="32" Height="32"/>
+                                        <Image Source="{m:SafeAsset avares://DiffusionNexus.UI/Assets/yt.png}" Width="32" Height="32"/>
                                         <TextBlock Text="Youtube" VerticalAlignment="Center"
                                                    IsVisible="{Binding IsMenuOpen}"/>
                                     </StackPanel>
@@ -65,7 +65,7 @@ x:Name="MainWin">
                                         Command="{Binding OpenPatreonCommand}"
                                         HorizontalContentAlignment="Left">
                                     <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <Image Source="avares://DiffusionNexus.UI/Assets/patreon.png" Width="32" Height="32"/>
+                                        <Image Source="{m:SafeAsset avares://DiffusionNexus.UI/Assets/patreon.png}" Width="32" Height="32"/>
                                         <TextBlock Text="Patreon" VerticalAlignment="Center"
                                                    IsVisible="{Binding IsMenuOpen}"/>
                                     </StackPanel>
@@ -74,7 +74,7 @@ x:Name="MainWin">
                                         Command="{Binding OpenCivitaiCommand}"
                                         HorizontalContentAlignment="Left">
                                     <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <Image Source="avares://DiffusionNexus.UI/Assets/civitai.png" Width="32" Height="32"/>
+                                        <Image Source="{m:SafeAsset avares://DiffusionNexus.UI/Assets/civitai.png}" Width="32" Height="32"/>
                                         <TextBlock Text="Civitai" VerticalAlignment="Center"
                                                    IsVisible="{Binding IsMenuOpen}"/>
                                     </StackPanel>
@@ -175,7 +175,7 @@ x:Name="MainWin">
                                HorizontalAlignment="Center"/>
                     
                     <!-- Banner Image -->
-                    <Image Source="avares://DiffusionNexus.UI/Assets/Banner-cut.png"
+                    <Image Source="{m:SafeAsset avares://DiffusionNexus.UI/Assets/Banner-cut.png}"
                            Stretch="Uniform"
                            MaxHeight="120"
                            HorizontalAlignment="Center"/>

--- a/DiffusionNexus.UI/Views/DiffusionNexusMainWindow.axaml.cs
+++ b/DiffusionNexus.UI/Views/DiffusionNexusMainWindow.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using DiffusionNexus.UI.Services;
 using DiffusionNexus.UI.ViewModels;
 
 namespace DiffusionNexus.UI.Views;
@@ -8,6 +9,7 @@ public partial class DiffusionNexusMainWindow : Window
     public DiffusionNexusMainWindow()
     {
         InitializeComponent();
+        Icon = SafeAssetBitmap.LoadWindowIcon("avares://DiffusionNexus.UI/Assets/AIKnowledgeIcon.png");
         Closing += OnWindowClosing;
     }
 

--- a/DiffusionNexus.UI/Views/ImageCompareView.axaml
+++ b/DiffusionNexus.UI/Views/ImageCompareView.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="using:DiffusionNexus.UI.ViewModels"
              xmlns:controls="using:DiffusionNexus.UI.Views.Controls"
              xmlns:converters="using:DiffusionNexus.UI.Converters"
+             xmlns:m="using:DiffusionNexus.UI.Markup"
              mc:Ignorable="d"
              d:DesignWidth="1200"
              d:DesignHeight="900"
@@ -214,7 +215,7 @@
                 Opacity="0.9"
                 IsHitTestVisible="False">
           <StackPanel Orientation="Vertical" Spacing="4">
-            <Image Source="avares://DiffusionNexus.UI/Assets/mouse.png"
+            <Image Source="{m:SafeAsset avares://DiffusionNexus.UI/Assets/mouse.png}"
                    Width="280"
                    Stretch="Uniform"
                    HorizontalAlignment="Center"/>


### PR DESCRIPTION
Brings the readiness-checker hotfix (#358) from `main` into `develop` with the two-way conflicts resolved.

Equivalent to merging `main` into `develop`, but expressed as a single non-merge commit on top of `main` so it passes the server-side push hook (which rejects merge commits whose first parent is `develop`'s tip).

## Conflicts resolved

Both files had both branches making changes in the same spot.

### `DiffusionNexus.UI/ViewModels/LoraDatasetHelperViewModel.cs`
Both sides added a new optional last parameter to the constructor:
- develop: `IDownloadCoordinator? downloadCoordinator = null`
- main (hotfix): `Domain.Services.UnifiedLogging.IUnifiedLogger? unifiedLogger = null`

Kept both, in order: `downloadCoordinator`, then `unifiedLogger`. The design-time constructor's 19 positional `null`s still bind correctly because both params are optional.

### `DiffusionNexus.UI/App.axaml.cs`
`LoraDatasetHelperViewModel` DI registration: develop appended `sp.GetService<IDownloadCoordinator>()` at the end and added a new `DiscoverComfyUiCaptioningPaths` helper method; main appended `sp.GetService<IUnifiedLogger>()`. The registration now passes both, in the constructor's order, and the captioning-path helper is preserved untouched.

## Verification

Solution builds clean. 76 readiness/feature/captioning tests pass (`ComfyUI*`, `Workload*`, `Outpaint*`, `Inpaint*`, `Readiness*`, `Configuration*`, `Captioning*`).

## Notes

- PR #359 (`main → develop`) can be closed once this merges; the contents land here.