### PR TITLE
chore: bump Installer SDK references to 1.2.26

### DIFF
--- a/DiffusionNexus.UI/DiffusionNexus.UI.csproj
+++ b/DiffusionNexus.UI/DiffusionNexus.UI.csproj
@@ -66,11 +66,11 @@
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="SkiaSharp" Version="3.119.4" />
     <PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.660" />
-    <PackageReference Include="DiffusionNexus.Installer.SDK.Models" Version="1.2.25" />
-    <PackageReference Include="DiffusionNexus.Installer.SDK.Services" Version="1.2.25" />
-    <PackageReference Include="DiffusionNexus.Installer.SDK.DataAccess" Version="1.2.25" />
-    <PackageReference Include="DiffusionNexus.Installer.SDK.Shared" Version="1.2.25" />
-    <PackageReference Include="DiffusionNexus.Installer.SDK.Database" Version="1.2.25" />
+    <PackageReference Include="DiffusionNexus.Installer.SDK.Models" Version="1.2.26" />
+    <PackageReference Include="DiffusionNexus.Installer.SDK.Services" Version="1.2.26" />
+    <PackageReference Include="DiffusionNexus.Installer.SDK.DataAccess" Version="1.2.26" />
+    <PackageReference Include="DiffusionNexus.Installer.SDK.Shared" Version="1.2.26" />
+    <PackageReference Include="DiffusionNexus.Installer.SDK.Database" Version="1.2.26" />
     <PackageReference Include="StableDiffusion.NET.Backend.Cuda12.Windows" Version="6.0.0" />
     <PackageReference Include="WeCantSpell.Hunspell" Version="7.0.1" />
     <!-- Pin transitive dependency to fix NU1903 (GHSA-xrw6-gwf8-vvr9) -->


### PR DESCRIPTION
Bumps `DiffusionNexus.UI` Installer-SDK `PackageReference`s from 1.2.25 to **1.2.26** (Models/Services/DataAccess/Shared/Database).

1.2.26 is an additive, non-breaking SDK release (new `DownloadProgress.IsFailed/ModelId/SourceUrl`); nothing was removed, so the main app needs no code change. Verified with a Release build of `DiffusionNexus.UI` against the published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)