### PR TITLE
ci: stop duplicate build+test on push to main

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,7 +2,7 @@ name: .NET 10 Build & Test
 
 on:
   push:
-    branches: [main, develop]
+    branches: [develop]
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Problem
Every push to `main` (i.e. a release merge) kicks off **two** workflows plus the PR gate, so the app builds **three** times per release:

1. **PR into main** → `.NET 10 Build & Test` (`pull_request` trigger) — the real gate: build + EF pending-model check + tests.
2. **Push to main** → `.NET 10 Build & Test` again (`push: [main]`) — same build+test, **no artifact**. Redundant.
3. **Push to main** → `Release on Main` — build + publish the single-file zip artifact.

Run #2 re-verifies exactly what the PR already verified in #1.

## Fix
Drop `main` from the `push` trigger in `dotnet.yml`. Coverage is unchanged where it matters:
- PRs into any branch still run the full build+test gate (`pull_request` trigger untouched).
- `develop` pushes still build+test.
- `main` now runs only `Release on Main`.

## Follow-up
`develop` carries the same `dotnet.yml`; a matching change is needed there so the next release merge doesn't reintroduce the `main` push trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)