### PR TITLE
fix(service): case-insensitive check-name map + loud miss in quality scoring

### DIFF
--- a/DiffusionNexus.Service/Services/DatasetQuality/Scoring/CheckScoreAdapter.cs
+++ b/DiffusionNexus.Service/Services/DatasetQuality/Scoring/CheckScoreAdapter.cs
@@ -1,5 +1,6 @@
 using DiffusionNexus.Domain.Enums;
 using DiffusionNexus.Domain.Models;
+using Serilog;
 
 namespace DiffusionNexus.Service.Services.DatasetQuality.Scoring;
 
@@ -20,8 +21,11 @@ public static class CheckScoreAdapter
 
     /// <summary>
     /// Maps a check name to its scoring category and weight.
+    /// Keys are matched case-insensitively: a check's display <c>Name</c> must line
+    /// up with a key here, but casing/spacing drift between the two must not
+    /// silently drop the check from the composite score (see issue #432).
     /// </summary>
-    private static readonly Dictionary<string, (QualityScoreCategory Category, double Weight)> CheckCategoryMap = new()
+    private static readonly Dictionary<string, (QualityScoreCategory Category, double Weight)> CheckCategoryMap = new(StringComparer.OrdinalIgnoreCase)
     {
         // Caption quality checks (weight reflects importance)
         ["Format Consistency"] = (QualityScoreCategory.CaptionQuality, 1.2),
@@ -45,7 +49,17 @@ public static class CheckScoreAdapter
     public static CheckScore? ScoreFromIssues(string checkName, IReadOnlyList<Issue> issues, int totalFiles)
     {
         if (!CheckCategoryMap.TryGetValue(checkName, out var mapping))
+        {
+            // This check's issues are silently excluded from the composite quality
+            // score. Log loudly instead of returning null unnoticed — a rename or
+            // casing drift in an IDatasetCheck implementation should be visible.
+            Log.Warning(
+                "CheckScoreAdapter: no scoring category mapped for check name \"{CheckName}\" — " +
+                "it will not contribute to the composite quality score. Check CheckCategoryMap in " +
+                "CheckScoreAdapter.cs against the check's Name property for a naming/casing mismatch.",
+                checkName);
             return null;
+        }
 
         double score = CalculateScoreFromIssues(issues, totalFiles);
 

--- a/DiffusionNexus.Tests/DatasetQuality/Scoring/CheckScoreAdapterTests.cs
+++ b/DiffusionNexus.Tests/DatasetQuality/Scoring/CheckScoreAdapterTests.cs
@@ -2,6 +2,9 @@ using DiffusionNexus.Domain.Enums;
 using DiffusionNexus.Domain.Models;
 using DiffusionNexus.Service.Services.DatasetQuality.Scoring;
 using FluentAssertions;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
 
 namespace DiffusionNexus.Tests.DatasetQuality.Scoring;
 
@@ -60,11 +63,54 @@ public class CheckScoreAdapterTests
         result.Weight.Should().Be(1.0);
     }
 
-    [Fact]
-    public void WhenCheckNameCasingDiffersThenLookupFailsAndReturnsNull()
+    [Theory]
+    [InlineData("trigger word")]
+    [InlineData("TRIGGER WORD")]
+    [InlineData("Trigger word")]
+    public void WhenCheckNameCasingDiffersThenLookupStillResolvesToTheRightCategoryAndWeight(string checkName)
     {
-        // The map uses the default ordinal comparer — names must match exactly.
-        CheckScoreAdapter.ScoreFromIssues("trigger word", [], 10).Should().BeNull();
+        // The map uses an ordinal-ignore-case comparer — casing/spacing drift in a
+        // check's display name must not silently drop it from the composite score.
+        var result = CheckScoreAdapter.ScoreFromIssues(checkName, [], 10);
+
+        result.Should().NotBeNull();
+        result!.Category.Should().Be(QualityScoreCategory.CaptionQuality);
+        result.Weight.Should().Be(1.5);
+    }
+
+    [Fact]
+    public void WhenCheckNameIsUnknownThenAWarningIsLoggedInsteadOfFailingSilently()
+    {
+        var events = new List<LogEvent>();
+        var testLogger = new LoggerConfiguration()
+            .MinimumLevel.Warning()
+            .WriteTo.Sink(new DelegatingSink(events.Add))
+            .CreateLogger();
+
+        var previousLogger = Log.Logger;
+        Log.Logger = testLogger;
+        try
+        {
+            CheckScoreAdapter.ScoreFromIssues("Not A Real Check", [], 10).Should().BeNull();
+        }
+        finally
+        {
+            Log.Logger = previousLogger;
+            testLogger.Dispose();
+        }
+
+        events.Should().ContainSingle(e =>
+            e.Level == LogEventLevel.Warning &&
+            e.RenderMessage().Contains("Not A Real Check"));
+    }
+
+    /// <summary>Minimal Serilog sink that forwards every emitted event to a delegate,
+    /// used to assert a warning was logged without pulling in a test-sink package.</summary>
+    private sealed class DelegatingSink : ILogEventSink
+    {
+        private readonly Action<LogEvent> _write;
+        public DelegatingSink(Action<LogEvent> write) => _write = write;
+        public void Emit(LogEvent logEvent) => _write(logEvent);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
`CheckScoreAdapter`'s check-name → (category, weight) map was built with the default ordinal, case-sensitive comparer, and the miss path returned `null` silently — a mis-cased or renamed check simply stopped contributing to the composite quality score with no trace, and the score still rendered as if complete.

## Fix
- Map now uses `StringComparer.OrdinalIgnoreCase`, so casing drift can no longer silently drop a check.
- An unmapped check name now logs a Serilog warning (the project's established ambient-`Log` idiom — verified as the file's surrounding convention) before returning `null`.
- Enum/type re-keying of the stringly-typed map was scoped out as a follow-up per the issue's own framing.

## Found along the way (now tracked, deliberately not smuggled into this branch)
- https://github.com/Little-God1983/DiffusionNexus/issues/448 — a LIVE instance of the bug class this comparer cannot bridge: map key `"Spelling"` vs `SpellCheckQualityCheck.Name == "Spell Check"`. Fixing it changes user-visible composite scores, so it needs its own decision + PR. Thanks to this branch it is now loud at runtime instead of invisible.
- https://github.com/Little-God1983/DiffusionNexus/issues/449 — the aggregator NaN "Related" item from the issue: investigated, needs a contract decision (two pinned tests pin the competing outcomes), documented there.

## Tests
- Pinned casing test flipped into a `[Theory]` (`trigger word` / `TRIGGER WORD` / `Trigger word` all resolve) — RED (4 failures) → GREEN.
- New test: unknown name still returns null but emits a Warning event (in-test Serilog sink, no new packages).
- Focused: CheckScoreAdapter 35/35, DatasetQuality 552/552. Full unit suite: 2962/2963 (sole failure is the pre-existing #444 disk-space test issue, fixed in PR #445).
- Task-reviewed (spec + quality): approved; both deferrals adjudicated as correct calls by the reviewer.

Fixes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)