### PR TITLE
fix(civitai-browser): client-side sort during search + nsfwLevel-based NSFW gating

### DIFF
--- a/DiffusionNexus.Civitai/Models/CivitaiModel.cs
+++ b/DiffusionNexus.Civitai/Models/CivitaiModel.cs
@@ -28,6 +28,16 @@ public sealed record CivitaiModel
     [JsonPropertyName("nsfw")]
     public bool Nsfw { get; init; }
 
+    /// <summary>
+    /// Browsing-level bitmask of the content this model carries:
+    /// 1=PG, 2=PG13, 4=R, 8=X, 16=XXX, 32=Blocked. Broader than <see cref="Nsfw"/>,
+    /// which is only true for models *designated* mature — a model with
+    /// <c>nsfw=false</c> can still include X/XXX gallery imagery (bits 8/16 set here).
+    /// 0 when the API omitted the field.
+    /// </summary>
+    [JsonPropertyName("nsfwLevel")]
+    public int NsfwLevel { get; init; }
+
     /// <summary>Whether the model is of a person of interest.</summary>
     [JsonPropertyName("poi")]
     public bool Poi { get; init; }

--- a/DiffusionNexus.Civitai/Models/CivitaiModelImage.cs
+++ b/DiffusionNexus.Civitai/Models/CivitaiModelImage.cs
@@ -19,9 +19,15 @@ public sealed record CivitaiModelImage
     [JsonPropertyName("nsfw")]
     public bool Nsfw { get; init; }
 
-    /// <summary>The NSFW level of the image.</summary>
+    /// <summary>
+    /// Browsing-level bitmask of this image: 1=PG, 2=PG13, 4=R, 8=X, 16=XXX.
+    /// The API used to send the legacy string levels (None/Soft/Mature/X) but has
+    /// returned this numeric scheme for a long time — the old
+    /// <c>CivitaiNsfwLevel</c> enum typing silently swallowed every value.
+    /// Null when the API omitted the field.
+    /// </summary>
     [JsonPropertyName("nsfwLevel")]
-    public CivitaiNsfwLevel? NsfwLevel { get; init; }
+    public int? NsfwLevel { get; init; }
 
     /// <summary>
     /// Image width in pixels. Nullable because Civitai sends <c>null</c> for some

--- a/DiffusionNexus.Tests/Civitai/CivitaiNsfwPolicyTests.cs
+++ b/DiffusionNexus.Tests/Civitai/CivitaiNsfwPolicyTests.cs
@@ -1,0 +1,157 @@
+using System.Text.Json;
+using DiffusionNexus.Civitai.Models;
+using DiffusionNexus.UI.Services.CivitaiBrowser;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.Civitai;
+
+/// <summary>
+/// Civitai rates content with a numeric nsfwLevel bitmask (1=PG, 2=PG13, 4=R,
+/// 8=X, 16=XXX) on both models and images. The model-level "nsfw" boolean only
+/// marks models *designated* mature — models with nsfw=false routinely carry
+/// X/XXX gallery images (and with our nsfw=true request the API returns every
+/// image unfiltered). These tests pin the client-side gating policy.
+/// </summary>
+public class CivitaiNsfwPolicyTests
+{
+    private static CivitaiModelImage Image(int? level, string type = "image", string url = "https://img/x.jpeg")
+        => new() { Url = url, Type = type, NsfwLevel = level };
+
+    private static CivitaiModel Model(
+        bool nsfw = false,
+        int nsfwLevel = 0,
+        params CivitaiModelImage[] images)
+        => new()
+        {
+            Id = 1,
+            Name = "m",
+            Nsfw = nsfw,
+            NsfwLevel = nsfwLevel,
+            ModelVersions = [new CivitaiModelVersion { Images = images }]
+        };
+
+    #region Deserialization — numeric nsfwLevel bitmask
+
+    [Fact]
+    public void ModelNsfwLevel_DeserializesNumericBitmask()
+    {
+        var json = """{"id":2782544,"name":"x","nsfw":false,"nsfwLevel":26}""";
+
+        var model = JsonSerializer.Deserialize<CivitaiModel>(json)!;
+
+        model.NsfwLevel.Should().Be(26);
+    }
+
+    [Fact]
+    public void ImageNsfwLevel_DeserializesNumericBitmask()
+    {
+        var json = """{"url":"https://img/x.jpeg","nsfwLevel":16}""";
+
+        var image = JsonSerializer.Deserialize<CivitaiModelImage>(json)!;
+
+        image.NsfwLevel.Should().Be(16);
+    }
+
+    #endregion
+
+    #region IsCardNsfw
+
+    [Fact]
+    public void IsCardNsfw_FlaggedModel_IsNsfw_EvenWithSafeImages()
+    {
+        var model = Model(nsfw: true, nsfwLevel: 60, Image(2));
+
+        CivitaiNsfwPolicy.IsCardNsfw(model).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsCardNsfw_UnflaggedModelWithAtLeastOneSafeImage_IsNotNsfw()
+    {
+        // Real-world shape (model 2782544): nsfw=false, first image XXX, second PG13.
+        var model = Model(nsfw: false, nsfwLevel: 26, Image(16), Image(2));
+
+        CivitaiNsfwPolicy.IsCardNsfw(model).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsCardNsfw_UnflaggedModelWithOnlyAdultImages_IsNsfw()
+    {
+        var model = Model(nsfw: false, nsfwLevel: 24, Image(8), Image(16));
+
+        CivitaiNsfwPolicy.IsCardNsfw(model).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsCardNsfw_NoImages_UsesModelLevelBitmask()
+    {
+        CivitaiNsfwPolicy.IsCardNsfw(Model(nsfwLevel: 24)).Should().BeTrue();   // X|XXX only
+        CivitaiNsfwPolicy.IsCardNsfw(Model(nsfwLevel: 3)).Should().BeFalse();   // PG|PG13
+        CivitaiNsfwPolicy.IsCardNsfw(Model(nsfwLevel: 0)).Should().BeFalse();   // unrated, not flagged
+    }
+
+    #endregion
+
+    #region SelectPreview
+
+    [Fact]
+    public void SelectPreview_NsfwOff_SkipsAdultImages_PicksFirstSafe()
+    {
+        var xxx = Image(16);
+        var safe = Image(2);
+        var model = Model(images: [xxx, safe]);
+
+        CivitaiNsfwPolicy.SelectPreview(model, showNsfw: false).Should().BeSameAs(safe);
+    }
+
+    [Fact]
+    public void SelectPreview_NsfwOn_KeepsFirstImage_EvenIfAdult()
+    {
+        var xxx = Image(16);
+        var safe = Image(2);
+        var model = Model(images: [xxx, safe]);
+
+        CivitaiNsfwPolicy.SelectPreview(model, showNsfw: true).Should().BeSameAs(xxx);
+    }
+
+    [Fact]
+    public void SelectPreview_PrefersStillImageOverVideo_AmongCandidates()
+    {
+        var safeVideo = Image(2, type: "video", url: "https://img/x.mp4");
+        var safeStill = Image(1);
+        var model = Model(images: [safeVideo, safeStill]);
+
+        CivitaiNsfwPolicy.SelectPreview(model, showNsfw: false).Should().BeSameAs(safeStill);
+    }
+
+    [Fact]
+    public void SelectPreview_NsfwOff_UnratedImage_IsNotConsideredSafe()
+    {
+        // With nsfw=true image passthrough an unrated image could be anything —
+        // treat it as unsafe rather than risk an adult thumbnail.
+        var unrated = Image(null);
+        var safe = Image(2);
+        var model = Model(images: [unrated, safe]);
+
+        CivitaiNsfwPolicy.SelectPreview(model, showNsfw: false).Should().BeSameAs(safe);
+    }
+
+    [Fact]
+    public void SelectPreview_NsfwOff_NoSafeImage_ReturnsNull()
+    {
+        var model = Model(images: [Image(8), Image(16)]);
+
+        CivitaiNsfwPolicy.SelectPreview(model, showNsfw: false).Should().BeNull();
+    }
+
+    [Fact]
+    public void SelectPreview_IgnoresImagesWithoutUrl()
+    {
+        var blank = Image(2, url: " ");
+        var safe = Image(2);
+        var model = Model(images: [blank, safe]);
+
+        CivitaiNsfwPolicy.SelectPreview(model, showNsfw: false).Should().BeSameAs(safe);
+    }
+
+    #endregion
+}

--- a/DiffusionNexus.Tests/Civitai/CivitaiResultViewModelNsfwTests.cs
+++ b/DiffusionNexus.Tests/Civitai/CivitaiResultViewModelNsfwTests.cs
@@ -1,0 +1,96 @@
+using DiffusionNexus.Civitai.Models;
+using DiffusionNexus.UI.ViewModels.CivitaiBrowser;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.Civitai;
+
+/// <summary>
+/// Card-level NSFW behavior: the preview thumbnail must respect the browser's
+/// "Show NSFW content" toggle (the API returns every gallery image unfiltered
+/// because we request nsfw=true), and card NSFW-ness comes from the nsfwLevel
+/// policy, not the narrow model-level nsfw boolean.
+/// </summary>
+public class CivitaiResultViewModelNsfwTests
+{
+    private const string AdultUrl = "https://cdn.example/adult.jpeg";
+    private const string SafeUrl = "https://cdn.example/safe.jpeg";
+
+    private static CivitaiModel ModelWithAdultFirstImage() => new()
+    {
+        Id = 2782544,
+        Name = "unflagged model with XXX first image",
+        Nsfw = false,
+        NsfwLevel = 26,
+        ModelVersions =
+        [
+            new CivitaiModelVersion
+            {
+                Images =
+                [
+                    new CivitaiModelImage { Url = AdultUrl, NsfwLevel = 16 },
+                    new CivitaiModelImage { Url = SafeUrl, NsfwLevel = 2 }
+                ]
+            }
+        ]
+    };
+
+    [Fact]
+    public void NsfwOff_CardPicksSafePreview_NotFirstImage()
+    {
+        var vm = new CivitaiResultViewModel(ModelWithAdultFirstImage(), showNsfwPreviews: false);
+
+        vm.PreviewUrl.Should().Be(SafeUrl);
+    }
+
+    [Fact]
+    public void NsfwOn_CardPicksFirstImage()
+    {
+        var vm = new CivitaiResultViewModel(ModelWithAdultFirstImage(), showNsfwPreviews: true);
+
+        vm.PreviewUrl.Should().Be(AdultUrl);
+    }
+
+    [Fact]
+    public void ApplyNsfwPreference_TogglingOff_SwitchesToSafePreview()
+    {
+        var vm = new CivitaiResultViewModel(ModelWithAdultFirstImage(), showNsfwPreviews: true);
+
+        vm.ApplyNsfwPreference(showNsfw: false);
+
+        vm.PreviewUrl.Should().Be(SafeUrl);
+    }
+
+    [Fact]
+    public void ApplyNsfwPreference_TogglingOn_SwitchesToFirstImage()
+    {
+        var vm = new CivitaiResultViewModel(ModelWithAdultFirstImage(), showNsfwPreviews: false);
+
+        vm.ApplyNsfwPreference(showNsfw: true);
+
+        vm.PreviewUrl.Should().Be(AdultUrl);
+    }
+
+    [Fact]
+    public void IsNsfw_ComesFromPolicy_NotModelBoolean()
+    {
+        // nsfw=false but only adult imagery → card counts as NSFW.
+        var onlyAdult = new CivitaiModel
+        {
+            Id = 2,
+            Name = "adult-only gallery",
+            Nsfw = false,
+            NsfwLevel = 24,
+            ModelVersions =
+            [
+                new CivitaiModelVersion
+                {
+                    Images = [new CivitaiModelImage { Url = AdultUrl, NsfwLevel = 16 }]
+                }
+            ]
+        };
+
+        var vm = new CivitaiResultViewModel(onlyAdult, showNsfwPreviews: true);
+
+        vm.IsNsfw.Should().BeTrue();
+    }
+}

--- a/DiffusionNexus.Tests/Civitai/CivitaiSearchResultSorterTests.cs
+++ b/DiffusionNexus.Tests/Civitai/CivitaiSearchResultSorterTests.cs
@@ -1,0 +1,186 @@
+using DiffusionNexus.Civitai;
+using DiffusionNexus.Civitai.Models;
+using DiffusionNexus.UI.Services.CivitaiBrowser;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.Civitai;
+
+/// <summary>
+/// The Civitai REST API silently ignores sort= whenever query= is present
+/// (results arrive in Meilisearch relevance order), so the browser re-sorts
+/// fetched pages client-side. These tests pin the sort semantics.
+/// </summary>
+public class CivitaiSearchResultSorterTests
+{
+    private static CivitaiModel Model(
+        int id,
+        int downloads = 0,
+        int thumbsUp = 0,
+        params string?[] versionPublishedAt)
+    {
+        return new CivitaiModel
+        {
+            Id = id,
+            Name = $"model-{id}",
+            Stats = new CivitaiModelStats { DownloadCount = downloads, ThumbsUpCount = thumbsUp },
+            ModelVersions = versionPublishedAt
+                .Select(d => new CivitaiModelVersion
+                {
+                    PublishedAt = d is null ? null : DateTimeOffset.Parse(d)
+                })
+                .ToList()
+        };
+    }
+
+    private static int[] Ids(IEnumerable<CivitaiModel> models) => models.Select(m => m.Id).ToArray();
+
+    [Fact]
+    public void Newest_OrdersByLatestVersionPublishedAtDescending()
+    {
+        var models = new[]
+        {
+            Model(1, versionPublishedAt: "2023-05-01T00:00:00Z"),
+            Model(2, versionPublishedAt: "2026-07-16T00:00:00Z"),
+            Model(3, versionPublishedAt: "2024-01-01T00:00:00Z")
+        };
+
+        var sorted = CivitaiSearchResultSorter.Sort(models, m => m, CivitaiModelSort.Newest);
+
+        Ids(sorted).Should().Equal(2, 3, 1);
+    }
+
+    [Fact]
+    public void Newest_UsesMaxPublishedAtAcrossAllVersions_NotJustTheFirst()
+    {
+        // Model 1's FIRST listed version is old, but a later entry is the newest
+        // of the whole set — the sorter must consider every version.
+        var models = new[]
+        {
+            Model(1, versionPublishedAt: new[] { "2023-01-01T00:00:00Z", "2026-07-16T00:00:00Z" }),
+            Model(2, versionPublishedAt: "2025-01-01T00:00:00Z")
+        };
+
+        var sorted = CivitaiSearchResultSorter.Sort(models, m => m, CivitaiModelSort.Newest);
+
+        Ids(sorted).Should().Equal(1, 2);
+    }
+
+    [Fact]
+    public void Newest_ModelsWithoutAnyPublishedDate_SortLast()
+    {
+        var models = new[]
+        {
+            Model(1, versionPublishedAt: (string?)null),
+            Model(2, versionPublishedAt: "2024-01-01T00:00:00Z"),
+            Model(3) // no versions at all
+        };
+
+        var sorted = CivitaiSearchResultSorter.Sort(models, m => m, CivitaiModelSort.Newest);
+
+        sorted[0].Id.Should().Be(2);
+        Ids(sorted).Skip(1).Should().BeEquivalentTo([1, 3]);
+    }
+
+    [Fact]
+    public void MostDownloaded_OrdersByDownloadCountDescending()
+    {
+        var models = new[]
+        {
+            Model(1, downloads: 10),
+            Model(2, downloads: 5000),
+            Model(3, downloads: 200)
+        };
+
+        var sorted = CivitaiSearchResultSorter.Sort(models, m => m, CivitaiModelSort.MostDownloaded);
+
+        Ids(sorted).Should().Equal(2, 3, 1);
+    }
+
+    [Fact]
+    public void HighestRated_OrdersByThumbsUpCountDescending()
+    {
+        var models = new[]
+        {
+            Model(1, thumbsUp: 3),
+            Model(2, thumbsUp: 900),
+            Model(3, thumbsUp: 42)
+        };
+
+        var sorted = CivitaiSearchResultSorter.Sort(models, m => m, CivitaiModelSort.HighestRated);
+
+        Ids(sorted).Should().Equal(2, 3, 1);
+    }
+
+    [Fact]
+    public void UnknownSort_PreservesIncomingOrder()
+    {
+        var models = new[]
+        {
+            Model(1, versionPublishedAt: "2023-01-01T00:00:00Z"),
+            Model(2, versionPublishedAt: "2026-01-01T00:00:00Z")
+        };
+
+        var sorted = CivitaiSearchResultSorter.Sort(models, m => m, "Relevancy");
+
+        Ids(sorted).Should().Equal(1, 2);
+    }
+
+    [Fact]
+    public void EqualKeys_PreserveIncomingRelevanceOrder()
+    {
+        // Stable sort: items the key can't distinguish keep Meilisearch's
+        // relevance order instead of being shuffled.
+        var models = new[]
+        {
+            Model(1, downloads: 100),
+            Model(2, downloads: 100),
+            Model(3, downloads: 100)
+        };
+
+        var sorted = CivitaiSearchResultSorter.Sort(models, m => m, CivitaiModelSort.MostDownloaded);
+
+        Ids(sorted).Should().Equal(1, 2, 3);
+    }
+
+    [Fact]
+    public void ApplyOrder_ReordersCollectionInPlace_PreservingInstances()
+    {
+        var a = Model(1);
+        var b = Model(2);
+        var c = Model(3);
+        var collection = new System.Collections.ObjectModel.ObservableCollection<CivitaiModel> { a, b, c };
+
+        CivitaiSearchResultSorter.ApplyOrder(collection, new[] { c, a, b });
+
+        collection.Should().Equal(c, a, b);
+    }
+
+    [Fact]
+    public void ApplyOrder_AlreadyOrdered_RaisesNoCollectionChanges()
+    {
+        var a = Model(1);
+        var b = Model(2);
+        var collection = new System.Collections.ObjectModel.ObservableCollection<CivitaiModel> { a, b };
+        var changes = 0;
+        collection.CollectionChanged += (_, _) => changes++;
+
+        CivitaiSearchResultSorter.ApplyOrder(collection, new[] { a, b });
+
+        changes.Should().Be(0);
+    }
+
+    [Fact]
+    public void NullModels_SortLast_WithoutThrowing()
+    {
+        // The browser's design-time sample card has no CivitaiModel behind it.
+        var items = new (int Tag, CivitaiModel? Model)[]
+        {
+            (1, null),
+            (2, Model(2, versionPublishedAt: "2024-01-01T00:00:00Z"))
+        };
+
+        var sorted = CivitaiSearchResultSorter.Sort(items, i => i.Model, CivitaiModelSort.Newest);
+
+        sorted.Select(i => i.Tag).Should().Equal(2, 1);
+    }
+}

--- a/DiffusionNexus.UI/Services/CivitaiBrowser/CivitaiNsfwPolicy.cs
+++ b/DiffusionNexus.UI/Services/CivitaiBrowser/CivitaiNsfwPolicy.cs
@@ -1,0 +1,76 @@
+using DiffusionNexus.Civitai.Models;
+
+namespace DiffusionNexus.UI.Services.CivitaiBrowser;
+
+/// <summary>
+/// Client-side NSFW gating for the Civitai browser. The browser always requests
+/// <c>nsfw=true</c> (so the toggle flips without a refetch), which also makes the
+/// API return every gallery image unfiltered — so both card visibility and preview
+/// choice must be gated here, using the numeric nsfwLevel bitmask
+/// (1=PG, 2=PG13, 4=R, 8=X, 16=XXX), not just the narrow model-level nsfw boolean.
+/// </summary>
+public static class CivitaiNsfwPolicy
+{
+    /// <summary>PG (1) and PG13 (2) — everything Civitai shows without an NSFW opt-in.</summary>
+    private const int SafeLevelMask = 0b11;
+
+    /// <summary>
+    /// True when the image is rated PG/PG13. Unrated images (null or 0) count as
+    /// unsafe: with nsfw=true passthrough an unrated image could be anything, and a
+    /// wrongly-shown adult thumbnail is worse than a wrongly-hidden safe one.
+    /// </summary>
+    public static bool IsImageSafe(CivitaiModelImage image)
+        => image.NsfwLevel is int level && level != 0 && (level & ~SafeLevelMask) == 0;
+
+    /// <summary>
+    /// True when the card must be hidden while the NSFW toggle is off: the model is
+    /// designated mature, or it has nothing safe to show — no PG/PG13 gallery image
+    /// (falling back to the model-level bitmask when the gallery is empty).
+    /// </summary>
+    public static bool IsCardNsfw(CivitaiModel model)
+    {
+        if (model.Nsfw) return true;
+
+        var images = AllImages(model).ToList();
+        if (images.Count > 0) return !images.Any(IsImageSafe);
+
+        // No gallery at all — trust the model-level bitmask; an unrated (0) model
+        // that isn't flagged stays visible.
+        return model.NsfwLevel != 0 && (model.NsfwLevel & SafeLevelMask) == 0;
+    }
+
+    /// <summary>
+    /// Picks the preview image for a card. Candidates are every gallery image with a
+    /// URL — restricted to safe ones when <paramref name="showNsfw"/> is off. Still
+    /// images are preferred over videos (same preference the browser always had, so
+    /// no CDN poster extraction is needed). Null when nothing qualifies.
+    /// </summary>
+    public static CivitaiModelImage? SelectPreview(CivitaiModel model, bool showNsfw)
+    {
+        var candidates = AllImages(model)
+            .Where(i => !string.IsNullOrWhiteSpace(i.Url))
+            .Where(i => showNsfw || IsImageSafe(i))
+            .ToList();
+
+        return candidates.FirstOrDefault(i => !IsVideoAsset(i)) ?? candidates.FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Whether a preview asset is animated. Uses the API's own <c>type</c> field first
+    /// (authoritative), falling back to the URL extension for records that didn't report it.
+    /// </summary>
+    public static bool IsVideoAsset(CivitaiModelImage? image)
+    {
+        if (image is null) return false;
+        if (string.Equals(image.Type, "video", StringComparison.OrdinalIgnoreCase)) return true;
+
+        var url = image.Url;
+        if (string.IsNullOrWhiteSpace(url)) return false;
+        return url.EndsWith(".mp4", StringComparison.OrdinalIgnoreCase)
+            || url.EndsWith(".webm", StringComparison.OrdinalIgnoreCase)
+            || url.EndsWith(".gif", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static IEnumerable<CivitaiModelImage> AllImages(CivitaiModel model)
+        => model.ModelVersions.SelectMany(v => v.Images);
+}

--- a/DiffusionNexus.UI/Services/CivitaiBrowser/CivitaiSearchResultSorter.cs
+++ b/DiffusionNexus.UI/Services/CivitaiBrowser/CivitaiSearchResultSorter.cs
@@ -1,0 +1,67 @@
+using DiffusionNexus.Civitai.Models;
+
+namespace DiffusionNexus.UI.Services.CivitaiBrowser;
+
+/// <summary>
+/// Client-side re-sort for Civitai browser results. The REST API silently ignores
+/// the <c>sort=</c> parameter whenever <c>query=</c> is present — results arrive in
+/// Meilisearch relevance order — so the browser re-sorts the fetched pages locally.
+/// </summary>
+public static class CivitaiSearchResultSorter
+{
+    /// <summary>
+    /// Orders <paramref name="items"/> by the given Civitai sort option using the
+    /// data already present on each model. Unknown sort values return the incoming
+    /// order unchanged; ties keep the incoming (relevance) order — OrderByDescending
+    /// is a stable sort. Items with a null model sort last.
+    /// </summary>
+    public static IReadOnlyList<T> Sort<T>(
+        IEnumerable<T> items,
+        Func<T, CivitaiModel?> modelSelector,
+        string? sort)
+    {
+        var list = items.ToList();
+
+        return sort switch
+        {
+            CivitaiModelSort.Newest => list
+                .OrderByDescending(i => LatestPublishedAt(modelSelector(i)))
+                .ToList(),
+            CivitaiModelSort.MostDownloaded => list
+                .OrderByDescending(i => modelSelector(i)?.Stats?.DownloadCount ?? 0)
+                .ToList(),
+            CivitaiModelSort.HighestRated => list
+                .OrderByDescending(i => modelSelector(i)?.Stats?.ThumbsUpCount ?? 0)
+                .ToList(),
+            _ => list
+        };
+    }
+
+    /// <summary>
+    /// Reorders <paramref name="collection"/> in place to match <paramref name="desiredOrder"/>
+    /// using Move operations, so bound item containers (and their selection state) survive
+    /// instead of being rebuilt by a clear-and-re-add. An already-ordered collection is untouched.
+    /// </summary>
+    public static void ApplyOrder<T>(
+        System.Collections.ObjectModel.ObservableCollection<T> collection,
+        IReadOnlyList<T> desiredOrder)
+    {
+        for (var target = 0; target < desiredOrder.Count; target++)
+        {
+            var current = collection.IndexOf(desiredOrder[target]);
+            if (current >= 0 && current != target) collection.Move(current, target);
+        }
+    }
+
+    private static DateTimeOffset LatestPublishedAt(CivitaiModel? model)
+    {
+        if (model is null || model.ModelVersions.Count == 0) return DateTimeOffset.MinValue;
+
+        var latest = DateTimeOffset.MinValue;
+        foreach (var version in model.ModelVersions)
+        {
+            if (version.PublishedAt is { } published && published > latest) latest = published;
+        }
+        return latest;
+    }
+}

--- a/DiffusionNexus.UI/ViewModels/CivitaiBrowser/CivitaiBrowserViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/CivitaiBrowser/CivitaiBrowserViewModel.cs
@@ -467,8 +467,9 @@ public partial class CivitaiBrowserViewModel : ObservableObject
             _nextCursor = cursor;
             OnPropertyChanged(nameof(HasMore));
 
-            // Tag-fallback: REST query= is a name-only substring match; civitai.com's web
-            // index also matches tags/descriptions. When a fresh name-search yielded thin
+            // Tag-fallback: REST query= is Meilisearch full-text these days (names, tags,
+            // and more), but an explicit tag= query can still surface models the text
+            // ranking pushed out of the fetched pages. When a fresh search yielded thin
             // results, fire a tag= query with the same text and merge unique ids in.
             if (isFirstBatch
                 && !string.IsNullOrWhiteSpace(SearchText)
@@ -476,6 +477,16 @@ public partial class CivitaiBrowserViewModel : ObservableObject
                 && lastQuery is not null)
             {
                 await RunTagFallbackAsync(lastQuery, apiKey, existingIds, ct);
+            }
+
+            // The REST API silently ignores sort= whenever query= is present — pages come
+            // back in Meilisearch relevance order — and the tag-fallback appends its items
+            // at the end. Re-sort the collected results locally so the selected sort still
+            // holds during a text search. Without a search term the API order is already
+            // correct, so don't touch it.
+            if (!string.IsNullOrWhiteSpace(SearchText))
+            {
+                await ResortResultsAsync();
             }
 
             var addedThisBatch = Results.Count - preBatchCount;
@@ -505,6 +516,20 @@ public partial class CivitaiBrowserViewModel : ObservableObject
         {
             IsBusy = false;
         }
+    }
+
+    /// <summary>
+    /// Re-sorts the result list on the UI thread by the currently selected sort option.
+    /// Move-based so bound cards keep their instances (selection, loaded previews).
+    /// </summary>
+    private async Task ResortResultsAsync()
+    {
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            if (Results.Count < 2) return;
+            var desired = CivitaiSearchResultSorter.Sort(Results, r => r.Model, SelectedSort);
+            CivitaiSearchResultSorter.ApplyOrder(Results, desired);
+        });
     }
 
     /// <summary>

--- a/DiffusionNexus.UI/ViewModels/CivitaiBrowser/CivitaiBrowserViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/CivitaiBrowser/CivitaiBrowserViewModel.cs
@@ -437,7 +437,7 @@ public partial class CivitaiBrowserViewModel : ObservableObject
                         if (model.ModelVersions.Count == 0) continue;
                         if (model.Mode is not null) continue; // skip archived/taken-down
                         if (!existingIds.Add(model.Id)) continue;
-                        var vm = new CivitaiResultViewModel(model)
+                        var vm = new CivitaiResultViewModel(model, ShowNsfwContent)
                         {
                             IsInstalled = IsModelInstalled(model),
                             EnqueueAllVersionsHandler = EnqueueAllVersionsForCard
@@ -574,7 +574,7 @@ public partial class CivitaiBrowserViewModel : ObservableObject
                 {
                     if (model.ModelVersions.Count == 0) continue;
                     if (!existingIds.Add(model.Id)) continue;
-                    var vm = new CivitaiResultViewModel(model)
+                    var vm = new CivitaiResultViewModel(model, ShowNsfwContent)
                     {
                         IsInstalled = IsModelInstalled(model),
                         EnqueueAllVersionsHandler = EnqueueAllVersionsForCard
@@ -702,6 +702,10 @@ public partial class CivitaiBrowserViewModel : ObservableObject
     {
         foreach (var result in Results)
         {
+            // Keep each card's thumbnail in line with the toggle: hiding NSFW swaps
+            // adult previews for the model's safest image (no-op when unchanged).
+            result.ApplyNsfwPreference(ShowNsfwContent);
+
             var hide = (HideEarlyAccessModels && result.IsEarlyAccess)
                        || (HideInstalledModels && result.IsInstalled)
                        || (!ShowNsfwContent && result.IsNsfw);

--- a/DiffusionNexus.UI/ViewModels/CivitaiBrowser/CivitaiResultViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/CivitaiBrowser/CivitaiResultViewModel.cs
@@ -16,7 +16,8 @@ namespace DiffusionNexus.UI.ViewModels.CivitaiBrowser;
 /// </summary>
 public partial class CivitaiResultViewModel : ObservableObject
 {
-    private readonly CancellationTokenSource _cts = new();
+    private CancellationTokenSource _cts = new();
+    private bool _showNsfwPreviews;
 
     /// <summary>
     /// Signals every in-flight preview download (image fetch, video stream,
@@ -28,15 +29,19 @@ public partial class CivitaiResultViewModel : ObservableObject
         try { _cts.Cancel(); } catch { /* already disposed */ }
     }
 
-    public CivitaiResultViewModel(CivitaiModel model)
+    public CivitaiResultViewModel(CivitaiModel model, bool showNsfwPreviews)
     {
         Model = model;
         Name = model.Name;
         Creator = model.Creator?.Username ?? "Unknown";
         DownloadCount = model.Stats?.DownloadCount ?? 0;
         ThumbsUp = model.Stats?.ThumbsUpCount ?? 0;
-        IsNsfw = model.Nsfw;
+        // Policy-based, NOT the raw model.Nsfw boolean: that flag only marks models
+        // *designated* mature, while unflagged models routinely carry X/XXX gallery
+        // imagery (we request nsfw=true, so the API returns every image unfiltered).
+        IsNsfw = CivitaiNsfwPolicy.IsCardNsfw(model);
         Category = InferCategoryFromTags(model.Tags) ?? string.Empty;
+        _showNsfwPreviews = showNsfwPreviews;
 
         var first = model.ModelVersions.FirstOrDefault();
         BaseModel = first?.BaseModel ?? "";
@@ -57,20 +62,22 @@ public partial class CivitaiResultViewModel : ObservableObject
         // Pre-select latest by default for cards' simple "select card → enqueue latest" flow.
         if (Versions.Count > 0) Versions[0].IsSelected = true;
 
-        // Prefer the first non-video preview across every version. Many models pair
-        // an animated demo with one or more static frames — use the still where
-        // available so we don't have to ask the CDN to extract a poster.
-        var allPreviews = model.ModelVersions
-            .SelectMany(v => v.Images)
-            .Where(i => !string.IsNullOrWhiteSpace(i.Url))
-            .ToList();
-        var preferred = allPreviews.FirstOrDefault(i => !IsVideoAsset(i))
-                        ?? allPreviews.FirstOrDefault();
+        SetPreview(CivitaiNsfwPolicy.SelectPreview(model, showNsfwPreviews));
 
-        IsVideoPreview = preferred is not null && IsVideoAsset(preferred);
-        // For video previews: keep the original URL (FFmpeg streams from it directly).
-        // For images: rewrite to a server-side-resized variant so we get a
-        // decoder-friendly thumbnail instead of full-resolution.
+        _ = LoadPreviewAsync();
+    }
+
+    /// <summary>
+    /// Applies preview selection to the card's bindable fields. Candidates come from
+    /// <see cref="CivitaiNsfwPolicy.SelectPreview"/> (stills preferred over videos;
+    /// restricted to PG/PG13 images while NSFW is hidden). For video previews the
+    /// original URL is kept (FFmpeg streams from it directly); images are rewritten
+    /// to a server-side-resized variant so we get a decoder-friendly thumbnail
+    /// instead of full-resolution.
+    /// </summary>
+    private void SetPreview(CivitaiModelImage? preferred)
+    {
+        IsVideoPreview = preferred is not null && CivitaiNsfwPolicy.IsVideoAsset(preferred);
         PreviewUrl = IsVideoPreview
             ? preferred?.Url
             : RewriteToResizedImageUrl(preferred?.Url);
@@ -79,11 +86,35 @@ public partial class CivitaiResultViewModel : ObservableObject
         _previewCacheKey = IsVideoPreview
             ? CivitaiPreviewCache.ComputeKey(preferred?.Id, preferred?.Url)
             : null;
+    }
 
+    /// <summary>
+    /// Re-evaluates the preview when the browser's "Show NSFW content" toggle flips:
+    /// hiding NSFW swaps an adult thumbnail for the model's safest image (and back).
+    /// The in-flight load of the old preview is cancelled so a slow stale download
+    /// can't overwrite the new thumbnail after the swap.
+    /// </summary>
+    public void ApplyNsfwPreference(bool showNsfw)
+    {
+        if (_showNsfwPreviews == showNsfw) return;
+        _showNsfwPreviews = showNsfw;
+        if (Model is null) return;
+
+        var preferred = CivitaiNsfwPolicy.SelectPreview(Model, showNsfw);
+        var newUrl = preferred is not null && CivitaiNsfwPolicy.IsVideoAsset(preferred)
+            ? preferred.Url
+            : RewriteToResizedImageUrl(preferred?.Url);
+        if (string.Equals(newUrl, PreviewUrl, StringComparison.Ordinal)) return;
+
+        try { _cts.Cancel(); } catch { /* already disposed */ }
+        _cts = new CancellationTokenSource();
+
+        PreviewImage = null;
+        SetPreview(preferred);
         _ = LoadPreviewAsync();
     }
 
-    private readonly string? _previewCacheKey;
+    private string? _previewCacheKey;
 
     private CivitaiResultViewModel() { }
 
@@ -108,8 +139,19 @@ public partial class CivitaiResultViewModel : ObservableObject
     public bool IsEarlyAccess { get; private init; }
     public bool IsNsfw { get; private init; }
     public string Category { get; private init; } = string.Empty;
-    public bool IsVideoPreview { get; private init; }
-    public string? PreviewUrl { get; private init; }
+    private bool _isVideoPreview;
+    public bool IsVideoPreview
+    {
+        get => _isVideoPreview;
+        private set => SetProperty(ref _isVideoPreview, value);
+    }
+
+    private string? _previewUrl;
+    public string? PreviewUrl
+    {
+        get => _previewUrl;
+        private set => SetProperty(ref _previewUrl, value);
+    }
 
     public ObservableCollection<CivitaiVersionPickItemViewModel> Versions { get; } = [];
 
@@ -207,23 +249,6 @@ public partial class CivitaiResultViewModel : ObservableObject
             if (sel.Count == 1) return sel[0].Name;
             return $"{sel.Count} versions selected";
         }
-    }
-
-    /// <summary>
-    /// Determines whether a Civitai preview asset is animated. Uses the API's own
-    /// <c>type</c> field first (authoritative), falling back to the URL extension for
-    /// records that didn't report it.
-    /// </summary>
-    private static bool IsVideoAsset(CivitaiModelImage? image)
-    {
-        if (image is null) return false;
-        if (string.Equals(image.Type, "video", StringComparison.OrdinalIgnoreCase)) return true;
-
-        var url = image.Url;
-        if (string.IsNullOrWhiteSpace(url)) return false;
-        return url.EndsWith(".mp4", StringComparison.OrdinalIgnoreCase)
-            || url.EndsWith(".webm", StringComparison.OrdinalIgnoreCase)
-            || url.EndsWith(".gif", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>


### PR DESCRIPTION
## Problems
1. Browsing Civitai in the LoRA viewer showed a different order (and different results) than civitai.com — most visibly, "Newest" was not newest-first while a search term was entered.
2. The "Show NSFW content" toggle could not hide adult thumbnails: unflagged models with XXX gallery images sailed straight through the filter.

## Root causes
**Sort:** The Civitai REST API **silently ignores `sort=` whenever `query=` is present**. With a query, results are resolved through Meilisearch and returned in relevance order — the `nextCursor` even switches from a `publishedAt|id` cursor to a plain numeric offset. Verified against the live API and the civitai/civitai server source. The website honors sort during search via Meili sort replicas, which the public REST API does not expose. The tag-fallback also appended its items unsorted at the end.

**NSFW:** The toggle filtered on the model-level `nsfw` boolean, which only marks models *designated* mature. Civitai rates actual content with a numeric `nsfwLevel` bitmask (1=PG, 2=PG13, 4=R, 8=X, 16=XXX) on models and images — and because the browser always requests `nsfw=true`, the API returns every gallery image unfiltered. Example: model 2782544 has `nsfw=false`, `nsfwLevel=26`, and a level-16 (XXX) first image that became the card thumbnail. Bonus: `CivitaiModelImage.NsfwLevel` was typed against the legacy string enum (None/Soft/Mature/X) and silently swallowed every numeric value; the model-level `nsfwLevel` was not mapped at all.

## Fixes
- **`CivitaiSearchResultSorter`** (pure, tested): Newest → max version `publishedAt` desc, Most Downloaded → `stats.downloadCount`, Highest Rated → `stats.thumbsUpCount`; stable sort keeps relevance order for ties. The browser re-sorts collected pages after each batch + tag-fallback, **only when a search term is active** (without a query the API order is already publishedAt-desc). Move-based reorder keeps card instances alive.
- **`CivitaiNsfwPolicy`** (pure, tested), mirroring civitai.com behavior: a card is NSFW when the model is flagged or has no PG/PG13 image at all (model-level bitmask fallback for empty galleries); while NSFW is hidden, the thumbnail is the first *safe* image instead of the first image (unrated counts as unsafe). Toggling swaps previews in place via `ApplyNsfwPreference`, cancelling the stale in-flight load.
- Numeric `nsfwLevel` mapped on `CivitaiModel` and `CivitaiModelImage` (int bitmask).

## Known limitation
With a query active, sorting applies to the fetched relevance pages (up to 10×50 + fallback), not the global result set — true global date-sorted search is not reachable through the public API.

## Tests
27 new tests (10 sorter, 12 NSFW policy, 5 card-preview behavior); full suite 2136/2136 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)