### PR TITLE
perf: fix startup time, backup UI freeze, and LoRA Viewer navigation hang

### DIFF
--- a/DiffusionNexus.DataAccess/Data/DiffusionNexusCoreDbContext.cs
+++ b/DiffusionNexus.DataAccess/Data/DiffusionNexusCoreDbContext.cs
@@ -110,8 +110,10 @@ public class DiffusionNexusCoreDbContext : DbContext
         var dir = directory ?? GetDatabaseDirectory();
         Directory.CreateDirectory(dir);
         var path = Path.Combine(dir, DatabaseFileName);
-        // Use default timeout and disable pooling to prevent connection locking issues
-        return $"Data Source={path};Mode=ReadWriteCreate;Cache=Shared;Pooling=False;Default Timeout=30";
+        // No shared cache: with WAL journaling (set at startup) private-cache
+        // connections let readers proceed while a writer commits — shared cache
+        // serialized them and stalled UI-thread reads behind background writes.
+        return $"Data Source={path};Mode=ReadWriteCreate;Pooling=False;Default Timeout=30";
     }
 
     /// <summary>

--- a/DiffusionNexus.Service/Services/BackupProgressGate.cs
+++ b/DiffusionNexus.Service/Services/BackupProgressGate.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace DiffusionNexus.Service.Services;
+
+/// <summary>
+/// Suppresses redundant backup progress reports. A report passes only when the
+/// integer percentage or the phase changed. This bounds UI dispatcher traffic
+/// to ~100 posts per backup regardless of dataset file count — reporting every
+/// N files froze the UI on many-small-file datasets (dispatcher storm).
+/// </summary>
+public sealed class BackupProgressGate
+{
+    private int _lastPercent = -1;
+    private string? _lastPhase;
+
+    public bool ShouldReport(int percent, string? phase)
+    {
+        if (percent == _lastPercent && string.Equals(phase, _lastPhase, StringComparison.Ordinal))
+            return false;
+
+        _lastPercent = percent;
+        _lastPhase = phase;
+        return true;
+    }
+}

--- a/DiffusionNexus.Service/Services/DatasetBackupService.cs
+++ b/DiffusionNexus.Service/Services/DatasetBackupService.cs
@@ -319,12 +319,20 @@ public class DatasetBackupService : IDatasetBackupService
     public Task<BackupAnalysisResult> AnalyzeBackupAsync(
         string backupZipPath,
         CancellationToken cancellationToken = default)
+        => Task.Run(() => AnalyzeBackupCore(backupZipPath, cancellationToken), cancellationToken);
+
+    /// <summary>
+    /// Synchronous body of <see cref="AnalyzeBackupAsync"/>. Dispatched onto a pool thread via
+    /// <c>Task.Run</c> so the ZIP scan never blocks the caller's thread (e.g. the UI thread in
+    /// the restore flow).
+    /// </summary>
+    private BackupAnalysisResult AnalyzeBackupCore(string backupZipPath, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(backupZipPath);
 
         if (!File.Exists(backupZipPath))
         {
-            return Task.FromResult(BackupAnalysisResult.Failed($"Backup file not found: {backupZipPath}"));
+            return BackupAnalysisResult.Failed($"Backup file not found: {backupZipPath}");
         }
 
         try
@@ -337,7 +345,7 @@ public class DatasetBackupService : IDatasetBackupService
             long totalSize = 0;
 
             using var archive = ZipFile.OpenRead(backupZipPath);
-            
+
             foreach (var entry in archive.Entries)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -356,7 +364,7 @@ public class DatasetBackupService : IDatasetBackupService
 
                 // Categorize by extension
                 var ext = Path.GetExtension(entry.Name);
-                
+
                 if (SupportedMediaTypes.ImageExtensionSet.Contains(ext))
                 {
                     imageCount++;
@@ -371,24 +379,32 @@ public class DatasetBackupService : IDatasetBackupService
                 }
             }
 
-            return Task.FromResult(BackupAnalysisResult.Succeeded(
+            return BackupAnalysisResult.Succeeded(
                 backupZipPath,
                 backupDate,
                 datasets.Count,
                 imageCount,
                 videoCount,
                 captionCount,
-                totalSize));
+                totalSize);
         }
         catch (Exception ex)
         {
             Log.Error(ex, "Failed to analyze backup: {BackupPath}", backupZipPath);
-            return Task.FromResult(BackupAnalysisResult.Failed($"Failed to analyze backup: {ex.Message}"));
+            return BackupAnalysisResult.Failed($"Failed to analyze backup: {ex.Message}");
         }
     }
 
     /// <inheritdoc />
-    public async Task<CurrentStorageStats> GetCurrentStorageStatsAsync(CancellationToken cancellationToken = default)
+    public Task<CurrentStorageStats> GetCurrentStorageStatsAsync(CancellationToken cancellationToken = default)
+        => Task.Run(() => GetCurrentStorageStatsCoreAsync(cancellationToken), cancellationToken);
+
+    /// <summary>
+    /// Async body of <see cref="GetCurrentStorageStatsAsync"/>. Dispatched onto a pool thread via
+    /// <c>Task.Run</c> so the filesystem scan never blocks the caller's thread (e.g. the UI thread
+    /// in the restore flow).
+    /// </summary>
+    private async Task<CurrentStorageStats> GetCurrentStorageStatsCoreAsync(CancellationToken cancellationToken)
     {
         var settings = await _settingsService.GetSettingsAsync(cancellationToken);
 
@@ -404,7 +420,7 @@ public class DatasetBackupService : IDatasetBackupService
         long totalSize = 0;
 
         var allFiles = Directory.EnumerateFiles(settings.DatasetStoragePath, "*", SearchOption.AllDirectories);
-        
+
         foreach (var file in allFiles)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -413,7 +429,7 @@ public class DatasetBackupService : IDatasetBackupService
             totalSize += fileInfo.Length;
 
             var ext = Path.GetExtension(file);
-            
+
             if (SupportedMediaTypes.ImageExtensionSet.Contains(ext))
             {
                 imageCount++;

--- a/DiffusionNexus.Service/Services/DatasetBackupService.cs
+++ b/DiffusionNexus.Service/Services/DatasetBackupService.cs
@@ -117,6 +117,8 @@ public class DatasetBackupService : IDatasetBackupService
                 var memBeforeMb = GC.GetTotalMemory(forceFullCollection: false) / 1024.0 / 1024.0;
                 Log.Information("Backup memory before: {MemBefore:F1} MB ({TotalFiles} files)", memBeforeMb, totalFiles);
 
+                var progressGate = new BackupProgressGate();
+
                 // Create ZIP archive with streaming FileStream to reduce memory pressure
                 using (var fileStream = new FileStream(backupPath, FileMode.CreateNew, FileAccess.Write, FileShare.None, bufferSize: 1 << 20))
                 using (var archive = new ZipArchive(fileStream, ZipArchiveMode.Create, leaveOpen: false))
@@ -136,9 +138,9 @@ public class DatasetBackupService : IDatasetBackupService
                             archive.CreateEntryFromFile(filePath, relativePath, compressionLevel);
                             processedFiles++;
 
-                            if (processedFiles % 10 == 0 || processedFiles == totalFiles)
+                            var percent = 5 + (int)(90.0 * processedFiles / totalFiles);
+                            if (progressGate.ShouldReport(percent, "Creating backup"))
                             {
-                                var percent = 5 + (int)(90.0 * processedFiles / totalFiles);
                                 progress?.Report(new BackupProgress
                                 {
                                     Phase = "Creating backup",

--- a/DiffusionNexus.Tests/DataAccess/WalJournalModeTests.cs
+++ b/DiffusionNexus.Tests/DataAccess/WalJournalModeTests.cs
@@ -1,0 +1,58 @@
+using Microsoft.Data.Sqlite;
+
+namespace DiffusionNexus.Tests.DataAccess;
+
+public class WalJournalModeTests
+{
+    [Fact]
+    public void ConnectionString_DoesNotUseSharedCache()
+    {
+        // GetConnectionString(string? directory) treats its argument as a directory
+        // (it Directory.CreateDirectory()s it and combines it with the fixed db
+        // filename) — pass a directory here, same as JournalModePragma_PersistsWal,
+        // rather than a bare temp-file path.
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        try
+        {
+            var cs = DiffusionNexus.DataAccess.Data.DiffusionNexusCoreDbContext.GetConnectionString(dir);
+            Assert.DoesNotContain("Cache=Shared", cs, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void JournalModePragma_PersistsWal()
+    {
+        // WAL requires a file-backed DB (in-memory SQLite ignores it), so use a temp directory.
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var cs = DiffusionNexus.DataAccess.Data.DiffusionNexusCoreDbContext.GetConnectionString(dir);
+
+            using (var connection = new SqliteConnection(cs))
+            {
+                connection.Open();
+                using var enable = connection.CreateCommand();
+                enable.CommandText = "PRAGMA journal_mode=WAL;";
+                enable.ExecuteScalar();
+            }
+
+            // New connection: WAL must persist in the database file.
+            using (var connection = new SqliteConnection(cs))
+            {
+                connection.Open();
+                using var query = connection.CreateCommand();
+                query.CommandText = "PRAGMA journal_mode;";
+                Assert.Equal("wal", (string?)query.ExecuteScalar());
+            }
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/DiffusionNexus.Tests/Helpers/BatchedListFillerTests.cs
+++ b/DiffusionNexus.Tests/Helpers/BatchedListFillerTests.cs
@@ -69,4 +69,45 @@ public class BatchedListFillerTests
 
         Assert.Equal(new[] { 6, 7, 8, 9 }, target);
     }
+
+    [Fact]
+    public void SourceShrinksMidFill_ClampsToNewTail_WithoutThrowing_AndCompletes()
+    {
+        var source = Enumerable.Range(0, 10).ToList();
+        var target = new List<int>();
+        var posts = new Queue<Action>();
+        var completed = 0;
+
+        BatchedListFiller.Fill(target, source, 0, 10, batchSize: 4, post: posts.Enqueue, onCompleted: () => completed++);
+
+        // Synchronous batch landed [0..3]. The source shrinks (e.g. a tile is
+        // deleted) before the posted batches run — the fill must clamp to the
+        // new tail instead of reading past it.
+        source.RemoveRange(5, 5); // count 10 -> 5
+
+        while (posts.Count > 0) posts.Dequeue().Invoke();
+
+        Assert.Equal(new[] { 0, 1, 2, 3, 4 }, target);
+        Assert.Equal(1, completed);
+    }
+
+    [Fact]
+    public void SourceShrinksBelowFilledCount_MidFill_StopsCleanly_AndCompletes()
+    {
+        var source = Enumerable.Range(0, 10).ToList();
+        var target = new List<int>();
+        var posts = new Queue<Action>();
+        var completed = 0;
+
+        BatchedListFiller.Fill(target, source, 0, 10, batchSize: 4, post: posts.Enqueue, onCompleted: () => completed++);
+
+        // Shrink below what the synchronous batch already consumed — the next
+        // index (4) is now past the tail entirely.
+        source.RemoveRange(2, 8); // count 10 -> 2
+
+        while (posts.Count > 0) posts.Dequeue().Invoke();
+
+        Assert.Equal(new[] { 0, 1, 2, 3 }, target); // only the synchronous batch
+        Assert.Equal(1, completed);
+    }
 }

--- a/DiffusionNexus.Tests/Helpers/BatchedListFillerTests.cs
+++ b/DiffusionNexus.Tests/Helpers/BatchedListFillerTests.cs
@@ -1,0 +1,72 @@
+using DiffusionNexus.UI.Helpers;
+
+namespace DiffusionNexus.Tests.Helpers;
+
+public class BatchedListFillerTests
+{
+    [Fact]
+    public void FillsEverything_InOrder_AcrossBatches()
+    {
+        var source = Enumerable.Range(0, 10).ToList();
+        var target = new List<int>();
+        var posts = new Queue<Action>();
+
+        BatchedListFiller.Fill(target, source, 0, 10, batchSize: 3, post: posts.Enqueue);
+
+        Assert.Equal(new[] { 0, 1, 2 }, target); // first batch is synchronous
+        while (posts.Count > 0) posts.Dequeue().Invoke();
+        Assert.Equal(source, target);
+    }
+
+    [Fact]
+    public void SmallSource_FillsSynchronously_WithoutPosting()
+    {
+        var target = new List<int>();
+        var posts = new Queue<Action>();
+
+        BatchedListFiller.Fill(target, new List<int> { 1, 2 }, 0, 2, batchSize: 5, post: posts.Enqueue);
+
+        Assert.Equal(new[] { 1, 2 }, target);
+        Assert.Empty(posts);
+    }
+
+    [Fact]
+    public void Cancel_AbandonsRemainingBatches()
+    {
+        var source = Enumerable.Range(0, 10).ToList();
+        var target = new List<int>();
+        var posts = new Queue<Action>();
+
+        var cancel = BatchedListFiller.Fill(target, source, 0, 10, batchSize: 4, post: posts.Enqueue);
+        cancel();
+        while (posts.Count > 0) posts.Dequeue().Invoke();
+
+        Assert.Equal(new[] { 0, 1, 2, 3 }, target); // only the synchronous batch landed
+    }
+
+    [Fact]
+    public void OnCompleted_FiresOnce_AfterLastBatch()
+    {
+        var source = Enumerable.Range(0, 7).ToList();
+        var target = new List<int>();
+        var posts = new Queue<Action>();
+        var completed = 0;
+
+        BatchedListFiller.Fill(target, source, 0, 7, 3, posts.Enqueue, () => completed++);
+        while (posts.Count > 0) posts.Dequeue().Invoke();
+
+        Assert.Equal(1, completed);
+    }
+
+    [Fact]
+    public void RespectsStartOffset()
+    {
+        var source = Enumerable.Range(0, 10).ToList();
+        var target = new List<int>();
+        var posts = new Queue<Action>();
+
+        BatchedListFiller.Fill(target, source, 6, 10, 10, posts.Enqueue);
+
+        Assert.Equal(new[] { 6, 7, 8, 9 }, target);
+    }
+}

--- a/DiffusionNexus.Tests/Services/AutoCompleteDeferralTests.cs
+++ b/DiffusionNexus.Tests/Services/AutoCompleteDeferralTests.cs
@@ -1,0 +1,23 @@
+using DiffusionNexus.UI.Services.SpellCheck;
+
+namespace DiffusionNexus.Tests.Services;
+
+public class AutoCompleteDeferralTests
+{
+    [Fact]
+    public async Task DeferredCtor_DoesNotStartLoading_UntilSignal()
+    {
+        var signal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        // Nonexistent directory: LoadFromDictionary returns immediately once it runs,
+        // so LoadCompleted completing == the load ran.
+        var svc = new AutoCompleteService(signal.Task,
+            Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
+
+        await Task.Delay(150);
+        Assert.False(svc.LoadCompleted.IsCompleted);
+
+        signal.SetResult();
+        await svc.LoadCompleted.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(svc.LoadCompleted.IsCompletedSuccessfully);
+    }
+}

--- a/DiffusionNexus.Tests/Services/BackupProgressGateTests.cs
+++ b/DiffusionNexus.Tests/Services/BackupProgressGateTests.cs
@@ -1,0 +1,50 @@
+using DiffusionNexus.Service.Services;
+
+namespace DiffusionNexus.Tests.Services;
+
+public class BackupProgressGateTests
+{
+    [Fact]
+    public void FirstReport_AlwaysPasses()
+    {
+        var gate = new BackupProgressGate();
+        Assert.True(gate.ShouldReport(5, "Creating backup"));
+    }
+
+    [Fact]
+    public void SamePercentAndPhase_IsSuppressed()
+    {
+        var gate = new BackupProgressGate();
+        gate.ShouldReport(42, "Creating backup");
+        Assert.False(gate.ShouldReport(42, "Creating backup"));
+    }
+
+    [Fact]
+    public void PercentChange_Passes()
+    {
+        var gate = new BackupProgressGate();
+        gate.ShouldReport(42, "Creating backup");
+        Assert.True(gate.ShouldReport(43, "Creating backup"));
+    }
+
+    [Fact]
+    public void PhaseChange_PassesEvenAtSamePercent()
+    {
+        var gate = new BackupProgressGate();
+        gate.ShouldReport(98, "Creating backup");
+        Assert.True(gate.ShouldReport(98, "Cleaning up old backups"));
+    }
+
+    [Fact]
+    public void ManySmallFileUpdates_CollapseToAtMostOnePerPercent()
+    {
+        var gate = new BackupProgressGate();
+        var emitted = 0;
+        for (var file = 1; file <= 100_000; file++)
+        {
+            var percent = 5 + (int)(90.0 * file / 100_000);
+            if (gate.ShouldReport(percent, "Creating backup")) emitted++;
+        }
+        Assert.InRange(emitted, 1, 91);
+    }
+}

--- a/DiffusionNexus.Tests/Services/DatasetBackupAnalysisTests.cs
+++ b/DiffusionNexus.Tests/Services/DatasetBackupAnalysisTests.cs
@@ -1,0 +1,45 @@
+using DiffusionNexus.Domain.Services;
+using DiffusionNexus.Service.Services;
+using Moq;
+
+namespace DiffusionNexus.Tests.Services;
+
+/// <summary>
+/// Pins the observable behavior of <see cref="DatasetBackupService.AnalyzeBackupAsync"/>
+/// across the Task.Run/Core refactor (a threading-only change — counts and success/failure
+/// shape must stay identical).
+/// </summary>
+public class DatasetBackupAnalysisTests
+{
+    [Fact]
+    public async Task AnalyzeBackupAsync_CountsEntries_OfASmallZip()
+    {
+        var dir = Directory.CreateTempSubdirectory();
+        try
+        {
+            var contentDir = Directory.CreateTempSubdirectory();
+            try
+            {
+                await File.WriteAllTextAsync(Path.Combine(contentDir.FullName, "a.txt"), "alpha");
+                await File.WriteAllTextAsync(Path.Combine(contentDir.FullName, "b.txt"), "beta");
+                var zipPath = Path.Combine(dir.FullName, "backup.zip");
+                System.IO.Compression.ZipFile.CreateFromDirectory(contentDir.FullName, zipPath);
+
+                var service = new DatasetBackupService(new Mock<IAppSettingsService>().Object);
+
+                var result = await service.AnalyzeBackupAsync(zipPath);
+
+                Assert.True(result.Success);
+                Assert.Equal(2, result.CaptionCount); // a.txt + b.txt are ".txt" caption entries
+            }
+            finally
+            {
+                contentDir.Delete(recursive: true);
+            }
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+}

--- a/DiffusionNexus.Tests/Services/StartupProgressServiceTests.cs
+++ b/DiffusionNexus.Tests/Services/StartupProgressServiceTests.cs
@@ -1,0 +1,82 @@
+using DiffusionNexus.UI.Services.Startup;
+
+namespace DiffusionNexus.Tests.Services;
+
+public class StartupProgressServiceTests
+{
+    private static StartupProgressService NewService(bool canvas = false)
+        => new(StartupProgressService.BuildDefaultChecks(includeDiffusionCanvas: canvas));
+
+    [Fact]
+    public void DefaultChecks_HaveExpectedOrderAndGating()
+    {
+        var svc = NewService();
+        Assert.Equal(
+            new[] { "database", "installer-manager", "lora-dataset-helper", "lora-viewer",
+                    "generation-gallery", "image-comparer", "workflows", "settings",
+                    "diffusion-engine", "updates" },
+            svc.Checks.Select(c => c.Id).ToArray());
+        Assert.All(svc.Checks.Where(c => c.Id != "updates"), c => Assert.True(c.GatesReadiness));
+        Assert.False(svc.Checks.Single(c => c.Id == "updates").GatesReadiness);
+    }
+
+    [Fact]
+    public void CanvasFlag_InsertsDiffusionCanvasAfterGenerationGallery()
+    {
+        var svc = NewService(canvas: true);
+        var ids = svc.Checks.Select(c => c.Id).ToList();
+        Assert.Equal(ids.IndexOf("generation-gallery") + 1, ids.IndexOf("diffusion-canvas"));
+    }
+
+    [Fact]
+    public void BeginCompleteFail_TransitionStatesAndRaiseEvents()
+    {
+        var svc = NewService();
+        var raised = new List<(string Id, StartupCheckState State)>();
+        svc.CheckChanged += c => raised.Add((c.Id, c.State));
+
+        svc.Begin("database");
+        svc.Complete("database");
+        svc.Begin("settings");
+        svc.Fail("settings", "boom");
+
+        Assert.Equal(StartupCheckState.Done, svc.Checks.Single(c => c.Id == "database").State);
+        var settings = svc.Checks.Single(c => c.Id == "settings");
+        Assert.Equal(StartupCheckState.Failed, settings.State);
+        Assert.Equal("boom", settings.Error);
+        Assert.Equal(
+            new[] { ("database", StartupCheckState.Running), ("database", StartupCheckState.Done),
+                    ("settings", StartupCheckState.Running), ("settings", StartupCheckState.Failed) },
+            raised.ToArray());
+    }
+
+    [Fact]
+    public void CoreChecksTerminal_IgnoresUpdates_AndCountsFailedAsTerminal()
+    {
+        var svc = NewService();
+        foreach (var c in svc.Checks.Where(c => c.GatesReadiness))
+        {
+            Assert.False(svc.CoreChecksTerminal);
+            svc.Begin(c.Id);
+            if (c.Id == "lora-viewer") svc.Fail(c.Id, "x"); else svc.Complete(c.Id);
+        }
+        Assert.True(svc.CoreChecksTerminal); // "updates" still Pending — must not gate
+    }
+
+    [Fact]
+    public void UiReady_CompletesOnceOnSignal()
+    {
+        var svc = NewService();
+        Assert.False(svc.UiReady.IsCompleted);
+        svc.SignalUiReady();
+        svc.SignalUiReady(); // idempotent, must not throw
+        Assert.True(svc.UiReady.IsCompletedSuccessfully);
+    }
+
+    [Fact]
+    public void UnknownId_Throws()
+    {
+        var svc = NewService();
+        Assert.Throws<ArgumentException>(() => svc.Begin("nope"));
+    }
+}

--- a/DiffusionNexus.Tests/Startup/RenderingConfigTests.cs
+++ b/DiffusionNexus.Tests/Startup/RenderingConfigTests.cs
@@ -1,0 +1,35 @@
+using DiffusionNexus.UI.Startup;
+
+namespace DiffusionNexus.Tests.Startup;
+
+public class RenderingConfigTests
+{
+    [Theory]
+    [InlineData("1")]
+    [InlineData("true")]
+    [InlineData("TRUE")]
+    [InlineData("yes")]
+    public void UseSoftwareRendering_IsTrue_WhenEnvVarOptsIn(string value)
+    {
+        Assert.True(RenderingConfig.UseSoftwareRendering(_ => value));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("0")]
+    [InlineData("false")]
+    [InlineData("off")]
+    public void UseSoftwareRendering_IsFalse_ByDefault(string? value)
+    {
+        Assert.False(RenderingConfig.UseSoftwareRendering(_ => value));
+    }
+
+    [Fact]
+    public void UseSoftwareRendering_ReadsTheDocumentedVariable()
+    {
+        string? requested = null;
+        RenderingConfig.UseSoftwareRendering(name => { requested = name; return null; });
+        Assert.Equal("DIFFUSIONNEXUS_SOFTWARE_RENDERING", requested);
+    }
+}

--- a/DiffusionNexus.Tests/ViewModels/StartupOverlayViewModelTests.cs
+++ b/DiffusionNexus.Tests/ViewModels/StartupOverlayViewModelTests.cs
@@ -1,0 +1,45 @@
+using DiffusionNexus.UI.Services.Startup;
+using DiffusionNexus.UI.ViewModels;
+
+namespace DiffusionNexus.Tests.ViewModels;
+
+public class StartupOverlayViewModelTests
+{
+    [Fact]
+    public void Rows_MirrorServiceChecks_InOrder()
+    {
+        var svc = new StartupProgressService(StartupProgressService.BuildDefaultChecks(false));
+        var vm = new StartupOverlayViewModel(svc);
+        Assert.Equal(svc.Checks.Select(c => c.DisplayName), vm.Rows.Select(r => r.DisplayName));
+        Assert.All(vm.Rows, r => Assert.True(r.IsPending));
+    }
+
+    [Fact]
+    public void CheckChanged_UpdatesTheMatchingRow_AndRaisesPropertyChanged()
+    {
+        var svc = new StartupProgressService(StartupProgressService.BuildDefaultChecks(false));
+        var vm = new StartupOverlayViewModel(svc);
+        var row = vm.Rows.Single(r => r.DisplayName == "Database");
+        var raised = new List<string?>();
+        row.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        svc.Begin("database");
+        Assert.True(row.IsRunning);
+        svc.Complete("database");
+        Assert.True(row.IsDone);
+        Assert.Contains(nameof(StartupCheckRowViewModel.IsRunning), raised);
+        Assert.Contains(nameof(StartupCheckRowViewModel.IsDone), raised);
+    }
+
+    [Fact]
+    public void FailedCheck_ExposesError()
+    {
+        var svc = new StartupProgressService(StartupProgressService.BuildDefaultChecks(false));
+        var vm = new StartupOverlayViewModel(svc);
+        svc.Begin("settings");
+        svc.Fail("settings", "boom");
+        var row = vm.Rows.Single(r => r.DisplayName == "Settings");
+        Assert.True(row.IsFailed);
+        Assert.Equal("boom", row.Error);
+    }
+}

--- a/DiffusionNexus.Tests/ViewModels/UnifiedConsoleBatchingTests.cs
+++ b/DiffusionNexus.Tests/ViewModels/UnifiedConsoleBatchingTests.cs
@@ -1,0 +1,130 @@
+using DiffusionNexus.Domain.Services.UnifiedLogging;
+using DiffusionNexus.UI.ViewModels;
+
+namespace DiffusionNexus.Tests.ViewModels;
+
+/// <summary>
+/// Verifies that <see cref="UnifiedConsoleViewModel"/> coalesces a burst of log
+/// entries arriving through <see cref="IUnifiedLogger.LogStream"/> into a single
+/// scheduled flush instead of one dispatcher post per entry.
+/// </summary>
+public class UnifiedConsoleBatchingTests
+{
+    [Fact]
+    public void BurstOfEntries_SchedulesSingleFlush_AndDeliversAll()
+    {
+        var logger = new FakeUnifiedLogger();
+        var vm = new UnifiedConsoleViewModel(logger, new FakeTaskTracker());
+
+        var scheduled = new Queue<Action>();
+        vm.ScheduleFlush = scheduled.Enqueue; // replace the dispatcher seam
+
+        for (var i = 0; i < 50; i++)
+            logger.Emit(TestLogEntry(i)); // pushes through LogStream
+
+        Assert.Single(scheduled); // burst coalesced into one flush
+        scheduled.Dequeue().Invoke();
+        Assert.Equal(50, vm.FilteredEntries.Count);
+
+        logger.Emit(TestLogEntry(50)); // after a flush, a new one is scheduled
+        Assert.Single(scheduled);
+    }
+
+    /// <summary>
+    /// Builds a minimal <see cref="LogEntry"/> that passes the ViewModel's default
+    /// filters (Info level, no category/task/search/instance filter active).
+    /// </summary>
+    private static LogEntry TestLogEntry(int i) =>
+        new(
+            Timestamp: DateTime.UtcNow,
+            Level: LogLevel.Info,
+            Category: LogCategory.General,
+            Source: "Test",
+            Message: $"Entry {i}");
+
+    /// <summary>
+    /// Minimal <see cref="IUnifiedLogger"/> fake for VM tests: a controllable
+    /// <see cref="LogStream"/> ("Emit") plus no-op logging methods. Mirrors the
+    /// production <c>UnifiedLogger</c>'s own hand-rolled <see cref="IObservable{T}"/>
+    /// so the test doesn't need a System.Reactive dependency.
+    /// </summary>
+    private sealed class FakeUnifiedLogger : IUnifiedLogger
+    {
+        private readonly List<IObserver<LogEntry>> _observers = [];
+
+        public FakeUnifiedLogger()
+        {
+            LogStream = new ObservableStream(this);
+        }
+
+        /// <summary>Pushes an entry to every current subscriber, synchronously.</summary>
+        public void Emit(LogEntry entry)
+        {
+            foreach (var observer in _observers.ToArray())
+                observer.OnNext(entry);
+        }
+
+        public IObservable<LogEntry> LogStream { get; }
+
+        public void Log(LogLevel level, LogCategory category, string source, string message,
+            string? detail = null, Exception? ex = null, string? taskId = null)
+        { }
+
+        public void Trace(LogCategory category, string source, string message, string? detail = null) { }
+        public void Debug(LogCategory category, string source, string message, string? detail = null) { }
+        public void Info(LogCategory category, string source, string message, string? detail = null) { }
+        public void Warn(LogCategory category, string source, string message, string? detail = null) { }
+        public void Error(LogCategory category, string source, string message, Exception? ex = null) { }
+        public void Fatal(LogCategory category, string source, string message, Exception ex) { }
+
+        public IReadOnlyList<LogEntry> GetEntries(LogCategory? category = null, LogLevel? minLevel = null) => [];
+
+        public void Clear() { }
+
+        private sealed class ObservableStream(FakeUnifiedLogger owner) : IObservable<LogEntry>
+        {
+            public IDisposable Subscribe(IObserver<LogEntry> observer)
+            {
+                owner._observers.Add(observer);
+                return new Unsubscriber(owner, observer);
+            }
+        }
+
+        private sealed class Unsubscriber(FakeUnifiedLogger owner, IObserver<LogEntry> observer) : IDisposable
+        {
+            public void Dispose() => owner._observers.Remove(observer);
+        }
+    }
+
+    /// <summary>
+    /// Minimal <see cref="ITaskTracker"/> fake. <see cref="UnifiedConsoleViewModel"/>
+    /// only subscribes to <see cref="TaskChanged"/> in its constructor; nothing else
+    /// is exercised by the batching test.
+    /// </summary>
+    private sealed class FakeTaskTracker : ITaskTracker
+    {
+#pragma warning disable CS0067 // fake never needs to raise this; VM only subscribes/unsubscribes
+        public event EventHandler<TrackedTaskInfo>? TaskChanged;
+#pragma warning restore CS0067
+
+        public IObservable<IReadOnlyList<TrackedTaskInfo>> ActiveTasks { get; } = new EmptyActiveTasksObservable();
+
+        public IReadOnlyList<TrackedTaskInfo> AllTasks => [];
+
+        public ITrackedTaskHandle BeginTask(string name, LogCategory category, CancellationTokenSource? cts = null)
+            => throw new NotSupportedException("Not exercised by UnifiedConsoleBatchingTests.");
+
+        public void CancelTask(string taskId) { }
+
+        private sealed class EmptyActiveTasksObservable : IObservable<IReadOnlyList<TrackedTaskInfo>>
+        {
+            public IDisposable Subscribe(IObserver<IReadOnlyList<TrackedTaskInfo>> observer) => NoopDisposable.Instance;
+        }
+
+        private sealed class NoopDisposable : IDisposable
+        {
+            public static readonly NoopDisposable Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/DiffusionNexus.UI/App.axaml.cs
+++ b/DiffusionNexus.UI/App.axaml.cs
@@ -1426,18 +1426,35 @@ public partial class App : Application
     {
         try
         {
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            static async Task Timed(System.Diagnostics.Stopwatch sw, string name, Func<Task> start)
+            {
+                var begin = sw.ElapsedMilliseconds;
+                Serilog.Log.Information("LoadStartupData: {Phase} starting at +{Start}ms", name, begin);
+                var task = start();
+                var headEnd = sw.ElapsedMilliseconds;
+                if (headEnd - begin > 50)
+                    Serilog.Log.Information("LoadStartupData: {Phase} synchronous head took {Head}ms ON THE UI THREAD", name, headEnd - begin);
+                await task;
+                Serilog.Log.Information("LoadStartupData: {Phase} finished at +{End}ms ({Duration}ms total)", name, sw.ElapsedMilliseconds, sw.ElapsedMilliseconds - begin);
+            }
+
             // Disclaimer + settings must complete first � other modules depend on them.
-            await mainViewModel.CheckDisclaimerStatusAsync();
-            await settingsVm.LoadCommand.ExecuteAsync(null);
+            await Timed(sw, "disclaimer", () => mainViewModel.CheckDisclaimerStatusAsync());
+            await Timed(sw, "settings", () => settingsVm.LoadCommand.ExecuteAsync(null));
 
             // Remaining modules are independent � load in parallel.
+            // NOTE: each command runs synchronously on the UI thread until its first
+            // real await — the per-phase "synchronous head" stamps expose which load
+            // is hogging the dispatcher.
             await Task.WhenAll(
-                loraViewerVm.RefreshCommand.ExecuteAsync(null),
-                generationGalleryVm.LoadMediaCommand.ExecuteAsync(null),
-                installerManagerVm.LoadInstallationsCommand.ExecuteAsync(null),
-                loraDatasetHelperVm.DatasetManagement
-                    .CheckStorageConfigurationCommand.ExecuteAsync(null),
-                mainViewModel.LoadServerMessagesAsync());
+                Timed(sw, "loraViewer", () => loraViewerVm.RefreshCommand.ExecuteAsync(null)),
+                Timed(sw, "generationGallery", () => generationGalleryVm.LoadMediaCommand.ExecuteAsync(null)),
+                Timed(sw, "installerManager", () => installerManagerVm.LoadInstallationsCommand.ExecuteAsync(null)),
+                Timed(sw, "datasetStorageCheck", () => loraDatasetHelperVm.DatasetManagement
+                    .CheckStorageConfigurationCommand.ExecuteAsync(null)),
+                Timed(sw, "serverMessages", () => mainViewModel.LoadServerMessagesAsync()));
+            Serilog.Log.Information("LoadStartupData: all phases complete at +{Total}ms", sw.ElapsedMilliseconds);
         }
         catch (Exception ex)
         {

--- a/DiffusionNexus.UI/App.axaml.cs
+++ b/DiffusionNexus.UI/App.axaml.cs
@@ -175,11 +175,19 @@ public partial class App : Application
     /// and module registration (which inflates XAML views) resume on the UI thread
     /// afterwards. On completion (success or failure) the main window's startup
     /// overlay is dismissed via <see cref="DiffusionNexusMainWindowViewModel.IsStartupComplete"/>.
+    /// <para>Each phase reports to the <see cref="DiffusionNexus.UI.Services.Startup.StartupProgressService"/>
+    /// ready-check list. The <c>finally</c> block enforces the hard requirement that the
+    /// UI is responsive the moment the overlay vanishes: it drains the dispatcher with a
+    /// Background-priority sentinel, sets <see cref="DiffusionNexusMainWindowViewModel.IsStartupComplete"/>,
+    /// then releases deferred background work (autocomplete trie) via
+    /// <see cref="DiffusionNexus.UI.Services.Startup.StartupProgressService.SignalUiReady"/>.</para>
     /// </summary>
     private async Task CompleteStartupAsync(DiffusionNexusMainWindowViewModel mainViewModel)
     {
+        var startupProgress = Services!.GetRequiredService<DiffusionNexus.UI.Services.Startup.StartupProgressService>();
         try
         {
+            startupProgress.Begin("database");
             // Database initialization is pure logging + EF work — safe off the UI thread.
             await Task.Run(() =>
             {
@@ -188,10 +196,11 @@ public partial class App : Application
                 Serilog.Log.Information("Initializing SDK database...");
                 InitializeSdkDatabase();
             });
+            startupProgress.Complete("database");
 
             // Everything below resumes on the Avalonia UI thread (its SynchronizationContext
             // was captured at the await above), which these steps require: they touch
-            // converter singletons, spell-check wiring and — via RegisterModules — inflate
+            // converter singletons, spell-check wiring and — via RegisterModulesAsync — inflate
             // XAML views. Do NOT add ConfigureAwait(false) in this method.
             Serilog.Log.Information("Initializing thumbnail service...");
             InitializeThumbnailService();
@@ -217,12 +226,26 @@ public partial class App : Application
             mainViewModel.InitializeInstanceManagement();
 
             Serilog.Log.Information("Registering modules...");
-            RegisterModules(mainViewModel);
+            await RegisterModulesAsync(mainViewModel, startupProgress);
 
-            // Ensure the local-diffusion outputs folder is visible in the Generation Gallery.
-            // Fire-and-forget: failure to register must not block startup (registrar logs internally).
+            // Diffusion Engine: the heavy native warm-up happens inside module
+            // construction; this check confirms the backend singleton resolves.
             if (DiffusionNexus.UI.Services.Diffusion.DiffusionFeatureFlags.UseLocalDiffusionBackend)
             {
+                startupProgress.Begin("diffusion-engine");
+                try
+                {
+                    _ = Services!.GetRequiredService<DiffusionNexus.UI.Services.Diffusion.LocalDiffusionBackendProvider>();
+                    startupProgress.Complete("diffusion-engine");
+                }
+                catch (Exception ex)
+                {
+                    Serilog.Log.Error(ex, "Diffusion engine warm-up failed");
+                    startupProgress.Fail("diffusion-engine", ex.Message);
+                }
+
+                // Ensure the local-diffusion outputs folder is visible in the Generation Gallery.
+                // Fire-and-forget: failure to register must not block startup (registrar logs internally).
                 _ = Task.Run(async () =>
                 {
                     try
@@ -237,19 +260,36 @@ public partial class App : Application
                     }
                 });
             }
+            else
+            {
+                startupProgress.Complete("diffusion-engine");
+            }
         }
         catch (Exception ex)
         {
             Serilog.Log.Fatal(ex, "Deferred startup initialization failed");
+            foreach (var check in startupProgress.Checks)
+            {
+                if (check.State is DiffusionNexus.UI.Services.Startup.StartupCheckState.Pending
+                                or DiffusionNexus.UI.Services.Startup.StartupCheckState.Running
+                    && check.GatesReadiness)
+                {
+                    startupProgress.Fail(check.Id, ex.Message);
+                }
+            }
             Services?.GetService<IActivityLogService>()
                 ?.LogError("Startup", "Startup initialization failed — some features may be unavailable", ex);
         }
         finally
         {
-            // Reached on the UI thread whether the await completed or Task.Run threw
-            // (the exception resumes on the captured UI SynchronizationContext), so this
-            // observable-property set — which dismisses the overlay — is UI-thread-safe.
+            // HARD REQUIREMENT (user): the UI must be responsive when the overlay
+            // vanishes. All core checks are terminal here; drain everything at-and-
+            // above Background priority before dismissing, then release deferred
+            // background work (autocomplete trie) via SignalUiReady.
+            await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
+                static () => { }, Avalonia.Threading.DispatcherPriority.Background);
             mainViewModel.IsStartupComplete = true;
+            startupProgress.SignalUiReady();
         }
     }
 
@@ -1216,83 +1256,156 @@ public partial class App : Application
         }
     }
 
-    private void RegisterModules(DiffusionNexusMainWindowViewModel mainViewModel)
+    /// <summary>
+    /// Builds and registers every module, one module per Background-priority
+    /// dispatcher tick, so rendering and input interleave with construction
+    /// (the old synchronous loop held the UI thread ~3.6s and froze the
+    /// startup overlay). Each module reports Running/Done/Failed to the
+    /// ready-check list. Must be called on the UI thread.
+    /// </summary>
+    private async Task RegisterModulesAsync(
+        DiffusionNexusMainWindowViewModel mainViewModel,
+        DiffusionNexus.UI.Services.Startup.StartupProgressService startupProgress)
     {
+        // Locals consumed after the per-block loop (navigation-event wiring +
+        // LoadStartupDataAsync) are declared nullable up front: a block that fails
+        // leaves its slot null, and the compound guard below skips wiring + data
+        // load for the degraded app (the ready-check list shows which module died).
+        InstallerManagerViewModel? installerManagerVm = null;
+        LoraDatasetHelperViewModel? loraDatasetHelperVm = null;
+        ModuleItem? loraDatasetHelperModule = null;
+        LoraViewerViewModel? loraViewerVm = null;
+        GenerationGalleryViewModel? generationGalleryVm = null;
+        ImageCompareViewModel? imageCompareVm = null;
+        ModuleItem? imageComparerModule = null;
+        PipelinesViewModel? pipelinesVm = null;
+        ModuleItem? pipelinesModule = null;
+        SettingsViewModel? settingsVm = null;
+        ModuleItem? settingsModule = null;
+
         // Installer Manager module
-        var installerManagerVm = Services!.GetRequiredService<InstallerManagerViewModel>();
-        var installerManagerView = new InstallerManagerView { DataContext = installerManagerVm };
-        var installerManagerModule = new ModuleItem(
-            "Installer Manager",
-            "avares://DiffusionNexus.UI/Assets/Installer.png", // TODO: add dedicated Installer Manager icon
-            installerManagerView)
+        startupProgress.Begin("installer-manager");
+        try
         {
-            ViewModel = installerManagerVm
-        };
-
-        mainViewModel.RegisterModule(installerManagerModule);
-
-        // Open the unified console panel when the installer manager requests it (e.g., during updates)
-        installerManagerVm.UnifiedConsolePanelRequested += (_, _) =>
-        {
-            Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+            installerManagerVm = Services!.GetRequiredService<InstallerManagerViewModel>();
+            var installerManagerView = new InstallerManagerView { DataContext = installerManagerVm };
+            var installerManagerModule = new ModuleItem(
+                "Installer Manager",
+                "avares://DiffusionNexus.UI/Assets/Installer.png", // TODO: add dedicated Installer Manager icon
+                installerManagerView)
             {
-                if (mainViewModel.StatusBar is { } statusBar)
+                ViewModel = installerManagerVm
+            };
+
+            mainViewModel.RegisterModule(installerManagerModule);
+
+            // Open the unified console panel when the installer manager requests it (e.g., during updates)
+            installerManagerVm.UnifiedConsolePanelRequested += (_, _) =>
+            {
+                Avalonia.Threading.Dispatcher.UIThread.Post(() =>
                 {
-                    statusBar.IsLogPanelOpen = true;
-                    if (statusBar.UnifiedConsole is not null)
-                        statusBar.UnifiedConsole.IsPanelOpen = true;
-                }
-            });
-        };
+                    if (mainViewModel.StatusBar is { } statusBar)
+                    {
+                        statusBar.IsLogPanelOpen = true;
+                        if (statusBar.UnifiedConsole is not null)
+                            statusBar.UnifiedConsole.IsPanelOpen = true;
+                    }
+                });
+            };
 
-        // Wire Unified Console ↔ Installer Manager update synchronisation:
-        // 1. Console "Update" button delegates to the Installer Manager's centralised logic
-        // 2. Installer Manager state changes flow back to the console tabs
-        if (mainViewModel.StatusBar?.UnifiedConsole is { } unifiedConsole)
-        {
-            unifiedConsole.SetUpdateDelegate(installerManagerVm.UpdatePackageByIdAsync);
+            // Wire Unified Console ↔ Installer Manager update synchronisation:
+            // 1. Console "Update" button delegates to the Installer Manager's centralised logic
+            // 2. Installer Manager state changes flow back to the console tabs
+            if (mainViewModel.StatusBar?.UnifiedConsole is { } unifiedConsole)
+            {
+                unifiedConsole.SetUpdateDelegate(installerManagerVm.UpdatePackageByIdAsync);
 
-            installerManagerVm.InstallerUpdateStateChanged += (_, e) =>
-                unifiedConsole.OnExternalUpdateStateChanged(e);
+                installerManagerVm.InstallerUpdateStateChanged += (_, e) =>
+                    unifiedConsole.OnExternalUpdateStateChanged(e);
+            }
+            startupProgress.Complete("installer-manager");
         }
+        catch (Exception ex)
+        {
+            Serilog.Log.Error(ex, "Module registration failed: {Module}", "installer-manager");
+            startupProgress.Fail("installer-manager", ex.Message);
+        }
+        await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
+            static () => { }, Avalonia.Threading.DispatcherPriority.Background);
 
         // LoRA Dataset Helper module - default on startup
-        var loraDatasetHelperVm = Services!.GetRequiredService<LoraDatasetHelperViewModel>();
-        var loraDatasetHelperView = new LoraDatasetHelperView { DataContext = loraDatasetHelperVm };
-        var loraDatasetHelperModule = new ModuleItem(
-            "LoRA Dataset Helper",
-            "avares://DiffusionNexus.UI/Assets/LoraTrain.png",
-            loraDatasetHelperView)
+        startupProgress.Begin("lora-dataset-helper");
+        try
         {
-            ViewModel = loraDatasetHelperVm
-        };
+            loraDatasetHelperVm = Services!.GetRequiredService<LoraDatasetHelperViewModel>();
+            var loraDatasetHelperView = new LoraDatasetHelperView { DataContext = loraDatasetHelperVm };
+            loraDatasetHelperModule = new ModuleItem(
+                "LoRA Dataset Helper",
+                "avares://DiffusionNexus.UI/Assets/LoraTrain.png",
+                loraDatasetHelperView)
+            {
+                ViewModel = loraDatasetHelperVm
+            };
 
-        mainViewModel.RegisterModule(loraDatasetHelperModule);
+            mainViewModel.RegisterModule(loraDatasetHelperModule);
+            startupProgress.Complete("lora-dataset-helper");
+        }
+        catch (Exception ex)
+        {
+            Serilog.Log.Error(ex, "Module registration failed: {Module}", "lora-dataset-helper");
+            startupProgress.Fail("lora-dataset-helper", ex.Message);
+        }
+        await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
+            static () => { }, Avalonia.Threading.DispatcherPriority.Background);
 
         // LoRA Viewer module
-        var loraViewerVm = Services!.GetRequiredService<LoraViewerViewModel>();
-        var loraViewerView = new LoraViewerView { DataContext = loraViewerVm };
-
-        mainViewModel.RegisterModule(new ModuleItem(
-            "LoRA Viewer",
-            "avares://DiffusionNexus.UI/Assets/LoraSort.png",
-            loraViewerView,
-            isVisible: true)
+        startupProgress.Begin("lora-viewer");
+        try
         {
-            ViewModel = loraViewerVm
-        });
+            loraViewerVm = Services!.GetRequiredService<LoraViewerViewModel>();
+            var loraViewerView = new LoraViewerView { DataContext = loraViewerVm };
+
+            mainViewModel.RegisterModule(new ModuleItem(
+                "LoRA Viewer",
+                "avares://DiffusionNexus.UI/Assets/LoraSort.png",
+                loraViewerView,
+                isVisible: true)
+            {
+                ViewModel = loraViewerVm
+            });
+            startupProgress.Complete("lora-viewer");
+        }
+        catch (Exception ex)
+        {
+            Serilog.Log.Error(ex, "Module registration failed: {Module}", "lora-viewer");
+            startupProgress.Fail("lora-viewer", ex.Message);
+        }
+        await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
+            static () => { }, Avalonia.Threading.DispatcherPriority.Background);
 
         // Generation Gallery module
-        var generationGalleryVm = Services!.GetRequiredService<GenerationGalleryViewModel>();
-        var generationGalleryView = new GenerationGalleryView { DataContext = generationGalleryVm };
-
-        mainViewModel.RegisterModule(new ModuleItem(
-            "Generation Gallery",
-            "avares://DiffusionNexus.UI/Assets/GalleryView.png",
-            generationGalleryView)
+        startupProgress.Begin("generation-gallery");
+        try
         {
-            ViewModel = generationGalleryVm
-        });
+            generationGalleryVm = Services!.GetRequiredService<GenerationGalleryViewModel>();
+            var generationGalleryView = new GenerationGalleryView { DataContext = generationGalleryVm };
+
+            mainViewModel.RegisterModule(new ModuleItem(
+                "Generation Gallery",
+                "avares://DiffusionNexus.UI/Assets/GalleryView.png",
+                generationGalleryView)
+            {
+                ViewModel = generationGalleryVm
+            });
+            startupProgress.Complete("generation-gallery");
+        }
+        catch (Exception ex)
+        {
+            Serilog.Log.Error(ex, "Module registration failed: {Module}", "generation-gallery");
+            startupProgress.Fail("generation-gallery", ex.Message);
+        }
+        await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
+            static () => { }, Avalonia.Threading.DispatcherPriority.Background);
 
         // Diffusion Canvas module — local Z-Image-Turbo generation on an Invoke-AI-style canvas.
         // Gated behind DiffusionFeatureFlags.UseLocalDiffusionBackend so the module disappears
@@ -1301,117 +1414,178 @@ public partial class App : Application
         // (IsDiffusionCanvasEnabled) reveals it.
         if (DiffusionNexus.UI.Services.Diffusion.DiffusionFeatureFlags.UseLocalDiffusionBackend)
         {
-            var diffusionCanvasVm = Services!.GetRequiredService<DiffusionNexus.UI.ViewModels.DiffusionCanvas.DiffusionCanvasViewModel>();
-            var diffusionCanvasView = new DiffusionNexus.UI.Views.DiffusionCanvas.DiffusionCanvasView
+            startupProgress.Begin("diffusion-canvas");
+            try
             {
-                DataContext = diffusionCanvasVm
-            };
+                var diffusionCanvasVm = Services!.GetRequiredService<DiffusionNexus.UI.ViewModels.DiffusionCanvas.DiffusionCanvasViewModel>();
+                var diffusionCanvasView = new DiffusionNexus.UI.Views.DiffusionCanvas.DiffusionCanvasView
+                {
+                    DataContext = diffusionCanvasVm
+                };
 
-            var diffusionCanvasModule = new ModuleItem(
-                "Diffusion Canvas",
-                "avares://DiffusionNexus.UI/Assets/PromptEdit.png", // TODO: dedicated canvas icon
-                diffusionCanvasView,
-                isVisible: mainViewModel.IsDiffusionCanvasEnabled)
+                var diffusionCanvasModule = new ModuleItem(
+                    "Diffusion Canvas",
+                    "avares://DiffusionNexus.UI/Assets/PromptEdit.png", // TODO: dedicated canvas icon
+                    diffusionCanvasView,
+                    isVisible: mainViewModel.IsDiffusionCanvasEnabled)
+                {
+                    ViewModel = diffusionCanvasVm
+                };
+
+                mainViewModel.RegisterModule(diffusionCanvasModule);
+                mainViewModel.SetDiffusionCanvasModule(diffusionCanvasModule);
+                startupProgress.Complete("diffusion-canvas");
+            }
+            catch (Exception ex)
             {
-                ViewModel = diffusionCanvasVm
-            };
-
-            mainViewModel.RegisterModule(diffusionCanvasModule);
-            mainViewModel.SetDiffusionCanvasModule(diffusionCanvasModule);
+                Serilog.Log.Error(ex, "Module registration failed: {Module}", "diffusion-canvas");
+                startupProgress.Fail("diffusion-canvas", ex.Message);
+            }
         }
+        await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
+            static () => { }, Avalonia.Threading.DispatcherPriority.Background);
 
         // Image Comparer module
-        var datasetState = Services!.GetRequiredService<IDatasetState>();
-        var thumbnailOrchestrator = Services!.GetService<IThumbnailOrchestrator>();
-        var dialogService = Services!.GetRequiredService<IDialogService>();
-        var imageCompareVm = new ImageCompareViewModel(datasetState, thumbnailOrchestrator, dialogService);
-        var imageCompareView = new ImageCompareView { DataContext = imageCompareVm };
-
-        var imageComparerModule = new ModuleItem(
-            "Image Comparer",
-            "avares://DiffusionNexus.UI/Assets/ImageComparer.png",
-            imageCompareView)
+        startupProgress.Begin("image-comparer");
+        try
         {
-            ViewModel = imageCompareVm
-        };
+            var datasetState = Services!.GetRequiredService<IDatasetState>();
+            var thumbnailOrchestrator = Services!.GetService<IThumbnailOrchestrator>();
+            var dialogService = Services!.GetRequiredService<IDialogService>();
+            imageCompareVm = new ImageCompareViewModel(datasetState, thumbnailOrchestrator, dialogService);
+            var imageCompareView = new ImageCompareView { DataContext = imageCompareVm };
 
-        mainViewModel.RegisterModule(imageComparerModule);
+            imageComparerModule = new ModuleItem(
+                "Image Comparer",
+                "avares://DiffusionNexus.UI/Assets/ImageComparer.png",
+                imageCompareView)
+            {
+                ViewModel = imageCompareVm
+            };
+
+            mainViewModel.RegisterModule(imageComparerModule);
+            startupProgress.Complete("image-comparer");
+        }
+        catch (Exception ex)
+        {
+            Serilog.Log.Error(ex, "Module registration failed: {Module}", "image-comparer");
+            startupProgress.Fail("image-comparer", ex.Message);
+        }
+        await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
+            static () => { }, Avalonia.Threading.DispatcherPriority.Background);
 
         // Pipelines module — tile gallery of guided image pipelines (currently Anime-To-Real).
-        var pipelinesVm = Services!.GetRequiredService<PipelinesViewModel>();
-        var pipelinesView = new PipelinesView { DataContext = pipelinesVm };
-
-        var pipelinesModule = new ModuleItem(
-            "Workflows",
-            "avares://DiffusionNexus.UI/Assets/HumanCogwheel.png",
-            pipelinesView)
+        startupProgress.Begin("workflows");
+        try
         {
-            ViewModel = pipelinesVm
-        };
+            pipelinesVm = Services!.GetRequiredService<PipelinesViewModel>();
+            var pipelinesView = new PipelinesView { DataContext = pipelinesVm };
 
-        mainViewModel.RegisterModule(pipelinesModule);
+            pipelinesModule = new ModuleItem(
+                "Workflows",
+                "avares://DiffusionNexus.UI/Assets/HumanCogwheel.png",
+                pipelinesView)
+            {
+                ViewModel = pipelinesVm
+            };
+
+            mainViewModel.RegisterModule(pipelinesModule);
+            startupProgress.Complete("workflows");
+        }
+        catch (Exception ex)
+        {
+            Serilog.Log.Error(ex, "Module registration failed: {Module}", "workflows");
+            startupProgress.Fail("workflows", ex.Message);
+        }
+        await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
+            static () => { }, Avalonia.Threading.DispatcherPriority.Background);
 
         // Settings module
-        var settingsVm = Services!.GetRequiredService<SettingsViewModel>();
-        var settingsView = new SettingsView { DataContext = settingsVm };
-
-        var settingsModule = new ModuleItem(
-            "Settings",
-            "avares://DiffusionNexus.UI/Assets/settings.png",
-            settingsView);
-
-        mainViewModel.RegisterModule(settingsModule);
-
-        // Subscribe to navigation events
-        var eventAggregator = Services!.GetRequiredService<IDatasetEventAggregator>();
-        
-        eventAggregator.NavigateToImageEditorRequested += (_, _) =>
+        startupProgress.Begin("settings");
+        try
         {
-            mainViewModel.NavigateToModuleCommand.Execute(loraDatasetHelperModule);
-        };
+            settingsVm = Services!.GetRequiredService<SettingsViewModel>();
+            var settingsView = new SettingsView { DataContext = settingsVm };
 
-        eventAggregator.NavigateToBatchCropScaleRequested += (_, _) =>
+            settingsModule = new ModuleItem(
+                "Settings",
+                "avares://DiffusionNexus.UI/Assets/settings.png",
+                settingsView);
+
+            mainViewModel.RegisterModule(settingsModule);
+            startupProgress.Complete("settings");
+        }
+        catch (Exception ex)
         {
-            mainViewModel.NavigateToModuleCommand.Execute(loraDatasetHelperModule);
-        };
+            Serilog.Log.Error(ex, "Module registration failed: {Module}", "settings");
+            startupProgress.Fail("settings", ex.Message);
+        }
+        await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
+            static () => { }, Avalonia.Threading.DispatcherPriority.Background);
 
-        eventAggregator.NavigateToBatchUpscaleRequested += (_, _) =>
+        // If any module failed to build, its slot is null: skip event wiring + data
+        // load for the degraded app (the ready-check list shows which module died).
+        if (installerManagerVm is not null && loraDatasetHelperVm is not null && loraViewerVm is not null
+            && generationGalleryVm is not null && imageCompareVm is not null && pipelinesVm is not null
+            && settingsVm is not null && settingsModule is not null && loraDatasetHelperModule is not null
+            && imageComparerModule is not null && pipelinesModule is not null)
         {
-            mainViewModel.NavigateToModuleCommand.Execute(loraDatasetHelperModule);
-        };
+            // Subscribe to navigation events
+            var eventAggregator = Services!.GetRequiredService<IDatasetEventAggregator>();
 
-        eventAggregator.NavigateToCaptioningRequested += (_, _) =>
+            eventAggregator.NavigateToImageEditorRequested += (_, _) =>
+            {
+                mainViewModel.NavigateToModuleCommand.Execute(loraDatasetHelperModule);
+            };
+
+            eventAggregator.NavigateToBatchCropScaleRequested += (_, _) =>
+            {
+                mainViewModel.NavigateToModuleCommand.Execute(loraDatasetHelperModule);
+            };
+
+            eventAggregator.NavigateToBatchUpscaleRequested += (_, _) =>
+            {
+                mainViewModel.NavigateToModuleCommand.Execute(loraDatasetHelperModule);
+            };
+
+            eventAggregator.NavigateToCaptioningRequested += (_, _) =>
+            {
+                mainViewModel.NavigateToModuleCommand.Execute(loraDatasetHelperModule);
+            };
+
+            eventAggregator.NavigateToSettingsRequested += (_, _) =>
+            {
+                mainViewModel.NavigateToModuleCommand.Execute(settingsModule);
+            };
+
+            eventAggregator.NavigateToImageComparerRequested += (_, e) =>
+            {
+                imageCompareVm.LoadExternalImages(e.ImagePaths);
+                mainViewModel.NavigateToModuleCommand.Execute(imageComparerModule);
+            };
+
+            eventAggregator.NavigateToWorkflowRequested += (_, e) =>
+            {
+                mainViewModel.NavigateToModuleCommand.Execute(pipelinesModule);
+                _ = pipelinesVm.OpenWorkflowAsync(e.WorkflowId, e.ImagePaths);
+            };
+
+            // Load startup data sequentially to avoid concurrent DbContext access.
+            // All scoped services share a single DiffusionNexusCoreDbContext instance
+            // which is NOT thread-safe; fire-and-forget Execute() calls run concurrently.
+            _ = LoadStartupDataAsync(
+                mainViewModel,
+                settingsVm,
+                loraViewerVm,
+                generationGalleryVm,
+                installerManagerVm,
+                loraDatasetHelperVm,
+                startupProgress);
+        }
+        else
         {
-            mainViewModel.NavigateToModuleCommand.Execute(loraDatasetHelperModule);
-        };
-
-        eventAggregator.NavigateToSettingsRequested += (_, _) =>
-        {
-            mainViewModel.NavigateToModuleCommand.Execute(settingsModule);
-        };
-
-        eventAggregator.NavigateToImageComparerRequested += (_, e) =>
-        {
-            imageCompareVm.LoadExternalImages(e.ImagePaths);
-            mainViewModel.NavigateToModuleCommand.Execute(imageComparerModule);
-        };
-
-        eventAggregator.NavigateToWorkflowRequested += (_, e) =>
-        {
-            mainViewModel.NavigateToModuleCommand.Execute(pipelinesModule);
-            _ = pipelinesVm.OpenWorkflowAsync(e.WorkflowId, e.ImagePaths);
-        };
-
-        // Load startup data sequentially to avoid concurrent DbContext access.
-        // All scoped services share a single DiffusionNexusCoreDbContext instance
-        // which is NOT thread-safe; fire-and-forget Execute() calls run concurrently.
-        _ = LoadStartupDataAsync(
-            mainViewModel,
-            settingsVm,
-            loraViewerVm,
-            generationGalleryVm,
-            installerManagerVm,
-            loraDatasetHelperVm);
+            Serilog.Log.Warning("Skipping navigation wiring and startup data load: one or more modules failed to register.");
+        }
     }
 
     /// <summary>
@@ -1426,7 +1600,8 @@ public partial class App : Application
         LoraViewerViewModel loraViewerVm,
         GenerationGalleryViewModel generationGalleryVm,
         InstallerManagerViewModel installerManagerVm,
-        LoraDatasetHelperViewModel loraDatasetHelperVm)
+        LoraDatasetHelperViewModel loraDatasetHelperVm,
+        DiffusionNexus.UI.Services.Startup.StartupProgressService startupProgress)
     {
         try
         {
@@ -1454,7 +1629,20 @@ public partial class App : Application
             await Task.WhenAll(
                 Timed(sw, "loraViewer", () => loraViewerVm.RefreshCommand.ExecuteAsync(null)),
                 Timed(sw, "generationGallery", () => generationGalleryVm.LoadMediaCommand.ExecuteAsync(null)),
-                Timed(sw, "installerManager", () => installerManagerVm.LoadInstallationsCommand.ExecuteAsync(null)),
+                Timed(sw, "installerManager", async () =>
+                {
+                    startupProgress.Begin("updates");
+                    try
+                    {
+                        await installerManagerVm.LoadInstallationsCommand.ExecuteAsync(null);
+                        startupProgress.Complete("updates");
+                    }
+                    catch (Exception ex)
+                    {
+                        startupProgress.Fail("updates", ex.Message);
+                        throw;
+                    }
+                }),
                 Timed(sw, "datasetStorageCheck", () => loraDatasetHelperVm.DatasetManagement
                     .CheckStorageConfigurationCommand.ExecuteAsync(null)),
                 Timed(sw, "serverMessages", () => mainViewModel.LoadServerMessagesAsync()));

--- a/DiffusionNexus.UI/App.axaml.cs
+++ b/DiffusionNexus.UI/App.axaml.cs
@@ -111,43 +111,18 @@ public partial class App : Application
                 _appScope = rootProvider.CreateScope();
                 Services = _appScope.ServiceProvider;
 
-                // Initialize ThumbnailService for converters
-                Serilog.Log.Information("Initializing thumbnail service...");
-                InitializeThumbnailService();
-
-                // Initialize spell check and autocomplete for caption editors
-                Serilog.Log.Information("Initializing spell check services...");
-                InitializeSpellCheckServices();
-
-                // Initialize databases
-                Serilog.Log.Information("Initializing app database...");
-                InitializeDatabase();
-
-                Serilog.Log.Information("Initializing SDK database...");
-                InitializeSdkDatabase();
-
-                // Create main window with modules
+                // Create main window view model
                 Serilog.Log.Information("Creating main window view model...");
                 var mainViewModel = new DiffusionNexusMainWindowViewModel();
 
-                // Initialize status bar with activity log service
+                // Initialize status bar with activity log service. This only constructs
+                // the in-memory status-bar / unified-console view models (no DB access);
+                // DB-backed instance loading is wired later in CompleteStartupAsync.
                 Serilog.Log.Information("Initializing status bar...");
                 mainViewModel.InitializeStatusBar();
 
-                // Force-resolve the InstanceProcessManager singleton so its constructor
-                // wires PackageProcessManager.OutputReceived ? IUnifiedLogger.
-                // Without this, process stdout/stderr never reaches the Unified Console.
-                Serilog.Log.Information("Initializing instance process manager...");
-                _ = Services!.GetRequiredService<IInstanceProcessManager>();
-
-                // Wire the Civitai base-model catalog into the Unified Console:
-                // - log how old the on-disk definition is right now
-                // - log every refresh attempt (cache hit, live fetch + result, fallback)
-                Serilog.Log.Information("Initializing Civitai base-model catalog...");
-                InitializeCivitaiBaseModelCatalog();
-
-                // Create and assign the main window before registering modules,
-                // because module resolution requires IDialogService which needs MainWindow.
+                // Create and assign the main window before showing it. Module resolution
+                // (deferred to CompleteStartupAsync) requires IDialogService, which needs MainWindow.
                 Serilog.Log.Information("Creating main window...");
                 var mainWindow = new DiffusionNexusMainWindow
                 {
@@ -156,33 +131,8 @@ public partial class App : Application
                 desktop.MainWindow = mainWindow;
                 Serilog.Log.Information("Main window assigned to desktop.MainWindow");
 
-                Serilog.Log.Information("Registering modules...");
-                RegisterModules(mainViewModel);
-
-                // Ensure the local-diffusion outputs folder is visible in the Generation Gallery.
-                // Fire-and-forget: failure to register must not block startup (registrar logs internally).
-                if (DiffusionNexus.UI.Services.Diffusion.DiffusionFeatureFlags.UseLocalDiffusionBackend)
-                {
-                    _ = Task.Run(async () =>
-                    {
-                        try
-                        {
-                            using var scope = Services!.CreateScope();
-                            var registrar = scope.ServiceProvider.GetRequiredService<DiffusionNexus.UI.Services.Diffusion.OutputsFolderRegistrar>();
-                            await registrar.EnsureRegisteredAsync();
-                        }
-                        catch (Exception ex)
-                        {
-                            Serilog.Log.Warning(ex, "OutputsFolderRegistrar failed during startup.");
-                        }
-                    });
-                }
-
-                // Force show the window explicitly
-                mainWindow.Show();
-                Serilog.Log.Information("Main window Show() called");
-
-                // Cleanup on shutdown
+                // Cleanup on shutdown — registered before Show() so it is wired before
+                // anything can close the app.
                 desktop.ShutdownRequested += (_, _) =>
                 {
                     // Dispose the instance process manager (unwires events)
@@ -198,6 +148,14 @@ public partial class App : Application
                     Services?.GetService<PackageProcessManager>()?.Dispose();
                     _appScope?.Dispose();
                 };
+
+                // Show FIRST: the window becomes visible and interactive immediately;
+                // databases, service warm-up and module registration follow asynchronously
+                // (CompleteStartupAsync). A lightweight overlay covers the module host until then.
+                mainWindow.Show();
+                Serilog.Log.Information("Main window Show() called");
+
+                _ = CompleteStartupAsync(mainViewModel);
             }
             catch (Exception ex)
             {
@@ -209,6 +167,90 @@ public partial class App : Application
         Serilog.Log.Information("Calling base.OnFrameworkInitializationCompleted...");
         base.OnFrameworkInitializationCompleted();
         Serilog.Log.Information("OnFrameworkInitializationCompleted finished");
+    }
+
+    /// <summary>
+    /// Deferred startup: everything that used to run before Show() but doesn't
+    /// need to. Database init runs on a pool thread; the UI-affine service warm-up
+    /// and module registration (which inflates XAML views) resume on the UI thread
+    /// afterwards. On completion (success or failure) the main window's startup
+    /// overlay is dismissed via <see cref="DiffusionNexusMainWindowViewModel.IsStartupComplete"/>.
+    /// </summary>
+    private async Task CompleteStartupAsync(DiffusionNexusMainWindowViewModel mainViewModel)
+    {
+        try
+        {
+            // Database initialization is pure logging + EF work — safe off the UI thread.
+            await Task.Run(() =>
+            {
+                Serilog.Log.Information("Initializing app database...");
+                InitializeDatabase();
+                Serilog.Log.Information("Initializing SDK database...");
+                InitializeSdkDatabase();
+            });
+
+            // Everything below resumes on the Avalonia UI thread (its SynchronizationContext
+            // was captured at the await above), which these steps require: they touch
+            // converter singletons, spell-check wiring and — via RegisterModules — inflate
+            // XAML views. Do NOT add ConfigureAwait(false) in this method.
+            Serilog.Log.Information("Initializing thumbnail service...");
+            InitializeThumbnailService();
+
+            Serilog.Log.Information("Initializing spell check services...");
+            InitializeSpellCheckServices();
+
+            // Force-resolve the InstanceProcessManager singleton so its constructor
+            // wires PackageProcessManager output -> IUnifiedLogger. Without this, process
+            // stdout/stderr never reaches the Unified Console.
+            Serilog.Log.Information("Initializing instance process manager...");
+            _ = Services!.GetRequiredService<IInstanceProcessManager>();
+
+            // Wire the Civitai base-model catalog into the Unified Console (age report +
+            // per-refresh logging), then kick off a background load.
+            Serilog.Log.Information("Initializing Civitai base-model catalog...");
+            InitializeCivitaiBaseModelCatalog();
+
+            // Wire DB-backed instance management now that the databases exist. Moved here
+            // from InitializeStatusBar because it triggers LoadInstancesAsync, which reads
+            // the core database's InstallerPackages table (see Step 4 of the perf plan).
+            Serilog.Log.Information("Initializing instance management...");
+            mainViewModel.InitializeInstanceManagement();
+
+            Serilog.Log.Information("Registering modules...");
+            RegisterModules(mainViewModel);
+
+            // Ensure the local-diffusion outputs folder is visible in the Generation Gallery.
+            // Fire-and-forget: failure to register must not block startup (registrar logs internally).
+            if (DiffusionNexus.UI.Services.Diffusion.DiffusionFeatureFlags.UseLocalDiffusionBackend)
+            {
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        using var scope = Services!.CreateScope();
+                        var registrar = scope.ServiceProvider.GetRequiredService<DiffusionNexus.UI.Services.Diffusion.OutputsFolderRegistrar>();
+                        await registrar.EnsureRegisteredAsync();
+                    }
+                    catch (Exception ex)
+                    {
+                        Serilog.Log.Warning(ex, "OutputsFolderRegistrar failed during startup.");
+                    }
+                });
+            }
+        }
+        catch (Exception ex)
+        {
+            Serilog.Log.Fatal(ex, "Deferred startup initialization failed");
+            Services?.GetService<IActivityLogService>()
+                ?.LogError("Startup", "Startup initialization failed — some features may be unavailable", ex);
+        }
+        finally
+        {
+            // Reached on the UI thread whether the await completed or Task.Run threw
+            // (the exception resumes on the captured UI SynchronizationContext), so this
+            // observable-property set — which dismisses the overlay — is UI-thread-safe.
+            mainViewModel.IsStartupComplete = true;
+        }
     }
 
     /// <summary>

--- a/DiffusionNexus.UI/App.axaml.cs
+++ b/DiffusionNexus.UI/App.axaml.cs
@@ -114,6 +114,8 @@ public partial class App : Application
                 // Create main window view model
                 Serilog.Log.Information("Creating main window view model...");
                 var mainViewModel = new DiffusionNexusMainWindowViewModel();
+                mainViewModel.StartupOverlay = new StartupOverlayViewModel(
+                    Services!.GetRequiredService<DiffusionNexus.UI.Services.Startup.StartupProgressService>());
 
                 // Initialize status bar with activity log service. This only constructs
                 // the in-memory status-bar / unified-console view models (no DB access);

--- a/DiffusionNexus.UI/App.axaml.cs
+++ b/DiffusionNexus.UI/App.axaml.cs
@@ -411,6 +411,11 @@ public partial class App : Application
             // Post-migration verification to catch schema gaps
             Serilog.Log.Information("InitializeDatabase: Post-migration schema verification...");
             CheckAndRepairSchema(dbContext);
+
+            // WAL: readers no longer block behind writers (e.g. the end-of-backup
+            // LastBackupAt write). Persistent — set once per launch is idempotent.
+            Serilog.Log.Information("InitializeDatabase: Ensuring WAL journal mode...");
+            dbContext.Database.ExecuteSqlRaw("PRAGMA journal_mode=WAL;");
         }
         catch (SqliteException ex) when (ex.Message.Contains("already exists"))
         {

--- a/DiffusionNexus.UI/App.axaml.cs
+++ b/DiffusionNexus.UI/App.axaml.cs
@@ -292,6 +292,7 @@ public partial class App : Application
                 static () => { }, Avalonia.Threading.DispatcherPriority.Background);
             mainViewModel.IsStartupComplete = true;
             startupProgress.SignalUiReady();
+            Serilog.Log.Information("Startup ready - overlay dismissed");
         }
     }
 

--- a/DiffusionNexus.UI/App.axaml.cs
+++ b/DiffusionNexus.UI/App.axaml.cs
@@ -1044,7 +1044,11 @@ public partial class App : Application
         services.AddSingleton<IUserDictionaryService, UserDictionaryService>();
         services.AddSingleton<ISpellCheckService>(sp =>
             new SpellCheckService(sp.GetRequiredService<IUserDictionaryService>()));
-        services.AddSingleton<IAutoCompleteService, AutoCompleteService>();
+        services.AddSingleton(_ => new DiffusionNexus.UI.Services.Startup.StartupProgressService(
+            DiffusionNexus.UI.Services.Startup.StartupProgressService.BuildDefaultChecks(
+                DiffusionNexus.UI.Services.Diffusion.DiffusionFeatureFlags.UseLocalDiffusionBackend)));
+        services.AddSingleton<IAutoCompleteService>(sp => new AutoCompleteService(
+            sp.GetRequiredService<DiffusionNexus.UI.Services.Startup.StartupProgressService>().UiReady));
 
         // Bridge UI spell check into the domain contract used by dataset quality checks
         services.AddSingleton<ISpellChecker>(sp =>

--- a/DiffusionNexus.UI/App.axaml.cs
+++ b/DiffusionNexus.UI/App.axaml.cs
@@ -484,11 +484,21 @@ public partial class App : Application
                     break;
             }
 
-            // Apply any pending schema migrations on top of the (seed) data.
+            // Apply pending schema migrations on top of the (seed) data — but only
+            // when there are any; an unconditional Migrate() costs a full EF
+            // migration pass on every launch (mirrors the core-DB gating above).
             var sdkContext = Services!.GetRequiredService<SdkContext>();
-            Serilog.Log.Information("InitializeSdkDatabase: Applying migrations to SDK database...");
-            sdkContext.Database.Migrate();
-            Serilog.Log.Information("InitializeSdkDatabase: Migration completed successfully");
+            var pendingSdkMigrations = sdkContext.Database.GetPendingMigrations().ToList();
+            if (pendingSdkMigrations.Count > 0)
+            {
+                Serilog.Log.Information("InitializeSdkDatabase: Applying {Count} pending migration(s)...", pendingSdkMigrations.Count);
+                sdkContext.Database.Migrate();
+                Serilog.Log.Information("InitializeSdkDatabase: Migration completed successfully");
+            }
+            else
+            {
+                Serilog.Log.Information("InitializeSdkDatabase: No pending migrations - SKIPPING Migrate()");
+            }
 
             activityLog?.LogInfo(logSource, $"Database loaded from: {runtimeDb}");
         }

--- a/DiffusionNexus.UI/DiffusionNexus.UI.csproj
+++ b/DiffusionNexus.UI/DiffusionNexus.UI.csproj
@@ -56,6 +56,13 @@
     <PackageReference Include="Avalonia.Skia" Version="11.3.13" />
     <PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.3.13" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.13" />
+    <!-- ItemsRepeater + UniformGridLayout power the virtualizing LoRA-viewer tile grid
+         (only the tiles inside the viewport are realized, so 2K+ LoRAs open instantly
+         and scroll smoothly). These types are NOT in core Avalonia 11.3.x; they ship in
+         this standalone package, whose newest 11.x release is 11.1.5 (Avalonia published
+         no 11.2/11.3 build of it). 11.1.5 resolves and runs against 11.3.13 core — the
+         combo every 11.3.x consumer of ItemsRepeater necessarily uses. -->
+    <PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.1.5" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DiffusionNexus.UI/Helpers/BatchedListFiller.cs
+++ b/DiffusionNexus.UI/Helpers/BatchedListFiller.cs
@@ -29,11 +29,17 @@ public static class BatchedListFiller
         {
             if (cancelled) return;
 
-            var batchEnd = Math.Min(next + batchSize, endExclusive);
+            // Re-clamp against source.Count on every tick: the source can
+            // shrink between posted batches (e.g. an item is deleted while the
+            // fill is still streaming). endExclusive was captured at Fill time,
+            // so trusting it alone would read past the new tail and throw.
+            var batchEnd = Math.Min(Math.Min(next + batchSize, endExclusive), source.Count);
             for (; next < batchEnd; next++)
                 target.Add(source[next]);
 
-            if (next < endExclusive)
+            // A shrink can also leave next at/past the new tail — that is
+            // terminal too: stop posting and complete cleanly.
+            if (next < endExclusive && next < source.Count)
                 post(AddBatch);
             else
                 onCompleted?.Invoke();

--- a/DiffusionNexus.UI/Helpers/BatchedListFiller.cs
+++ b/DiffusionNexus.UI/Helpers/BatchedListFiller.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+
+namespace DiffusionNexus.UI.Helpers;
+
+/// <summary>
+/// Fills a target list from a source range in scheduler-batched chunks. The
+/// first batch is added synchronously (instant first paint); subsequent batches
+/// go through <paramref name="post"/> (in production: Dispatcher post at
+/// Background priority) so layout and input can interleave. Prevents realizing
+/// hundreds of item containers in a single layout pass.
+/// </summary>
+public static class BatchedListFiller
+{
+    /// <returns>A cancel action that abandons the not-yet-run batches.</returns>
+    public static Action Fill<T>(
+        IList<T> target,
+        IReadOnlyList<T> source,
+        int start,
+        int endExclusive,
+        int batchSize,
+        Action<Action> post,
+        Action? onCompleted = null)
+    {
+        var cancelled = false;
+        var next = start;
+
+        void AddBatch()
+        {
+            if (cancelled) return;
+
+            var batchEnd = Math.Min(next + batchSize, endExclusive);
+            for (; next < batchEnd; next++)
+                target.Add(source[next]);
+
+            if (next < endExclusive)
+                post(AddBatch);
+            else
+                onCompleted?.Invoke();
+        }
+
+        AddBatch();
+        return () => cancelled = true;
+    }
+}

--- a/DiffusionNexus.UI/Program.cs
+++ b/DiffusionNexus.UI/Program.cs
@@ -53,13 +53,26 @@ class Program
     }
 
     public static AppBuilder BuildAvaloniaApp()
-        => AppBuilder.Configure<App>()
+    {
+        var builder = AppBuilder.Configure<App>()
             .UsePlatformDetect()
-            // Force software rendering to diagnose GPU issues
-            .With(new Win32PlatformOptions
-            {
-                RenderingMode = [Win32RenderingMode.Software]
-            })
             .WithInterFont()
             .LogToTrace();
+
+        // Hardware rendering by default (ANGLE, with Avalonia's built-in software
+        // fallback). DIFFUSIONNEXUS_SOFTWARE_RENDERING=1 forces the software
+        // compositor on machines with broken GPU drivers.
+        // TODO: Linux Implementation — the override below is Win32-specific.
+        if (Startup.RenderingConfig.UseSoftwareRendering(Environment.GetEnvironmentVariable))
+        {
+            Log.Information("Rendering: software compositor forced via {EnvVar}",
+                Startup.RenderingConfig.SoftwareRenderingEnvVar);
+            builder = builder.With(new Win32PlatformOptions
+            {
+                RenderingMode = [Win32RenderingMode.Software]
+            });
+        }
+
+        return builder;
+    }
 }

--- a/DiffusionNexus.UI/Services/SpellCheck/AutoCompleteService.cs
+++ b/DiffusionNexus.UI/Services/SpellCheck/AutoCompleteService.cs
@@ -12,18 +12,43 @@ public sealed class AutoCompleteService : IAutoCompleteService
     private readonly object _lock = new();
 
     /// <summary>
-    /// Creates an AutoCompleteService and seeds it from the Hunspell dictionary.
+    /// Creates an AutoCompleteService and seeds it from the Hunspell dictionary
+    /// immediately on a background task. Used by tests and non-startup callers.
     /// </summary>
     public AutoCompleteService(string? dictionaryDirectory = null)
+        : this(Task.CompletedTask, dictionaryDirectory)
+    {
+    }
+
+    /// <summary>
+    /// Defers the dictionary load until <paramref name="startSignal"/> completes,
+    /// then runs it on a dedicated BelowNormal-priority thread. The load costs
+    /// ~20s of CPU (Hunspell suffix expansion); at startup it must neither run
+    /// on the UI thread nor compete with startup work for cores — the app signals
+    /// StartupProgressService.UiReady after the overlay's drain sentinel, and the
+    /// load begins only then. GetSuggestions/RecordWord tolerate the not-yet-loaded
+    /// state (they briefly contend on _lock and see a partial trie).
+    /// </summary>
+    public AutoCompleteService(Task startSignal, string? dictionaryDirectory = null)
     {
         var dir = dictionaryDirectory ?? Path.Combine(AppContext.BaseDirectory, "Dictionaries");
+        LoadCompleted = LoadAfterSignalAsync(startSignal, dir);
+    }
 
-        // Background-load so the UI thread doesn't block on Hunspell's ~6s parse plus
-        // inflected-form generation. GetSuggestions/RecordWord called during the load
-        // window will briefly contend on _lock — acceptable because caption editors
-        // aren't visible during the first seconds of cold start.
-        // Tests (and any caller that needs to wait) can await LoadCompleted.
-        LoadCompleted = Task.Run(() => LoadFromDictionary(dir));
+    private async Task LoadAfterSignalAsync(Task startSignal, string dir)
+    {
+        try { await startSignal.ConfigureAwait(false); }
+        catch { /* a faulted signal must not kill autocomplete; load anyway */ }
+
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new Thread(() => { LoadFromDictionary(dir); tcs.TrySetResult(); })
+        {
+            IsBackground = true,
+            Priority = ThreadPriority.BelowNormal,
+            Name = "AutoCompleteTrieLoad",
+        };
+        thread.Start();
+        await tcs.Task.ConfigureAwait(false);
     }
 
     /// <summary>

--- a/DiffusionNexus.UI/Services/SpellCheck/AutoCompleteService.cs
+++ b/DiffusionNexus.UI/Services/SpellCheck/AutoCompleteService.cs
@@ -26,8 +26,10 @@ public sealed class AutoCompleteService : IAutoCompleteService
     /// ~20s of CPU (Hunspell suffix expansion); at startup it must neither run
     /// on the UI thread nor compete with startup work for cores — the app signals
     /// StartupProgressService.UiReady after the overlay's drain sentinel, and the
-    /// load begins only then. GetSuggestions/RecordWord tolerate the not-yet-loaded
-    /// state (they briefly contend on _lock and see a partial trie).
+    /// load begins only then. The build takes <c>_lock</c> per word (not for the
+    /// whole build), so GetSuggestions/RecordWord never block on the build itself —
+    /// callers see a partial trie mid-load and wait only microseconds per call, even
+    /// while a caption editor is open and the user is actively typing.
     /// </summary>
     public AutoCompleteService(Task startSignal, string? dictionaryDirectory = null)
     {
@@ -109,14 +111,19 @@ public sealed class AutoCompleteService : IAutoCompleteService
             // RootWords only contains stems (e.g. "disappoint") but not
             // derived forms ("disappointed", "disappointing"). We expand each
             // root with common English suffixes and validate via Check().
-            lock (_lock)
+            // The lock is taken per root word (not around the whole loop) so a
+            // UI-thread caller (GetSuggestions/RecordWord) never waits on the
+            // full ~20s build — only on the microseconds it takes to insert one
+            // word's worth of entries.
+            foreach (var entry in wordList.RootWords)
             {
-                foreach (var entry in wordList.RootWords)
-                {
-                    if (entry.Length < 2 || !entry.All(c => char.IsLetter(c) || c == '\''))
-                        continue;
+                if (entry.Length < 2 || !entry.All(c => char.IsLetter(c) || c == '\''))
+                    continue;
 
-                    var lower = entry.ToLowerInvariant();
+                var lower = entry.ToLowerInvariant();
+
+                lock (_lock)
+                {
                     Insert(lower, 1, increment: false);
 
                     // Generate common inflected forms and keep any that the dictionary accepts
@@ -147,22 +154,25 @@ public sealed class AutoCompleteService : IAutoCompleteService
             var path = Path.Combine(directory, "supplementary_words.txt");
             if (!File.Exists(path)) return;
 
+            // Locked per line (not around the whole file loop) for the same reason as
+            // LoadFromDictionary: keep UI-thread callers from ever waiting on more than
+            // one word's worth of work.
             int count = 0;
-            lock (_lock)
+            foreach (var line in File.ReadLines(path))
             {
-                foreach (var line in File.ReadLines(path))
+                var trimmed = line.Trim();
+                if (trimmed.Length < 2 || trimmed.StartsWith('#'))
+                    continue;
+
+                // Only index words that consist of letters, hyphens, or apostrophes
+                if (!trimmed.All(c => char.IsLetter(c) || c is '\'' or '-'))
+                    continue;
+
+                lock (_lock)
                 {
-                    var trimmed = line.Trim();
-                    if (trimmed.Length < 2 || trimmed.StartsWith('#'))
-                        continue;
-
-                    // Only index words that consist of letters, hyphens, or apostrophes
-                    if (!trimmed.All(c => char.IsLetter(c) || c is '\'' or '-'))
-                        continue;
-
                     Insert(trimmed.ToLowerInvariant(), 1, increment: false);
-                    count++;
                 }
+                count++;
             }
 
             Serilog.Log.Information(

--- a/DiffusionNexus.UI/Services/Startup/StartupCheck.cs
+++ b/DiffusionNexus.UI/Services/Startup/StartupCheck.cs
@@ -1,0 +1,19 @@
+namespace DiffusionNexus.UI.Services.Startup;
+
+public enum StartupCheckState { Pending, Running, Done, Failed }
+
+/// <summary>
+/// One row of the startup ready-check list. Mutable state is owned by
+/// <see cref="StartupProgressService"/>; consumers only read.
+/// </summary>
+public sealed class StartupCheck
+{
+    public required string Id { get; init; }
+    public required string DisplayName { get; init; }
+
+    /// <summary>False for checks that must never delay overlay dismissal (Updates).</summary>
+    public bool GatesReadiness { get; init; } = true;
+
+    public StartupCheckState State { get; internal set; } = StartupCheckState.Pending;
+    public string? Error { get; internal set; }
+}

--- a/DiffusionNexus.UI/Services/Startup/StartupProgressService.cs
+++ b/DiffusionNexus.UI/Services/Startup/StartupProgressService.cs
@@ -1,0 +1,70 @@
+namespace DiffusionNexus.UI.Services.Startup;
+
+/// <summary>
+/// Ordered startup ready-check list (spec 2026-07-15). Plain C# — no Avalonia —
+/// so it is unit-testable and usable from any startup phase. CheckChanged is
+/// raised synchronously on the caller's thread; all production callers are
+/// UI-thread startup phases, so the overlay ViewModel needs no marshaling.
+/// </summary>
+public sealed class StartupProgressService
+{
+    private readonly List<StartupCheck> _checks;
+    private readonly TaskCompletionSource _uiReady =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public StartupProgressService(IReadOnlyList<StartupCheck> checks)
+        => _checks = [.. checks];
+
+    public IReadOnlyList<StartupCheck> Checks => _checks;
+
+    public event Action<StartupCheck>? CheckChanged;
+
+    /// <summary>Completed by the app after the overlay's dispatcher-drain sentinel
+    /// has run — i.e., when the UI is provably responsive. Deferred background
+    /// work (autocomplete trie) starts on this signal.</summary>
+    public Task UiReady => _uiReady.Task;
+
+    public bool CoreChecksTerminal => _checks
+        .Where(c => c.GatesReadiness)
+        .All(c => c.State is StartupCheckState.Done or StartupCheckState.Failed);
+
+    public void Begin(string id) => Set(id, StartupCheckState.Running, null);
+    public void Complete(string id) => Set(id, StartupCheckState.Done, null);
+    public void Fail(string id, string message) => Set(id, StartupCheckState.Failed, message);
+
+    public void SignalUiReady() => _uiReady.TrySetResult();
+
+    private void Set(string id, StartupCheckState state, string? error)
+    {
+        var check = _checks.FirstOrDefault(c => c.Id == id)
+            ?? throw new ArgumentException($"Unknown startup check '{id}'.", nameof(id));
+        check.State = state;
+        check.Error = error;
+        CheckChanged?.Invoke(check);
+    }
+
+    /// <summary>Single source of truth for the check list. Module entries MUST match
+    /// the registration order in App.RegisterModulesAsync (Task 4).</summary>
+    public static IReadOnlyList<StartupCheck> BuildDefaultChecks(bool includeDiffusionCanvas)
+    {
+        var checks = new List<StartupCheck>
+        {
+            new() { Id = "database", DisplayName = "Database" },
+            new() { Id = "installer-manager", DisplayName = "Installer Manager" },
+            new() { Id = "lora-dataset-helper", DisplayName = "LoRA Dataset Helper" },
+            new() { Id = "lora-viewer", DisplayName = "LoRA Viewer" },
+            new() { Id = "generation-gallery", DisplayName = "Generation Gallery" },
+        };
+        if (includeDiffusionCanvas)
+            checks.Add(new() { Id = "diffusion-canvas", DisplayName = "Diffusion Canvas" });
+        checks.AddRange(
+        [
+            new StartupCheck { Id = "image-comparer", DisplayName = "Image Comparer" },
+            new StartupCheck { Id = "workflows", DisplayName = "Workflows" },
+            new StartupCheck { Id = "settings", DisplayName = "Settings" },
+            new StartupCheck { Id = "diffusion-engine", DisplayName = "Diffusion Engine" },
+            new StartupCheck { Id = "updates", DisplayName = "Updates", GatesReadiness = false },
+        ]);
+        return checks;
+    }
+}

--- a/DiffusionNexus.UI/Startup/RenderingConfig.cs
+++ b/DiffusionNexus.UI/Startup/RenderingConfig.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace DiffusionNexus.UI.Startup;
+
+/// <summary>
+/// Decides which Win32 rendering mode the app requests. Hardware rendering
+/// (Avalonia's default: ANGLE with automatic software fallback) is the norm;
+/// setting DIFFUSIONNEXUS_SOFTWARE_RENDERING=1 forces the software compositor
+/// as an escape hatch for machines with broken GPU drivers.
+/// </summary>
+public static class RenderingConfig
+{
+    public const string SoftwareRenderingEnvVar = "DIFFUSIONNEXUS_SOFTWARE_RENDERING";
+
+    public static bool UseSoftwareRendering(Func<string, string?> getEnvironmentVariable)
+    {
+        var value = getEnvironmentVariable(SoftwareRenderingEnvVar);
+        return value is not null
+            && (value.Equals("1", StringComparison.OrdinalIgnoreCase)
+                || value.Equals("true", StringComparison.OrdinalIgnoreCase)
+                || value.Equals("yes", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/DiffusionNexus.UI/ViewModels/DiffusionNexusMainWindowViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/DiffusionNexusMainWindowViewModel.cs
@@ -69,16 +69,29 @@ public partial class DiffusionNexusMainWindowViewModel : ViewModelBase
     /// finished. The main window shows a lightweight loading overlay while false.
     /// </summary>
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowDisclaimer))]
     private bool _isStartupComplete;
 
     [ObservableProperty]
     private ModuleItem? _selectedModule;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowDisclaimer))]
     private bool _isDisclaimerAccepted;
 
     [ObservableProperty]
     private bool _disclaimerCheckboxChecked;
+
+    /// <summary>
+    /// Gates the disclaimer overlay so it can only appear after deferred startup
+    /// has finished. <see cref="CheckDisclaimerStatusAsync"/> reads the database
+    /// and now runs at the tail of deferred startup (Task 6), so showing the
+    /// disclaimer any earlier would cover the "Starting DiffusionNexus…" overlay
+    /// on every launch — even for users who accepted long ago — and would let the
+    /// Continue button issue a DB write concurrent with the pool-thread DB
+    /// migration on fresh installs.
+    /// </summary>
+    public bool ShowDisclaimer => IsStartupComplete && !IsDisclaimerAccepted;
 
     [ObservableProperty]
     private StatusBarViewModel? _statusBar;

--- a/DiffusionNexus.UI/ViewModels/DiffusionNexusMainWindowViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/DiffusionNexusMainWindowViewModel.cs
@@ -72,6 +72,10 @@ public partial class DiffusionNexusMainWindowViewModel : ViewModelBase
     [NotifyPropertyChangedFor(nameof(ShowDisclaimer))]
     private bool _isStartupComplete;
 
+    /// <summary>Ready-check list shown by the startup overlay (null only in design mode).</summary>
+    [ObservableProperty]
+    private StartupOverlayViewModel? _startupOverlay;
+
     [ObservableProperty]
     private ModuleItem? _selectedModule;
 

--- a/DiffusionNexus.UI/ViewModels/DiffusionNexusMainWindowViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/DiffusionNexusMainWindowViewModel.cs
@@ -64,6 +64,13 @@ public partial class DiffusionNexusMainWindowViewModel : ViewModelBase
     [ObservableProperty]
     private object? _currentModuleView;
 
+    /// <summary>
+    /// False until deferred startup (database init + module registration) has
+    /// finished. The main window shows a lightweight loading overlay while false.
+    /// </summary>
+    [ObservableProperty]
+    private bool _isStartupComplete;
+
     [ObservableProperty]
     private ModuleItem? _selectedModule;
 
@@ -224,13 +231,28 @@ public partial class DiffusionNexusMainWindowViewModel : ViewModelBase
             _activityLogService.DownloadProgressChanged += OnDownloadProgressChanged;
             IsDownloadInProgress = _activityLogService.IsDownloadInProgress;
             ActiveDownloadName = _activityLogService.DownloadOperationName;
+        }
+    }
 
-            // Wire instance management (Start/Stop/Restart) into the Unified Console
-            var processManager = App.Services?.GetService<Services.PackageProcessManager>();
-            if (processManager is not null && App.Services is not null)
-            {
-                StatusBar.InitializeInstanceManagement(processManager, App.Services);
-            }
+    /// <summary>
+    /// Wires instance management (Start/Stop/Restart) into the Unified Console.
+    /// Kept separate from <see cref="InitializeStatusBar"/> because it triggers
+    /// DB-backed instance loading — <c>UnifiedConsoleViewModel.LoadInstancesAsync</c>
+    /// reads the core database's <c>InstallerPackages</c> table — so it must run
+    /// only after the databases have been initialized. Invoked from
+    /// <c>App.CompleteStartupAsync</c> once DB init has completed.
+    /// </summary>
+    public void InitializeInstanceManagement()
+    {
+        if (StatusBar is null)
+        {
+            return;
+        }
+
+        var processManager = App.Services?.GetService<Services.PackageProcessManager>();
+        if (processManager is not null && App.Services is not null)
+        {
+            StatusBar.InitializeInstanceManagement(processManager, App.Services);
         }
     }
 

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -189,6 +189,27 @@ public partial class LoraViewerViewModel : BusyViewModelBase
     private const int WindowSize = 200;
     private const int SlideStep = 50;
 
+    /// <summary>
+    /// Number of items added to <see cref="FilteredTiles"/> synchronously before
+    /// the rest of the window fill hands off to the dispatcher. Keeps the first
+    /// paint instant while avoiding a single layout pass over the whole window.
+    /// </summary>
+    private const int FillBatchSize = 24;
+
+    /// <summary>Cancels the in-flight batched window fill, if any.</summary>
+    private Action? _cancelWindowFill;
+
+    /// <summary>
+    /// True while a batched window fill is running. Slide operations bail out
+    /// while this is set — they mutate <see cref="_windowStart"/> and splice
+    /// <see cref="FilteredTiles"/> directly, which would race with a fill still
+    /// appending to the same collection.
+    /// </summary>
+    private bool _windowFillInProgress;
+
+    /// <summary>Set on the first call to <see cref="OnViewAttached"/> so later re-attaches don't re-trigger the batched refill.</summary>
+    private bool _firstAttachHandled;
+
     /// <summary>True when the window can be slid forward (more items off the end).</summary>
     public bool HasMoreForward => _windowStart + FilteredTiles.Count < _allFiltered.Count;
 
@@ -2694,16 +2715,32 @@ public partial class LoraViewerViewModel : BusyViewModelBase
 
     /// <summary>
     /// Recreates the items in <see cref="FilteredTiles"/> from the current window
-    /// position. Used after a filter change.
+    /// position. Used after a filter change. Fills in dispatcher-batched chunks
+    /// (first chunk synchronous for instant content, rest at <see cref="DispatcherPriority.Background"/>)
+    /// so realizing up to <see cref="WindowSize"/> tile containers never happens
+    /// in a single synchronous layout pass. A fill already in progress (from a
+    /// prior call) is cancelled first so its stale batches don't keep appending
+    /// after this rebuild has cleared and restarted the window.
     /// </summary>
     private void RebuildFilteredTilesWindow()
     {
+        _cancelWindowFill?.Invoke();
         FilteredTiles.Clear();
+
         var end = Math.Min(_windowStart + WindowSize, _allFiltered.Count);
-        for (var i = _windowStart; i < end; i++)
-        {
-            FilteredTiles.Add(_allFiltered[i]);
-        }
+        _windowFillInProgress = true;
+        _cancelWindowFill = Helpers.BatchedListFiller.Fill(
+            FilteredTiles,
+            _allFiltered,
+            _windowStart,
+            end,
+            FillBatchSize,
+            post: action => Dispatcher.UIThread.Post(action, DispatcherPriority.Background),
+            onCompleted: () =>
+            {
+                _windowFillInProgress = false;
+                TriggerVisibleUpdateCheck();
+            });
     }
 
     /// <summary>
@@ -2716,6 +2753,7 @@ public partial class LoraViewerViewModel : BusyViewModelBase
     public void SlideForward()
     {
         LastSlideForwardCount = 0;
+        if (_windowFillInProgress) return;
         if (!HasMoreForward) return;
 
         // How many items can we actually add to the end?
@@ -2748,6 +2786,7 @@ public partial class LoraViewerViewModel : BusyViewModelBase
     public void SlideBackward()
     {
         LastSlideBackwardCount = 0;
+        if (_windowFillInProgress) return;
         if (!HasMoreBackward) return;
 
         var step = Math.Min(SlideStep, _windowStart);
@@ -2768,6 +2807,23 @@ public partial class LoraViewerViewModel : BusyViewModelBase
         LastSlideBackwardCount = step;
         OnPropertyChanged(nameof(HasMoreForward));
         OnPropertyChanged(nameof(HasMoreBackward));
+    }
+
+    /// <summary>
+    /// Called by the view when it enters the visual tree. On first attach the
+    /// window is already fully populated from the startup load — refill it in
+    /// batches so the initial navigation doesn't realize every tile container
+    /// in one synchronous layout pass. Subsequent attaches keep their already
+    /// generated containers, so no refill is needed (and refilling would reset
+    /// the user's scroll position).
+    /// </summary>
+    public void OnViewAttached()
+    {
+        if (_firstAttachHandled) return;
+        _firstAttachHandled = true;
+
+        if (FilteredTiles.Count > FillBatchSize)
+            RebuildFilteredTilesWindow();
     }
 
     /// <summary>

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -267,8 +267,13 @@ public partial class LoraViewerViewModel : BusyViewModelBase
     #region Commands
 
     /// <summary>
-    /// Refresh the model list.
-    /// Uses database-first approach: load cached data immediately, then discover new files.
+    /// Refresh the model list, database-first: show the cached tiles from the catalog DB
+    /// immediately (a lightweight projection query + in-memory grouping — no filesystem
+    /// walk), so the grid paints in well under a second even for thousands of LoRAs. The
+    /// slow work — scanning the source folders for new files and verifying that existing
+    /// files still exist on disk — then runs in the background via
+    /// <see cref="ReconcileLibraryInBackgroundAsync"/>, which rebuilds the grid only if it
+    /// finds a change (a new file appears, a deleted file drops out, a moved file relocates).
     /// </summary>
     [RelayCommand]
     private async Task RefreshAsync()
@@ -280,51 +285,36 @@ public partial class LoraViewerViewModel : BusyViewModelBase
             return;
         }
 
+        var showedCachedTiles = false;
         try
         {
             IsBusy = true;
             BusyMessage = "Loading models...";
-            SyncStatus = "Starting refresh...";
+            SyncStatus = "Loading models from database...";
 
-            // Offload all heavy I/O (file discovery + DB reads + grouping) to a
-            // single background task so the UI thread stays responsive.
-            // DiscoverNewFilesAsync already marshals progress to the UI via Dispatcher.Post.
-            var (uniqueModelCount, tiles) = await Task.Run(async () =>
+            // 1. Show whatever is already cached — instantly.
+            var (uniqueModelCount, tiles) = await Task.Run(LoadCachedTilesAsync);
+
+            if (tiles.Count > 0)
             {
-                await DiscoverNewFilesAsync();
-                await BackfillCivitaiModelPageIdAsync();
-
-                Dispatcher.UIThread.Post(() => SyncStatus = "Loading models from database...");
-
-                // Use a fresh DI scope so the DbContext sees the latest committed data
-                // (DiscoverNewFilesAsync and other operations write via their own scopes).
-                using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
-                var freshSyncService = scope.ServiceProvider.GetRequiredService<IModelSyncService>();
-
-                // Issue #380: one tile per (Model, LoRA-source-location). A LoRA with files
-                // in two configured locations produces two tiles; each tile keeps its
-                // version switcher and exposes only the versions present in that location.
-                var files = await freshSyncService.LoadCachedFilesAsync();
-                var distinctModels = files.Select(f => f.Model.Id).Distinct().Count();
-                var perLocationTiles = BuildPerLocationTiles(files);
-                return (distinctModels, perLocationTiles);
-            });
-
-            // Back on UI thread after await — update observable collections
-            AllTiles.Clear();
-            foreach (var tile in tiles)
-            {
-                tile.Deleted += OnTileDeleted;
-                tile.DetailRequested += OnTileDetailRequested;
-                AllTiles.Add(tile);
+                ReplaceTiles(tiles);
+                SyncStatus = $"Loaded {uniqueModelCount} models ({AllTiles.Count} tiles)";
+                showedCachedTiles = true;
             }
-            TotalModelCount = AllTiles.Sum(t => t.ModelCount);
-            RebuildAvailableBaseModels();
-            ApplyFilters();
-            SyncStatus = $"Loaded {uniqueModelCount} models ({AllTiles.Count} tiles)";
-
-            // Phase 3: Verify existing files in background (low priority)
-            _ = VerifyFilesInBackgroundAsync();
+            else
+            {
+                // Empty cache (first run / never scanned): discover inline so the grid fills
+                // in one pass instead of flashing the "No Models" empty state.
+                SyncStatus = "Discovering models...";
+                await Task.Run(async () =>
+                {
+                    await DiscoverNewFilesAsync();
+                    await BackfillCivitaiModelPageIdAsync();
+                });
+                var (freshCount, freshTiles) = await Task.Run(LoadCachedTilesAsync);
+                ReplaceTiles(freshTiles);
+                SyncStatus = $"Loaded {freshCount} models ({AllTiles.Count} tiles)";
+            }
         }
         catch (Exception ex)
         {
@@ -335,14 +325,107 @@ public partial class LoraViewerViewModel : BusyViewModelBase
             IsBusy = false;
             BusyMessage = null;
         }
+
+        // 2. Reconcile against disk in the background (adds + deletions + moves). When the
+        //    cache was empty we already discovered inline above, so only verification remains.
+        if (showedCachedTiles)
+            _ = ReconcileLibraryInBackgroundAsync();
+        else
+            _ = VerifyFilesInBackgroundAsync();
     }
 
     /// <summary>
-    /// Discover new files and add them to the database.
+    /// Loads the installed-file rows from the catalog DB (a lightweight projection — no
+    /// thumbnail BLOBs, no filesystem access) and groups them into per-location tiles
+    /// (issue #380: one tile per (Model, LoRA-source root)). Runs on the thread pool.
+    /// </summary>
+    private async Task<(int UniqueModelCount, List<ModelTileViewModel> Tiles)> LoadCachedTilesAsync()
+    {
+        using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+        var freshSyncService = scope.ServiceProvider.GetRequiredService<IModelSyncService>();
+        var files = await freshSyncService.LoadCachedFilesAsync();
+        var distinctModels = files.Select(f => f.Model.Id).Distinct().Count();
+        var tiles = BuildPerLocationTiles(files);
+        return (distinctModels, tiles);
+    }
+
+    /// <summary>
+    /// Swaps the tile set on the UI thread: unsubscribes the outgoing tiles, replaces
+    /// <see cref="AllTiles"/> with <paramref name="tiles"/>, and refreshes the counts,
+    /// base-model filter, and filtered view.
+    /// </summary>
+    private void ReplaceTiles(List<ModelTileViewModel> tiles)
+    {
+        foreach (var oldTile in AllTiles)
+        {
+            oldTile.Deleted -= OnTileDeleted;
+            oldTile.DetailRequested -= OnTileDetailRequested;
+        }
+
+        AllTiles.Clear();
+        foreach (var tile in tiles)
+        {
+            tile.Deleted += OnTileDeleted;
+            tile.DetailRequested += OnTileDetailRequested;
+            AllTiles.Add(tile);
+        }
+
+        TotalModelCount = AllTiles.Sum(t => t.ModelCount);
+        RebuildAvailableBaseModels();
+        ApplyFilters();
+    }
+
+    /// <summary>
+    /// Background reconciliation against the filesystem: discovers newly added files and
+    /// verifies existing ones (marking on-disk-deleted files invalid so they drop out of
+    /// the grid, and relocating moved files). Rebuilds the grid from the DB only when
+    /// something actually changed, so the common "nothing changed since last launch" case
+    /// leaves the visible tiles (and the scroll position) untouched.
+    /// </summary>
+    private async Task ReconcileLibraryInBackgroundAsync()
+    {
+        try
+        {
+            _logger?.Info(LogCategory.General, "LoraReconcile", "Background reconcile started (discover + verify)");
+
+            var (added, missing, moved) = await Task.Run(async () =>
+            {
+                var newCount = await DiscoverNewFilesAsync();
+                await BackfillCivitaiModelPageIdAsync();
+
+                using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+                var syncService = scope.ServiceProvider.GetRequiredService<IModelSyncService>();
+                var progress = new Progress<SyncProgress>(p =>
+                    Dispatcher.UIThread.Post(() =>
+                        SyncStatus = p.Phase == "Verification complete" ? null : p.Phase));
+
+                // MissingCount = files gone from disk (now filtered out of LoadCachedFilesAsync);
+                // MovedCount = files whose path changed. Either, or a new file, changes the grid.
+                var result = await syncService.VerifyAndSyncFilesAsync(progress);
+                return (newCount, result.MissingCount, result.MovedCount);
+            });
+
+            var changed = added > 0 || missing > 0 || moved > 0;
+            _logger?.Info(LogCategory.General, "LoraReconcile",
+                $"Reconcile done: {added} new, {missing} missing (deleted from disk), {moved} moved → rebuild={changed}");
+
+            if (changed)
+                await RebuildTilesFromDatabaseAsync();
+        }
+        catch (Exception ex)
+        {
+            // Background work — a discovery/verify failure must not disrupt the visible grid.
+            _logger?.Warn(LogCategory.General, "LoraReconcile", $"Reconcile failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Discover new files and add them to the database. Returns the number of new models
+    /// discovered so callers can decide whether the grid needs rebuilding.
     /// Uses a fresh DI scope so the DbContext sees the latest committed data
     /// (avoids duplicates when files were already persisted by other operations).
     /// </summary>
-    private async Task DiscoverNewFilesAsync()
+    private async Task<int> DiscoverNewFilesAsync()
     {
         try
         {
@@ -366,6 +449,8 @@ public partial class LoraViewerViewModel : BusyViewModelBase
             {
                 SyncStatus = $"Discovered {newModels.Count} new files";
             });
+
+            return newModels.Count;
         }
         catch (Exception ex)
         {
@@ -373,6 +458,8 @@ public partial class LoraViewerViewModel : BusyViewModelBase
             {
                 SyncStatus = $"Discovery error: {ex.Message}";
             });
+
+            return 0;
         }
     }
 

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -160,7 +160,13 @@ public partial class LoraViewerViewModel : BusyViewModelBase
     public ObservableCollection<ModelTileViewModel> AllTiles { get; } = [];
 
     /// <summary>
-    /// Filtered model tiles for display.
+    /// The filtered, sorted tile set bound to the view. The view renders it through a
+    /// virtualizing <c>ItemsRepeater</c> (<c>UniformGridLayout</c>), so only the tiles
+    /// inside the scroll viewport are realized — the full set can hold thousands of
+    /// tiles without the UI thread paying to materialize (or load thumbnails for) them
+    /// all. Each realized <see cref="ModelTileViewModel"/> loads its thumbnail on
+    /// <see cref="ModelTileViewModel.Activate"/> and releases it on
+    /// <see cref="ModelTileViewModel.Deactivate"/> as its container recycles.
     /// </summary>
     public ObservableCollection<ModelTileViewModel> FilteredTiles { get; } = [];
 
@@ -177,54 +183,14 @@ public partial class LoraViewerViewModel : BusyViewModelBase
     private IReadOnlyList<string>? _catalogBaseModels;
 
     /// <summary>
-    /// Full filtered set of tiles. <see cref="FilteredTiles"/> is a window into this
-    /// list (max <see cref="WindowSize"/> items) — the count / status bar / search
-    /// index all work against this full list, only rendering is windowed.
+    /// Upper bound on how many tiles the passive "new version available" check looks
+    /// at per filter pass. With the virtualizing grid the view no longer tracks a
+    /// scroll window, so this simply caps the opportunistic background check at the
+    /// same magnitude as the old visible window — preventing a request storm (and
+    /// Civitai rate-limiting) for libraries with thousands of LoRAs. The explicit
+    /// "Download Metadata" flow remains the way to sync the entire library.
     /// </summary>
-    private readonly List<ModelTileViewModel> _allFiltered = [];
-
-    /// <summary>First index of the current window into <see cref="_allFiltered"/>.</summary>
-    private int _windowStart;
-
-    private const int WindowSize = 200;
-    private const int SlideStep = 50;
-
-    /// <summary>
-    /// Number of items added to <see cref="FilteredTiles"/> synchronously before
-    /// the rest of the window fill hands off to the dispatcher. Keeps the first
-    /// paint instant while avoiding a single layout pass over the whole window.
-    /// </summary>
-    private const int FillBatchSize = 24;
-
-    /// <summary>Cancels the in-flight batched window fill, if any.</summary>
-    private Action? _cancelWindowFill;
-
-    /// <summary>
-    /// True while a batched window fill is running. Slide operations bail out
-    /// while this is set — they mutate <see cref="_windowStart"/> and splice
-    /// <see cref="FilteredTiles"/> directly, which would race with a fill still
-    /// appending to the same collection.
-    /// </summary>
-    private bool _windowFillInProgress;
-
-    /// <summary>Set on the first call to <see cref="OnViewAttached"/> so later re-attaches don't re-trigger the batched refill.</summary>
-    private bool _firstAttachHandled;
-
-    /// <summary>True when the window can be slid forward (more items off the end).</summary>
-    public bool HasMoreForward => _windowStart + FilteredTiles.Count < _allFiltered.Count;
-
-    /// <summary>True when the window can be slid backward (more items before the start).</summary>
-    public bool HasMoreBackward => _windowStart > 0;
-
-    /// <summary>
-    /// The size of the most recent forward slide. The view reads this after
-    /// <see cref="SlideForward"/> so it can compensate the scroll offset and keep
-    /// the same tiles visible. Reset to 0 between slides.
-    /// </summary>
-    public int LastSlideForwardCount { get; private set; }
-
-    /// <summary>Same purpose as <see cref="LastSlideForwardCount"/> but for backward slides.</summary>
-    public int LastSlideBackwardCount { get; private set; }
+    private const int PassiveUpdateCheckLimit = 200;
 
     #endregion
 
@@ -2452,29 +2418,11 @@ public partial class LoraViewerViewModel : BusyViewModelBase
         Dispatcher.UIThread.Post(() =>
         {
             AllTiles.Remove(tile);
-            // Keep the windowing backing store in sync. The tile may or may not be
-            // in the visible FilteredTiles window depending on scroll position.
-            _allFiltered.Remove(tile);
+            // Removing from the bound collection detaches the tile's container (if it
+            // was realized); the virtualizing grid reflows the rest automatically.
             FilteredTiles.Remove(tile);
-            // _windowStart may now point past the end if the user was at the bottom
-            // and the removed tile happened to be at the end of the window.
-            if (_windowStart > _allFiltered.Count)
-            {
-                _windowStart = Math.Max(0, _allFiltered.Count - WindowSize);
-            }
-            // A batched window fill may still be streaming when the delete lands.
-            // Its remaining batches would read the shrunk _allFiltered with stale
-            // indices (shifted/duplicate tiles in the window). Rebuild — which
-            // cancels the in-flight fill first — so the window refills from the
-            // post-delete list. The idle path (no fill running) is unchanged.
-            if (_windowFillInProgress)
-            {
-                RebuildFilteredTilesWindow();
-            }
             TotalModelCount = AllTiles.Count;
-            FilteredModelCount = _allFiltered.Sum(t => t.ModelCount);
-            OnPropertyChanged(nameof(HasMoreForward));
-            OnPropertyChanged(nameof(HasMoreBackward));
+            FilteredModelCount = FilteredTiles.Sum(t => t.ModelCount);
             RebuildAvailableBaseModels();
         });
     }
@@ -2704,140 +2652,28 @@ public partial class LoraViewerViewModel : BusyViewModelBase
         var filtered = SortTiles(query.ToList());
 
         // Unchanged result set AND order (e.g. the extra keystroke matched the same
-        // tiles): keep the current window and scroll position, skip the expensive
-        // rebuild. A sort change reorders the list, so SequenceEqual is false and the
-        // rebuild runs. Refresh paths always create new tile instances, so they never hit this.
-        if (filtered.SequenceEqual(_allFiltered))
+        // tiles): keep the current tiles and scroll position, skip the rebuild. A sort
+        // change reorders the list, so SequenceEqual is false and the rebuild runs.
+        // Refresh paths always create new tile instances, so they never hit this.
+        if (filtered.SequenceEqual(FilteredTiles))
         {
             return;
         }
 
-        _allFiltered.Clear();
-        _allFiltered.AddRange(filtered);
+        // Populate the bound collection in place (one Reset from Clear, then Adds) so the
+        // stable ObservableCollection instance keeps its bindings. The view's ItemsRepeater
+        // virtualizes, so assigning the full filtered set here never realizes off-screen
+        // tiles — no manual scroll window is needed.
+        FilteredTiles.Clear();
+        foreach (var tile in filtered)
+        {
+            FilteredTiles.Add(tile);
+        }
 
-        // 2. Reset the window to the head and rebuild FilteredTiles.
-        _windowStart = 0;
-        RebuildFilteredTilesWindow();
-
-        // 3. Status / count reflects the FULL filtered set, not just the window.
-        FilteredModelCount = _allFiltered.Sum(t => t.ModelCount);
-        OnPropertyChanged(nameof(HasMoreForward));
-        OnPropertyChanged(nameof(HasMoreBackward));
+        // Status / count reflects the full filtered set.
+        FilteredModelCount = FilteredTiles.Sum(t => t.ModelCount);
 
         TriggerVisibleUpdateCheck();
-    }
-
-    /// <summary>
-    /// Recreates the items in <see cref="FilteredTiles"/> from the current window
-    /// position. Used after a filter change. Fills in dispatcher-batched chunks
-    /// (first chunk synchronous for instant content, rest at <see cref="DispatcherPriority.Background"/>)
-    /// so realizing up to <see cref="WindowSize"/> tile containers never happens
-    /// in a single synchronous layout pass. A fill already in progress (from a
-    /// prior call) is cancelled first so its stale batches don't keep appending
-    /// after this rebuild has cleared and restarted the window.
-    /// </summary>
-    private void RebuildFilteredTilesWindow()
-    {
-        _cancelWindowFill?.Invoke();
-        FilteredTiles.Clear();
-
-        var end = Math.Min(_windowStart + WindowSize, _allFiltered.Count);
-        _windowFillInProgress = true;
-        _cancelWindowFill = Helpers.BatchedListFiller.Fill(
-            FilteredTiles,
-            _allFiltered,
-            _windowStart,
-            end,
-            FillBatchSize,
-            post: action => Dispatcher.UIThread.Post(action, DispatcherPriority.Background),
-            onCompleted: () =>
-            {
-                _windowFillInProgress = false;
-                TriggerVisibleUpdateCheck();
-            });
-    }
-
-    /// <summary>
-    /// Slides the visible window forward by <see cref="SlideStep"/> items: removes
-    /// the first N from <see cref="FilteredTiles"/> and appends the next N from
-    /// <see cref="_allFiltered"/>. The removed tiles' containers detach from the
-    /// visual tree, which calls <see cref="ModelTileViewModel.Deactivate"/> and
-    /// releases their decoded thumbnail bitmaps.
-    /// </summary>
-    public void SlideForward()
-    {
-        LastSlideForwardCount = 0;
-        if (_windowFillInProgress) return;
-        if (!HasMoreForward) return;
-
-        // How many items can we actually add to the end?
-        var available = _allFiltered.Count - (_windowStart + FilteredTiles.Count);
-        var step = Math.Min(SlideStep, available);
-        if (step <= 0) return;
-
-        // Add to the END first, *then* remove from the start. The reverse order
-        // briefly shrinks the ItemsControl below the user's current scroll offset
-        // and the ScrollViewer clamps it — the subsequent offset compensation
-        // fights that clamp and the user gets "stuck" partway through the window.
-        var addStart = _windowStart + FilteredTiles.Count;
-        var addEnd = Math.Min(addStart + step, _allFiltered.Count);
-        for (var i = addStart; i < addEnd; i++)
-        {
-            FilteredTiles.Add(_allFiltered[i]);
-        }
-        for (var i = 0; i < step && FilteredTiles.Count > 0; i++)
-        {
-            FilteredTiles.RemoveAt(0);
-        }
-        _windowStart += step;
-
-        LastSlideForwardCount = step;
-        OnPropertyChanged(nameof(HasMoreForward));
-        OnPropertyChanged(nameof(HasMoreBackward));
-    }
-
-    /// <summary>Mirror of <see cref="SlideForward"/> but in the opposite direction.</summary>
-    public void SlideBackward()
-    {
-        LastSlideBackwardCount = 0;
-        if (_windowFillInProgress) return;
-        if (!HasMoreBackward) return;
-
-        var step = Math.Min(SlideStep, _windowStart);
-        if (step <= 0) return;
-
-        // Same anti-clamp reasoning as SlideForward: prepend first, then drop the
-        // bottom. Total item count never dips below WindowSize during the slide.
-        for (var i = step - 1; i >= 0; i--)
-        {
-            FilteredTiles.Insert(0, _allFiltered[_windowStart - step + i]);
-        }
-        _windowStart -= step;
-        for (var i = 0; i < step && FilteredTiles.Count > 0; i++)
-        {
-            FilteredTiles.RemoveAt(FilteredTiles.Count - 1);
-        }
-
-        LastSlideBackwardCount = step;
-        OnPropertyChanged(nameof(HasMoreForward));
-        OnPropertyChanged(nameof(HasMoreBackward));
-    }
-
-    /// <summary>
-    /// Called by the view when it enters the visual tree. On first attach the
-    /// window is already fully populated from the startup load — refill it in
-    /// batches so the initial navigation doesn't realize every tile container
-    /// in one synchronous layout pass. Subsequent attaches keep their already
-    /// generated containers, so no refill is needed (and refilling would reset
-    /// the user's scroll position).
-    /// </summary>
-    public void OnViewAttached()
-    {
-        if (_firstAttachHandled) return;
-        _firstAttachHandled = true;
-
-        if (FilteredTiles.Count > FillBatchSize)
-            RebuildFilteredTilesWindow();
     }
 
     /// <summary>
@@ -2867,9 +2703,11 @@ public partial class LoraViewerViewModel : BusyViewModelBase
             return;
         }
 
-        // Snapshot the tiles so concurrent collection edits don't surface as
-        // InvalidOperationException inside the checker.
-        var snapshot = FilteredTiles.ToArray();
+        // Snapshot the tiles (Take also snapshots) so concurrent collection edits don't
+        // surface as InvalidOperationException inside the checker. Capped at
+        // PassiveUpdateCheckLimit — see the field's remarks — so a multi-thousand-LoRA
+        // library doesn't fire one Civitai request per tile on every filter pass.
+        var snapshot = FilteredTiles.Take(PassiveUpdateCheckLimit).ToArray();
 
         _ = Task.Run(async () =>
         {

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -15,6 +15,7 @@ using DiffusionNexus.Infrastructure;
 using DiffusionNexus.Service.Services;
 using DiffusionNexus.UI.Services;
 using DiffusionNexus.UI.Services.CivitaiBrowser;
+using DiffusionNexus.UI.Utilities;
 using DiffusionNexus.UI.ViewModels.CivitaiBrowser;
 using Microsoft.Extensions.DependencyInjection;
 using SkiaSharp;
@@ -168,7 +169,7 @@ public partial class LoraViewerViewModel : BusyViewModelBase
     /// <see cref="ModelTileViewModel.Activate"/> and releases it on
     /// <see cref="ModelTileViewModel.Deactivate"/> as its container recycles.
     /// </summary>
-    public ObservableCollection<ModelTileViewModel> FilteredTiles { get; } = [];
+    public BatchObservableCollection<ModelTileViewModel> FilteredTiles { get; } = [];
 
     /// <summary>
     /// Distinct base model names available for filtering, built from all tiles.
@@ -2747,15 +2748,12 @@ public partial class LoraViewerViewModel : BusyViewModelBase
             return;
         }
 
-        // Populate the bound collection in place (one Reset from Clear, then Adds) so the
-        // stable ObservableCollection instance keeps its bindings. The view's ItemsRepeater
-        // virtualizes, so assigning the full filtered set here never realizes off-screen
-        // tiles — no manual scroll window is needed.
-        FilteredTiles.Clear();
-        foreach (var tile in filtered)
-        {
-            FilteredTiles.Add(tile);
-        }
+        // Swap the whole set in one shot: BatchObservableCollection.ReplaceAll fires a
+        // single CollectionChanged.Reset, so the ItemsRepeater does ONE realization pass
+        // (of the ~visible tiles) instead of processing N per-item Add notifications — the
+        // difference between a smooth filter and a multi-tens-of-ms UI-thread stall per
+        // keystroke at thousands of tiles.
+        FilteredTiles.ReplaceAll(filtered);
 
         // Status / count reflects the full filtered set.
         FilteredModelCount = FilteredTiles.Sum(t => t.ModelCount);

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -2457,6 +2457,15 @@ public partial class LoraViewerViewModel : BusyViewModelBase
             {
                 _windowStart = Math.Max(0, _allFiltered.Count - WindowSize);
             }
+            // A batched window fill may still be streaming when the delete lands.
+            // Its remaining batches would read the shrunk _allFiltered with stale
+            // indices (shifted/duplicate tiles in the window). Rebuild — which
+            // cancels the in-flight fill first — so the window refills from the
+            // post-delete list. The idle path (no fill running) is unchanged.
+            if (_windowFillInProgress)
+            {
+                RebuildFilteredTilesWindow();
+            }
             TotalModelCount = AllTiles.Count;
             FilteredModelCount = _allFiltered.Sum(t => t.ModelCount);
             OnPropertyChanged(nameof(HasMoreForward));

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -419,21 +419,26 @@ public partial class LoraViewerViewModel : BusyViewModelBase
     {
         try
         {
-            using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
-            var syncService = scope.ServiceProvider.GetRequiredService<IModelSyncService>();
-
+            // Progress<T> captures the UI SynchronizationContext here (UI thread),
+            // so the callback is already marshaled — no nested Post needed.
             var progress = new Progress<SyncProgress>(p =>
             {
-                Dispatcher.UIThread.Post(() =>
+                if (p.Phase == "Verification complete")
                 {
-                    if (p.Phase == "Verification complete")
-                    {
-                        SyncStatus = null; // Clear status when done
-                    }
-                });
+                    SyncStatus = null; // Clear status when done
+                }
             });
 
-            await syncService.VerifyAndSyncFilesAsync(progress);
+            // The verify walks the library and SHA-hashes candidate files; its
+            // "async" service continuations otherwise resume on the UI thread
+            // (10s dispatcher hog on a cold cache — see 2026-07-15 startup trace).
+            // Run the whole thing on the pool with its own scope.
+            await Task.Run(async () =>
+            {
+                using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+                var syncService = scope.ServiceProvider.GetRequiredService<IModelSyncService>();
+                await syncService.VerifyAndSyncFilesAsync(progress);
+            });
         }
         catch
         {

--- a/DiffusionNexus.UI/ViewModels/ModelTileViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/ModelTileViewModel.cs
@@ -1284,8 +1284,20 @@ public partial class ModelTileViewModel : ViewModelBase
 
         if (primaryImage?.ThumbnailData is { Length: > 0 } data && !primaryImage.IsThumbnailDeferred)
         {
-            // Thumbnail BLOB already in memory — decode and display
-            DecodeThumbnailFromBytes(data);
+            // Thumbnail BLOB already in memory — decode off the UI thread (downscaled,
+            // no JPEG round-trip), then marshal only the property assignment back.
+            // Guard with `ct` since Activate/Deactivate/version-switch can make this
+            // in-flight decode stale before it reaches the UI thread.
+            _ = Task.Run(() =>
+            {
+                var bitmap = CreateTileBitmap(data);
+                if (ct.IsCancellationRequested) return;
+                Dispatcher.UIThread.Post(() =>
+                {
+                    if (ct.IsCancellationRequested) return;
+                    ThumbnailImage = bitmap;
+                });
+            });
         }
         else if (primaryImage is not null && primaryImage.IsThumbnailDeferred)
         {
@@ -1308,29 +1320,37 @@ public partial class ModelTileViewModel : ViewModelBase
         }
     }
 
+    /// <summary>Decode width for tile thumbnails: 250px tile at up to 200% display scaling.</summary>
+    private const int TileDecodeWidth = 500;
+
     /// <summary>
-    /// Decodes thumbnail bytes into a displayable Bitmap via SkiaSharp.
+    /// Decodes thumbnail bytes into a displayable Bitmap, downscaled to the tile
+    /// width. Safe to call from any thread — Avalonia Bitmaps are immutable and
+    /// may be created off the UI thread. Falls back to a Skia transcode for
+    /// formats Avalonia's decoder rejects.
     /// </summary>
-    private void DecodeThumbnailFromBytes(byte[] data)
+    internal static Bitmap? CreateTileBitmap(byte[] data)
     {
         try
         {
-            using var skBitmap = SKBitmap.Decode(data);
-            if (skBitmap is not null)
-            {
-                using var skImage = SKImage.FromBitmap(skBitmap);
-                using var encoded = skImage.Encode(SKEncodedImageFormat.Jpeg, 90);
-                using var stream = new MemoryStream(encoded.ToArray());
-                ThumbnailImage = new Bitmap(stream);
-            }
-            else
-            {
-                ThumbnailImage = null;
-            }
+            using var stream = new MemoryStream(data);
+            return Bitmap.DecodeToWidth(stream, TileDecodeWidth);
         }
         catch
         {
-            ThumbnailImage = null;
+            try
+            {
+                using var skBitmap = SKBitmap.Decode(data);
+                if (skBitmap is null) return null;
+                using var skImage = SKImage.FromBitmap(skBitmap);
+                using var encoded = skImage.Encode(SKEncodedImageFormat.Jpeg, 90);
+                using var stream = new MemoryStream(encoded.ToArray());
+                return new Bitmap(stream);
+            }
+            catch
+            {
+                return null;
+            }
         }
     }
 
@@ -1372,7 +1392,11 @@ public partial class ModelTileViewModel : ViewModelBase
                 image.ThumbnailData = data;
                 image.ThumbnailMimeType = mimeType;
 
-                await Dispatcher.UIThread.InvokeAsync(() => DecodeThumbnailFromBytes(data));
+                // Decode on this (pool) thread; only the bound-property
+                // assignment needs the UI thread.
+                var bitmap = CreateTileBitmap(data);
+                ct.ThrowIfCancellationRequested();
+                await Dispatcher.UIThread.InvokeAsync(() => ThumbnailImage = bitmap);
             }
             else
             {

--- a/DiffusionNexus.UI/ViewModels/ModelTileViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/ModelTileViewModel.cs
@@ -1358,10 +1358,21 @@ public partial class ModelTileViewModel : ViewModelBase
     /// Lazy-loads a thumbnail BLOB from the database for a single image.
     /// Called when the bulk query deferred loading to save memory at scale.
     /// </summary>
+    /// <summary>
+    /// Delay between a tile scrolling into view and its thumbnail actually loading. Tiles
+    /// that scroll past within this window (deactivated → <paramref name="ct"/> cancelled)
+    /// never touch the DB or decoder, so flinging through the list doesn't fire a load per
+    /// tile it flies over. Awaiting with ConfigureAwait(false) also pushes the DI-scope /
+    /// DbContext / query setup off the UI thread — it used to run as this method's
+    /// synchronous head on the caller (the UI thread), one hit per realized tile.
+    /// </summary>
+    private const int ThumbnailSettleDelayMs = 100;
+
     private async Task LazyLoadThumbnailFromDbAsync(ModelImage image, CancellationToken ct)
     {
         try
         {
+            await Task.Delay(ThumbnailSettleDelayMs, ct).ConfigureAwait(false);
             using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
             var unitOfWork = scope.ServiceProvider.GetRequiredService<DataAccess.UnitOfWork.IUnitOfWork>();
             var (data, mimeType) = await unitOfWork.Models

--- a/DiffusionNexus.UI/ViewModels/SettingsViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/SettingsViewModel.cs
@@ -973,13 +973,12 @@ public partial class SettingsViewModel : BusyViewModelBase
 
         try
         {
+            // Progress<T> captures the UI SynchronizationContext at construction
+            // (this runs on the UI thread), so the callback is already marshaled.
             var progress = new Progress<BackupProgress>(p =>
             {
-                Avalonia.Threading.Dispatcher.UIThread.Post(() =>
-                {
-                    BusyMessage = $"Backup: {p.Phase} ({p.ProgressPercent}%)";
-                    _activityLogService?.ReportBackupProgress(p.ProgressPercent, p.Phase);
-                });
+                BusyMessage = $"Backup: {p.Phase} ({p.ProgressPercent}%)";
+                _activityLogService?.ReportBackupProgress(p.ProgressPercent, p.Phase);
             });
 
             // Run backup on a background thread with its own DI scope to avoid
@@ -1122,15 +1121,15 @@ public partial class SettingsViewModel : BusyViewModelBase
                 // Perform the restore
                 BusyMessage = "Restoring backup...";
 
+                // Progress<T> captures the UI SynchronizationContext at construction
+                // (this runs on the UI thread inside RunBusyAsync, which does not
+                // offload), so the callback is already marshaled.
                 var progress = new Progress<BackupProgress>(p =>
                 {
-                    Avalonia.Threading.Dispatcher.UIThread.Post(() =>
-                    {
-                        var fileInfo = p.TotalFiles > 0
-                            ? $" — {p.FilesProcessed}/{p.TotalFiles}"
-                            : string.Empty;
-                        BusyMessage = $"Restore: {p.Phase} ({p.ProgressPercent}%){fileInfo}";
-                    });
+                    var fileInfo = p.TotalFiles > 0
+                        ? $" — {p.FilesProcessed}/{p.TotalFiles}"
+                        : string.Empty;
+                    BusyMessage = $"Restore: {p.Phase} ({p.ProgressPercent}%){fileInfo}";
                 });
 
                 // Run the restore on a background thread with its own DI scope.

--- a/DiffusionNexus.UI/ViewModels/StartupOverlayViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/StartupOverlayViewModel.cs
@@ -1,0 +1,47 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using DiffusionNexus.UI.Services.Startup;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+/// <summary>
+/// Binds the startup ready-check list to the overlay. CheckChanged is raised
+/// on the UI thread by every production caller (startup phases), so no
+/// marshaling is needed here.
+/// </summary>
+public sealed partial class StartupOverlayViewModel : ViewModelBase
+{
+    public IReadOnlyList<StartupCheckRowViewModel> Rows { get; }
+
+    public StartupOverlayViewModel(StartupProgressService service)
+    {
+        var rows = service.Checks.ToDictionary(c => c.Id, c => new StartupCheckRowViewModel(c));
+        Rows = service.Checks.Select(c => rows[c.Id]).ToList();
+        service.CheckChanged += check => rows[check.Id].Refresh(check);
+    }
+}
+
+public sealed partial class StartupCheckRowViewModel : ObservableObject
+{
+    public string DisplayName { get; }
+
+    [ObservableProperty] private bool _isPending;
+    [ObservableProperty] private bool _isRunning;
+    [ObservableProperty] private bool _isDone;
+    [ObservableProperty] private bool _isFailed;
+    [ObservableProperty] private string? _error;
+
+    public StartupCheckRowViewModel(StartupCheck check)
+    {
+        DisplayName = check.DisplayName;
+        Refresh(check);
+    }
+
+    public void Refresh(StartupCheck check)
+    {
+        IsPending = check.State == StartupCheckState.Pending;
+        IsRunning = check.State == StartupCheckState.Running;
+        IsDone = check.State == StartupCheckState.Done;
+        IsFailed = check.State == StartupCheckState.Failed;
+        Error = check.Error;
+    }
+}

--- a/DiffusionNexus.UI/ViewModels/Tabs/DatasetManagementViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/Tabs/DatasetManagementViewModel.cs
@@ -992,13 +992,12 @@ public partial class DatasetManagementViewModel : ObservableObject, IDialogServi
 
         try
         {
+            // Progress<T> captures the UI SynchronizationContext at construction
+            // (this runs on the UI thread), so the callback is already marshaled.
             var progress = new Progress<BackupProgress>(p =>
             {
-                Avalonia.Threading.Dispatcher.UIThread.Post(() =>
-                {
-                    BackupStatusText = $"Backup: {p.ProgressPercent}%";
-                    _activityLog?.ReportBackupProgress(p.ProgressPercent, p.Phase);
-                });
+                BackupStatusText = $"Backup: {p.ProgressPercent}%";
+                _activityLog?.ReportBackupProgress(p.ProgressPercent, p.Phase);
             });
 
             // Run backup on a background thread with its own DI scope to avoid
@@ -1062,13 +1061,12 @@ public partial class DatasetManagementViewModel : ObservableObject, IDialogServi
 
         try
         {
+            // Progress<T> captures the UI SynchronizationContext at construction
+            // (this runs on the UI thread), so the callback is already marshaled.
             var progress = new Progress<BackupProgress>(p =>
             {
-                Avalonia.Threading.Dispatcher.UIThread.Post(() =>
-                {
-                    BackupStatusText = $"Backup: {p.ProgressPercent}%";
-                    _activityLog?.ReportBackupProgress(p.ProgressPercent, p.Phase);
-                });
+                BackupStatusText = $"Backup: {p.ProgressPercent}%";
+                _activityLog?.ReportBackupProgress(p.ProgressPercent, p.Phase);
             });
 
             // Run backup on a background thread with its own DI scope to avoid

--- a/DiffusionNexus.UI/ViewModels/Tabs/DatasetManagementViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/Tabs/DatasetManagementViewModel.cs
@@ -977,7 +977,14 @@ public partial class DatasetManagementViewModel : ObservableObject, IDialogServi
         _isBackupInProgress = true;
         BackupNowCommand.NotifyCanExecuteChanged();
 
-        var isDue = await _backupService.IsBackupDueAsync();
+        // SQLite "async" queries execute synchronously on the calling thread —
+        // run the due-check on a pool thread with its own scope, like the backup.
+        var isDue = await Task.Run(async () =>
+        {
+            using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            var scopedBackupService = scope.ServiceProvider.GetRequiredService<IDatasetBackupService>();
+            return await scopedBackupService.IsBackupDueAsync();
+        });
         if (!isDue)
         {
             _isBackupInProgress = false;
@@ -1018,7 +1025,12 @@ public partial class DatasetManagementViewModel : ObservableObject, IDialogServi
                 // The backup ran on a separate DI scope, so the main DbContext still has
                 // the old LastBackupAt cached. Force the fresh timestamp to prevent
                 // UpdateBackupStatus from seeing a stale value and immediately re-triggering.
-                var settings = await _settingsService.GetSettingsAsync();
+                var settings = await Task.Run(async () =>
+                {
+                    using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+                    var scopedSettings = scope.ServiceProvider.GetRequiredService<IAppSettingsService>();
+                    return await scopedSettings.GetSettingsAsync();
+                });
                 settings.LastBackupAt = DateTimeOffset.UtcNow;
                 UpdateBackupStatus(settings);
             }
@@ -1087,7 +1099,12 @@ public partial class DatasetManagementViewModel : ObservableObject, IDialogServi
                 // The backup ran on a separate DI scope, so the main DbContext still has
                 // the old LastBackupAt cached. Force the fresh timestamp to prevent
                 // UpdateBackupStatus from seeing a stale value and immediately re-triggering.
-                var settings = await _settingsService.GetSettingsAsync();
+                var settings = await Task.Run(async () =>
+                {
+                    using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+                    var scopedSettings = scope.ServiceProvider.GetRequiredService<IAppSettingsService>();
+                    return await scopedSettings.GetSettingsAsync();
+                });
                 settings.LastBackupAt = DateTimeOffset.UtcNow;
                 UpdateBackupStatus(settings);
             }

--- a/DiffusionNexus.UI/ViewModels/UnifiedConsoleViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/UnifiedConsoleViewModel.cs
@@ -30,6 +30,17 @@ public partial class UnifiedConsoleViewModel : ViewModelBase, IDisposable
     private IDisposable? _logSubscription;
     private bool _disposed;
 
+    private readonly System.Collections.Concurrent.ConcurrentQueue<LogEntry> _pendingEntries = new();
+    private int _flushScheduled;
+
+    /// <summary>
+    /// Test seam: how a pending log flush is scheduled onto the UI thread.
+    /// Background priority lets bursts of process output coalesce into one pass
+    /// instead of one dispatcher post per log line.
+    /// </summary>
+    internal Action<Action> ScheduleFlush { get; set; } =
+        action => Dispatcher.UIThread.Post(action, DispatcherPriority.Background);
+
     #region Observable Properties
 
     [ObservableProperty]
@@ -165,19 +176,33 @@ public partial class UnifiedConsoleViewModel : ViewModelBase, IDisposable
 
     private void OnLogEntryReceived(LogEntry entry)
     {
-        Dispatcher.UIThread.Post(() =>
-        {
-            lock (_entriesLock)
-            {
-                _allEntries.Add(entry);
-            }
-            UpdateCounts();
+        _pendingEntries.Enqueue(entry);
+        if (Interlocked.CompareExchange(ref _flushScheduled, 1, 0) == 0)
+            ScheduleFlush(FlushPendingLogEntries);
+    }
 
+    private void FlushPendingLogEntries()
+    {
+        // Reset the gate BEFORE draining: an entry arriving mid-drain schedules
+        // the next flush instead of being stranded in the queue.
+        Interlocked.Exchange(ref _flushScheduled, 0);
+
+        var drained = new List<LogEntry>();
+        while (_pendingEntries.TryDequeue(out var entry))
+            drained.Add(entry);
+        if (drained.Count == 0) return;
+
+        lock (_entriesLock)
+        {
+            _allEntries.AddRange(drained);
+        }
+        UpdateCounts();
+
+        foreach (var entry in drained)
+        {
             if (ShouldInclude(entry))
-            {
                 FilteredEntries.Add(entry);
-            }
-        });
+        }
     }
 
     #endregion

--- a/DiffusionNexus.UI/Views/Controls/ModelTileControl.axaml
+++ b/DiffusionNexus.UI/Views/Controls/ModelTileControl.axaml
@@ -16,9 +16,22 @@
           BorderBrush="#3D3D3D"
           BorderThickness="1"
           ClipToBounds="True"
-          Cursor="Hand">
+          Cursor="Hand"
+          Classes="tile">
+    <Border.Styles>
+      <!-- The action buttons are laid out only while the tile is hovered. During scroll
+           they are collapsed (IsVisible=False → not measured/arranged), which removes the
+           bulk of the per-tile layout cost that made fast scrolling stutter; they reveal
+           on pointer-over. -->
+      <Style Selector="Border.tile Grid.tileActions">
+        <Setter Property="IsVisible" Value="False"/>
+      </Style>
+      <Style Selector="Border.tile:pointerover Grid.tileActions">
+        <Setter Property="IsVisible" Value="True"/>
+      </Style>
+    </Border.Styles>
 
-    <Grid RowDefinitions="*,Auto">
+    <Grid>
 
       <!-- Thumbnail Area (clickable to open details) -->
       <Button Grid.Row="0"
@@ -115,23 +128,40 @@
         </ItemsControl>
       </Border>
 
-      <!-- Model Info: Name + Filename (overlay on thumbnail bottom) -->
+      <!-- Model Info (name + filename, always visible) with the action buttons stacked
+           directly below, revealed on hover. Kept as a single bottom-anchored overlay so
+           revealing the actions never reflows the tile. -->
       <Border Grid.Row="0"
               VerticalAlignment="Bottom"
               Background="#CC000000"
-              Padding="8,4">
-        <StackPanel Spacing="1">
-          <TextBlock Text="{Binding DisplayName}"
-                     FontSize="13"
-                     FontWeight="SemiBold"
-                     Foreground="White"
-                     TextTrimming="CharacterEllipsis"
-                     ToolTip.Tip="{Binding DisplayName}"/>
-          <TextBlock Text="{Binding FileName}"
-                     FontSize="11"
-                     Foreground="#99FFFFFF"
-                     TextTrimming="CharacterEllipsis"
-                     ToolTip.Tip="{Binding FileName}"/>
+              Padding="0">
+        <StackPanel>
+          <StackPanel Spacing="1" Margin="8,4">
+            <TextBlock Text="{Binding DisplayName}"
+                       FontSize="13"
+                       FontWeight="SemiBold"
+                       Foreground="White"
+                       TextTrimming="CharacterEllipsis"
+                       ToolTip.Tip="{Binding DisplayName}"/>
+            <TextBlock Text="{Binding FileName}"
+                       FontSize="11"
+                       Foreground="#99FFFFFF"
+                       TextTrimming="CharacterEllipsis"
+                       ToolTip.Tip="{Binding FileName}"/>
+          </StackPanel>
+
+          <!-- Action buttons: collapsed during scroll, shown on pointer-over (see .tileActions style). -->
+          <Grid Classes="tileActions"
+                ColumnDefinitions="*,*,*,*,*"
+                Background="#252525"
+                Margin="0"
+                Height="34">
+            <Button Grid.Column="0" Content="🌐" Command="{Binding OpenOnCivitaiCommand}" ToolTip.Tip="Open on Civitai" HorizontalAlignment="Center" Padding="6,4" FontSize="14"/>
+            <Button Grid.Column="1" Content="📋" Command="{Binding CopyTriggerWordsCommand}" ToolTip.Tip="Copy Trigger Words" HorizontalAlignment="Center" Padding="6,4" FontSize="14"/>
+            <Button Grid.Column="2" Content="🧾" Command="{Binding CopyFileNameCommand}" ToolTip.Tip="Copy Filename to Clipboard (for ComfyUI search)" HorizontalAlignment="Center" Padding="6,4" FontSize="14"/>
+            <Button Grid.Column="3" Content="📁" Command="{Binding OpenFolderCommand}" ToolTip.Tip="Open Folder" HorizontalAlignment="Center" Padding="6,4" FontSize="14"/>
+            <Button Grid.Column="4" Content="❌" FontWeight="Bold" Foreground="#FF6B6B" Command="{Binding DeleteCommand}" ToolTip.Tip="Delete Model" HorizontalAlignment="Center" Padding="6,4" FontSize="14"/>
+          </Grid>
         </StackPanel>
       </Border>
 
@@ -170,65 +200,6 @@
                      HorizontalAlignment="Center"/>
         </Border>
       </StackPanel>
-
-      <!-- Bottom Action Buttons -->
-      <Border Grid.Row="1"
-              Background="#252525"
-              Padding="8,6"
-              Margin="0"
-              CornerRadius="0,0,8,8">
-
-        <Grid ColumnDefinitions="*,*,*,*,*">
-
-          <!-- Open on Civitai -->
-          <Button Grid.Column="0"
-                  Content="🌐"
-                  Command="{Binding OpenOnCivitaiCommand}"
-                  ToolTip.Tip="Open on Civitai"
-                  HorizontalAlignment="Center"
-                  Padding="6,4"
-                  FontSize="14"/>
-
-          <!-- Copy Trigger Words -->
-          <Button Grid.Column="1"
-                  Content="📋"
-                  Command="{Binding CopyTriggerWordsCommand}"
-                  ToolTip.Tip="Copy Trigger Words"
-                  HorizontalAlignment="Center"
-                  Padding="6,4"
-                  FontSize="14"/>
-
-          <!-- Copy Real Filename -->
-          <Button Grid.Column="2"
-                  Content="🧾"
-                  Command="{Binding CopyFileNameCommand}"
-                  ToolTip.Tip="Copy Filename to Clipboard (for ComfyUI search)"
-                  HorizontalAlignment="Center"
-                  Padding="6,4"
-                  FontSize="14"/>
-
-          <!-- Open Folder -->
-          <Button Grid.Column="3"
-                  Content="📁"
-                  Command="{Binding OpenFolderCommand}"
-                  ToolTip.Tip="Open Folder"
-                  HorizontalAlignment="Center"
-                  Padding="6,4"
-                  FontSize="14"/>
-
-          <!-- Delete -->
-          <Button Grid.Column="4"
-                  Content="❌"
-                  FontWeight="Bold"
-                  Foreground="#FF6B6B"
-                  Command="{Binding DeleteCommand}"
-                  ToolTip.Tip="Delete Model"
-                  HorizontalAlignment="Center"
-                  Padding="6,4"
-                  FontSize="14"/>
-          
-        </Grid>
-      </Border>
 
     </Grid>
 

--- a/DiffusionNexus.UI/Views/DiffusionNexusMainWindow.axaml
+++ b/DiffusionNexus.UI/Views/DiffusionNexusMainWindow.axaml
@@ -220,30 +220,33 @@ x:Name="MainWin">
                                      registration) completes. Reuses the app's busy-overlay idiom
                                      (dimming Border + centered indeterminate ProgressBar). -->
                                 <Border IsVisible="{Binding !IsStartupComplete}"
-                                        Background="#80000000">
-                                    <Border Background="#E01E1E1E"
-                                            CornerRadius="8"
-                                            Padding="28,20"
-                                            MinWidth="320"
+                                        Background="#B0000000">
+                                    <Border Background="#F01E1E1E"
+                                            CornerRadius="14"
+                                            Padding="56,44"
+                                            MinWidth="520"
+                                            BorderBrush="#3A3A3A"
+                                            BorderThickness="1"
+                                            BoxShadow="0 18 56 0 #B0000000"
                                             HorizontalAlignment="Center"
                                             VerticalAlignment="Center">
-                                        <StackPanel Spacing="10">
+                                        <StackPanel Spacing="16">
                                             <TextBlock Text="Starting DiffusionNexus…"
-                                                       FontSize="16" FontWeight="SemiBold"
+                                                       FontSize="28" FontWeight="SemiBold"
                                                        HorizontalAlignment="Center"
-                                                       Margin="0,0,0,6"/>
+                                                       Margin="0,0,0,16"/>
                                             <ItemsControl ItemsSource="{Binding StartupOverlay.Rows}">
                                                 <ItemsControl.ItemTemplate>
                                                     <DataTemplate x:DataType="vm:StartupCheckRowViewModel">
-                                                        <Grid ColumnDefinitions="24,*" Margin="0,2">
-                                                            <Panel Grid.Column="0" Width="18" Height="18">
-                                                                <TextBlock Text="•" Opacity="0.35"
+                                                        <Grid ColumnDefinitions="32,*" Margin="0,4">
+                                                            <Panel Grid.Column="0" Width="24" Height="24">
+                                                                <TextBlock Text="•" Opacity="0.35" FontSize="20"
                                                                            IsVisible="{Binding IsPending}"
                                                                            HorizontalAlignment="Center"/>
                                                                 <ProgressBar IsIndeterminate="True"
                                                                              IsVisible="{Binding IsRunning}"
-                                                                             Width="16" Height="16"/>
-                                                                <TextBlock Text="✓" Foreground="#4CAF50" FontWeight="Bold"
+                                                                             Width="20" Height="20"/>
+                                                                <TextBlock Text="✓" Foreground="#4CAF50" FontWeight="Bold" FontSize="16"
                                                                            Classes.done="{Binding IsDone}"
                                                                            IsHitTestVisible="False"
                                                                            HorizontalAlignment="Center">
@@ -261,13 +264,14 @@ x:Name="MainWin">
                                                                         </Transitions>
                                                                     </TextBlock.Transitions>
                                                                 </TextBlock>
-                                                                <TextBlock Text="✗" Foreground="#F44336" FontWeight="Bold"
+                                                                <TextBlock Text="✗" Foreground="#F44336" FontWeight="Bold" FontSize="16"
                                                                            IsVisible="{Binding IsFailed}"
                                                                            ToolTip.Tip="{Binding Error}"
                                                                            HorizontalAlignment="Center"/>
                                                             </Panel>
                                                             <TextBlock Grid.Column="1" Text="{Binding DisplayName}"
-                                                                       VerticalAlignment="Center" Margin="8,0,0,0"/>
+                                                                       FontSize="16"
+                                                                       VerticalAlignment="Center" Margin="10,0,0,0"/>
                                                         </Grid>
                                                     </DataTemplate>
                                                 </ItemsControl.ItemTemplate>

--- a/DiffusionNexus.UI/Views/DiffusionNexusMainWindow.axaml
+++ b/DiffusionNexus.UI/Views/DiffusionNexusMainWindow.axaml
@@ -244,8 +244,14 @@ x:Name="MainWin">
                                                                              IsVisible="{Binding IsRunning}"
                                                                              Width="16" Height="16"/>
                                                                 <TextBlock Text="✓" Foreground="#4CAF50" FontWeight="Bold"
-                                                                           IsVisible="{Binding IsDone}"
+                                                                           Opacity="0"
+                                                                           Classes.done="{Binding IsDone}"
                                                                            HorizontalAlignment="Center">
+                                                                    <TextBlock.Styles>
+                                                                        <Style Selector="TextBlock.done">
+                                                                            <Setter Property="Opacity" Value="1"/>
+                                                                        </Style>
+                                                                    </TextBlock.Styles>
                                                                     <TextBlock.Transitions>
                                                                         <Transitions>
                                                                             <DoubleTransition Property="Opacity" Duration="0:0:0.25"/>

--- a/DiffusionNexus.UI/Views/DiffusionNexusMainWindow.axaml
+++ b/DiffusionNexus.UI/Views/DiffusionNexusMainWindow.axaml
@@ -213,13 +213,30 @@ x:Name="MainWin">
                                 </ItemsControl.ItemTemplate>
                             </ItemsControl>
 
-                            <ContentControl Grid.Row="1" Content="{Binding CurrentModuleView}">
-                                <ContentControl.ContentTemplate>
-                                    <DataTemplate>
-                                        <ContentPresenter Content="{Binding}"/>
-                                    </DataTemplate>
-                                </ContentControl.ContentTemplate>
-                            </ContentControl>
+                            <Panel Grid.Row="1">
+                                <ContentControl Grid.Row="1" Content="{Binding CurrentModuleView}">
+                                    <ContentControl.ContentTemplate>
+                                        <DataTemplate>
+                                            <ContentPresenter Content="{Binding}"/>
+                                        </DataTemplate>
+                                    </ContentControl.ContentTemplate>
+                                </ContentControl>
+
+                                <!-- Startup overlay: shown until deferred startup (DB init + module
+                                     registration) completes. Reuses the app's busy-overlay idiom
+                                     (dimming Border + centered indeterminate ProgressBar). -->
+                                <Border IsVisible="{Binding !IsStartupComplete}"
+                                        Background="#80000000">
+                                    <StackPanel HorizontalAlignment="Center"
+                                                VerticalAlignment="Center"
+                                                Spacing="12">
+                                        <ProgressBar IsIndeterminate="True" Width="220"/>
+                                        <TextBlock Text="Starting DiffusionNexus…"
+                                                   HorizontalAlignment="Center"
+                                                   Foreground="White"/>
+                                    </StackPanel>
+                                </Border>
+                            </Panel>
                         </Grid>
                     </Border>
                 </SplitView.Content>

--- a/DiffusionNexus.UI/Views/DiffusionNexusMainWindow.axaml
+++ b/DiffusionNexus.UI/Views/DiffusionNexusMainWindow.axaml
@@ -244,10 +244,13 @@ x:Name="MainWin">
                                                                              IsVisible="{Binding IsRunning}"
                                                                              Width="16" Height="16"/>
                                                                 <TextBlock Text="✓" Foreground="#4CAF50" FontWeight="Bold"
-                                                                           Opacity="0"
                                                                            Classes.done="{Binding IsDone}"
+                                                                           IsHitTestVisible="False"
                                                                            HorizontalAlignment="Center">
                                                                     <TextBlock.Styles>
+                                                                        <Style Selector="TextBlock">
+                                                                            <Setter Property="Opacity" Value="0"/>
+                                                                        </Style>
                                                                         <Style Selector="TextBlock.done">
                                                                             <Setter Property="Opacity" Value="1"/>
                                                                         </Style>

--- a/DiffusionNexus.UI/Views/DiffusionNexusMainWindow.axaml
+++ b/DiffusionNexus.UI/Views/DiffusionNexusMainWindow.axaml
@@ -214,7 +214,7 @@ x:Name="MainWin">
                             </ItemsControl>
 
                             <Panel Grid.Row="1">
-                                <ContentControl Grid.Row="1" Content="{Binding CurrentModuleView}">
+                                <ContentControl Content="{Binding CurrentModuleView}">
                                     <ContentControl.ContentTemplate>
                                         <DataTemplate>
                                             <ContentPresenter Content="{Binding}"/>
@@ -249,7 +249,7 @@ x:Name="MainWin">
 
         <!-- Disclaimer Overlay - blocks interaction when not accepted -->
         <Border Background="#E0000000"
-                IsVisible="{Binding !IsDisclaimerAccepted}"
+                IsVisible="{Binding ShowDisclaimer}"
                 IsHitTestVisible="True"
                 ZIndex="1000">
             <Border Background="#2D2D30"

--- a/DiffusionNexus.UI/Views/DiffusionNexusMainWindow.axaml
+++ b/DiffusionNexus.UI/Views/DiffusionNexusMainWindow.axaml
@@ -221,14 +221,50 @@ x:Name="MainWin">
                                      (dimming Border + centered indeterminate ProgressBar). -->
                                 <Border IsVisible="{Binding !IsStartupComplete}"
                                         Background="#80000000">
-                                    <StackPanel HorizontalAlignment="Center"
-                                                VerticalAlignment="Center"
-                                                Spacing="12">
-                                        <ProgressBar IsIndeterminate="True" Width="220"/>
-                                        <TextBlock Text="Starting DiffusionNexus…"
-                                                   HorizontalAlignment="Center"
-                                                   Foreground="White"/>
-                                    </StackPanel>
+                                    <Border Background="#E01E1E1E"
+                                            CornerRadius="8"
+                                            Padding="28,20"
+                                            MinWidth="320"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Center">
+                                        <StackPanel Spacing="10">
+                                            <TextBlock Text="Starting DiffusionNexus…"
+                                                       FontSize="16" FontWeight="SemiBold"
+                                                       HorizontalAlignment="Center"
+                                                       Margin="0,0,0,6"/>
+                                            <ItemsControl ItemsSource="{Binding StartupOverlay.Rows}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate x:DataType="vm:StartupCheckRowViewModel">
+                                                        <Grid ColumnDefinitions="24,*" Margin="0,2">
+                                                            <Panel Grid.Column="0" Width="18" Height="18">
+                                                                <TextBlock Text="•" Opacity="0.35"
+                                                                           IsVisible="{Binding IsPending}"
+                                                                           HorizontalAlignment="Center"/>
+                                                                <ProgressBar IsIndeterminate="True"
+                                                                             IsVisible="{Binding IsRunning}"
+                                                                             Width="16" Height="16"/>
+                                                                <TextBlock Text="✓" Foreground="#4CAF50" FontWeight="Bold"
+                                                                           IsVisible="{Binding IsDone}"
+                                                                           HorizontalAlignment="Center">
+                                                                    <TextBlock.Transitions>
+                                                                        <Transitions>
+                                                                            <DoubleTransition Property="Opacity" Duration="0:0:0.25"/>
+                                                                        </Transitions>
+                                                                    </TextBlock.Transitions>
+                                                                </TextBlock>
+                                                                <TextBlock Text="✗" Foreground="#F44336" FontWeight="Bold"
+                                                                           IsVisible="{Binding IsFailed}"
+                                                                           ToolTip.Tip="{Binding Error}"
+                                                                           HorizontalAlignment="Center"/>
+                                                            </Panel>
+                                                            <TextBlock Grid.Column="1" Text="{Binding DisplayName}"
+                                                                       VerticalAlignment="Center" Margin="8,0,0,0"/>
+                                                        </Grid>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </StackPanel>
+                                    </Border>
                                 </Border>
                             </Panel>
                         </Grid>

--- a/DiffusionNexus.UI/Views/DiffusionNexusMainWindow.axaml
+++ b/DiffusionNexus.UI/Views/DiffusionNexusMainWindow.axaml
@@ -214,13 +214,7 @@ x:Name="MainWin">
                             </ItemsControl>
 
                             <Panel Grid.Row="1">
-                                <ContentControl Content="{Binding CurrentModuleView}">
-                                    <ContentControl.ContentTemplate>
-                                        <DataTemplate>
-                                            <ContentPresenter Content="{Binding}"/>
-                                        </DataTemplate>
-                                    </ContentControl.ContentTemplate>
-                                </ContentControl>
+                                <ContentControl Content="{Binding CurrentModuleView}"/>
 
                                 <!-- Startup overlay: shown until deferred startup (DB init + module
                                      registration) completes. Reuses the app's busy-overlay idiom

--- a/DiffusionNexus.UI/Views/LoraViewerView.axaml
+++ b/DiffusionNexus.UI/Views/LoraViewerView.axaml
@@ -230,7 +230,7 @@
                 <air:ItemsRepeater.Layout>
                   <al:UniformGridLayout Orientation="Horizontal"
                                         MinItemWidth="262"
-                                        MinItemHeight="316"
+                                        MinItemHeight="276"
                                         MinColumnSpacing="0"
                                         MinRowSpacing="0"
                                         ItemsStretch="None"/>

--- a/DiffusionNexus.UI/Views/LoraViewerView.axaml
+++ b/DiffusionNexus.UI/Views/LoraViewerView.axaml
@@ -5,6 +5,8 @@
              xmlns:vm="using:DiffusionNexus.UI.ViewModels"
              xmlns:browser="using:DiffusionNexus.UI.Views.CivitaiBrowser"
              xmlns:controls="using:DiffusionNexus.UI.Views.Controls"
+             xmlns:air="using:Avalonia.Controls"
+             xmlns:al="using:Avalonia.Layout"
              mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
              x:Class="DiffusionNexus.UI.Views.LoraViewerView"
              x:DataType="vm:LoraViewerViewModel">
@@ -211,37 +213,36 @@
 
           <Grid>
 
-            <!-- Tile grid. FilteredTiles is a *window* into the full filtered set
-                 (~200 items at a time). The view's code-behind subscribes to the
-                 ScrollViewer below and asks the VM to slide the window when the user
-                 nears the top or bottom — items leaving the window get their
-                 containers detached, which calls Deactivate() on the bound VM and
-                 releases its decoded thumbnail bitmap. The complete filtered set
-                 still lives on the VM (`AllFilteredTiles`) so the count / search
-                 index are unaffected. -->
-            <ScrollViewer Name="TileScrollViewer"
-                          Padding="16"
+            <!-- Tile grid. FilteredTiles holds the FULL filtered set; the ItemsRepeater
+                 with a UniformGridLayout virtualizes it, so only the tiles inside the
+                 scroll viewport are realized (a 2K+ LoRA library opens instantly and
+                 scrolls smoothly). As a container recycles out of view its ModelTileControl
+                 detaches, calling Deactivate() on the bound VM to release the decoded
+                 thumbnail; scrolling a tile in calls Activate() to load it on demand.
+                 Item footprint = 250 wide + 6 margin all round; MinItemHeight leaves a
+                 small row gap above the tile's natural height so nothing clips. -->
+            <ScrollViewer Padding="16"
                           HorizontalScrollBarVisibility="Disabled"
                           VerticalScrollBarVisibility="Auto">
 
-              <StackPanel>
-                <ItemsControl ItemsSource="{Binding FilteredTiles}">
-                  <ItemsControl.ItemsPanel>
-                    <ItemsPanelTemplate>
-                      <WrapPanel Orientation="Horizontal"/>
-                    </ItemsPanelTemplate>
-                  </ItemsControl.ItemsPanel>
-                  <ItemsControl.ItemTemplate>
-                    <DataTemplate x:DataType="vm:ModelTileViewModel">
-                      <Border Margin="6" Width="250">
-                        <controls:ModelTileControl/>
-                      </Border>
-                    </DataTemplate>
-                  </ItemsControl.ItemTemplate>
-                </ItemsControl>
-
-                <Border Height="40"/>
-              </StackPanel>
+              <air:ItemsRepeater ItemsSource="{Binding FilteredTiles}"
+                                 Margin="0,0,0,40">
+                <air:ItemsRepeater.Layout>
+                  <al:UniformGridLayout Orientation="Horizontal"
+                                        MinItemWidth="262"
+                                        MinItemHeight="316"
+                                        MinColumnSpacing="0"
+                                        MinRowSpacing="0"
+                                        ItemsStretch="None"/>
+                </air:ItemsRepeater.Layout>
+                <air:ItemsRepeater.ItemTemplate>
+                  <DataTemplate x:DataType="vm:ModelTileViewModel">
+                    <Border Margin="6" Width="250">
+                      <controls:ModelTileControl/>
+                    </Border>
+                  </DataTemplate>
+                </air:ItemsRepeater.ItemTemplate>
+              </air:ItemsRepeater>
 
             </ScrollViewer>
 

--- a/DiffusionNexus.UI/Views/LoraViewerView.axaml.cs
+++ b/DiffusionNexus.UI/Views/LoraViewerView.axaml.cs
@@ -1,43 +1,17 @@
-using System;
-using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
-using DiffusionNexus.UI.ViewModels;
 
 namespace DiffusionNexus.UI.Views;
 
 /// <summary>
-/// View for browsing and managing LoRA models.
+/// View for browsing and managing LoRA models. The tile grid is a virtualizing
+/// <c>ItemsRepeater</c> (<c>UniformGridLayout</c>) inside the ScrollViewer — see
+/// LoraViewerView.axaml — so only the tiles inside the viewport are realized and
+/// each tile loads/releases its thumbnail as its container recycles. No manual
+/// scroll-window management lives here anymore.
 /// </summary>
 public partial class LoraViewerView : UserControl
 {
-    private ScrollViewer? _tileScrollViewer;
-
-    /// <summary>
-    /// Approximate height of one row of tiles in DIPs. Used to estimate which item
-    /// index is at the top of the viewport. The tile control's design height is
-    /// 340 px + a 12 px outer margin from the tile-template Border.
-    /// </summary>
-    private const double EstimatedRowHeight = 360;
-
-    /// <summary>Approximate width of one tile slot (250 + 12 margin).</summary>
-    private const double EstimatedTileWidth = 262;
-
-    /// <summary>
-    /// How close to the bottom of the loaded window (in tile indices) the user has
-    /// to be before we slide the window forward. Set wider than the slide step so
-    /// the trigger has room to fire repeatedly as the user scrolls — at 75 with
-    /// step=50, the trigger zone always covers the "freshly loaded" buffer.
-    /// </summary>
-    private const int SlideTriggerDistance = 75;
-
-    /// <summary>
-    /// Guards against re-entrant slides — sliding sets the new scroll offset,
-    /// which can fire a ScrollChanged event that would otherwise trigger another
-    /// slide immediately.
-    /// </summary>
-    private bool _slideInFlight;
-
     public LoraViewerView()
     {
         InitializeComponent();
@@ -46,103 +20,5 @@ public partial class LoraViewerView : UserControl
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);
-    }
-
-    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
-    {
-        base.OnAttachedToVisualTree(e);
-        _tileScrollViewer = this.FindControl<ScrollViewer>("TileScrollViewer");
-        if (_tileScrollViewer is not null)
-        {
-            _tileScrollViewer.ScrollChanged += OnTileScrollChanged;
-        }
-
-        if (DataContext is LoraViewerViewModel vm)
-        {
-            vm.OnViewAttached();
-        }
-    }
-
-    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
-    {
-        if (_tileScrollViewer is not null)
-        {
-            _tileScrollViewer.ScrollChanged -= OnTileScrollChanged;
-        }
-        _tileScrollViewer = null;
-        base.OnDetachedFromVisualTree(e);
-    }
-
-    private void OnTileScrollChanged(object? sender, ScrollChangedEventArgs e)
-    {
-        if (_slideInFlight) return;
-        if (DataContext is not LoraViewerViewModel vm) return;
-        if (_tileScrollViewer is null) return;
-
-        var sv = _tileScrollViewer;
-        var viewportWidth = sv.Viewport.Width;
-        var tilesPerRow = Math.Max(1, (int)(viewportWidth / EstimatedTileWidth));
-
-        // Index (within FilteredTiles) of the first tile visible at the top of the
-        // viewport, given the current scroll offset.
-        var firstVisibleIdx = (int)(sv.Offset.Y / EstimatedRowHeight) * tilesPerRow;
-        var windowedCount = vm.FilteredTiles.Count;
-
-        // Forward: user has scrolled into the trailing edge of the window.
-        if (windowedCount - firstVisibleIdx <= SlideTriggerDistance && vm.HasMoreForward)
-        {
-            SlideForward(vm, tilesPerRow);
-        }
-        // Backward: user has scrolled to (or near) the top, and earlier items exist.
-        else if (firstVisibleIdx < SlideTriggerDistance && vm.HasMoreBackward)
-        {
-            SlideBackward(vm, tilesPerRow);
-        }
-    }
-
-    /// <summary>
-    /// Triggers a forward slide on the VM and compensates the scroll offset so the
-    /// tiles currently under the user's eye stay visually anchored. Without this,
-    /// removing N items from the start of the list pulls the rest up by N rows /
-    /// tilesPerRow, jolting the viewport up.
-    /// </summary>
-    private void SlideForward(LoraViewerViewModel vm, int tilesPerRow)
-    {
-        _slideInFlight = true;
-        try
-        {
-            vm.SlideForward();
-            var removed = vm.LastSlideForwardCount;
-            if (removed > 0 && _tileScrollViewer is not null)
-            {
-                var rowsRemoved = (double)removed / tilesPerRow;
-                var newY = Math.Max(0, _tileScrollViewer.Offset.Y - rowsRemoved * EstimatedRowHeight);
-                _tileScrollViewer.Offset = _tileScrollViewer.Offset.WithY(newY);
-            }
-        }
-        finally
-        {
-            _slideInFlight = false;
-        }
-    }
-
-    private void SlideBackward(LoraViewerViewModel vm, int tilesPerRow)
-    {
-        _slideInFlight = true;
-        try
-        {
-            vm.SlideBackward();
-            var added = vm.LastSlideBackwardCount;
-            if (added > 0 && _tileScrollViewer is not null)
-            {
-                var rowsAdded = (double)added / tilesPerRow;
-                var newY = _tileScrollViewer.Offset.Y + rowsAdded * EstimatedRowHeight;
-                _tileScrollViewer.Offset = _tileScrollViewer.Offset.WithY(newY);
-            }
-        }
-        finally
-        {
-            _slideInFlight = false;
-        }
     }
 }

--- a/DiffusionNexus.UI/Views/LoraViewerView.axaml.cs
+++ b/DiffusionNexus.UI/Views/LoraViewerView.axaml.cs
@@ -56,6 +56,11 @@ public partial class LoraViewerView : UserControl
         {
             _tileScrollViewer.ScrollChanged += OnTileScrollChanged;
         }
+
+        if (DataContext is LoraViewerViewModel vm)
+        {
+            vm.OnViewAttached();
+        }
     }
 
     protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)

--- a/docs/superpowers/plans/2026-07-15-startup-ready-check-screen.md
+++ b/docs/superpowers/plans/2026-07-15-startup-ready-check-screen.md
@@ -1,0 +1,874 @@
+# Startup Ready-Check Screen Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the frozen "Starting DiffusionNexus…" overlay with an animated ready-check list over a startup that never blocks the UI thread, vanishing only when the app is provably responsive.
+
+**Architecture:** Three layers. (1) De-blocking: module registration is chunked one-module-per-Background-dispatcher-tick; the LoRA file verify moves its work inside `Task.Run`; the autocomplete trie load defers until the UI-ready signal and runs at `BelowNormal` priority. (2) Progress model: a plain-C# `StartupProgressService` singleton holds the ordered check list (Database → modules → Diffusion Engine → Updates) with Pending/Running/Done/Failed states. (3) UI: a checklist card bound to the service replaces the overlay's inner panel; the overlay is dismissed only after all core checks are terminal AND a Background-priority drain sentinel has run (structural guarantee: UI responsive at vanish).
+
+**Tech Stack:** .NET 10, Avalonia 11, CommunityToolkit.Mvvm, xUnit (DiffusionNexus.Tests).
+
+**Spec:** `docs/superpowers/specs/2026-07-15-startup-ready-check-design.md` (user-approved). Read it before starting a task if the task's intent is unclear.
+
+## Global Constraints
+
+- Repo: `e:\Repos\DiffusionNexus`, branch `feature/ui-performance-improvements` (all work goes into PR #410 — user decision). Never push to develop/main; do not open new PRs.
+- Build: `dotnet build DiffusionNexus.sln`. Tests: `dotnet test DiffusionNexus.Tests/DiffusionNexus.Tests.csproj` (filtered while iterating; full project before each commit; NEVER bare `dotnet test` on the solution — it stalls).
+- Do NOT add global Avalonia test bootstrapping to DiffusionNexus.Tests. `StartupProgressService` and `AutoCompleteService` are plain C# precisely so they are testable without it. UI/composition changes are verified by running the app (controller does this).
+- Line numbers reference branch `feature/ui-performance-improvements` @ f7f3d77 + spec commit; they may drift a few lines — anchor by the quoted code.
+- Hard acceptance criterion (user): **the UI must be responsive the moment the overlay vanishes.** The drain-sentinel ordering in Task 4 is the load-bearing implementation of this — do not reorder it.
+- Do NOT launch the GUI app from implementer subagents; the controller runs all app-level verification.
+
+---
+
+### Task 1: `StartupProgressService` — the check-list state machine
+
+**Files:**
+- Create: `DiffusionNexus.UI/Services/Startup/StartupCheck.cs`
+- Create: `DiffusionNexus.UI/Services/Startup/StartupProgressService.cs`
+- Test: `DiffusionNexus.Tests/Services/StartupProgressServiceTests.cs`
+
+**Interfaces:**
+- Produces (consumed by Tasks 2, 4, 5):
+  - `enum StartupCheckState { Pending, Running, Done, Failed }`
+  - `sealed class StartupCheck { string Id; string DisplayName; StartupCheckState State; string? Error; bool GatesReadiness; }`
+  - `sealed class StartupProgressService` with:
+    - `IReadOnlyList<StartupCheck> Checks` (fixed order, built by ctor)
+    - `event Action<StartupCheck>? CheckChanged` (raised synchronously on the caller's thread — callers are UI-thread startup phases)
+    - `void Begin(string id)`, `void Complete(string id)`, `void Fail(string id, string message)`
+    - `bool CoreChecksTerminal` — true when every check with `GatesReadiness == true` is Done or Failed
+    - `void SignalUiReady()` / `Task UiReady` — TaskCompletionSource-backed; completed exactly once by the app after the drain sentinel (Task 4)
+    - `static IReadOnlyList<StartupCheck> BuildDefaultChecks(bool includeDiffusionCanvas)` — the single source of truth for the list
+- No Avalonia types anywhere in these files.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using DiffusionNexus.UI.Services.Startup;
+
+namespace DiffusionNexus.Tests.Services;
+
+public class StartupProgressServiceTests
+{
+    private static StartupProgressService NewService(bool canvas = false)
+        => new(StartupProgressService.BuildDefaultChecks(includeDiffusionCanvas: canvas));
+
+    [Fact]
+    public void DefaultChecks_HaveExpectedOrderAndGating()
+    {
+        var svc = NewService();
+        Assert.Equal(
+            new[] { "database", "installer-manager", "lora-dataset-helper", "lora-viewer",
+                    "generation-gallery", "image-comparer", "workflows", "settings",
+                    "diffusion-engine", "updates" },
+            svc.Checks.Select(c => c.Id).ToArray());
+        Assert.All(svc.Checks.Where(c => c.Id != "updates"), c => Assert.True(c.GatesReadiness));
+        Assert.False(svc.Checks.Single(c => c.Id == "updates").GatesReadiness);
+    }
+
+    [Fact]
+    public void CanvasFlag_InsertsDiffusionCanvasAfterGenerationGallery()
+    {
+        var svc = NewService(canvas: true);
+        var ids = svc.Checks.Select(c => c.Id).ToList();
+        Assert.Equal(ids.IndexOf("generation-gallery") + 1, ids.IndexOf("diffusion-canvas"));
+    }
+
+    [Fact]
+    public void BeginCompleteFail_TransitionStatesAndRaiseEvents()
+    {
+        var svc = NewService();
+        var raised = new List<(string Id, StartupCheckState State)>();
+        svc.CheckChanged += c => raised.Add((c.Id, c.State));
+
+        svc.Begin("database");
+        svc.Complete("database");
+        svc.Begin("settings");
+        svc.Fail("settings", "boom");
+
+        Assert.Equal(StartupCheckState.Done, svc.Checks.Single(c => c.Id == "database").State);
+        var settings = svc.Checks.Single(c => c.Id == "settings");
+        Assert.Equal(StartupCheckState.Failed, settings.State);
+        Assert.Equal("boom", settings.Error);
+        Assert.Equal(
+            new[] { ("database", StartupCheckState.Running), ("database", StartupCheckState.Done),
+                    ("settings", StartupCheckState.Running), ("settings", StartupCheckState.Failed) },
+            raised.ToArray());
+    }
+
+    [Fact]
+    public void CoreChecksTerminal_IgnoresUpdates_AndCountsFailedAsTerminal()
+    {
+        var svc = NewService();
+        foreach (var c in svc.Checks.Where(c => c.GatesReadiness))
+        {
+            Assert.False(svc.CoreChecksTerminal);
+            svc.Begin(c.Id);
+            if (c.Id == "lora-viewer") svc.Fail(c.Id, "x"); else svc.Complete(c.Id);
+        }
+        Assert.True(svc.CoreChecksTerminal); // "updates" still Pending — must not gate
+    }
+
+    [Fact]
+    public void UiReady_CompletesOnceOnSignal()
+    {
+        var svc = NewService();
+        Assert.False(svc.UiReady.IsCompleted);
+        svc.SignalUiReady();
+        svc.SignalUiReady(); // idempotent, must not throw
+        Assert.True(svc.UiReady.IsCompletedSuccessfully);
+    }
+
+    [Fact]
+    public void UnknownId_Throws()
+    {
+        var svc = NewService();
+        Assert.Throws<ArgumentException>(() => svc.Begin("nope"));
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test DiffusionNexus.Tests/DiffusionNexus.Tests.csproj --filter "FullyQualifiedName~StartupProgressServiceTests"`
+Expected: FAIL — compile error, types do not exist.
+
+- [ ] **Step 3: Implement**
+
+`DiffusionNexus.UI/Services/Startup/StartupCheck.cs`:
+
+```csharp
+namespace DiffusionNexus.UI.Services.Startup;
+
+public enum StartupCheckState { Pending, Running, Done, Failed }
+
+/// <summary>
+/// One row of the startup ready-check list. Mutable state is owned by
+/// <see cref="StartupProgressService"/>; consumers only read.
+/// </summary>
+public sealed class StartupCheck
+{
+    public required string Id { get; init; }
+    public required string DisplayName { get; init; }
+
+    /// <summary>False for checks that must never delay overlay dismissal (Updates).</summary>
+    public bool GatesReadiness { get; init; } = true;
+
+    public StartupCheckState State { get; internal set; } = StartupCheckState.Pending;
+    public string? Error { get; internal set; }
+}
+```
+
+`DiffusionNexus.UI/Services/Startup/StartupProgressService.cs`:
+
+```csharp
+namespace DiffusionNexus.UI.Services.Startup;
+
+/// <summary>
+/// Ordered startup ready-check list (spec 2026-07-15). Plain C# — no Avalonia —
+/// so it is unit-testable and usable from any startup phase. CheckChanged is
+/// raised synchronously on the caller's thread; all production callers are
+/// UI-thread startup phases, so the overlay ViewModel needs no marshaling.
+/// </summary>
+public sealed class StartupProgressService
+{
+    private readonly List<StartupCheck> _checks;
+    private readonly TaskCompletionSource _uiReady =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public StartupProgressService(IReadOnlyList<StartupCheck> checks)
+        => _checks = [.. checks];
+
+    public IReadOnlyList<StartupCheck> Checks => _checks;
+
+    public event Action<StartupCheck>? CheckChanged;
+
+    /// <summary>Completed by the app after the overlay's dispatcher-drain sentinel
+    /// has run — i.e., when the UI is provably responsive. Deferred background
+    /// work (autocomplete trie) starts on this signal.</summary>
+    public Task UiReady => _uiReady.Task;
+
+    public bool CoreChecksTerminal => _checks
+        .Where(c => c.GatesReadiness)
+        .All(c => c.State is StartupCheckState.Done or StartupCheckState.Failed);
+
+    public void Begin(string id) => Set(id, StartupCheckState.Running, null);
+    public void Complete(string id) => Set(id, StartupCheckState.Done, null);
+    public void Fail(string id, string message) => Set(id, StartupCheckState.Failed, message);
+
+    public void SignalUiReady() => _uiReady.TrySetResult();
+
+    private void Set(string id, StartupCheckState state, string? error)
+    {
+        var check = _checks.FirstOrDefault(c => c.Id == id)
+            ?? throw new ArgumentException($"Unknown startup check '{id}'.", nameof(id));
+        check.State = state;
+        check.Error = error;
+        CheckChanged?.Invoke(check);
+    }
+
+    /// <summary>Single source of truth for the check list. Module entries MUST match
+    /// the registration order in App.RegisterModulesAsync (Task 4).</summary>
+    public static IReadOnlyList<StartupCheck> BuildDefaultChecks(bool includeDiffusionCanvas)
+    {
+        var checks = new List<StartupCheck>
+        {
+            new() { Id = "database", DisplayName = "Database" },
+            new() { Id = "installer-manager", DisplayName = "Installer Manager" },
+            new() { Id = "lora-dataset-helper", DisplayName = "LoRA Dataset Helper" },
+            new() { Id = "lora-viewer", DisplayName = "LoRA Viewer" },
+            new() { Id = "generation-gallery", DisplayName = "Generation Gallery" },
+        };
+        if (includeDiffusionCanvas)
+            checks.Add(new() { Id = "diffusion-canvas", DisplayName = "Diffusion Canvas" });
+        checks.AddRange(
+        [
+            new StartupCheck { Id = "image-comparer", DisplayName = "Image Comparer" },
+            new StartupCheck { Id = "workflows", DisplayName = "Workflows" },
+            new StartupCheck { Id = "settings", DisplayName = "Settings" },
+            new StartupCheck { Id = "diffusion-engine", DisplayName = "Diffusion Engine" },
+            new StartupCheck { Id = "updates", DisplayName = "Updates", GatesReadiness = false },
+        ]);
+        return checks;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test DiffusionNexus.Tests/DiffusionNexus.Tests.csproj --filter "FullyQualifiedName~StartupProgressServiceTests"`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Full suite + commit**
+
+Run: `dotnet build DiffusionNexus.sln` → succeeded; `dotnet test DiffusionNexus.Tests/DiffusionNexus.Tests.csproj` → all green.
+
+```bash
+git add DiffusionNexus.UI/Services/Startup/StartupCheck.cs DiffusionNexus.UI/Services/Startup/StartupProgressService.cs DiffusionNexus.Tests/Services/StartupProgressServiceTests.cs
+git commit -m "feat(startup): StartupProgressService check-list state machine"
+```
+
+---
+
+### Task 2: Defer + down-prioritize the autocomplete trie load
+
+**Files:**
+- Modify: `DiffusionNexus.UI/Services/SpellCheck/AutoCompleteService.cs:17-27` (constructor)
+- Modify: `DiffusionNexus.UI/App.axaml.cs:1047` (DI registration — anchor: `services.AddSingleton<IAutoCompleteService, AutoCompleteService>();`)
+- Test: extend `DiffusionNexus.Tests/...` wherever existing `AutoCompleteService` tests live (`grep -rln "AutoCompleteService" DiffusionNexus.Tests/` — add to that file; if none exists, create `DiffusionNexus.Tests/Services/AutoCompleteDeferralTests.cs`)
+
+**Interfaces:**
+- Consumes: `StartupProgressService.UiReady` (Task 1).
+- Produces: `AutoCompleteService(Task startSignal, string? dictionaryDirectory = null)` ctor overload. The existing `AutoCompleteService(string?)` ctor keeps its immediate-load behavior (existing tests must not change).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the existing AutoCompleteService test file (or the new file named above):
+
+```csharp
+    [Fact]
+    public async Task DeferredCtor_DoesNotStartLoading_UntilSignal()
+    {
+        var signal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        // Nonexistent directory: LoadFromDictionary returns immediately once it runs,
+        // so LoadCompleted completing == the load ran.
+        var svc = new AutoCompleteService(signal.Task,
+            Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
+
+        await Task.Delay(150);
+        Assert.False(svc.LoadCompleted.IsCompleted);
+
+        signal.SetResult();
+        await svc.LoadCompleted.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(svc.LoadCompleted.IsCompletedSuccessfully);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test DiffusionNexus.Tests/DiffusionNexus.Tests.csproj --filter "FullyQualifiedName~DeferredCtor_DoesNotStartLoading_UntilSignal"`
+Expected: FAIL — no such constructor (compile error).
+
+- [ ] **Step 3: Implement the deferred constructor**
+
+In `AutoCompleteService.cs`, replace the single constructor (`:17-27`) with:
+
+```csharp
+    /// <summary>
+    /// Creates an AutoCompleteService and seeds it from the Hunspell dictionary
+    /// immediately on a background task. Used by tests and non-startup callers.
+    /// </summary>
+    public AutoCompleteService(string? dictionaryDirectory = null)
+        : this(Task.CompletedTask, dictionaryDirectory)
+    {
+    }
+
+    /// <summary>
+    /// Defers the dictionary load until <paramref name="startSignal"/> completes,
+    /// then runs it on a dedicated BelowNormal-priority thread. The load costs
+    /// ~20s of CPU (Hunspell suffix expansion); at startup it must neither run
+    /// on the UI thread nor compete with startup work for cores — the app signals
+    /// StartupProgressService.UiReady after the overlay's drain sentinel, and the
+    /// load begins only then. GetSuggestions/RecordWord tolerate the not-yet-loaded
+    /// state (they briefly contend on _lock and see a partial trie).
+    /// </summary>
+    public AutoCompleteService(Task startSignal, string? dictionaryDirectory = null)
+    {
+        var dir = dictionaryDirectory ?? Path.Combine(AppContext.BaseDirectory, "Dictionaries");
+        LoadCompleted = LoadAfterSignalAsync(startSignal, dir);
+    }
+
+    private async Task LoadAfterSignalAsync(Task startSignal, string dir)
+    {
+        try { await startSignal.ConfigureAwait(false); }
+        catch { /* a faulted signal must not kill autocomplete; load anyway */ }
+
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new Thread(() => { LoadFromDictionary(dir); tcs.TrySetResult(); })
+        {
+            IsBackground = true,
+            Priority = ThreadPriority.BelowNormal,
+            Name = "AutoCompleteTrieLoad",
+        };
+        thread.Start();
+        await tcs.Task.ConfigureAwait(false);
+    }
+```
+
+(`LoadFromDictionary` already catches internally and never throws.)
+
+- [ ] **Step 4: Wire DI to the deferred signal**
+
+In `App.axaml.cs` `ConfigureServices`, `StartupProgressService` must be registered (this task adds it; Task 4 consumes the same registration). Immediately BEFORE the line `services.AddSingleton<IAutoCompleteService, AutoCompleteService>();` add:
+
+```csharp
+        services.AddSingleton(_ => new DiffusionNexus.UI.Services.Startup.StartupProgressService(
+            DiffusionNexus.UI.Services.Startup.StartupProgressService.BuildDefaultChecks(
+                DiffusionNexus.UI.Services.Diffusion.DiffusionFeatureFlags.UseLocalDiffusionBackend)));
+```
+
+and replace the `IAutoCompleteService` registration with:
+
+```csharp
+        services.AddSingleton<IAutoCompleteService>(sp => new AutoCompleteService(
+            sp.GetRequiredService<DiffusionNexus.UI.Services.Startup.StartupProgressService>().UiReady));
+```
+
+- [ ] **Step 5: Run tests (deferral + all existing AutoComplete tests), build, full suite, commit**
+
+Run: `dotnet test DiffusionNexus.Tests/DiffusionNexus.Tests.csproj --filter "FullyQualifiedName~AutoComplete"` → all green (existing tests use the immediate ctor and must be untouched).
+Run: `dotnet build DiffusionNexus.sln`; full test project → all green.
+
+```bash
+git add DiffusionNexus.UI/Services/SpellCheck/AutoCompleteService.cs DiffusionNexus.UI/App.axaml.cs DiffusionNexus.Tests/
+git commit -m "perf(startup): defer autocomplete trie load until UI-ready; BelowNormal priority"
+```
+
+---
+
+### Task 3: Move the LoRA file verify genuinely off the UI thread
+
+**Files:**
+- Modify: `DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs:418-442` (`VerifyFilesInBackgroundAsync`)
+- Test: none new (thin dispatch change on a VM path that needs a live dispatcher; verified by trace/app-run — controller owns it). Existing suite must stay green.
+
+**Interfaces:** none produced; self-contained.
+
+**Why:** the CPU trace showed 10.1s of UI-thread time in `ModelFileSyncService.TryFindMovedFileAsync` (7.3s hashing) because this method awaits the service call on the UI context — every continuation of the fake-async service runs on the dispatcher. Additionally its `Progress<SyncProgress>` handler double-hops (Progress marshal + nested `Dispatcher.UIThread.Post`) per report.
+
+- [ ] **Step 1: Replace the method**
+
+Replace `VerifyFilesInBackgroundAsync` (`:418-442`) with:
+
+```csharp
+    private async Task VerifyFilesInBackgroundAsync()
+    {
+        try
+        {
+            // Progress<T> captures the UI SynchronizationContext here (UI thread),
+            // so the callback is already marshaled — no nested Post needed.
+            var progress = new Progress<SyncProgress>(p =>
+            {
+                if (p.Phase == "Verification complete")
+                {
+                    SyncStatus = null; // Clear status when done
+                }
+            });
+
+            // The verify walks the library and SHA-hashes candidate files; its
+            // "async" service continuations otherwise resume on the UI thread
+            // (10s dispatcher hog on a cold cache — see 2026-07-15 startup trace).
+            // Run the whole thing on the pool with its own scope.
+            await Task.Run(async () =>
+            {
+                using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+                var syncService = scope.ServiceProvider.GetRequiredService<IModelSyncService>();
+                await syncService.VerifyAndSyncFilesAsync(progress);
+            });
+        }
+        catch
+        {
+            // Silently fail - this is background work
+        }
+    }
+```
+
+- [ ] **Step 2: Build + full suite**
+
+Run: `dotnet build DiffusionNexus.sln` → succeeded; `dotnet test DiffusionNexus.Tests/DiffusionNexus.Tests.csproj` → all green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+git commit -m "perf(lora-viewer): run file verification on the thread pool, not the UI dispatcher"
+```
+
+---
+
+### Task 4: Chunked module registration + readiness gate in `CompleteStartupAsync`
+
+**Files:**
+- Modify: `DiffusionNexus.UI/App.axaml.cs` — `CompleteStartupAsync` (`:179-254`), `RegisterModules` (`:1215-1411`), `LoadStartupDataAsync` (`:1419+`)
+- Test: none new (startup composition — controller verifies by app run + the Task 1 unit tests already cover the gate logic).
+
+**Interfaces:**
+- Consumes: `StartupProgressService` (Task 1; DI-registered in Task 2).
+- Produces: `RegisterModulesAsync(DiffusionNexusMainWindowViewModel, StartupProgressService)` replacing `RegisterModules`; `CompleteStartupAsync` drives Database/Diffusion-Engine checks, the drain sentinel, `SignalUiReady()`, and `IsStartupComplete`. Task 5's overlay binds to the same service instance.
+
+- [ ] **Step 1: Convert `RegisterModules` to chunked `RegisterModulesAsync`**
+
+Rename `private void RegisterModules(DiffusionNexusMainWindowViewModel mainViewModel)` to:
+
+```csharp
+    /// <summary>
+    /// Builds and registers every module, one module per Background-priority
+    /// dispatcher tick, so rendering and input interleave with construction
+    /// (the old synchronous loop held the UI thread ~3.6s and froze the
+    /// startup overlay). Each module reports Running/Done/Failed to the
+    /// ready-check list. Must be called on the UI thread.
+    /// </summary>
+    private async Task RegisterModulesAsync(
+        DiffusionNexusMainWindowViewModel mainViewModel,
+        DiffusionNexus.UI.Services.Startup.StartupProgressService startupProgress)
+```
+
+Inside, wrap EACH existing module block in this exact pattern. The blocks and their check ids, in current source order (anchor by the comment headers quoted):
+
+| # | Anchor comment in current code | Check id |
+|---|---|---|
+| 1 | `// Installer Manager module` | `installer-manager` |
+| 2 | `// LoRA Dataset Helper module - default on startup` | `lora-dataset-helper` |
+| 3 | `// LoRA Viewer module` | `lora-viewer` |
+| 4 | `// Generation Gallery module` | `generation-gallery` |
+| 5 | `// Diffusion Canvas module — local Z-Image-Turbo...` (inside its existing `if (DiffusionFeatureFlags.UseLocalDiffusionBackend)`) | `diffusion-canvas` |
+| 6 | `// Image Comparer module` | `image-comparer` |
+| 7 | `// Pipelines module — tile gallery...` | `workflows` |
+| 8 | `// Settings module` | `settings` |
+
+Pattern — shown in full for block 1; apply identically to blocks 2–8 (each keeps its existing body verbatim, including the Installer-Manager console wiring that follows its registration):
+
+```csharp
+        startupProgress.Begin("installer-manager");
+        try
+        {
+            // ==== existing block body, unchanged, from
+            // `var installerManagerVm = Services!.GetRequiredService<InstallerManagerViewModel>();`
+            // through the `installerManagerVm.InstallerUpdateStateChanged += ...` console wiring ====
+            startupProgress.Complete("installer-manager");
+        }
+        catch (Exception ex)
+        {
+            Serilog.Log.Error(ex, "Module registration failed: {Module}", "installer-manager");
+            startupProgress.Fail("installer-manager", ex.Message);
+        }
+        await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
+            static () => { }, Avalonia.Threading.DispatcherPriority.Background);
+```
+
+Notes for the implementer:
+- The trailing no-op `InvokeAsync(..., Background)` is the chunk boundary: awaiting it yields the UI thread until everything above Background priority (input, render) has run. One boundary after EVERY block, including the last.
+- Block 5 keeps its existing `if (DiffusionFeatureFlags.UseLocalDiffusionBackend)` guard OUTSIDE the Begin/try (when the flag is off there is no `diffusion-canvas` check — `BuildDefaultChecks` didn't create one — so Begin must not be called).
+- A failed block must not abort the loop: the `try/catch` per block replaces today's all-or-nothing behavior deliberately (spec §4). Locals used later (e.g. `installerManagerVm`) must be declared BEFORE the `try` (`InstallerManagerViewModel? installerManagerVm = null;`) and null-guarded where consumed: the event-aggregator wiring section and the `LoadStartupDataAsync` call at the end each get `if (x is null) return;`-style guards — concretely, wrap the entire "Subscribe to navigation events" section and the `LoadStartupDataAsync` call in `if (installerManagerVm is not null && loraDatasetHelperVm is not null && loraViewerVm is not null && generationGalleryVm is not null && imageCompareVm is not null && pipelinesVm is not null && settingsVm is not null && settingsModule is not null && loraDatasetHelperModule is not null && imageComparerModule is not null && pipelinesModule is not null)` (single guard; if any module failed to build, skip wiring + data load and log a warning — the app is already degraded and the checks show which module died).
+- The `_ = LoadStartupDataAsync(...)` tail call gains one argument: `startupProgress` (see Step 3).
+
+- [ ] **Step 2: Drive the gate from `CompleteStartupAsync`**
+
+Replace the body of `CompleteStartupAsync` (`:179-254`) with (keep the existing doc comment, extend it with the gate note):
+
+```csharp
+    private async Task CompleteStartupAsync(DiffusionNexusMainWindowViewModel mainViewModel)
+    {
+        var startupProgress = Services!.GetRequiredService<DiffusionNexus.UI.Services.Startup.StartupProgressService>();
+        try
+        {
+            startupProgress.Begin("database");
+            // Database initialization is pure logging + EF work — safe off the UI thread.
+            await Task.Run(() =>
+            {
+                Serilog.Log.Information("Initializing app database...");
+                InitializeDatabase();
+                Serilog.Log.Information("Initializing SDK database...");
+                InitializeSdkDatabase();
+            });
+            startupProgress.Complete("database");
+
+            // Everything below resumes on the Avalonia UI thread (its SynchronizationContext
+            // was captured at the await above). Do NOT add ConfigureAwait(false) in this method.
+            Serilog.Log.Information("Initializing thumbnail service...");
+            InitializeThumbnailService();
+
+            Serilog.Log.Information("Initializing spell check services...");
+            InitializeSpellCheckServices();
+
+            Serilog.Log.Information("Initializing instance process manager...");
+            _ = Services!.GetRequiredService<IInstanceProcessManager>();
+
+            Serilog.Log.Information("Initializing Civitai base-model catalog...");
+            InitializeCivitaiBaseModelCatalog();
+
+            Serilog.Log.Information("Initializing instance management...");
+            mainViewModel.InitializeInstanceManagement();
+
+            Serilog.Log.Information("Registering modules...");
+            await RegisterModulesAsync(mainViewModel, startupProgress);
+
+            // Diffusion Engine: the heavy native warm-up happens inside module
+            // construction; this check confirms the backend singleton resolves.
+            if (DiffusionNexus.UI.Services.Diffusion.DiffusionFeatureFlags.UseLocalDiffusionBackend)
+            {
+                startupProgress.Begin("diffusion-engine");
+                try
+                {
+                    _ = Services!.GetRequiredService<DiffusionNexus.UI.Services.Diffusion.LocalDiffusionBackendProvider>();
+                    startupProgress.Complete("diffusion-engine");
+                }
+                catch (Exception ex)
+                {
+                    Serilog.Log.Error(ex, "Diffusion engine warm-up failed");
+                    startupProgress.Fail("diffusion-engine", ex.Message);
+                }
+
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        using var scope = Services!.CreateScope();
+                        var registrar = scope.ServiceProvider.GetRequiredService<DiffusionNexus.UI.Services.Diffusion.OutputsFolderRegistrar>();
+                        await registrar.EnsureRegisteredAsync();
+                    }
+                    catch (Exception ex)
+                    {
+                        Serilog.Log.Warning(ex, "OutputsFolderRegistrar failed during startup.");
+                    }
+                });
+            }
+            else
+            {
+                startupProgress.Complete("diffusion-engine");
+            }
+        }
+        catch (Exception ex)
+        {
+            Serilog.Log.Fatal(ex, "Deferred startup initialization failed");
+            foreach (var check in startupProgress.Checks)
+            {
+                if (check.State is DiffusionNexus.UI.Services.Startup.StartupCheckState.Pending
+                                or DiffusionNexus.UI.Services.Startup.StartupCheckState.Running
+                    && check.GatesReadiness)
+                {
+                    startupProgress.Fail(check.Id, ex.Message);
+                }
+            }
+            Services?.GetService<IActivityLogService>()
+                ?.LogError("Startup", "Startup initialization failed — some features may be unavailable", ex);
+        }
+        finally
+        {
+            // HARD REQUIREMENT (user): the UI must be responsive when the overlay
+            // vanishes. All core checks are terminal here; drain everything at-and-
+            // above Background priority before dismissing, then release deferred
+            // background work (autocomplete trie) via SignalUiReady.
+            await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
+                static () => { }, Avalonia.Threading.DispatcherPriority.Background);
+            mainViewModel.IsStartupComplete = true;
+            startupProgress.SignalUiReady();
+        }
+    }
+```
+
+Notes:
+- `await` inside `finally` is legal C# and stays on the UI thread here.
+- The old un-gated `startupProgress.Complete("diffusion-engine")` else-branch keeps the check honest when the local backend is compiled out.
+- The `OutputsFolderRegistrar` block moved inside the flag branch it already depended on — verify with the diff that its behavior is unchanged.
+
+- [ ] **Step 3: Wire the `updates` check into `LoadStartupDataAsync`**
+
+Change the signature to accept the service:
+
+```csharp
+    private static async Task LoadStartupDataAsync(
+        DiffusionNexusMainWindowViewModel mainViewModel,
+        SettingsViewModel settingsVm,
+        LoraViewerViewModel loraViewerVm,
+        GenerationGalleryViewModel generationGalleryVm,
+        InstallerManagerViewModel installerManagerVm,
+        LoraDatasetHelperViewModel loraDatasetHelperVm,
+        DiffusionNexus.UI.Services.Startup.StartupProgressService startupProgress)
+```
+
+and wrap the existing `installerManager` Timed phase (the update checks run inside `LoadInstallationsCommand`):
+
+```csharp
+                Timed(sw, "installerManager", async () =>
+                {
+                    startupProgress.Begin("updates");
+                    try
+                    {
+                        await installerManagerVm.LoadInstallationsCommand.ExecuteAsync(null);
+                        startupProgress.Complete("updates");
+                    }
+                    catch (Exception ex)
+                    {
+                        startupProgress.Fail("updates", ex.Message);
+                        throw;
+                    }
+                }),
+```
+
+(The other Timed phases are unchanged. `updates` has `GatesReadiness == false`, so it never delays the overlay; when it completes after dismissal nobody is listening — that is by design.)
+
+- [ ] **Step 4: Build + full suite**
+
+Run: `dotnet build DiffusionNexus.sln` → succeeded; `dotnet test DiffusionNexus.Tests/DiffusionNexus.Tests.csproj` → all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DiffusionNexus.UI/App.axaml.cs
+git commit -m "perf(startup): chunk module registration per dispatcher tick; readiness gate with drain sentinel"
+```
+
+---
+
+### Task 5: The ready-check overlay UI
+
+**Files:**
+- Create: `DiffusionNexus.UI/ViewModels/StartupOverlayViewModel.cs`
+- Modify: `DiffusionNexus.UI/ViewModels/DiffusionNexusMainWindowViewModel.cs` (add `StartupOverlay` property)
+- Modify: `DiffusionNexus.UI/App.axaml.cs:114-122` (construct overlay VM pre-Show)
+- Modify: `DiffusionNexus.UI/Views/DiffusionNexusMainWindow.axaml:225-238` (replace the overlay's inner StackPanel)
+- Test: `DiffusionNexus.Tests/ViewModels/StartupOverlayViewModelTests.cs`
+
+**Interfaces:**
+- Consumes: `StartupProgressService` (Task 1), `IsStartupComplete` (existing).
+- Produces: `StartupOverlayViewModel` with `IReadOnlyList<StartupCheckRowViewModel> Rows`; row exposes `DisplayName`, `IsPending`, `IsRunning`, `IsDone`, `IsFailed`, `Error` (INotifyPropertyChanged via CommunityToolkit).
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using DiffusionNexus.UI.Services.Startup;
+using DiffusionNexus.UI.ViewModels;
+
+namespace DiffusionNexus.Tests.ViewModels;
+
+public class StartupOverlayViewModelTests
+{
+    [Fact]
+    public void Rows_MirrorServiceChecks_InOrder()
+    {
+        var svc = new StartupProgressService(StartupProgressService.BuildDefaultChecks(false));
+        var vm = new StartupOverlayViewModel(svc);
+        Assert.Equal(svc.Checks.Select(c => c.DisplayName), vm.Rows.Select(r => r.DisplayName));
+        Assert.All(vm.Rows, r => Assert.True(r.IsPending));
+    }
+
+    [Fact]
+    public void CheckChanged_UpdatesTheMatchingRow_AndRaisesPropertyChanged()
+    {
+        var svc = new StartupProgressService(StartupProgressService.BuildDefaultChecks(false));
+        var vm = new StartupOverlayViewModel(svc);
+        var row = vm.Rows.Single(r => r.DisplayName == "Database");
+        var raised = new List<string?>();
+        row.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        svc.Begin("database");
+        Assert.True(row.IsRunning);
+        svc.Complete("database");
+        Assert.True(row.IsDone);
+        Assert.Contains(nameof(StartupCheckRowViewModel.IsRunning), raised);
+        Assert.Contains(nameof(StartupCheckRowViewModel.IsDone), raised);
+    }
+
+    [Fact]
+    public void FailedCheck_ExposesError()
+    {
+        var svc = new StartupProgressService(StartupProgressService.BuildDefaultChecks(false));
+        var vm = new StartupOverlayViewModel(svc);
+        svc.Begin("settings");
+        svc.Fail("settings", "boom");
+        var row = vm.Rows.Single(r => r.DisplayName == "Settings");
+        Assert.True(row.IsFailed);
+        Assert.Equal("boom", row.Error);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test DiffusionNexus.Tests/DiffusionNexus.Tests.csproj --filter "FullyQualifiedName~StartupOverlayViewModelTests"`
+Expected: FAIL — types do not exist.
+
+- [ ] **Step 3: Implement the ViewModels**
+
+`DiffusionNexus.UI/ViewModels/StartupOverlayViewModel.cs`:
+
+```csharp
+using CommunityToolkit.Mvvm.ComponentModel;
+using DiffusionNexus.UI.Services.Startup;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+/// <summary>
+/// Binds the startup ready-check list to the overlay. CheckChanged is raised
+/// on the UI thread by every production caller (startup phases), so no
+/// marshaling is needed here.
+/// </summary>
+public sealed partial class StartupOverlayViewModel : ViewModelBase
+{
+    public IReadOnlyList<StartupCheckRowViewModel> Rows { get; }
+
+    public StartupOverlayViewModel(StartupProgressService service)
+    {
+        var rows = service.Checks.ToDictionary(c => c.Id, c => new StartupCheckRowViewModel(c));
+        Rows = service.Checks.Select(c => rows[c.Id]).ToList();
+        service.CheckChanged += check => rows[check.Id].Refresh(check);
+    }
+}
+
+public sealed partial class StartupCheckRowViewModel : ObservableObject
+{
+    public string DisplayName { get; }
+
+    [ObservableProperty] private bool _isPending;
+    [ObservableProperty] private bool _isRunning;
+    [ObservableProperty] private bool _isDone;
+    [ObservableProperty] private bool _isFailed;
+    [ObservableProperty] private string? _error;
+
+    public StartupCheckRowViewModel(StartupCheck check)
+    {
+        DisplayName = check.DisplayName;
+        Refresh(check);
+    }
+
+    public void Refresh(StartupCheck check)
+    {
+        IsPending = check.State == StartupCheckState.Pending;
+        IsRunning = check.State == StartupCheckState.Running;
+        IsDone = check.State == StartupCheckState.Done;
+        IsFailed = check.State == StartupCheckState.Failed;
+        Error = check.Error;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test DiffusionNexus.Tests/DiffusionNexus.Tests.csproj --filter "FullyQualifiedName~StartupOverlayViewModelTests"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Expose the overlay VM on the main window VM and construct it pre-Show**
+
+In `DiffusionNexusMainWindowViewModel` (near the other `[ObservableProperty]` fields):
+
+```csharp
+    /// <summary>Ready-check list shown by the startup overlay (null only in design mode).</summary>
+    [ObservableProperty]
+    private StartupOverlayViewModel? _startupOverlay;
+```
+
+In `App.OnFrameworkInitializationCompleted`, after `var mainViewModel = new DiffusionNexusMainWindowViewModel();` (`:116`) add:
+
+```csharp
+                mainViewModel.StartupOverlay = new StartupOverlayViewModel(
+                    Services!.GetRequiredService<DiffusionNexus.UI.Services.Startup.StartupProgressService>());
+```
+
+(Order matters: `Services` is assigned at `:112`, before this point — the checklist is fully rendered from the first frame.)
+
+- [ ] **Step 6: Replace the overlay's inner panel in the XAML**
+
+In `DiffusionNexusMainWindow.axaml`, replace the `<StackPanel ...>` inside the startup-overlay `Border` (`:230-237` — the one containing `ProgressBar` + `Starting DiffusionNexus…`) with:
+
+```xml
+                                    <Border Background="#E01E1E1E"
+                                            CornerRadius="8"
+                                            Padding="28,20"
+                                            MinWidth="320"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Center">
+                                        <StackPanel Spacing="10">
+                                            <TextBlock Text="Starting DiffusionNexus…"
+                                                       FontSize="16" FontWeight="SemiBold"
+                                                       HorizontalAlignment="Center"
+                                                       Margin="0,0,0,6"/>
+                                            <ItemsControl ItemsSource="{Binding StartupOverlay.Rows}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate x:DataType="vm:StartupCheckRowViewModel">
+                                                        <Grid ColumnDefinitions="24,*" Margin="0,2">
+                                                            <Panel Grid.Column="0" Width="18" Height="18">
+                                                                <TextBlock Text="•" Opacity="0.35"
+                                                                           IsVisible="{Binding IsPending}"
+                                                                           HorizontalAlignment="Center"/>
+                                                                <ProgressBar IsIndeterminate="True"
+                                                                             IsVisible="{Binding IsRunning}"
+                                                                             Width="16" Height="16"/>
+                                                                <TextBlock Text="✓" Foreground="#4CAF50" FontWeight="Bold"
+                                                                           IsVisible="{Binding IsDone}"
+                                                                           HorizontalAlignment="Center">
+                                                                    <TextBlock.Transitions>
+                                                                        <Transitions>
+                                                                            <DoubleTransition Property="Opacity" Duration="0:0:0.25"/>
+                                                                        </Transitions>
+                                                                    </TextBlock.Transitions>
+                                                                </TextBlock>
+                                                                <TextBlock Text="✗" Foreground="#F44336" FontWeight="Bold"
+                                                                           IsVisible="{Binding IsFailed}"
+                                                                           ToolTip.Tip="{Binding Error}"
+                                                                           HorizontalAlignment="Center"/>
+                                                            </Panel>
+                                                            <TextBlock Grid.Column="1" Text="{Binding DisplayName}"
+                                                                       VerticalAlignment="Center" Margin="8,0,0,0"/>
+                                                        </Grid>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </StackPanel>
+                                    </Border>
+```
+
+The outer dim `Border` (`Background="#80000000"`, `IsVisible="{Binding !IsStartupComplete}"`) stays exactly as-is — semi-transparent per the spec, input-blocking while visible, dismissed by the Task 4 gate. If Avalonia's indeterminate `ProgressBar` looks wrong at 16×16, substitute the app's existing small-spinner idiom (check how busy overlays in other views render spinners and reuse that control/style — the reuse rule) and note the substitution in the report.
+
+- [ ] **Step 7: Build + full suite + commit**
+
+Run: `dotnet build DiffusionNexus.sln` → succeeded; `dotnet test DiffusionNexus.Tests/DiffusionNexus.Tests.csproj` → all green.
+
+```bash
+git add DiffusionNexus.UI/ViewModels/StartupOverlayViewModel.cs DiffusionNexus.UI/ViewModels/DiffusionNexusMainWindowViewModel.cs DiffusionNexus.UI/App.axaml.cs DiffusionNexus.UI/Views/DiffusionNexusMainWindow.axaml DiffusionNexus.Tests/ViewModels/StartupOverlayViewModelTests.cs
+git commit -m "feat(startup): animated ready-check overlay bound to StartupProgressService"
+```
+
+---
+
+## Final integration (controller-owned)
+
+- [ ] Full suite one last time: `dotnet test DiffusionNexus.Tests/DiffusionNexus.Tests.csproj` → all green.
+- [ ] Release build + app run (controller): PrintWindow screenshots at ~1s intervals during startup must show the checklist progressing (≥3 distinct frames — proves the animation never freezes); overlay gone ≤ ~8s warm.
+- [ ] **Responsiveness proof:** injected click (PostMessage) ≤500ms after the overlay vanishes must act (e.g. nav toggle). This is the user's hard acceptance criterion.
+- [ ] Cold-log check on next real launch: `LoadStartupData:` lines show no synchronous UI-thread head > ~250ms; no unexplained multi-second silent gaps.
+- [ ] Push to `feature/ui-performance-improvements`; update PR #410 description with the ready-check screen section + new screenshots.
+
+## Explicitly out of scope
+
+- Hunspell/trie algorithmic optimization; per-module lazy construction; real health-check logic; gating on Updates or file-verify; skip/cancel affordances; fade-out animation of the overlay itself (instant dismissal is fine — the checks are the animation).

--- a/docs/superpowers/specs/2026-07-15-startup-ready-check-design.md
+++ b/docs/superpowers/specs/2026-07-15-startup-ready-check-design.md
@@ -1,0 +1,141 @@
+# Startup Ready-Check Screen — Design
+
+**Date:** 2026-07-15
+**Branch / PR:** `feature/ui-performance-improvements` → PR #410 (user chose: everything into this PR)
+**Status:** Approved by user (design conversation 2026-07-15)
+
+## Problem
+
+After the perf-plan restructure, the window appears in ~2 s, but live testing and a CPU
+trace of a cold Release launch showed two UI-thread blockades that make startup feel worse,
+not better:
+
+1. **`RegisterModules` builds all 8 module VM graphs + XAML views in one ~3.6 s synchronous
+   UI-thread block.** The "Starting DiffusionNexus…" overlay freezes mid-animation, then the
+   whole UI "refreshes" at once.
+2. **`LoraViewerViewModel.VerifyFilesInBackgroundAsync` is background in name only.** Its
+   async continuations resume on the UI dispatcher; the trace shows **10.1 s of UI-thread
+   time inside `ModelFileSyncService.TryFindMovedFileAsync`, 7.3 s of it hashing model files
+   (`ComputeFileHashAsync`)**. The app is SHA-hashing multi-GB safetensors on the UI thread
+   right after modules appear — the "can't click anywhere for 10+ seconds" hang.
+
+Secondary: the autocomplete trie build burns ~22 s of background CPU (Hunspell
+suffix-expansion `Check()` calls) during startup, competing for cores while everything else
+warms up.
+
+The user's core requirement: **the app must never hang with nothing to show.** Duration is
+secondary; visible progress and a responsive UI are primary.
+
+## Goals
+
+- No UI-thread block longer than ~1 frame during startup (the animation must never freeze).
+- A startup screen that shows an animated ready-check list, semi-transparent so the real app
+  is visible behind it, vanishing automatically when the app is genuinely usable.
+- **Hard acceptance criterion (user): the UI is responsive at the moment the screen
+  vanishes** — nothing heavy may remain queued on the dispatcher.
+
+## Non-Goals
+
+- Real health-check logic (checks are a live progress display of actual startup phases; a
+  phase that throws shows ✗ and the app continues degraded — no new validation code).
+- Gating the screen on network work (update checks) or on the model-file verify.
+- Optimizing Hunspell/trie internals (only scheduling changes).
+- Lazy per-module construction on first navigation (out of scope per the original perf plan).
+
+## Design
+
+### 1. De-blocking prerequisites
+
+**1a. Chunked module registration.** `RegisterModules` becomes an async sequence: each
+module's (ViewModel + View) construction runs in its own `DispatcherPriority.Background`
+tick (`await Dispatcher.UIThread.InvokeAsync(BuildModuleN, Background)` or equivalent). Frames
+render and input pumps between builds. Total build time is unchanged (~3.6 s) but the UI
+breathes throughout. Registration order and everything each registration does today
+(including firing `LoadStartupDataAsync` at the end) is preserved.
+
+**1b. File verify truly off-thread.** The body of the LoRA viewer's
+`VerifyFilesInBackgroundAsync` work (`ModelFileSyncService.VerifyAndSyncFilesAsync` call)
+moves inside `Task.Run(...)` with a fresh DI scope — the same pattern `RefreshAsync` already
+uses for its scan. Only final VM property updates marshal back via the dispatcher. This
+deletes hang #2 outright.
+
+**1c. Trie taming.** `AutoCompleteService`'s dictionary load keeps its own thread but runs at
+`ThreadPriority.BelowNormal`, and its start is deferred until the ready gate has fired
+(readiness signal from the progress service; a plain `TaskCompletionSource` hook — the
+service must not reference Avalonia). Autocomplete suggestions simply become available a few
+seconds later; `GetSuggestions`/`RecordWord` already tolerate the not-yet-loaded state.
+
+### 2. Progress model — `StartupProgressService`
+
+Plain C# (no Avalonia types), registered as a singleton, unit-testable:
+
+- Ordered, fixed list of `StartupCheck` items created at startup:
+  `Database` → one item per module in registration order (display names: Installer Manager,
+  LoRA Dataset Helper, LoRA Viewer, Generation Gallery, Image Comparer, Workflows, Settings)
+  → `Diffusion Engine` → `Updates`.
+  (Module items are created from the same table `RegisterModules` iterates — the list can
+  never drift from the real module registry. Hidden modules still get built, so they still
+  get an item.)
+- Item states: `Pending → Running → Done | Failed`. State changes raise an event
+  (`CheckChanged`) the overlay ViewModel subscribes to; all raises happen on the UI thread
+  (callers are UI-thread phases) so no marshaling is needed in the VM.
+- `Diffusion Engine` flips `Running → Done` when the module whose construction performs the
+  local-diffusion backend/LLama warm-up finishes building (the LLama native-library load
+  happens inside module construction today — the item completes together with that module's
+  build step, identified in the implementation plan by where `LocalDiffusionBackendProvider`
+  is first resolved). When `DiffusionFeatureFlags.UseLocalDiffusionBackend` is off, the item
+  completes immediately as Done (plain ✓, no special "skipped" styling).
+- `Updates` maps to the installer-manager update checks; it may still be Running when the
+  screen vanishes (non-gating) and completes invisibly — results surface exactly as today
+  (status-bar/update badges).
+- A phase that throws marks its item `Failed` (✗, tooltip carries the message), logs to the
+  activity log, and startup continues — mirrors today's catch-and-continue behavior.
+
+### 3. The screen
+
+- Replaces the current "Starting DiffusionNexus…" StackPanel in the same `Panel` slot of
+  `DiffusionNexusMainWindow.axaml` (module host wrap). The dim Border stays
+  (`#80000000` — semi-transparent per user requirement; the app is visible building up
+  behind it) and continues to block input while visible.
+- Centered card: one row per check — item name + state glyph. Running item shows the
+  existing small spinner idiom (indeterminate `ProgressBar` or rotating glyph — reuse the
+  app's busy styling); Done flips to an animated ✓ (simple opacity/scale transition,
+  Avalonia `Transitions` — no custom animation framework).
+- Overlay ViewModel: `StartupOverlayViewModel` (list of row VMs mirroring the service).
+  Bound with the same compiled-binding conventions as the rest of the window.
+
+**Vanish gate (the hard criterion):** the screen fades out only when
+1. `Database`, all module items, and `Diffusion Engine` are Done/Failed, **and**
+2. a **dispatcher-drain sentinel** has run: after (1), post a no-op at
+   `DispatcherPriority.Background`; when it executes, the queue at-and-above Background is
+   provably drained — nothing heavy is left. Then set `IsStartupComplete = true` (existing
+   overlay dismissal flag) and fade (brief opacity transition).
+`Updates`, the file verify, and the trie never gate the fade.
+
+### 4. Failure & edge behavior
+
+- Any phase exception: item ✗, activity-log error, startup continues; the gate treats
+  Failed as terminal so the screen still vanishes.
+- Deferred-startup catastrophic failure (existing `CompleteStartupAsync` catch): marks all
+  remaining items Failed, gate fires, screen vanishes — same degraded-but-alive shell as
+  today, but now the user can see *which* step died.
+- Window closed during startup: existing shutdown path unchanged; overlay needs no special
+  handling (it dies with the window).
+
+### 5. Verification / acceptance
+
+- Unit tests: `StartupProgressService` state machine (ordering, gate readiness with
+  Failed items, Updates non-gating); chunked-registration helper if extracted as a pure
+  sequence utility. No Avalonia bootstrapping in tests (repo constraint).
+- App run (controller-verified, PrintWindow screenshots): multiple distinct frames during
+  startup showing the checklist progressing (proves animation isn't frozen);
+- **Responsiveness proof:** injected click (PostMessage) within 500 ms after the overlay
+  vanishes must land (e.g. nav toggle acts) — verifies the drain-sentinel gate.
+- Cold-start check: `LoadStartupData:`/phase instrumentation lines show no synchronous
+  UI-thread head > ~250 ms; no silent multi-second gaps attributable to the UI thread.
+- Full suite green; all commits into PR #410.
+
+## Out of scope (explicit)
+
+- Hunspell/trie algorithmic optimization; per-module lazy construction; real health checks;
+  making Updates or file-verify gating; skip/cancel affordances on the startup screen.


### PR DESCRIPTION
Implements the full 10-task plan from `docs/superpowers/plans/2026-07-14-ui-performance-improvements.md`, eliminating the three reported UI stalls.

## Root causes fixed
1. **Slow startup** — everything (2 DB init/migration passes + 8 module VMs + 8 XAML view inflations) ran synchronously on the UI thread *before* `Show()`, on top of a forced software renderer.
2. **Backup UI hang** — a progress dispatcher storm: one report per 10 files × ~6 UI-thread posts per report on many-small-file datasets.
3. **LoRA Viewer freeze** — first navigation realized up to 200 tile subtrees in one synchronous layout pass, followed by ~200 UI-thread thumbnail decodes with a JPEG re-encode round trip.

## Changes (by commit)
- `3bde5e1` Hardware rendering by default; `DIFFUSIONNEXUS_SOFTWARE_RENDERING=1` escape hatch (`RenderingConfig`).
- `bf8bd6a` `BackupProgressGate` caps progress to ≤1 report per percent/phase change; removed the redundant nested `Dispatcher.UIThread.Post` from **all four** `Progress<BackupProgress>` callbacks (plan counted three; the restore-path site was verified UI-thread-constructed and included).
- `6ade303` Tile thumbnails decode off the UI thread via `Bitmap.DecodeToWidth(500)` (no JPEG round trip; Skia fallback for exotic formats); only the bound-property assignment is marshaled.
- `d0c59dd` + `15f4384` `BatchedListFiller`: tile window fills in dispatcher-batched chunks (first 24 synchronous, rest at Background priority); hardened against source shrink mid-fill + window rebuild on delete-mid-fill (2 reproducing tests).
- `0d3cc69` SDK DB `Migrate()` gated on `GetPendingMigrations()` (mirrors core-DB gating).
- `467821d` **Startup restructure**: `Show()` first with a "Starting DiffusionNexus…" overlay → DB inits on a pool thread → UI-affine init + `RegisterModules` on the UI thread. Status-bar instance management (reads core DB) extracted to run post-DB-init.
- `6b2dfae` Backup due-check + post-backup settings reads wrapped in `Task.Run` with fresh DI scopes (Microsoft.Data.Sqlite executes "async" synchronously on the calling thread).
- `10165ce` Unified Console log delivery batched: `ConcurrentQueue` + single-flush Interlocked gate + Background-priority flush (one dispatcher post per burst instead of per line).
- `95f9622` Core DB: `Cache=Shared` removed; `PRAGMA journal_mode=WAL` ensured at startup — readers no longer block behind writers (e.g. the end-of-backup write).
- `7ab4068` `AnalyzeBackupAsync`/`GetCurrentStorageStatsAsync` now genuinely run on a pool thread (public `Task.Run` dispatch + private Core bodies), unfreezing the restore/analysis dialogs.
- `1619157` Final-review fix: disclaimer overlay now gated on `IsStartupComplete && !IsDisclaimerAccepted` — without this, the deferred startup made the full-window disclaimer the de-facto startup screen and left its Continue button live during DB init on fresh installs.

## Startup timing (Serilog, process start → `Main window Show() called`)
| | Before (develop) | After (this branch) |
|---|---|---|
| Same machine, same data | **~12.1 s** (18:53 launch; other launches today 9–13 s) | **~1.7–2.0 s** (two launches) |

The remaining DB/module work continues behind the overlay; modules landed ~3.6 s in on the verification run.

## Verification
- Full suite green at every task boundary; final: **2084/2084** (baseline 2058, +26 new tests). TDD (RED→GREEN evidence) for every task that admits unit tests.
- Per-task adversarial code review (spec + quality) after each task; two Important findings caught and fixed mid-run (delete-mid-fill crash in the batched fill; disclaimer/startup-overlay interaction).
- Final whole-branch review traced cross-task seams (deferred-init reachability, WAL ordering on pool thread, DI-scope composition, dispatcher-priority fairness): **Ready to merge**.
- App-run log verification on this machine: `Show()` precedes DB init; `No pending migrations - SKIPPING Migrate()` on both DBs on second launch; WAL persisted in the DB header (bytes 18/19 = 2/2); window `Responding=True` throughout deferred startup; only pre-existing errors in the log (mp4 thumbnail failures present in old runs too).
- Pre-WAL safety backup of the live core DB was taken (`Diffusion_Nexus-core.db.pre-wal-backup-2026-07-14` in the app data folder).

## Manual smoke pass still owed (release checklist)
1. Overlay appears on launch and dismisses when modules land; window draggable during it.
2. Disclaimer appears only after startup completes (fresh-install path) and not at all for accepted users.
3. Backup Now on a many-small-file dataset: window stays interactive while percent climbs.
4. LoRA Viewer first click: tiles stream in, no multi-second freeze; delete a tile while tiles are still streaming (crash fix regression check).
5. Kill-switch recovery: rename the core DB → app comes up and recreates it.
6. No missing shell icons during the overlay phase (thumbnail service now initializes post-Show).

## Follow-ups (deliberately not in this PR — one hygiene PR later)
- Gate restore progress cadence like backup; service-level gate-reduction test; `GetCurrentStorageStatsAsync` pin test.
- `RunScopedAsync` helper for the 5× scope boilerplate + refresh two stale DbContext comments; console flush dispose-guard.
- Pre-existing dead code: `TryDeleteLockedDatabase` targets the wrong filename (`DiffusionNexusCore.sqlite`) and has zero call sites.
- Two cold thumbnail paths still decode on the UI thread (first-fetch only); log the WAL pragma result; user-visible error state if deferred startup hard-fails.
- Pre-existing (surfaced by review): `DatasetBackupService.IsOperationInProgress` is ineffective across fresh DI scopes; Settings-tab and Dataset-tab backups can run concurrently.

> **Ops note:** with WAL enabled, any file-copy-style backup of `Diffusion_Nexus-core.db` must include the `-wal` sidecar or checkpoint first (sidecar only exists while a connection is open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)