### PR TITLE
Test coverage Priority 1 — coverage tooling + Captioning unit tests (refs #325)

### DIFF
--- a/DiffusionNexus.Tests/Inference/Captioning/CaptioningModelManagerTests.cs
+++ b/DiffusionNexus.Tests/Inference/Captioning/CaptioningModelManagerTests.cs
@@ -1,0 +1,421 @@
+using DiffusionNexus.Domain.Enums;
+using DiffusionNexus.Domain.Services;
+using DiffusionNexus.Inference.Captioning;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.Inference.Captioning;
+
+/// <summary>
+/// Unit tests for <see cref="CaptioningModelManager"/>. Uses temp directories
+/// plus the sparse-file pattern (<see cref="FileStream.SetLength"/>) to fake
+/// the multi-gigabyte model GGUFs without touching the network or actually
+/// allocating disk space — every fixture stays well under a megabyte.
+/// </summary>
+public sealed class CaptioningModelManagerTests : IDisposable
+{
+    private readonly string _root;
+    private readonly CaptioningModelManager _manager;
+
+    public CaptioningModelManagerTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "dn-capmgr-" + Guid.NewGuid().ToString("N"));
+        _manager = new CaptioningModelManager(_root, httpClient: null);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    /// <summary>
+    /// Writes a sparse file at <paramref name="absolutePath"/> with the given logical
+    /// length. NTFS allocates a small extent header — actual disk usage is bytes,
+    /// not gigabytes — but <see cref="FileInfo.Length"/> reports the full length, so
+    /// <see cref="CaptioningModelManager.GetModelStatus"/>'s 80%-threshold check
+    /// honours the fake size.
+    /// </summary>
+    private static void WriteSparseFile(string absolutePath, long length)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(absolutePath)!);
+        using var fs = new FileStream(absolutePath, FileMode.Create, FileAccess.Write);
+        fs.SetLength(length);
+    }
+
+    #region Constructor
+
+    [Fact]
+    public void Ctor_CreatesModelsDirectory()
+    {
+        var path = Path.Combine(_root, "models-fresh");
+        Directory.Exists(path).Should().BeFalse();
+
+        _ = new CaptioningModelManager(path, httpClient: null);
+
+        Directory.Exists(path).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Ctor_DefaultPath_DoesNotThrow()
+    {
+        // Default ctor must build a usable manager without arguments.
+        // Exercising it covers the default-folder branch (LocalAppData).
+        var manager = new CaptioningModelManager();
+        manager.SearchPaths.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void SearchPaths_StartsWithBasePath()
+    {
+        _manager.SearchPaths[0].Should().Be(_root);
+    }
+
+    #endregion
+
+    #region Static helpers — IsDownloadable / IsTiered / VRAM tiers
+
+    [Theory]
+    [InlineData(CaptioningModelType.LLaVA_v1_6_34B, true)]
+    [InlineData(CaptioningModelType.Qwen2_5_VL_7B, true)]
+    [InlineData(CaptioningModelType.Qwen3_VL_8B, true)]
+    [InlineData(CaptioningModelType.Qwen3_VL_8B_Abliterated_Caption, true)]
+    [InlineData(CaptioningModelType.Qwen3_VL_8B_NSFW_Caption_V4, true)]
+    public void IsDownloadable_TrueForKnownModels(CaptioningModelType modelType, bool expected)
+    {
+        CaptioningModelManager.IsDownloadable(modelType).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(CaptioningModelType.LLaVA_v1_6_34B, false)]
+    [InlineData(CaptioningModelType.Qwen2_5_VL_7B, false)]
+    [InlineData(CaptioningModelType.Qwen3_VL_8B, false)]
+    [InlineData(CaptioningModelType.Qwen3_VL_8B_Abliterated_Caption, true)]
+    [InlineData(CaptioningModelType.Qwen3_VL_8B_NSFW_Caption_V4, true)]
+    public void IsTieredDownloadable_OnlyTrueForVramTieredModels(CaptioningModelType modelType, bool expected)
+    {
+        CaptioningModelManager.IsTieredDownloadable(modelType).Should().Be(expected);
+    }
+
+    [Fact]
+    public void GetSupportedVramTiers_ReturnsCanonicalSetForTieredModels()
+    {
+        var tiers = CaptioningModelManager.GetSupportedVramTiers(
+            CaptioningModelType.Qwen3_VL_8B_Abliterated_Caption);
+
+        tiers.Should().Equal(8, 12, 16, 24, 32);
+    }
+
+    [Fact]
+    public void GetSupportedVramTiers_EmptyForNonTieredModels()
+    {
+        CaptioningModelManager.GetSupportedVramTiers(CaptioningModelType.LLaVA_v1_6_34B)
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetSupportedVramTiers_ReturnsACopyEachCall()
+    {
+        // Mutating the returned array must not affect the next caller.
+        var a = CaptioningModelManager.GetSupportedVramTiers(
+            CaptioningModelType.Qwen3_VL_8B_Abliterated_Caption);
+        a[0] = -999;
+        var b = CaptioningModelManager.GetSupportedVramTiers(
+            CaptioningModelType.Qwen3_VL_8B_Abliterated_Caption);
+
+        b[0].Should().Be(8);
+    }
+
+    #endregion
+
+    #region Display-name / Description
+
+    [Theory]
+    [InlineData(CaptioningModelType.LLaVA_v1_6_34B)]
+    [InlineData(CaptioningModelType.Qwen2_5_VL_7B)]
+    [InlineData(CaptioningModelType.Qwen3_VL_8B)]
+    [InlineData(CaptioningModelType.Qwen3_VL_8B_Abliterated_Caption)]
+    [InlineData(CaptioningModelType.Qwen3_VL_8B_NSFW_Caption_V4)]
+    public void GetDisplayName_ReturnsNonEmptyHumanReadableString(CaptioningModelType modelType)
+    {
+        var name = CaptioningModelManager.GetDisplayName(modelType);
+        name.Should().NotBeNullOrWhiteSpace();
+        // Friendlier than the raw enum value.
+        name.Should().NotBe(modelType.ToString());
+    }
+
+    [Theory]
+    [InlineData(CaptioningModelType.LLaVA_v1_6_34B)]
+    [InlineData(CaptioningModelType.Qwen2_5_VL_7B)]
+    [InlineData(CaptioningModelType.Qwen3_VL_8B)]
+    [InlineData(CaptioningModelType.Qwen3_VL_8B_Abliterated_Caption)]
+    [InlineData(CaptioningModelType.Qwen3_VL_8B_NSFW_Caption_V4)]
+    public void GetDescription_ReturnsNonEmptyString(CaptioningModelType modelType)
+    {
+        CaptioningModelManager.GetDescription(modelType).Should().NotBeNullOrWhiteSpace();
+    }
+
+    #endregion
+
+    #region Path resolution
+
+    [Theory]
+    [InlineData(CaptioningModelType.LLaVA_v1_6_34B)]
+    [InlineData(CaptioningModelType.Qwen2_5_VL_7B)]
+    [InlineData(CaptioningModelType.Qwen3_VL_8B)]
+    public void GetModelPath_NonTieredReturnsAbsolutePathInBaseFolderWhenMissing(CaptioningModelType modelType)
+    {
+        var path = _manager.GetModelPath(modelType);
+
+        Path.IsPathRooted(path).Should().BeTrue();
+        path.Should().StartWith(_root);
+        Path.GetExtension(path).Should().Be(".gguf");
+    }
+
+    [Theory]
+    [InlineData(CaptioningModelType.LLaVA_v1_6_34B)]
+    [InlineData(CaptioningModelType.Qwen2_5_VL_7B)]
+    [InlineData(CaptioningModelType.Qwen3_VL_8B)]
+    public void GetClipProjectorPath_NonTieredReturnsAbsolutePathInBaseFolderWhenMissing(CaptioningModelType modelType)
+    {
+        var path = _manager.GetClipProjectorPath(modelType);
+
+        Path.IsPathRooted(path).Should().BeTrue();
+        path.Should().StartWith(_root);
+        Path.GetExtension(path).Should().Be(".gguf");
+    }
+
+    [Theory]
+    [InlineData(CaptioningModelType.Qwen3_VL_8B_Abliterated_Caption)]
+    [InlineData(CaptioningModelType.Qwen3_VL_8B_NSFW_Caption_V4)]
+    public void GetModelPath_TieredFallsBackToSmallestTierWhenNothingOnDisk(CaptioningModelType modelType)
+    {
+        // No tier is on disk, so the manager should return the path for the
+        // smallest defined tier (8 GB) inside the base folder.
+        var defaultPath = _manager.GetModelPath(modelType);
+        var explicitSmallTierPath = _manager.GetModelPath(modelType, vramGb: 8);
+
+        Path.GetFileName(defaultPath).Should().Be(Path.GetFileName(explicitSmallTierPath));
+    }
+
+    [Fact]
+    public void GetModelPath_TieredWithExplicitTier_PicksLargestThatFits()
+    {
+        // 22 GB doesn't match any tier exactly; should pick the next-smaller (16 GB).
+        var pathAt16 = _manager.GetModelPath(
+            CaptioningModelType.Qwen3_VL_8B_Abliterated_Caption, vramGb: 16);
+        var pathAt22 = _manager.GetModelPath(
+            CaptioningModelType.Qwen3_VL_8B_Abliterated_Caption, vramGb: 22);
+
+        Path.GetFileName(pathAt16).Should().Be(Path.GetFileName(pathAt22));
+    }
+
+    [Fact]
+    public void GetModelPath_TieredBelowSmallestThrows()
+    {
+        var act = () => _manager.GetModelPath(
+            CaptioningModelType.Qwen3_VL_8B_Abliterated_Caption, vramGb: 4);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void GetExpectedTierTotalBytes_SumsModelPlusMmproj()
+    {
+        var total = _manager.GetExpectedTierTotalBytes(
+            CaptioningModelType.Qwen3_VL_8B_Abliterated_Caption, vramGb: 8);
+
+        // Two non-zero file sizes summed — should comfortably exceed each individually.
+        total.Should().BeGreaterThan(1_000_000_000);
+    }
+
+    #endregion
+
+    #region Expected sizes
+
+    [Theory]
+    [InlineData(CaptioningModelType.LLaVA_v1_6_34B)]
+    [InlineData(CaptioningModelType.Qwen2_5_VL_7B)]
+    [InlineData(CaptioningModelType.Qwen3_VL_8B)]
+    [InlineData(CaptioningModelType.Qwen3_VL_8B_Abliterated_Caption)]
+    [InlineData(CaptioningModelType.Qwen3_VL_8B_NSFW_Caption_V4)]
+    public void GetExpectedModelSize_PositiveForEveryKnownModel(CaptioningModelType modelType)
+    {
+        _manager.GetExpectedModelSize(modelType).Should().BeGreaterThan(0);
+    }
+
+    #endregion
+
+    #region Status
+
+    [Theory]
+    [InlineData(CaptioningModelType.LLaVA_v1_6_34B)]
+    [InlineData(CaptioningModelType.Qwen2_5_VL_7B)]
+    [InlineData(CaptioningModelType.Qwen3_VL_8B)]
+    public void GetModelStatus_NotDownloaded_WhenNoFilesPresent(CaptioningModelType modelType)
+    {
+        _manager.GetModelStatus(modelType).Should().Be(CaptioningModelStatus.NotDownloaded);
+    }
+
+    [Fact]
+    public void GetModelStatus_Corrupted_WhenModelFileWayUnderExpectedSize()
+    {
+        // Plant the model + mmproj files but make the model file way under the
+        // expected size (80% threshold). Reports Corrupted.
+        var modelPath = _manager.GetModelPath(CaptioningModelType.Qwen2_5_VL_7B);
+        var mmprojPath = _manager.GetClipProjectorPath(CaptioningModelType.Qwen2_5_VL_7B);
+        var expectedSize = _manager.GetExpectedModelSize(CaptioningModelType.Qwen2_5_VL_7B);
+
+        // Model: 10% of expected — well below the 80% threshold.
+        WriteSparseFile(modelPath, expectedSize / 10);
+        // mmproj: any non-zero file is fine; status only checks the model size.
+        WriteSparseFile(mmprojPath, 1024);
+
+        _manager.GetModelStatus(CaptioningModelType.Qwen2_5_VL_7B)
+            .Should().Be(CaptioningModelStatus.Corrupted);
+    }
+
+    [Fact]
+    public void GetModelStatus_Ready_WhenBothFilesPresentAtExpectedSize()
+    {
+        var modelPath = _manager.GetModelPath(CaptioningModelType.Qwen2_5_VL_7B);
+        var mmprojPath = _manager.GetClipProjectorPath(CaptioningModelType.Qwen2_5_VL_7B);
+        var expectedSize = _manager.GetExpectedModelSize(CaptioningModelType.Qwen2_5_VL_7B);
+
+        WriteSparseFile(modelPath, expectedSize);
+        WriteSparseFile(mmprojPath, expectedSize / 4);
+
+        _manager.GetModelStatus(CaptioningModelType.Qwen2_5_VL_7B)
+            .Should().Be(CaptioningModelStatus.Ready);
+    }
+
+    [Fact]
+    public void GetModelInfo_PopulatesAllFields()
+    {
+        var info = _manager.GetModelInfo(CaptioningModelType.LLaVA_v1_6_34B);
+
+        info.ModelType.Should().Be(CaptioningModelType.LLaVA_v1_6_34B);
+        info.Status.Should().Be(CaptioningModelStatus.NotDownloaded);
+        info.FilePath.Should().NotBeNullOrWhiteSpace();
+        info.ExpectedSizeBytes.Should().BeGreaterThan(0);
+        info.DisplayName.Should().NotBeNullOrWhiteSpace();
+        info.Description.Should().NotBeNullOrWhiteSpace();
+        // No file on disk yet, so reported size is zero.
+        info.FileSizeBytes.Should().Be(0);
+    }
+
+    #endregion
+
+    #region DownloadModelAsync — short-circuit paths
+
+    [Fact]
+    public async Task DownloadModelAsync_TieredCalledOnNonTieredOverload_ShortCircuitsToFalse()
+    {
+        // Non-tiered overload must refuse a tiered model rather than guessing a tier.
+        var ok = await _manager.DownloadModelAsync(
+            CaptioningModelType.Qwen3_VL_8B_Abliterated_Caption,
+            progress: null,
+            cancellationToken: CancellationToken.None);
+
+        ok.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DownloadModelAsync_NonTieredAlreadyPresent_ShortCircuitsToTrue()
+    {
+        // Pre-plant a model + mmproj for Qwen3_VL_8B at full expected size.
+        var modelPath = _manager.GetModelPath(CaptioningModelType.Qwen3_VL_8B);
+        var mmprojPath = _manager.GetClipProjectorPath(CaptioningModelType.Qwen3_VL_8B);
+        var modelSize = _manager.GetExpectedModelSize(CaptioningModelType.Qwen3_VL_8B);
+
+        WriteSparseFile(modelPath, modelSize);
+        WriteSparseFile(mmprojPath, modelSize / 4);
+
+        // Use a synchronous IProgress so the callback has definitely fired
+        // before we observe it. Progress<T> would post to a SynchronizationContext
+        // (or the ThreadPool when none is present) and races the test thread.
+        var progressReports = new List<ModelDownloadProgress>();
+        var progress = new SyncProgress(progressReports.Add);
+
+        var ok = await _manager.DownloadModelAsync(
+            CaptioningModelType.Qwen3_VL_8B,
+            progress: progress,
+            cancellationToken: CancellationToken.None);
+
+        ok.Should().BeTrue();
+        // No HTTP call should have been issued — the short-circuit path reports
+        // 'already downloaded' as the final progress.
+        progressReports.Should().NotBeEmpty();
+        progressReports[^1].Status.Should().Contain("already downloaded");
+    }
+
+    /// <summary>Synchronous IProgress shim — runs the callback inline.</summary>
+    private sealed class SyncProgress : IProgress<ModelDownloadProgress>
+    {
+        private readonly Action<ModelDownloadProgress> _onReport;
+        public SyncProgress(Action<ModelDownloadProgress> onReport) => _onReport = onReport;
+        public void Report(ModelDownloadProgress value) => _onReport(value);
+    }
+
+    [Fact]
+    public async Task DownloadModelAsync_TieredAlreadyPresent_ShortCircuitsToTrue()
+    {
+        // Tiered overload short-circuits when the chosen tier's pair is present.
+        var modelPath = _manager.GetModelPath(
+            CaptioningModelType.Qwen3_VL_8B_Abliterated_Caption, vramGb: 8);
+        var mmprojPath = _manager.GetClipProjectorPath(
+            CaptioningModelType.Qwen3_VL_8B_Abliterated_Caption, vramGb: 8);
+        var tierTotal = _manager.GetExpectedTierTotalBytes(
+            CaptioningModelType.Qwen3_VL_8B_Abliterated_Caption, vramGb: 8);
+
+        // Use over-sized sparse files so each is comfortably above its 80% threshold.
+        WriteSparseFile(modelPath, tierTotal);
+        WriteSparseFile(mmprojPath, tierTotal);
+
+        var ok = await _manager.DownloadModelAsync(
+            CaptioningModelType.Qwen3_VL_8B_Abliterated_Caption,
+            vramGb: 8,
+            progress: null,
+            cancellationToken: CancellationToken.None);
+
+        ok.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region DeleteModel
+
+    [Fact]
+    public void DeleteModel_RemovesBothFilesWhenPresent()
+    {
+        var modelPath = _manager.GetModelPath(CaptioningModelType.Qwen3_VL_8B);
+        var mmprojPath = _manager.GetClipProjectorPath(CaptioningModelType.Qwen3_VL_8B);
+
+        WriteSparseFile(modelPath, 100);
+        WriteSparseFile(mmprojPath, 100);
+
+        _manager.DeleteModel(CaptioningModelType.Qwen3_VL_8B);
+
+        File.Exists(modelPath).Should().BeFalse();
+        File.Exists(mmprojPath).Should().BeFalse();
+    }
+
+    [Fact]
+    public void DeleteModel_DoesNotThrowWhenFilesAbsent()
+    {
+        var act = () => _manager.DeleteModel(CaptioningModelType.Qwen3_VL_8B);
+        act.Should().NotThrow();
+    }
+
+    #endregion
+
+    #region Download destinations
+
+    [Fact]
+    public void GetDownloadDestinations_AlwaysIncludesDefaultCoreFolder()
+    {
+        var destinations = _manager.GetDownloadDestinations();
+
+        destinations.Should().NotBeEmpty();
+        destinations.Should().Contain(d => d.IsDefault && d.Path == _root);
+    }
+
+    #endregion
+}

--- a/DiffusionNexus.Tests/Inference/Captioning/ImagePreprocessorTests.cs
+++ b/DiffusionNexus.Tests/Inference/Captioning/ImagePreprocessorTests.cs
@@ -1,0 +1,292 @@
+using DiffusionNexus.Inference.Captioning;
+using FluentAssertions;
+using SkiaSharp;
+
+namespace DiffusionNexus.Tests.Inference.Captioning;
+
+/// <summary>
+/// Unit tests for <see cref="ImagePreprocessor"/>. Uses real SkiaSharp encoders to
+/// generate PNG/JPEG/WebP fixtures in a temp directory so the codec path is
+/// exercised end-to-end without touching the network or a model.
+/// </summary>
+public sealed class ImagePreprocessorTests : IDisposable
+{
+    private readonly string _root;
+
+    public ImagePreprocessorTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "dn-imgpre-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    /// <summary>
+    /// Writes a valid solid-colour image of the requested size and format into the
+    /// temp directory. Returns the absolute path.
+    /// </summary>
+    private string WriteImage(string fileName, int width, int height, SKEncodedImageFormat format = SKEncodedImageFormat.Png)
+    {
+        var path = Path.Combine(_root, fileName);
+        using var bitmap = new SKBitmap(width, height);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(new SKColor(0x80, 0x40, 0xC0));
+        }
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(format, 90)
+            ?? throw new InvalidOperationException("Test fixture: SKImage.Encode returned null.");
+        File.WriteAllBytes(path, data.ToArray());
+        return path;
+    }
+
+    #region ImagePreprocessResult factories
+
+    [Fact]
+    public void Succeeded_Factory_SetsAllFields()
+    {
+        var bytes = new byte[] { 1, 2, 3 };
+
+        var result = ImagePreprocessResult.Succeeded(bytes, 640, 480, wasResized: true);
+
+        result.Success.Should().BeTrue();
+        result.ImageData.Should().BeSameAs(bytes);
+        result.Width.Should().Be(640);
+        result.Height.Should().Be(480);
+        result.WasResized.Should().BeTrue();
+        result.ErrorMessage.Should().BeNull();
+    }
+
+    [Fact]
+    public void Failed_Factory_CarriesErrorAndZerosTheRest()
+    {
+        var result = ImagePreprocessResult.Failed("nope");
+
+        result.Success.Should().BeFalse();
+        result.ImageData.Should().BeNull();
+        result.Width.Should().Be(0);
+        result.Height.Should().Be(0);
+        result.WasResized.Should().BeFalse();
+        result.ErrorMessage.Should().Be("nope");
+    }
+
+    #endregion
+
+    #region ValidateImageFile
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ValidateImageFile_RejectsNullOrWhitespacePath(string? path)
+    {
+        var (isValid, error) = ImagePreprocessor.ValidateImageFile(path!);
+        isValid.Should().BeFalse();
+        error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void ValidateImageFile_RejectsMissingFile()
+    {
+        var missing = Path.Combine(_root, "does-not-exist.png");
+
+        var (isValid, error) = ImagePreprocessor.ValidateImageFile(missing);
+
+        isValid.Should().BeFalse();
+        error.Should().Contain("does not exist");
+    }
+
+    [Fact]
+    public void ValidateImageFile_RejectsUnsupportedExtension()
+    {
+        var path = Path.Combine(_root, "readme.txt");
+        File.WriteAllText(path, new string('x', 200));
+
+        var (isValid, error) = ImagePreprocessor.ValidateImageFile(path);
+
+        isValid.Should().BeFalse();
+        error.Should().Contain("Unsupported file format");
+    }
+
+    [Fact]
+    public void ValidateImageFile_RejectsTooSmallFile()
+    {
+        // < 100 bytes — the configured minimum for an image-shaped payload.
+        var path = Path.Combine(_root, "tiny.png");
+        File.WriteAllBytes(path, new byte[] { 0x89, 0x50, 0x4E, 0x47 });
+
+        var (isValid, error) = ImagePreprocessor.ValidateImageFile(path);
+
+        isValid.Should().BeFalse();
+        error.Should().Contain("too small");
+    }
+
+    [Fact]
+    public void ValidateImageFile_AcceptsValidPng()
+    {
+        var path = WriteImage("ok.png", 64, 64);
+
+        var (isValid, error) = ImagePreprocessor.ValidateImageFile(path);
+
+        isValid.Should().BeTrue();
+        error.Should().BeNull();
+    }
+
+    #endregion
+
+    #region ProcessImage
+
+    [Fact]
+    public void ProcessImage_RejectsBelowMinDimension()
+    {
+        // The validator only checks file size, so we have to bypass it with a real
+        // (small but ≥100 byte) PNG whose decoded dimensions are below the 16-px floor.
+        var path = WriteImage("tiny-decoded.png", 8, 8);
+
+        var result = ImagePreprocessor.ProcessImage(path);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("too small");
+    }
+
+    [Fact]
+    public void ProcessImage_KeepsDimensionsWhenWithinCap()
+    {
+        var path = WriteImage("medium.png", 640, 480);
+
+        var result = ImagePreprocessor.ProcessImage(path);
+
+        result.Success.Should().BeTrue();
+        result.Width.Should().Be(640);
+        result.Height.Should().Be(480);
+        result.WasResized.Should().BeFalse();
+        result.ImageData.Should().NotBeNull();
+        result.ImageData!.Length.Should().BeGreaterThan(100);
+    }
+
+    [Fact]
+    public void ProcessImage_ResizesPreservingAspectRatioWhenOverCap()
+    {
+        // Source 2560×1280 (landscape, longer side over 1280 cap).
+        var path = WriteImage("big-landscape.png", 2560, 1280);
+
+        var result = ImagePreprocessor.ProcessImage(path);
+
+        result.Success.Should().BeTrue();
+        result.WasResized.Should().BeTrue();
+        // Longest side should clamp to MaxImageDimension; shorter side scales.
+        result.Width.Should().Be(ImagePreprocessor.MaxImageDimension);
+        result.Height.Should().Be(ImagePreprocessor.MaxImageDimension / 2);
+    }
+
+    [Fact]
+    public void ProcessImage_EncodesAsJpegRegardlessOfSourceFormat()
+    {
+        // A PNG source should still come back as JPEG bytes (codec quirk handled).
+        var path = WriteImage("source.png", 256, 256);
+
+        var result = ImagePreprocessor.ProcessImage(path);
+
+        result.Success.Should().BeTrue();
+        result.ImageData.Should().NotBeNull();
+        // JPEG SOI marker.
+        result.ImageData![0].Should().Be(0xFF);
+        result.ImageData![1].Should().Be(0xD8);
+    }
+
+    [Fact]
+    public void ProcessImage_FailsOnCorruptHeader()
+    {
+        var path = Path.Combine(_root, "broken.jpg");
+        File.WriteAllBytes(path, new byte[200]);  // 200 zero-bytes — not a valid JPEG.
+
+        var result = ImagePreprocessor.ProcessImage(path);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().NotBeNullOrWhiteSpace();
+    }
+
+    #endregion
+
+    #region ProcessImageFromBytes
+
+    [Fact]
+    public void ProcessImageFromBytes_ThrowsOnNull()
+    {
+        var act = () => ImagePreprocessor.ProcessImageFromBytes(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void ProcessImageFromBytes_RejectsTooSmallBuffer()
+    {
+        var result = ImagePreprocessor.ProcessImageFromBytes(new byte[] { 1, 2, 3 });
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("too small");
+    }
+
+    [Fact]
+    public void ProcessImageFromBytes_AcceptsValidPng()
+    {
+        var path = WriteImage("from-bytes.png", 256, 256);
+        var bytes = File.ReadAllBytes(path);
+
+        var result = ImagePreprocessor.ProcessImageFromBytes(bytes);
+
+        result.Success.Should().BeTrue();
+        result.Width.Should().Be(256);
+        result.Height.Should().Be(256);
+        result.WasResized.Should().BeFalse();
+        result.ImageData.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ProcessImageFromBytes_RejectsBelowMinDimension()
+    {
+        var path = WriteImage("tiny-from-bytes.png", 8, 8);
+        var bytes = File.ReadAllBytes(path);
+
+        var result = ImagePreprocessor.ProcessImageFromBytes(bytes);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("too small");
+    }
+
+    #endregion
+
+    #region Supported-format helpers
+
+    [Theory]
+    [InlineData(".png", true)]
+    [InlineData(".PNG", true)]
+    [InlineData(".jpg", true)]
+    [InlineData(".jpeg", true)]
+    [InlineData(".webp", true)]
+    [InlineData(".bmp", true)]
+    [InlineData(".gif", true)]
+    [InlineData(".tiff", false)]
+    [InlineData(".txt", false)]
+    [InlineData("", false)]
+    public void IsSupportedImageFormat_RespectsExtensionWhitelist(string extension, bool expected)
+    {
+        ImagePreprocessor.IsSupportedImageFormat("img" + extension).Should().Be(expected);
+    }
+
+    [Fact]
+    public void GetSupportedExtensions_ReturnsTheSameSetUsedForValidation()
+    {
+        var extensions = ImagePreprocessor.GetSupportedExtensions();
+
+        extensions.Should().NotBeEmpty();
+        extensions.Should().Contain(".png");
+        extensions.Should().Contain(".jpg");
+        // Make sure callers can iterate the result without surprises.
+        extensions.Count.Should().Be(extensions.Distinct().Count());
+    }
+
+    #endregion
+}

--- a/Doc/Coverage.md
+++ b/Doc/Coverage.md
@@ -1,0 +1,58 @@
+# Code Coverage
+
+Solution-wide line/branch coverage is collected via Coverlet driven by
+`coverage.runsettings` at the repository root. Coverlet is already a
+`PackageReference` on `DiffusionNexus.Tests` and `DiffusionNexus.IntegrationTests`,
+so no per-project setup is required.
+
+## One-shot local run
+
+```pwsh
+dotnet test DiffusionNexus.sln `
+    --settings coverage.runsettings `
+    --collect:"XPlat Code Coverage" `
+    --results-directory TestResults
+```
+
+The collector emits `TestResults/<run-guid>/coverage.cobertura.xml` per
+test project.
+
+## HTML report
+
+Install the global report renderer once:
+
+```pwsh
+dotnet tool install -g dotnet-reportgenerator-globaltool
+```
+
+Render after each test run:
+
+```pwsh
+reportgenerator `
+    -reports:TestResults/**/coverage.cobertura.xml `
+    -targetdir:Doc/CoverageReport `
+    -reporttypes:Html
+```
+
+Open `Doc/CoverageReport/index.html`.
+
+## What's excluded
+
+`coverage.runsettings` excludes:
+- EF Core migration scaffolding (`*Designer.cs`, `*ModelSnapshot.cs`)
+- Avalonia XAML codebehind (`*.g.cs`)
+- Anything under `obj/`
+- The two test assemblies themselves
+- Members tagged `[Obsolete]`, `[GeneratedCode]`, `[CompilerGenerated]`
+
+When adding a new generated project or vendored binding, extend the
+`ExcludeByFile` / `Exclude` blocks in `coverage.runsettings` rather than
+silencing per-file.
+
+## CI integration (not yet wired)
+
+Once a baseline is captured, wire the same `dotnet test` invocation into
+the GitHub Actions workflow and add a coverage-gate check via
+`reportgenerator -targetdir:... -reporttypes:Cobertura;TextSummary` plus
+a step that fails when `Line` or `Branch` drops below the agreed
+threshold. Start at the current measurement, then ratchet upward.

--- a/coverage.runsettings
+++ b/coverage.runsettings
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Solution-wide coverage configuration for `dotnet test`.
+  Usage:
+      dotnet test --settings coverage.runsettings --collect:"XPlat Code Coverage"
+
+  Output: TestResults/<run-guid>/coverage.cobertura.xml
+  Render an HTML report with:
+      dotnet tool install -g dotnet-reportgenerator-globaltool
+      reportgenerator -reports:**/coverage.cobertura.xml -targetdir:Doc/CoverageReport -reporttypes:Html
+
+  Tweak the Exclude block when adding new generated / vendored projects so
+  noise (migrations, designer files, native interop) doesn't depress the score.
+-->
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <ExcludeByFile>
+            <!-- EF Core generated migration scaffolding -->
+            **/Migrations/**/*Designer.cs,
+            **/Migrations/**/*ModelSnapshot.cs,
+            <!-- Avalonia-generated XAML codebehind -->
+            **/*.g.cs,
+            **/obj/**/*.cs
+          </ExcludeByFile>
+          <Exclude>
+            <!-- Tests themselves should never count toward the gate. -->
+            [DiffusionNexus.Tests]*,
+            [DiffusionNexus.IntegrationTests]*,
+            <!-- Auto-generated assemblies (SDK + Avalonia source generators). -->
+            [Microsoft.*]*,
+            [System.*]*
+          </Exclude>
+          <ExcludeByAttribute>
+            Obsolete,
+            GeneratedCodeAttribute,
+            CompilerGeneratedAttribute
+          </ExcludeByAttribute>
+          <UseSourceLink>true</UseSourceLink>
+          <IncludeTestAssembly>false</IncludeTestAssembly>
+          <SingleHit>false</SingleHit>
+          <DeterministicReport>true</DeterministicReport>
+          <SkipAutoProps>true</SkipAutoProps>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
Addresses Priority 1 items **#1** and **#4** of [Doc/TestCoverageEvaluation.md](Doc/TestCoverageEvaluation.md), per issue #325.

## #1 — Coverage tooling

* `coverage.runsettings` — solution-wide Coverlet config emitting Cobertura. Excludes EF migration scaffolding (`*Designer.cs`, `*ModelSnapshot.cs`), Avalonia XAML codebehind (`*.g.cs`), generated code, the test assemblies themselves, and members tagged `[Obsolete]`/`[GeneratedCode]`/`[CompilerGenerated]`.
* `Doc/Coverage.md` — one-shot local run instructions, the `reportgenerator` HTML render workflow, and a note for the (still-pending) CI gate.

## #4 — DiffusionNexus.Inference.Captioning unit tests

### `ImagePreprocessorTests.cs` — 29 tests
SkiaSharp PNG/JPEG fixtures in a per-test temp directory. Covers:
- `ImagePreprocessResult.Succeeded` / `.Failed` factories
- `ValidateImageFile` — null / empty / whitespace / missing / unsupported ext / too-small / valid
- `ProcessImage` — below-min decoded dimension (8×8), kept when within cap, resized preserving aspect ratio when over cap, JPEG re-encoded regardless of source format (`FF D8` SOI check), corrupt header rejection
- `ProcessImageFromBytes` — null throw, too-small buffer, valid PNG, below-min dimension
- `IsSupportedImageFormat` (case-insensitive whitelist) and `GetSupportedExtensions`

### `CaptioningModelManagerTests.cs` — 54 tests
Temp directory + sparse-file pattern (`FileStream.SetLength`) to fake multi-gigabyte GGUFs without disk allocation or HTTP. Covers:
- Ctor creates the models directory; default ctor works (no args)
- `IsDownloadable` / `IsTieredDownloadable` matrix for every `CaptioningModelType`
- `GetSupportedVramTiers` returns the canonical 8/12/16/24/32 set for tiered models, empty for non-tiered, and the array is freshly cloned each call (mutation safety)
- `GetDisplayName` / `GetDescription` for every model (non-empty, friendlier than the raw enum)
- `GetModelPath` / `GetClipProjectorPath` for both tiered and non-tiered — paths absolute, rooted under the manager's base folder when nothing on disk
- Tier-fallback policy: closest-fitting-below (22 GB → 16 GB tier), out-of-range throws
- `GetExpectedModelSize` positive for every known model; `GetExpectedTierTotalBytes` sums correctly
- Status: `NotDownloaded` / `Corrupted` (< 80% of expected size) / `Ready` (≥ 80%)
- `GetModelInfo` populates all fields
- `DownloadModelAsync` short-circuit paths:
  - Tiered model on the non-tiered overload → returns `false` (refuses to guess a tier)
  - Non-tiered already present at full size → returns `true`, last progress reports "already downloaded"
  - Tiered already present at full size → returns `true`
- `DeleteModel` removes both files when present, no-throw when absent
- `GetDownloadDestinations` always includes the default Core folder

A small `SyncProgress : IProgress<ModelDownloadProgress>` shim is used for the short-circuit progress assertions because `Progress<T>` would post to the captured `SynchronizationContext` (or the ThreadPool) and race the test thread.

## Verification

* Solution builds clean (`-p:UseAppHost=false` while the running app holds the .exe lock — harmless, dev-only).
* `dotnet test DiffusionNexus.Tests` — **1889 / 1890** pass. The single failure (`ActivityLogServiceTests.CompleteDownloadProgress_…`) is pre-existing on develop from commit `63d111a "change loglevel to debug"` and has nothing to do with this PR.
* `dotnet test --filter "FullyQualifiedName~CaptioningModelManagerTests|FullyQualifiedName~ImagePreprocessorTests"` — 83 / 83 pass.

## Remaining work for #325

* **Priority 1 #3** — wrap native `DiffusionContextHost` in an interface so `StableDiffusionCppBackend` is testable without loading the native DLL. Refactor blocker; not in this PR.
* **Priority 2 through 5** — ComfyUI service tests, metadata pipeline, DataAccess migration round-trip, MainWindow/Settings/About VM tests, integration tests per main-window module, CI coverage gate, project split. Each is a separate, scoped follow-up.