### PR TITLE
fix(app): single-source-of-truth SDK DB init (ISdkCatalogDatabase) [SDK 1.2.32]

### DIFF
--- a/DiffusionNexus.UI/App.axaml.cs
+++ b/DiffusionNexus.UI/App.axaml.cs
@@ -524,65 +524,75 @@ public partial class App : Application
     }
 
     /// <summary>
-    /// Ensures the SDK database (diffusion_nexus.db) is deployed and up-to-date by
-    /// delegating to <see cref="SdkDatabaseDeployer"/>, then applies any pending EF Core
-    /// migrations. Reports the resulting status (version, up-to-date, replaced) to the
-    /// unified activity log.
+    /// Reports the SDK catalog database status and applies any pending EF Core migrations.
+    /// Path resolution and the embedded-catalog deploy are owned entirely by
+    /// <see cref="ServiceCollectionExtensions.AddDiffusionNexusDataAccess"/> (which ran at DI
+    /// registration); this method reads the resulting <see cref="ISdkCatalogDatabase"/> for
+    /// reporting and migrates the SAME context the app uses. It deliberately does NOT re-resolve
+    /// the path or re-deploy — doing so previously diverged from the file the context opened
+    /// (a hardcoded %LocalAppData% deploy vs. an honored db_override.txt), surfacing as
+    /// "SQLite Error 14: unable to open database file".
     /// </summary>
     private static void InitializeSdkDatabase()
     {
-        const string databaseFileName = "diffusion_nexus.db";
         const string logSource = "Installer SDK";
 
         var activityLog = Services!.GetService<IActivityLogService>();
 
         try
         {
-            // The NuGet contentFiles mechanism copies the seed DB next to the executable.
-            var shippedDb = Path.Combine(AppContext.BaseDirectory, databaseFileName);
+            // Single source of truth: the resolved path + embedded-deploy outcome captured at
+            // registration. The deploy already happened there (before the first connection).
+            var catalog = Services!.GetRequiredService<ISdkCatalogDatabase>();
+            var runtimeDb = catalog.DatabasePath;
+            var deploy = catalog.DeployResult;
 
-            // Runtime location: directly in %LocalAppData% (no subfolder).
-            // TODO: Linux implementation — use XDG_DATA_HOME or ~/.local/share.
-            var runtimeDb = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                databaseFileName);
-
-            var result = SdkDatabaseDeployer.EnsureUpToDate(shippedDb, runtimeDb);
-
-            // a) DB version (always)
-            activityLog?.LogInfo(
-                logSource,
-                $"SDK database version: {result.ShippedVersion}",
-                $"Path: {runtimeDb}");
-
-            // b) up-to-date / c) replaced
-            switch (result.Outcome)
+            if (deploy is not null)
             {
-                case SdkDatabaseDeployOutcome.UpToDate:
-                case SdkDatabaseDeployOutcome.SamePath:
-                    activityLog?.LogInfo(logSource, "SDK database is up to date.");
-                    break;
-                case SdkDatabaseDeployOutcome.FirstTimeDeploy:
-                    activityLog?.LogSuccess(
-                        logSource,
-                        $"SDK database deployed for the first time (v{result.ShippedVersion}).");
-                    break;
-                case SdkDatabaseDeployOutcome.Upgraded:
-                    activityLog?.LogSuccess(
-                        logSource,
-                        $"SDK database upgraded from v{result.RuntimeVersionBefore ?? "unknown"} to v{result.ShippedVersion}.",
-                        $"Backup saved to: {result.BackupPath}");
-                    break;
-                case SdkDatabaseDeployOutcome.NoShippedDatabase:
-                    activityLog?.LogWarning(
-                        logSource,
-                        "No shipped SDK database found; using existing runtime DB.");
-                    break;
+                // a) DB version (always)
+                activityLog?.LogInfo(
+                    logSource,
+                    $"SDK database version: {deploy.ShippedVersion}",
+                    $"Path: {runtimeDb}");
+
+                // b) up-to-date / c) replaced
+                switch (deploy.Outcome)
+                {
+                    case SdkDatabaseDeployOutcome.UpToDate:
+                    case SdkDatabaseDeployOutcome.SamePath:
+                        activityLog?.LogInfo(logSource, "SDK database is up to date.");
+                        break;
+                    case SdkDatabaseDeployOutcome.FirstTimeDeploy:
+                        activityLog?.LogSuccess(
+                            logSource,
+                            $"SDK database deployed for the first time (v{deploy.ShippedVersion}).");
+                        break;
+                    case SdkDatabaseDeployOutcome.Upgraded:
+                        activityLog?.LogSuccess(
+                            logSource,
+                            $"SDK database upgraded from v{deploy.RuntimeVersionBefore ?? "unknown"} to v{deploy.ShippedVersion}.",
+                            $"Backup saved to: {deploy.BackupPath}");
+                        break;
+                    case SdkDatabaseDeployOutcome.NoShippedDatabase:
+                        activityLog?.LogWarning(
+                            logSource,
+                            "No shipped SDK database found; using existing runtime DB.");
+                        break;
+                }
+            }
+            else
+            {
+                // Consumer-managed path (a valid db_override.txt or an explicit path): the SDK does
+                // not deploy or version-stamp it — it is opened as-is.
+                activityLog?.LogInfo(
+                    logSource,
+                    "Using consumer-managed SDK database (no embedded deploy).",
+                    $"Path: {runtimeDb}");
             }
 
-            // Apply pending schema migrations on top of the (seed) data — but only
-            // when there are any; an unconditional Migrate() costs a full EF
-            // migration pass on every launch (mirrors the core-DB gating above).
+            // Apply pending schema migrations against the SAME context the app uses — but only
+            // when there are any; an unconditional Migrate() costs a full EF migration pass on
+            // every launch (mirrors the core-DB gating above).
             var sdkContext = Services!.GetRequiredService<SdkContext>();
             var pendingSdkMigrations = sdkContext.Database.GetPendingMigrations().ToList();
             if (pendingSdkMigrations.Count > 0)

--- a/DiffusionNexus.UI/DiffusionNexus.UI.csproj
+++ b/DiffusionNexus.UI/DiffusionNexus.UI.csproj
@@ -73,11 +73,11 @@
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="SkiaSharp" Version="3.119.4" />
     <PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.660" />
-    <PackageReference Include="DiffusionNexus.Installer.SDK.Models" Version="1.2.30" />
-    <PackageReference Include="DiffusionNexus.Installer.SDK.Services" Version="1.2.30" />
-    <PackageReference Include="DiffusionNexus.Installer.SDK.DataAccess" Version="1.2.30" />
-    <PackageReference Include="DiffusionNexus.Installer.SDK.Shared" Version="1.2.30" />
-    <PackageReference Include="DiffusionNexus.Installer.SDK.Database" Version="1.2.30" />
+    <PackageReference Include="DiffusionNexus.Installer.SDK.Models" Version="1.2.32" />
+    <PackageReference Include="DiffusionNexus.Installer.SDK.Services" Version="1.2.32" />
+    <PackageReference Include="DiffusionNexus.Installer.SDK.DataAccess" Version="1.2.32" />
+    <PackageReference Include="DiffusionNexus.Installer.SDK.Shared" Version="1.2.32" />
+    <PackageReference Include="DiffusionNexus.Installer.SDK.Database" Version="1.2.32" />
     <PackageReference Include="StableDiffusion.NET.Backend.Cuda12.Windows" Version="6.0.0" />
     <PackageReference Include="WeCantSpell.Hunspell" Version="7.0.1" />
     <!-- Pin transitive dependency to fix NU1903 (GHSA-xrw6-gwf8-vvr9) -->


### PR DESCRIPTION
## The design smell
`InitializeSdkDatabase` re-resolved the catalog path itself — a **hardcoded** `%LocalAppData%\diffusion_nexus.db` — and ran a **second, legacy** `EnsureUpToDate` deploy, while the EF context (registered by no-arg `AddDiffusionNexusDataAccess()`) **honored `db_override.txt`**. With an override set, deploy hit one file and migrate hit another → the "SQLite Error 14: unable to open database file" class of failure. It also duplicated the embedded-catalog deploy the SDK already does at registration.

## Fix
- Drop the hardcoded path and the legacy `EnsureUpToDate`. Read **`ISdkCatalogDatabase`** (new in SDK 1.2.32) for the resolved path + deploy result — the single source of truth — preserving the existing version / up-to-date / upgraded / path logging, and migrate the **same** context the app uses.
- The embedded-catalog deploy runs exactly once, at DI registration, against the resolved path (override-aware).
- Bump SDK refs **1.2.30 → 1.2.32** (the 1.2.31 DataAccess package blob is broken on the registry — a swallowed `--skip-duplicate` conflict; 1.2.32 is the clean republish).

## Verification
Builds against published NuGet **1.2.32**, 0 errors. SDK change is #37 (merged); the SDK now suppresses `PendingModelChangesWarning` itself and marks the divergent legacy `ResolveDatabasePath()` `[Obsolete]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)