### PR TITLE
Fix #397: run the Generation Gallery media scan off the UI thread

### DIFF
--- a/DiffusionNexus.Tests/Viewer/GenerationGalleryViewModelTests.cs
+++ b/DiffusionNexus.Tests/Viewer/GenerationGalleryViewModelTests.cs
@@ -577,6 +577,66 @@ public class GenerationGalleryViewModelTests : IDisposable
         viewModel.ToggleFavoritesButtonText.Should().Contain("Unmark");
     }
 
+    [Fact]
+    public void LoadMediaAsync_DoesNotRunMediaScanOnCallingThread()
+    {
+        // Startup regression guard for issue #397: the media scan does synchronous
+        // per-file IO and must not run inline on the thread that invokes the
+        // command (the UI thread at startup).
+        var galleryPath = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(galleryPath, "img.png"), "test");
+
+        var settings = new AppSettings
+        {
+            ImageGalleries = [new() { FolderPath = galleryPath, IsEnabled = true, Order = 0 }]
+        };
+
+        var mockSettings = new Mock<IAppSettingsService>();
+        mockSettings.Setup(service => service.GetSettingsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(settings);
+
+        // The favorites lookup runs once per scanned folder inside the enumeration
+        // loop and completes synchronously (like the real service when no
+        // .favorites.json exists), so its callback records the scan thread.
+        var scanThreadIds = new List<int>();
+        var mockFavorites = new Mock<IImageFavoritesService>();
+        mockFavorites.Setup(service => service.GetFavoritesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback(() => scanThreadIds.Add(Environment.CurrentManagedThreadId))
+            .ReturnsAsync(new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+
+        var viewModel = new GenerationGalleryViewModel(
+            mockSettings.Object,
+            new Mock<IDatasetEventAggregator>().Object,
+            new Mock<IDatasetState>().Object,
+            null,
+            favoritesService: mockFavorites.Object);
+
+        // Invoke the command from a dedicated non-pool thread standing in for the
+        // UI thread, so offloaded thread-pool work can never land back on it.
+        var callingThreadId = 0;
+        Exception? failure = null;
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                callingThreadId = Environment.CurrentManagedThreadId;
+                viewModel.LoadMediaCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+            }
+        });
+        thread.Start();
+        thread.Join(TimeSpan.FromSeconds(30)).Should().BeTrue("the gallery load must complete");
+
+        failure.Should().BeNull();
+        viewModel.MediaItems.Should().ContainSingle();
+        scanThreadIds.Should().NotBeEmpty();
+        scanThreadIds.Should().NotContain(callingThreadId,
+            "the media scan does blocking file IO and must not run on the thread that invoked the command (issue #397)");
+    }
+
     public void Dispose()
     {
         foreach (var path in _tempPaths)

--- a/DiffusionNexus.UI/ViewModels/GenerationGalleryViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/GenerationGalleryViewModel.cs
@@ -287,8 +287,13 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
         {
             var settings = await _settingsService.GetSettingsAsync();
             var enabledPaths = GetEnabledGalleryPaths(settings);
+            var includeSubFolders = IncludeSubFolders;
 
-            var mediaItems = await CollectMediaItemsAsync(enabledPaths, IncludeSubFolders);
+            // Offload the recursive folder scan (per-file IO syscalls + item creation)
+            // to the thread pool so the UI thread stays responsive; with large auto-
+            // registered output folders the inline scan froze the window for ~20s at
+            // startup (issue #397). RunBusyAsync itself does not offload.
+            var mediaItems = await Task.Run(() => CollectMediaItemsAsync(enabledPaths, includeSubFolders));
             await ApplyMediaItemsAsync(mediaItems, enabledPaths.Count);
 
             // Fire-and-forget: generate missing video thumbnails after gallery is displayed
@@ -614,17 +619,19 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
             return;
         }
 
-        var videoItems = items
-            .Where(i => i.IsVideo && !File.Exists(MediaFileExtensions.GetVideoThumbnailPath(i.FilePath)))
-            .ToList();
-
-        if (videoItems.Count == 0)
-        {
-            return;
-        }
-
         _ = Task.Run(async () =>
         {
+            // The File.Exists probe per video is blocking IO, so it belongs on the
+            // thread pool too — not on the UI thread that calls this method (#397).
+            var videoItems = items
+                .Where(i => i.IsVideo && !File.Exists(MediaFileExtensions.GetVideoThumbnailPath(i.FilePath)))
+                .ToList();
+
+            if (videoItems.Count == 0)
+            {
+                return;
+            }
+
             // Limit concurrency to avoid saturating CPU/disk with FFmpeg processes
             using var semaphore = new SemaphoreSlim(2);
 


### PR DESCRIPTION
## Summary

Fixes the primary cause of #397 (main window frozen ~20s after opening): `GenerationGalleryViewModel.LoadMediaAsync` ran the full recursive media-folder scan **inline on the UI thread** during startup.

## Root cause

- `RunBusyAsync` (`BusyViewModelBase.cs`) does not offload — it awaits the action on the UI `SynchronizationContext`.
- `CollectMediaItemsAsync` walks every enabled gallery folder recursively (`IncludeSubFolders` defaults to `true`) with one `File.GetCreationTimeUtc` syscall and one item-VM allocation per file.
- The only `await` inside the loop (per-folder favorites lookup) completes synchronously when no `.favorites.json` exists — the common case — so the scan **never yields** the UI thread. The busy spinner cannot even paint, because the thread that would render it is the one doing the scan.
- The scan is triggered at startup via `LoadStartupDataAsync` → `Task.WhenAll(... generationGalleryVm.LoadMediaCommand ...)`, whose continuations land on the UI thread right after `Show()`.
- On this machine the two auto-registered ComfyUI output folders alone contain **~24,500 files**; a cold-cache walk of that size on the UI thread plausibly accounts for the full ~20s.

## Fix

- `LoadMediaAsync` now runs `CollectMediaItemsAsync` via `Task.Run` — the same pattern `LoraViewerViewModel.RefreshAsync` already uses. `ApplyMediaItemsAsync` already marshals results back to the UI thread correctly (it was written to tolerate off-thread callers).
- The per-video `File.Exists` probe in `StartBackgroundVideoThumbnailGeneration` moved inside its existing `Task.Run` — same defect class (blocking per-file IO on the UI thread in the same code path).

## Verification

- **TDD regression test** (`LoadMediaAsync_DoesNotRunMediaScanOnCallingThread`): invokes `LoadMediaCommand` from a dedicated non-pool thread and asserts the scan does not run inline on it. Watched it fail before the fix (scan ran on calling thread), passes after.
- Full unit suite: **1983/1983 passing**.
- **A/B launch harness** (poll `Process.Responding` during startup, warm cache): on `develop` the window is hang-flagged until **15.6s** after launch; with the fix it recovers at **13.5s** and the window is fully painted. The residual stall comes from other startup work (see follow-ups in #397) — on a warm cache the scan is only ~2s of it, but cold-cache scans are the multi-second-to-20s component.

## Not in this PR (documented in #397)

Verified contributors that deserve their own changes: synchronous DB inits pre-Show (~1–3s, needs gating of dependent loads), eager construction of all 8 module views pre-Show, forced **software rendering** left in `Program.cs` (GPU-diagnostic leftover), and a per-log-entry UI-dispatcher amplification (3 subscribers × O(N) recounts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)