### PR TITLE
Release 0.10.1 — safe package updates

### DIFF
--- a/DiffusionNexus.DataAccess/DiffusionNexus.DataAccess.csproj
+++ b/DiffusionNexus.DataAccess/DiffusionNexus.DataAccess.csproj
@@ -15,6 +15,9 @@
 <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.*" />
+    <!-- Pin transitive SQLite native bundle to patched build; clears NU1903 (GHSA-2m69-gcr7-jv3q).
+         Stays in the 2.1.x line for compatibility with Microsoft.Data.Sqlite (EF Core 10). -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.*">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DiffusionNexus.Inference/DiffusionNexus.Inference.csproj
+++ b/DiffusionNexus.Inference/DiffusionNexus.Inference.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="SkiaSharp" Version="3.119.4" />
 
     <!-- Logging + DI surface -->
-    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="Serilog" Version="4.4.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.*" />
   </ItemGroup>
 

--- a/DiffusionNexus.Infrastructure/DiffusionNexus.Infrastructure.csproj
+++ b/DiffusionNexus.Infrastructure/DiffusionNexus.Infrastructure.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     
     <!-- Logging -->
-    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="Serilog" Version="4.4.0" />
     
     <!-- DI and HTTP -->
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.*" />

--- a/DiffusionNexus.IntegrationTests/DiffusionNexus.IntegrationTests.csproj
+++ b/DiffusionNexus.IntegrationTests/DiffusionNexus.IntegrationTests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Avalonia.Headless.XUnit" Version="11.3.13" />
     <PackageReference Include="FluentAssertions" Version="8.10.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/DiffusionNexus.Service/DiffusionNexus.Service.csproj
+++ b/DiffusionNexus.Service/DiffusionNexus.Service.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="Serilog" Version="4.4.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.*" />

--- a/DiffusionNexus.Tests/DiffusionNexus.Tests.csproj
+++ b/DiffusionNexus.Tests/DiffusionNexus.Tests.csproj
@@ -23,7 +23,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="8.10.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/DiffusionNexus.UI/DiffusionNexus.UI.csproj
+++ b/DiffusionNexus.UI/DiffusionNexus.UI.csproj
@@ -64,12 +64,12 @@
          combo every 11.3.x consumer of ItemsRepeater necessarily uses. -->
     <PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.1.5" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.*" />
-    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="Serilog" Version="4.4.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="SkiaSharp" Version="3.119.4" />
     <PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.660" />
@@ -82,9 +82,9 @@
     <PackageReference Include="WeCantSpell.Hunspell" Version="7.0.1" />
     <!-- Pin transitive dependency to fix NU1903 (GHSA-xrw6-gwf8-vvr9) -->
     <PackageReference Include="Tmds.DBus.Protocol" Version="0.21.3" />
-    <PackageReference Include="LibVLCSharp" Version="3.9.6" />
-    <PackageReference Include="LibVLCSharp.Avalonia" Version="3.9.6" />
-    <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.23" Condition="'$(RuntimeIdentifier)' == 'win-x64' OR '$(OS)' == 'Windows_NT'" />
+    <PackageReference Include="LibVLCSharp" Version="3.10.0" />
+    <PackageReference Include="LibVLCSharp.Avalonia" Version="3.10.0" />
+    <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.23.1" Condition="'$(RuntimeIdentifier)' == 'win-x64' OR '$(OS)' == 'Windows_NT'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Version: Major.Minor.Build.Revision -->
-    <Version>0.10.0.0</Version>
+    <Version>0.10.1.0</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <InformationalVersion>$(Version)</InformationalVersion>


### PR DESCRIPTION
Release **0.10.1**. Bumps `Directory.Build.props` 0.10.0.0 → 0.10.1.0 and applies safe (minor/patch) NuGet updates. Merging into `main` triggers the `Release on Main` workflow.

## Package updates (safe / non-breaking)
| Package | From → To |
|---|---|
| Serilog | 4.3.1 → 4.4.0 |
| Microsoft.NET.Test.Sdk | 18.5.1 → 18.8.1 |
| Microsoft.EntityFrameworkCore.Design | 10.0.3 → 10.0.10 |
| LibVLCSharp (+ .Avalonia) | 3.9.6 → 3.10.0 |
| VideoLAN.LibVLC.Windows | 3.0.23 → 3.0.23.1 |
| **SQLitePCLRaw.bundle_e_sqlite3** (pinned) | transitive 2.1.11 → **2.1.12** |

The SQLite pin clears the `NU1903` high-severity advisory (GHSA-2m69-gcr7-jv3q) that was warning on every prior build.

## Deferred (major, breaking — not in this patch)
Avalonia 12, SkiaSharp 4, SixLabors.ImageSharp 4, StableDiffusion.NET 7, Tmds.DBus.Protocol 0.94. These need real migration work and belong in a dedicated PR, not a 0.10.x patch.

Avalonia was evaluated for an 11.3.18 patch bump but **left at 11.3.13**: `Avalonia.Controls.DataGrid` has no 11.3.18 release (jumps to 12.0.0), and the only 11.x-updatable Avalonia package (`Avalonia.Diagnostics`) is excluded from release builds anyway.

## Verification
- `dotnet restore` clean — no NU1903, no downgrade errors
- `dotnet build -c Release` — 0 errors (only the pre-existing CS0162 unreachable-code warning remains)
- `dotnet test` (unit suite) — **2136 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)