### PR TITLE
Sync 0.10.1 release into develop

### DIFF
--- a/DiffusionNexus.DataAccess/DiffusionNexus.DataAccess.csproj
+++ b/DiffusionNexus.DataAccess/DiffusionNexus.DataAccess.csproj
@@ -15,6 +15,9 @@
 <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.*" />
+    <!-- Pin transitive SQLite native bundle to patched build; clears NU1903 (GHSA-2m69-gcr7-jv3q).
+         Stays in the 2.1.x line for compatibility with Microsoft.Data.Sqlite (EF Core 10). -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.*">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DiffusionNexus.Inference/DiffusionNexus.Inference.csproj
+++ b/DiffusionNexus.Inference/DiffusionNexus.Inference.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="SkiaSharp" Version="3.119.4" />
 
     <!-- Logging + DI surface -->
-    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="Serilog" Version="4.4.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.*" />
   </ItemGroup>
 

--- a/DiffusionNexus.Infrastructure/DiffusionNexus.Infrastructure.csproj
+++ b/DiffusionNexus.Infrastructure/DiffusionNexus.Infrastructure.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     
     <!-- Logging -->
-    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="Serilog" Version="4.4.0" />
     
     <!-- DI and HTTP -->
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.*" />

--- a/DiffusionNexus.IntegrationTests/DiffusionNexus.IntegrationTests.csproj
+++ b/DiffusionNexus.IntegrationTests/DiffusionNexus.IntegrationTests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Avalonia.Headless.XUnit" Version="11.3.13" />
     <PackageReference Include="FluentAssertions" Version="8.10.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/DiffusionNexus.Service/DiffusionNexus.Service.csproj
+++ b/DiffusionNexus.Service/DiffusionNexus.Service.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="Serilog" Version="4.4.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.*" />

--- a/DiffusionNexus.Tests/DiffusionNexus.Tests.csproj
+++ b/DiffusionNexus.Tests/DiffusionNexus.Tests.csproj
@@ -23,7 +23,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="8.10.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/DiffusionNexus.UI/DiffusionNexus.UI.csproj
+++ b/DiffusionNexus.UI/DiffusionNexus.UI.csproj
@@ -64,12 +64,12 @@
          combo every 11.3.x consumer of ItemsRepeater necessarily uses. -->
     <PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.1.5" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.*" />
-    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="Serilog" Version="4.4.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="SkiaSharp" Version="3.119.4" />
     <PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.660" />
@@ -82,9 +82,9 @@
     <PackageReference Include="WeCantSpell.Hunspell" Version="7.0.1" />
     <!-- Pin transitive dependency to fix NU1903 (GHSA-xrw6-gwf8-vvr9) -->
     <PackageReference Include="Tmds.DBus.Protocol" Version="0.21.3" />
-    <PackageReference Include="LibVLCSharp" Version="3.9.6" />
-    <PackageReference Include="LibVLCSharp.Avalonia" Version="3.9.6" />
-    <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.23" Condition="'$(RuntimeIdentifier)' == 'win-x64' OR '$(OS)' == 'Windows_NT'" />
+    <PackageReference Include="LibVLCSharp" Version="3.10.0" />
+    <PackageReference Include="LibVLCSharp.Avalonia" Version="3.10.0" />
+    <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.23.1" Condition="'$(RuntimeIdentifier)' == 'win-x64' OR '$(OS)' == 'Windows_NT'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Version: Major.Minor.Build.Revision -->
-    <Version>0.10.0.0</Version>
+    <Version>0.10.1.0</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <InformationalVersion>$(Version)</InformationalVersion>


### PR DESCRIPTION
Back-merge of the **0.10.1** release (PR #417, already merged to `main`) into `develop`, so develop carries the version bump and the safe package updates.

Contents (identical to #417):
- Version 0.10.0.0 → 0.10.1.0
- Serilog 4.4.0, Test.Sdk 18.8.1, EF Core Design 10.0.10, LibVLCSharp 3.10.0, VideoLAN 3.0.23.1
- Pin SQLitePCLRaw.bundle_e_sqlite3 2.1.12 (clears NU1903 / GHSA-2m69-gcr7-jv3q)

No new code — just brings develop up to what shipped on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)