### PR TITLE
chore: bump SDK refs 1.2.29 -> 1.2.30 (stale-override DB fix)

### DIFF
--- a/DiffusionNexus.UI/DiffusionNexus.UI.csproj
+++ b/DiffusionNexus.UI/DiffusionNexus.UI.csproj
@@ -73,11 +73,11 @@
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="SkiaSharp" Version="3.119.4" />
     <PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.660" />
-    <PackageReference Include="DiffusionNexus.Installer.SDK.Models" Version="1.2.29" />
-    <PackageReference Include="DiffusionNexus.Installer.SDK.Services" Version="1.2.29" />
-    <PackageReference Include="DiffusionNexus.Installer.SDK.DataAccess" Version="1.2.29" />
-    <PackageReference Include="DiffusionNexus.Installer.SDK.Shared" Version="1.2.29" />
-    <PackageReference Include="DiffusionNexus.Installer.SDK.Database" Version="1.2.29" />
+    <PackageReference Include="DiffusionNexus.Installer.SDK.Models" Version="1.2.30" />
+    <PackageReference Include="DiffusionNexus.Installer.SDK.Services" Version="1.2.30" />
+    <PackageReference Include="DiffusionNexus.Installer.SDK.DataAccess" Version="1.2.30" />
+    <PackageReference Include="DiffusionNexus.Installer.SDK.Shared" Version="1.2.30" />
+    <PackageReference Include="DiffusionNexus.Installer.SDK.Database" Version="1.2.30" />
     <PackageReference Include="StableDiffusion.NET.Backend.Cuda12.Windows" Version="6.0.0" />
     <PackageReference Include="WeCantSpell.Hunspell" Version="7.0.1" />
     <!-- Pin transitive dependency to fix NU1903 (GHSA-xrw6-gwf8-vvr9) -->


### PR DESCRIPTION
Bumps the SDK package references to **1.2.30**, which publishes the `ResolveDatabaseTarget` guard: a saved `db_override.txt` pointing at a deleted directory is ignored (falls back to the default LocalAppData catalog + embedded deploy) instead of crashing startup with `SQLite Error 14: unable to open database file`.

Context: root-caused on a live machine — a March `db_override.txt` pointed at a since-deleted `Downloads\Test\` folder; the fix existed on the SDK develop branch (PR #35 / commit 8a24cfc) but was never tagged, so builds on 1.2.29 still crashed. SDK v1.2.30 tagged + published today.

After this merges, the app self-heals from a stale override with no manual file removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)