### PR TITLE
ci: stop duplicate build+test on push to main

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,7 +2,7 @@ name: .NET 10 Build & Test
 
 on:
   push:
-    branches: [main, develop]
+    branches: [develop]
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Problem
Same fix as #422, targeting `develop` so it survives future releases.

Every push to `main` (a release merge) runs both `Release on Main` (artifact) and `.NET 10 Build & Test` (no artifact), on top of the PR gate that already build+tested the same commit — three builds per release. Dropping `main` from `dotnet.yml`'s `push` trigger only on `main` would be undone the next time a release branch cut from `develop` merges back, so `develop` needs the same change.

## Fix
Drop `main` from the `push` trigger. PRs (any base) and `develop` pushes stay fully build+tested.

Companion to #422 (main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)