### PR TITLE
fix(ui): case-insensitive O(1) LRU tracking in ThumbnailService

### DIFF
--- a/DiffusionNexus.Tests/Services/LruKeyTrackerTests.cs
+++ b/DiffusionNexus.Tests/Services/LruKeyTrackerTests.cs
@@ -143,6 +143,25 @@ public class LruKeyTrackerTests
     }
 
     [Fact]
+    public void EvictLeastRecentlyUsed_AfterDifferentCasingTouch_ReturnsOriginalFirstSeenCasing()
+    {
+        // Pins the casing-identity half of #429: re-touching with different casing
+        // moves the existing node (proven above), but the *stored* key string must
+        // still be the originally recorded casing, not the later touch's casing.
+        var tracker = new LruKeyTracker();
+        tracker.Touch(@"C:\ds\A.png");
+        tracker.Touch(@"C:\ds\b.png");
+
+        tracker.Touch(@"c:\ds\a.png");
+
+        // "A.png" is now most-recently-used, so "b.png" evicts first.
+        tracker.EvictLeastRecentlyUsed().Should().Be(@"C:\ds\b.png");
+
+        var evicted = tracker.EvictLeastRecentlyUsed();
+        evicted.Should().Be(@"C:\ds\A.png");
+    }
+
+    [Fact]
     public void EvictLeastRecentlyUsed_WhenEmpty_ReturnsNull()
     {
         var tracker = new LruKeyTracker();

--- a/DiffusionNexus.Tests/Services/LruKeyTrackerTests.cs
+++ b/DiffusionNexus.Tests/Services/LruKeyTrackerTests.cs
@@ -1,0 +1,165 @@
+using DiffusionNexus.UI.Services;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="LruKeyTracker"/> — the Avalonia-free LRU bookkeeping
+/// class extracted from <see cref="ThumbnailService"/> to fix #429 (a comparer
+/// mismatch between the case-insensitive cache dictionary and the case-sensitive
+/// <c>LinkedList&lt;string&gt;</c> access-order list let the cache grow unbounded).
+///
+/// These tests pin the fixed semantics: casing must never create duplicate tracked
+/// keys, eviction must actually shrink the tracked set, and both removal and
+/// re-touch must work regardless of casing.
+/// </summary>
+public class LruKeyTrackerTests
+{
+    [Fact]
+    public void Touch_SameKeyDifferentCasing_CountsAsOneTrackedKey()
+    {
+        var tracker = new LruKeyTracker();
+
+        tracker.Touch(@"C:\ds\Img.png");
+        tracker.Touch(@"c:\ds\img.png");
+
+        tracker.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public void Touch_ManyMixedCasingTouchesOfSameKey_NeverExceedsOneEntry()
+    {
+        var tracker = new LruKeyTracker();
+
+        tracker.Touch(@"C:\ds\Img.png");
+        tracker.Touch(@"c:\ds\IMG.png");
+        tracker.Touch(@"C:\DS\img.PNG");
+        tracker.Touch(@"c:\ds\img.png");
+
+        tracker.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public void EvictLeastRecentlyUsed_RemovesOldestKeyFirst()
+    {
+        var tracker = new LruKeyTracker();
+        tracker.Touch("a");
+        tracker.Touch("b");
+        tracker.Touch("c");
+
+        var evicted = tracker.EvictLeastRecentlyUsed();
+
+        evicted.Should().Be("a");
+        tracker.Count.Should().Be(2);
+    }
+
+    [Fact]
+    public void EvictLeastRecentlyUsed_ShrinksToCapEvenAfterMixedCasingTouches()
+    {
+        // Regression for the exact #429 scenario: a duplicate-appearing key (differing
+        // only by casing) must not let eviction drain the order list without the
+        // tracked count actually dropping to the cap.
+        var tracker = new LruKeyTracker();
+        tracker.Touch(@"C:\ds\a.png");
+        tracker.Touch(@"C:\ds\b.png");
+        tracker.Touch(@"C:\ds\c.png");
+
+        // Re-touch "a" and "b" with different casing — under the old LinkedList<string>
+        // behavior this would append stale duplicates instead of moving existing nodes.
+        tracker.Touch(@"c:\ds\A.PNG");
+        tracker.Touch(@"c:\ds\B.PNG");
+
+        // Only 3 distinct keys are tracked, so evicting down to a cap of 1 should take
+        // exactly 2 evictions and leave exactly 1 key tracked.
+        const int cap = 1;
+        var evictedCount = 0;
+        while (tracker.Count > cap)
+        {
+            var evicted = tracker.EvictLeastRecentlyUsed();
+            evicted.Should().NotBeNull();
+            evictedCount++;
+        }
+
+        evictedCount.Should().Be(2);
+        tracker.Count.Should().Be(cap);
+    }
+
+    [Fact]
+    public void Remove_WithMismatchedCasing_RemovesTrackedKey()
+    {
+        var tracker = new LruKeyTracker();
+        tracker.Touch(@"C:\ds\Img.png");
+
+        var removed = tracker.Remove(@"c:\ds\IMG.png");
+
+        removed.Should().BeTrue();
+        tracker.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void Remove_KeyNotTracked_ReturnsFalseAndLeavesOthersIntact()
+    {
+        var tracker = new LruKeyTracker();
+        tracker.Touch("a");
+
+        var removed = tracker.Remove("does-not-exist");
+
+        removed.Should().BeFalse();
+        tracker.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public void Touch_ExistingKey_MovesItToMostRecentlyUsed()
+    {
+        var tracker = new LruKeyTracker();
+        tracker.Touch("a");
+        tracker.Touch("b");
+        tracker.Touch("c");
+
+        // "a" is currently the least-recently-used. Re-touching it should push it to
+        // the most-recently-used end so the *next* eviction takes "b" instead.
+        tracker.Touch("a");
+
+        var evicted = tracker.EvictLeastRecentlyUsed();
+
+        evicted.Should().Be("b");
+    }
+
+    [Fact]
+    public void Touch_ExistingKeyDifferentCasing_MovesItToMostRecentlyUsed()
+    {
+        var tracker = new LruKeyTracker();
+        tracker.Touch(@"C:\ds\a.png");
+        tracker.Touch(@"C:\ds\b.png");
+        tracker.Touch(@"C:\ds\c.png");
+
+        // Re-touch "a" via a different casing — should still count as the same key
+        // and move to most-recently-used, not append a duplicate.
+        tracker.Touch(@"c:\ds\A.PNG");
+
+        tracker.Count.Should().Be(3);
+        var evicted = tracker.EvictLeastRecentlyUsed();
+        evicted.Should().Be(@"C:\ds\b.png");
+    }
+
+    [Fact]
+    public void EvictLeastRecentlyUsed_WhenEmpty_ReturnsNull()
+    {
+        var tracker = new LruKeyTracker();
+
+        tracker.EvictLeastRecentlyUsed().Should().BeNull();
+    }
+
+    [Fact]
+    public void Clear_RemovesAllTrackedKeys()
+    {
+        var tracker = new LruKeyTracker();
+        tracker.Touch("a");
+        tracker.Touch("b");
+
+        tracker.Clear();
+
+        tracker.Count.Should().Be(0);
+        tracker.EvictLeastRecentlyUsed().Should().BeNull();
+    }
+}

--- a/DiffusionNexus.UI/Services/LruKeyTracker.cs
+++ b/DiffusionNexus.UI/Services/LruKeyTracker.cs
@@ -1,0 +1,95 @@
+namespace DiffusionNexus.UI.Services;
+
+/// <summary>
+/// Tracks least-recently-used ordering for a set of string keys using a case-insensitive
+/// comparer (<see cref="StringComparer.OrdinalIgnoreCase"/>).
+///
+/// <para>
+/// Extracted from <see cref="ThumbnailService"/> to fix #429: the service's cache
+/// dictionary is case-insensitive, but the original access-order tracking was a
+/// <c>LinkedList&lt;string&gt;</c> whose <c>Remove(string)</c> compares ordinally
+/// case-sensitive. Windows paths are case-insensitive, so the same file arriving with
+/// different casing (e.g. <c>C:\ds\Img.png</c> vs <c>c:\ds\img.png</c>) was treated as
+/// one cache entry but two access-order entries, letting stale duplicates accumulate
+/// and preventing the cache from ever shrinking back to its configured cap.
+/// </para>
+///
+/// <para>
+/// This class has no Avalonia dependency (unlike <see cref="ThumbnailService"/>, whose
+/// other responsibilities require a real <c>Bitmap</c> and are hard to unit test without
+/// a headless Avalonia platform), so its LRU bookkeeping can be unit tested directly.
+/// </para>
+///
+/// <para>
+/// <b>Thread safety:</b> this class is not internally synchronized. Callers must apply
+/// their own external locking around all method calls if used from multiple threads
+/// (mirroring how <see cref="ThumbnailService"/> guards every call with its
+/// <c>_evictionLock</c>).
+/// </para>
+/// </summary>
+internal sealed class LruKeyTracker
+{
+    private readonly LinkedList<string> _order = new();
+    private readonly Dictionary<string, LinkedListNode<string>> _nodes = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Number of distinct tracked keys (case-insensitive).</summary>
+    public int Count => _nodes.Count;
+
+    /// <summary>
+    /// Marks <paramref name="key"/> as the most recently used. If a key that compares
+    /// equal case-insensitively is already tracked, its existing node is moved to the
+    /// most-recently-used end in place — it does not create a duplicate entry, and the
+    /// originally recorded casing is retained.
+    /// </summary>
+    public void Touch(string key)
+    {
+        if (_nodes.TryGetValue(key, out var node))
+        {
+            if (!ReferenceEquals(_order.Last, node))
+            {
+                _order.Remove(node);
+                _order.AddLast(node);
+            }
+
+            return;
+        }
+
+        var newNode = _order.AddLast(key);
+        _nodes[key] = newNode;
+    }
+
+    /// <summary>
+    /// Removes <paramref name="key"/> from tracking (compared case-insensitively), if present.
+    /// </summary>
+    /// <returns><see langword="true"/> if a tracked key was found and removed.</returns>
+    public bool Remove(string key)
+    {
+        if (!_nodes.Remove(key, out var node))
+            return false;
+
+        _order.Remove(node);
+        return true;
+    }
+
+    /// <summary>
+    /// Removes and returns the least-recently-used tracked key, or <see langword="null"/>
+    /// if nothing is tracked.
+    /// </summary>
+    public string? EvictLeastRecentlyUsed()
+    {
+        var node = _order.First;
+        if (node is null)
+            return null;
+
+        _order.RemoveFirst();
+        _nodes.Remove(node.Value);
+        return node.Value;
+    }
+
+    /// <summary>Removes all tracked keys.</summary>
+    public void Clear()
+    {
+        _order.Clear();
+        _nodes.Clear();
+    }
+}

--- a/DiffusionNexus.UI/Services/ThumbnailService.cs
+++ b/DiffusionNexus.UI/Services/ThumbnailService.cs
@@ -64,7 +64,11 @@ public sealed class ThumbnailService : IThumbnailService, IDisposable
 {
     private readonly int _maxCacheSize;
     private readonly ConcurrentDictionary<string, CacheEntry> _cache = new(StringComparer.OrdinalIgnoreCase);
-    private readonly LinkedList<string> _accessOrder = new();
+    // Case-insensitive LRU tracker so it agrees with the comparer used by _cache above.
+    // (#429: a LinkedList<string> here previously used the default, case-sensitive
+    // comparer, so paths differing only in casing produced stale duplicate entries
+    // that prevented the cache from ever shrinking back to _maxCacheSize.)
+    private readonly LruKeyTracker _accessOrder = new();
     private readonly object _evictionLock = new();
     private readonly SemaphoreSlim _loadSemaphore;
     private bool _disposed;
@@ -261,17 +265,18 @@ public sealed class ThumbnailService : IThumbnailService, IDisposable
         {
             // Add to cache
             _cache[imagePath] = entry;
-            
-            // Add to access order (most recent at end)
-            _accessOrder.Remove(imagePath); // Remove if exists
-            _accessOrder.AddLast(imagePath);
+
+            // Mark as most-recently-used (moves the existing entry if already tracked,
+            // case-insensitively, instead of appending a duplicate)
+            _accessOrder.Touch(imagePath);
 
             // Evict oldest entries if over capacity
-            while (_cache.Count > _maxCacheSize && _accessOrder.First is not null)
+            while (_cache.Count > _maxCacheSize)
             {
-                var oldestKey = _accessOrder.First.Value;
-                _accessOrder.RemoveFirst();
-                
+                var oldestKey = _accessOrder.EvictLeastRecentlyUsed();
+                if (oldestKey is null)
+                    break;
+
                 if (_cache.TryRemove(oldestKey, out _))
                 {
                     // NOTE: Don't dispose evicted bitmaps - they may still be bound to UI elements.
@@ -290,8 +295,7 @@ public sealed class ThumbnailService : IThumbnailService, IDisposable
     {
         lock (_evictionLock)
         {
-            _accessOrder.Remove(imagePath);
-            _accessOrder.AddLast(imagePath);
+            _accessOrder.Touch(imagePath);
         }
     }
 


### PR DESCRIPTION
## Summary
`ThumbnailService`'s cache was case-insensitive (`ConcurrentDictionary` with `OrdinalIgnoreCase`) but its LRU access-order list was a plain `LinkedList<string>` whose `Remove(string)` compares ordinally. On Windows' case-insensitive paths, the same file arriving as `C:\ds\Img.png` and `c:\ds\img.png` created ONE cache entry but TWO access-order keys — so eviction popped stale duplicates, could evict hot entries, and the eviction loop could drain the list without ever bringing the cache under its cap: an unbounded memory growth path in a decoded-bitmap cache.

## Fix
- New Avalonia-free `LruKeyTracker` (`DiffusionNexus.UI/Services/LruKeyTracker.cs`): `Dictionary<string, LinkedListNode<string>>` keyed `StringComparer.OrdinalIgnoreCase` — the same comparer as the cache — with node-overload `Remove`/`AddLast`, turning every former O(n) linear scan on cache hits into O(1) (this was also a perf fix, per the issue).
- `ThumbnailService` delegates all access-order bookkeeping to the tracker; zero `_accessOrder`/`LinkedList` remnants remain, and every tracker call sits inside the same `_evictionLock` scopes the old list used (verified 1:1 in review).
- Eviction is now structurally bounded: every cache mutation site pairs with a tracker call under the same lock, so "tracker empty while cache above cap" is impossible.

## Tests
No headless-Avalonia harness was added (deliberately — previously rejected in this repo). Instead the LRU bookkeeping is Bitmap-free and directly tested: 11 `LruKeyTracker` tests covering mixed-casing dedupe, eviction-to-cap after mixed-casing touches, mismatched-casing removal, re-touch → MRU, and first-seen-casing retention across cross-case re-touches (harmless by design: the retained casing is only ever used through the same case-insensitive comparer).

- Focused: LruKeyTracker 11/11. Full unit suite: 2969/2970 (sole failure is the pre-existing #444 disk-space test issue, fixed in PR #445).
- Task-reviewed (spec + quality): approved — all three named risks (leftover remnants, eviction termination, lock discipline) verified clean on inspection.

Fixes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)