### PR TITLE
fix(tests): probe file sizes via seam instead of 6GB fake files

### DIFF
--- a/DiffusionNexus.Inference/Captioning/CaptioningModelManager.cs
+++ b/DiffusionNexus.Inference/Captioning/CaptioningModelManager.cs
@@ -171,6 +171,14 @@ public sealed class CaptioningModelManager
     private readonly Dictionary<CaptioningModelType, bool> _downloadingModels = new();
 
     /// <summary>
+    /// Reports the on-disk length of a file, in bytes. Defaults to
+    /// <see cref="FileInfo.Length"/>; every "is this file the right size"
+    /// check in this class goes through it so tests can inject fake sizes
+    /// instead of writing real multi-gigabyte fixtures to disk.
+    /// </summary>
+    private readonly Func<string, long> _fileSizeProbe;
+
+    /// <summary>
     /// Environment variable read at construction to add extra search paths.
     /// Separator is the platform's <see cref="Path.PathSeparator"/> (';' on Windows).
     /// </summary>
@@ -194,10 +202,16 @@ public sealed class CaptioningModelManager
     /// The callback is invoked lazily, so it can return live results without
     /// requiring the manager to be reconstructed when installations change.
     /// </param>
+    /// <param name="fileSizeProbe">
+    /// Optional override for reading a file's length. Defaults to
+    /// <see cref="FileInfo.Length"/> on the real filesystem. Exposed purely as
+    /// a test seam — production callers should never need to pass this.
+    /// </param>
     public CaptioningModelManager(
         string? modelsBasePath,
         HttpClient? httpClient,
-        Func<IReadOnlyList<string>>? extraSearchPathsProvider = null)
+        Func<IReadOnlyList<string>>? extraSearchPathsProvider = null,
+        Func<string, long>? fileSizeProbe = null)
     {
         _modelsBasePath = modelsBasePath ?? Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
@@ -211,6 +225,7 @@ public sealed class CaptioningModelManager
 
         _staticSearchPaths = BuildStaticSearchPaths(_modelsBasePath);
         _extraSearchPathsProvider = extraSearchPathsProvider;
+        _fileSizeProbe = fileSizeProbe ?? (static path => new FileInfo(path).Length);
     }
 
     /// <summary>
@@ -699,11 +714,11 @@ public sealed class CaptioningModelManager
         if (!File.Exists(modelPath) || !File.Exists(clipPath))
             return CaptioningModelStatus.NotDownloaded;
 
-        var modelInfo = new FileInfo(modelPath);
+        var modelLength = _fileSizeProbe(modelPath);
         var expectedSize = GetExpectedModelSize(modelType);
 
         // Basic size check - model should be at least 80% of expected size
-        if (modelInfo.Length < expectedSize * 0.8)
+        if (modelLength < expectedSize * 0.8)
             return CaptioningModelStatus.Corrupted;
 
         return CaptioningModelStatus.Ready;
@@ -716,7 +731,7 @@ public sealed class CaptioningModelManager
     {
         var modelPath = GetModelPath(modelType);
         var status = GetModelStatus(modelType);
-        var fileSize = File.Exists(modelPath) ? new FileInfo(modelPath).Length : 0;
+        var fileSize = File.Exists(modelPath) ? _fileSizeProbe(modelPath) : 0;
         var expectedSize = GetExpectedModelSize(modelType);
 
         return new CaptioningModelInfo(
@@ -797,8 +812,8 @@ public sealed class CaptioningModelManager
             : Path.Combine(destinationDirectory, clipFileName);
 
         var alreadyPresent =
-            File.Exists(modelDestPath) && new FileInfo(modelDestPath).Length >= modelSize * 0.8 &&
-            File.Exists(clipDestPath) && new FileInfo(clipDestPath).Length >= clipSize * 0.8;
+            File.Exists(modelDestPath) && _fileSizeProbe(modelDestPath) >= modelSize * 0.8 &&
+            File.Exists(clipDestPath) && _fileSizeProbe(clipDestPath) >= clipSize * 0.8;
 
         if (alreadyPresent)
         {
@@ -824,7 +839,7 @@ public sealed class CaptioningModelManager
             var displayName = GetDisplayName(modelType);
 
             // CLIP/mmproj first — smaller, fails fast on connectivity issues.
-            if (!File.Exists(clipDestPath) || new FileInfo(clipDestPath).Length < clipSize * 0.8)
+            if (!File.Exists(clipDestPath) || _fileSizeProbe(clipDestPath) < clipSize * 0.8)
             {
                 progress?.Report(new ModelDownloadProgress(0, totalSize, $"Downloading {displayName} CLIP projector..."));
                 var clipSuccess = await DownloadFileInternalAsync(
@@ -837,7 +852,7 @@ public sealed class CaptioningModelManager
                     return false;
             }
 
-            if (!File.Exists(modelDestPath) || new FileInfo(modelDestPath).Length < modelSize * 0.8)
+            if (!File.Exists(modelDestPath) || _fileSizeProbe(modelDestPath) < modelSize * 0.8)
             {
                 progress?.Report(new ModelDownloadProgress(clipSize, totalSize, $"Downloading {displayName} model..."));
                 var modelSuccess = await DownloadFileInternalAsync(
@@ -920,8 +935,8 @@ public sealed class CaptioningModelManager
         // actually missing.
         var modelOnDisk = ResolveFile(tier.ModelFileName);
         var mmprojOnDisk = ResolveFile(tier.MmprojFileName);
-        var modelPresent = File.Exists(modelOnDisk) && new FileInfo(modelOnDisk).Length >= tier.ModelSizeBytes * 0.8;
-        var mmprojPresent = File.Exists(mmprojOnDisk) && new FileInfo(mmprojOnDisk).Length >= tier.MmprojSizeBytes * 0.8;
+        var modelPresent = File.Exists(modelOnDisk) && _fileSizeProbe(modelOnDisk) >= tier.ModelSizeBytes * 0.8;
+        var mmprojPresent = File.Exists(mmprojOnDisk) && _fileSizeProbe(mmprojOnDisk) >= tier.MmprojSizeBytes * 0.8;
 
         if (modelPresent && mmprojPresent)
         {

--- a/DiffusionNexus.Tests/Inference/Captioning/CaptioningModelManagerTests.cs
+++ b/DiffusionNexus.Tests/Inference/Captioning/CaptioningModelManagerTests.cs
@@ -7,9 +7,14 @@ namespace DiffusionNexus.Tests.Inference.Captioning;
 
 /// <summary>
 /// Unit tests for <see cref="CaptioningModelManager"/>. Uses temp directories
-/// plus the sparse-file pattern (<see cref="FileStream.SetLength"/>) to fake
-/// the multi-gigabyte model GGUFs without touching the network or actually
-/// allocating disk space — every fixture stays well under a megabyte.
+/// for real (but tiny) placeholder files, and the manager's
+/// <c>fileSizeProbe</c> constructor seam to fake multi-gigabyte GGUF sizes for
+/// the model/mmproj size-threshold checks — no fixture ever writes more than a
+/// few bytes to disk. See issue #444: an earlier version of this file believed
+/// <see cref="FileStream.SetLength"/> produced NTFS-sparse files; it does not
+/// (sparseness requires an explicit <c>FSCTL_SET_SPARSE</c> control code that
+/// .NET doesn't expose), so tests written that way allocated real multi-GB
+/// files and failed with <see cref="IOException"/> on disk-constrained machines.
 /// </summary>
 public sealed class CaptioningModelManagerTests : IDisposable
 {
@@ -28,17 +33,32 @@ public sealed class CaptioningModelManagerTests : IDisposable
     }
 
     /// <summary>
-    /// Writes a sparse file at <paramref name="absolutePath"/> with the given logical
-    /// length. NTFS allocates a small extent header — actual disk usage is bytes,
-    /// not gigabytes — but <see cref="FileInfo.Length"/> reports the full length, so
-    /// <see cref="CaptioningModelManager.GetModelStatus"/>'s 80%-threshold check
-    /// honours the fake size.
+    /// Creates a real file at <paramref name="absolutePath"/> containing exactly
+    /// <paramref name="length"/> bytes (default: empty). This is genuinely tiny
+    /// real content — not a sparse-file trick — so callers that care about the
+    /// file's actual on-disk size pass a small honest length (see the
+    /// "default real-filesystem probe" test below); callers that only need the
+    /// file to <em>exist</em> pair this with <see cref="FakeSizes"/> to fake out
+    /// whatever logical size <see cref="CaptioningModelManager"/> should see.
     /// </summary>
-    private static void WriteSparseFile(string absolutePath, long length)
+    private static void CreateFile(string absolutePath, int length = 0)
     {
         Directory.CreateDirectory(Path.GetDirectoryName(absolutePath)!);
-        using var fs = new FileStream(absolutePath, FileMode.Create, FileAccess.Write);
-        fs.SetLength(length);
+        File.WriteAllBytes(absolutePath, new byte[length]);
+    }
+
+    /// <summary>
+    /// Builds a <c>fileSizeProbe</c> delegate for the <see cref="CaptioningModelManager"/>
+    /// test seam: reports the given fake length for each listed path (case-insensitive)
+    /// and falls back to the real <see cref="FileInfo.Length"/> for anything else. Lets a
+    /// test assert size-threshold behaviour (e.g. the 80% corruption check, or the
+    /// "already downloaded" short-circuit) against a real-but-empty placeholder file
+    /// instead of writing gigabytes of real content.
+    /// </summary>
+    private static Func<string, long> FakeSizes(params (string Path, long Length)[] sizes)
+    {
+        var map = sizes.ToDictionary(s => s.Path, s => s.Length, StringComparer.OrdinalIgnoreCase);
+        return path => map.TryGetValue(path, out var length) ? length : new FileInfo(path).Length;
     }
 
     #region Constructor
@@ -258,15 +278,16 @@ public sealed class CaptioningModelManagerTests : IDisposable
     public void GetModelStatus_Corrupted_WhenModelFileWayUnderExpectedSize()
     {
         // Plant the model + mmproj files but make the model file way under the
-        // expected size (80% threshold). Reports Corrupted.
+        // expected (multi-gigabyte) size, using genuinely tiny real content —
+        // this test deliberately exercises the manager's *default*, unmocked
+        // file-size probe (real FileInfo.Length), so a handful of real bytes is
+        // "way under" the 80% threshold regardless of exact byte count.
         var modelPath = _manager.GetModelPath(CaptioningModelType.Qwen2_5_VL_7B);
         var mmprojPath = _manager.GetClipProjectorPath(CaptioningModelType.Qwen2_5_VL_7B);
-        var expectedSize = _manager.GetExpectedModelSize(CaptioningModelType.Qwen2_5_VL_7B);
 
-        // Model: 10% of expected — well below the 80% threshold.
-        WriteSparseFile(modelPath, expectedSize / 10);
+        CreateFile(modelPath, length: 64);
         // mmproj: any non-zero file is fine; status only checks the model size.
-        WriteSparseFile(mmprojPath, 1024);
+        CreateFile(mmprojPath, length: 32);
 
         _manager.GetModelStatus(CaptioningModelType.Qwen2_5_VL_7B)
             .Should().Be(CaptioningModelStatus.Corrupted);
@@ -275,14 +296,20 @@ public sealed class CaptioningModelManagerTests : IDisposable
     [Fact]
     public void GetModelStatus_Ready_WhenBothFilesPresentAtExpectedSize()
     {
+        // Real files stay empty placeholders; the injected fileSizeProbe fakes
+        // the multi-gigabyte "on disk" sizes GetModelStatus's 80%-threshold
+        // check reads, so this test costs bytes rather than gigabytes.
         var modelPath = _manager.GetModelPath(CaptioningModelType.Qwen2_5_VL_7B);
         var mmprojPath = _manager.GetClipProjectorPath(CaptioningModelType.Qwen2_5_VL_7B);
         var expectedSize = _manager.GetExpectedModelSize(CaptioningModelType.Qwen2_5_VL_7B);
 
-        WriteSparseFile(modelPath, expectedSize);
-        WriteSparseFile(mmprojPath, expectedSize / 4);
+        CreateFile(modelPath);
+        CreateFile(mmprojPath);
 
-        _manager.GetModelStatus(CaptioningModelType.Qwen2_5_VL_7B)
+        var manager = new CaptioningModelManager(_root, httpClient: null,
+            fileSizeProbe: FakeSizes((modelPath, expectedSize), (mmprojPath, expectedSize / 4)));
+
+        manager.GetModelStatus(CaptioningModelType.Qwen2_5_VL_7B)
             .Should().Be(CaptioningModelStatus.Ready);
     }
 
@@ -320,13 +347,19 @@ public sealed class CaptioningModelManagerTests : IDisposable
     [Fact]
     public async Task DownloadModelAsync_NonTieredAlreadyPresent_ShortCircuitsToTrue()
     {
-        // Pre-plant a model + mmproj for Qwen3_VL_8B at full expected size.
+        // Pre-plant empty placeholder files for Qwen3_VL_8B; the injected
+        // fileSizeProbe reports them as being at full expected size, so the
+        // manager short-circuits without either a real multi-gigabyte fixture
+        // or an HTTP call.
         var modelPath = _manager.GetModelPath(CaptioningModelType.Qwen3_VL_8B);
         var mmprojPath = _manager.GetClipProjectorPath(CaptioningModelType.Qwen3_VL_8B);
         var modelSize = _manager.GetExpectedModelSize(CaptioningModelType.Qwen3_VL_8B);
 
-        WriteSparseFile(modelPath, modelSize);
-        WriteSparseFile(mmprojPath, modelSize / 4);
+        CreateFile(modelPath);
+        CreateFile(mmprojPath);
+
+        var manager = new CaptioningModelManager(_root, httpClient: null,
+            fileSizeProbe: FakeSizes((modelPath, modelSize), (mmprojPath, modelSize / 4)));
 
         // Use a synchronous IProgress so the callback has definitely fired
         // before we observe it. Progress<T> would post to a SynchronizationContext
@@ -334,7 +367,7 @@ public sealed class CaptioningModelManagerTests : IDisposable
         var progressReports = new List<ModelDownloadProgress>();
         var progress = new SyncProgress(progressReports.Add);
 
-        var ok = await _manager.DownloadModelAsync(
+        var ok = await manager.DownloadModelAsync(
             CaptioningModelType.Qwen3_VL_8B,
             progress: progress,
             cancellationToken: CancellationToken.None);
@@ -358,6 +391,9 @@ public sealed class CaptioningModelManagerTests : IDisposable
     public async Task DownloadModelAsync_TieredAlreadyPresent_ShortCircuitsToTrue()
     {
         // Tiered overload short-circuits when the chosen tier's pair is present.
+        // Empty placeholder files stand in for the real GGUFs; the injected
+        // fileSizeProbe reports each as comfortably over its 80% threshold
+        // (tierTotal covers both files, so it's an over-sized fake for either).
         var modelPath = _manager.GetModelPath(
             CaptioningModelType.Qwen3_VL_8B_Abliterated_Caption, vramGb: 8);
         var mmprojPath = _manager.GetClipProjectorPath(
@@ -365,11 +401,13 @@ public sealed class CaptioningModelManagerTests : IDisposable
         var tierTotal = _manager.GetExpectedTierTotalBytes(
             CaptioningModelType.Qwen3_VL_8B_Abliterated_Caption, vramGb: 8);
 
-        // Use over-sized sparse files so each is comfortably above its 80% threshold.
-        WriteSparseFile(modelPath, tierTotal);
-        WriteSparseFile(mmprojPath, tierTotal);
+        CreateFile(modelPath);
+        CreateFile(mmprojPath);
 
-        var ok = await _manager.DownloadModelAsync(
+        var manager = new CaptioningModelManager(_root, httpClient: null,
+            fileSizeProbe: FakeSizes((modelPath, tierTotal), (mmprojPath, tierTotal)));
+
+        var ok = await manager.DownloadModelAsync(
             CaptioningModelType.Qwen3_VL_8B_Abliterated_Caption,
             vramGb: 8,
             progress: null,
@@ -388,8 +426,8 @@ public sealed class CaptioningModelManagerTests : IDisposable
         var modelPath = _manager.GetModelPath(CaptioningModelType.Qwen3_VL_8B);
         var mmprojPath = _manager.GetClipProjectorPath(CaptioningModelType.Qwen3_VL_8B);
 
-        WriteSparseFile(modelPath, 100);
-        WriteSparseFile(mmprojPath, 100);
+        CreateFile(modelPath, length: 100);
+        CreateFile(mmprojPath, length: 100);
 
         _manager.DeleteModel(CaptioningModelType.Qwen3_VL_8B);
 


### PR DESCRIPTION
## Summary
`CaptioningModelManagerTests.WriteSparseFile` claimed to create sparse files but never issued `FSCTL_SET_SPARSE`, so three tests each allocated ~5–6 GB of **real** disk in `%TEMP%` — failing the suite outright on machines with low free space on C: (reproduced here during a clean develop baseline run).

## Fix
- New narrow seam on `CaptioningModelManager`: optional `Func<string, long> fileSizeProbe` ctor parameter defaulting to the real `FileInfo.Length` — mirrors the class's existing `extraSearchPathsProvider` pattern, fully backward compatible (all three production call sites verified unchanged).
- All six file-size reads in the class routed through the probe; the 80% size-threshold decision logic is untouched and still exercised for real by the tests.
- The three offending tests now inject fake sizes (empty placeholder files, no gigabyte writes); the misleading `WriteSparseFile` helper is deleted and replaced by honestly-documented helpers. The `Corrupted` test keeps covering the default real-filesystem probe path with a 96-byte fixture (was ~468 MB).

## Tests
- Focused: `CaptioningModelManagerTests` 54/54 in 177 ms (previously failed with disk-space `IOException`).
- Full unit suite: **2960/2960** — this branch removes the only failure in the develop baseline.
- Task-reviewed (spec + quality): approved, no blocking findings.

Fixes #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)