### PR TITLE
fix(ui): never return an occupied path from GenerateUniqueFilePath

### DIFF
--- a/DiffusionNexus.Tests/ImageEditor/Services/DocumentServiceTests.cs
+++ b/DiffusionNexus.Tests/ImageEditor/Services/DocumentServiceTests.cs
@@ -162,10 +162,11 @@ public class DocumentServiceTests : IDisposable
     }
 
     [Fact]
-    public void WhenEveryCandidateUpToNineNineNineIsTakenThenTheCapReturnsTheLastCandidate()
+    public void WhenEveryCandidateUpToNineNineNineIsTakenThenAnIOExceptionIsThrownInsteadOfReturningAnOccupiedPath()
     {
-        // The loop bails once the counter reaches 1000, so it hands back
-        // "_edited_999" even though that file already exists.
+        // All 999 numbered slots are taken, so there is no unoccupied path left to hand
+        // back. Returning "_edited_999" anyway would silently overwrite that file, so the
+        // method must fail loudly instead of returning a path that already exists.
         var dir = Path.Combine(_tempDir.FullName, "full");
         Directory.CreateDirectory(dir);
         for (var i = 1; i <= 999; i++)
@@ -173,10 +174,28 @@ public class DocumentServiceTests : IDisposable
             File.WriteAllBytes(Path.Combine(dir, $"photo_edited_{i:D3}.png"), Array.Empty<byte>());
         }
 
+        var act = () => _sut.GenerateUniqueFilePath(dir, "photo", ".png");
+
+        act.Should().Throw<IOException>();
+    }
+
+    [Fact]
+    public void WhenNineNineEightOfNineNineNineCandidatesAreTakenThenTheOneFreeSlotIsReturned()
+    {
+        // One slot short of the cap: the normal "first free suffix" behavior must still
+        // apply right up to the boundary, not just far away from it.
+        var dir = Path.Combine(_tempDir.FullName, "almost-full");
+        Directory.CreateDirectory(dir);
+        for (var i = 1; i <= 999; i++)
+        {
+            if (i == 999) continue;
+            File.WriteAllBytes(Path.Combine(dir, $"photo_edited_{i:D3}.png"), Array.Empty<byte>());
+        }
+
         var path = _sut.GenerateUniqueFilePath(dir, "photo", ".png");
 
         path.Should().Be(Path.Combine(dir, "photo_edited_999.png"));
-        File.Exists(path).Should().BeTrue();
+        File.Exists(path).Should().BeFalse();
     }
 
     [Fact]

--- a/DiffusionNexus.UI/ImageEditor/Services/DocumentService.cs
+++ b/DiffusionNexus.UI/ImageEditor/Services/DocumentService.cs
@@ -59,17 +59,14 @@ internal sealed class DocumentService : IDocumentService
     /// <inheritdoc />
     public string GenerateUniqueFilePath(string directory, string baseName, string extension)
     {
-        var counter = 1;
-        string newPath;
-
-        do
+        for (var counter = 1; counter < 1000; counter++)
         {
-            var suffix = $"_edited_{counter:D3}";
-            newPath = Path.Combine(directory, $"{baseName}{suffix}{extension}");
-            counter++;
+            var candidate = Path.Combine(directory, $"{baseName}_edited_{counter:D3}{extension}");
+            if (!File.Exists(candidate))
+                return candidate;
         }
-        while (File.Exists(newPath) && counter < 1000);
 
-        return newPath;
+        throw new IOException(
+            $"Could not find an unused file name for '{baseName}' in '{directory}' after 999 attempts.");
     }
 }

--- a/DiffusionNexus.UI/ImageEditor/Services/IDocumentService.cs
+++ b/DiffusionNexus.UI/ImageEditor/Services/IDocumentService.cs
@@ -31,6 +31,11 @@ public interface IDocumentService
     /// <param name="directory">Target directory.</param>
     /// <param name="baseName">Base filename without extension.</param>
     /// <param name="extension">File extension including the dot.</param>
-    /// <returns>A unique file path.</returns>
+    /// <returns>A file path that does not currently exist.</returns>
+    /// <exception cref="IOException">
+    /// Thrown when all 999 numbered candidates (<c>_edited_001</c> through <c>_edited_999</c>)
+    /// already exist in <paramref name="directory"/>. The method never falls back to returning
+    /// an occupied path, since the caller would then silently overwrite existing user work.
+    /// </exception>
     string GenerateUniqueFilePath(string directory, string baseName, string extension);
 }


### PR DESCRIPTION
## Summary
`DocumentService.GenerateUniqueFilePath`'s `do/while` exited on **either** a free path **or** the 999-counter cap — at the cap it returned `..._edited_999` without checking existence, silently handing back an occupied path that the caller would overwrite (silent data loss).

## Fix
Explicit `for` loop over `_edited_001`..`_edited_999`: returns the first candidate that doesn't exist; if all 999 are occupied, throws an explicit `IOException` instead of silently returning an occupied path. Interface XML doc now documents the guarantee ("a file path that does not currently exist") and the exception contract.

Call-site analysis: `GenerateUniqueFilePath` currently has **zero** production call sites (interface + implementation + tests only), so the brief's preferred explicit-throw design carries no crash risk; whoever wires it into a save flow should catch `IOException` and surface it.

## Tests
- Pinned cap test flipped (RED→GREEN): 999 real files on disk → now asserts `Throws<IOException>` instead of pinning the overwrite.
- New boundary test: 998 files with `_edited_999` free → returns `_edited_999` and asserts it doesn't exist.
- Focused: DocumentServiceTests 30/30. Full unit suite: 2960/2961 (sole failure is the pre-existing #444 disk-space test issue, fixed in PR #445).
- Task-reviewed (spec + quality): approved — loop hand-traced, no off-by-one, no encoding churn (this file has pre-existing mixed CRLF/LF the fix carefully preserved).

Fixes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)