### PR TITLE
fix(ui): resync ImageViewer on Reset/Add collection changes

### DIFF
--- a/DiffusionNexus.Tests/ViewModels/ImageViewerViewModelTests.cs
+++ b/DiffusionNexus.Tests/ViewModels/ImageViewerViewModelTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using DiffusionNexus.UI.ViewModels;
 using FluentAssertions;
 
@@ -23,6 +24,28 @@ public class ImageViewerViewModelTests
 
     private static ObservableCollection<DatasetImageViewModel> Collection(params string[] names)
         => new(names.Select(Img));
+
+    /// <summary>
+    /// An <see cref="ObservableCollection{T}"/> that can replace its entire contents
+    /// through the protected <c>Items</c> list (no per-item Add/Remove events) and then
+    /// raise a single <see cref="NotifyCollectionChangedAction.Reset"/>, exactly like a
+    /// real "bulk reload" / "switch dataset" implementation would. This is the only way
+    /// to exercise a Reset that leaves some items in place — plain <c>Clear()</c> always
+    /// empties the collection.
+    /// </summary>
+    private sealed class ResettableCollection : ObservableCollection<DatasetImageViewModel>
+    {
+        public ResettableCollection(IEnumerable<DatasetImageViewModel> items) : base(items)
+        {
+        }
+
+        public void ResetWith(IEnumerable<DatasetImageViewModel> items)
+        {
+            Items.Clear();
+            foreach (var item in items) Items.Add(item);
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+        }
+    }
 
     #region Constructor clamping
 
@@ -154,13 +177,16 @@ public class ImageViewerViewModelTests
     public void WhenNavigateToRunsOnAnEmptyCollectionThenStateIsResetRatherThanRejected()
     {
         // The empty-collection branch runs before the range check, so even an
-        // out-of-range index clears the viewer instead of being ignored.
+        // out-of-range index clears the viewer instead of being ignored. Clear()
+        // itself already resets/closes the viewer via the collection-changed
+        // resync; this extra NavigateTo(5) call on the now-empty collection
+        // confirms the method is still safe (idempotent) when invoked directly.
         var images = Collection("a", "b");
         using var vm = new ImageViewerViewModel(images, 1, isFavoriteCheck: _ => true);
         vm.CurrentIndex.Should().Be(1);
         vm.IsFavorite.Should().BeTrue();
 
-        images.Clear(); // Reset action -> handler ignores it, viewer keeps a stale image
+        images.Clear();
         vm.NavigateTo(5);
 
         vm.CurrentImage.Should().BeNull();
@@ -397,25 +423,28 @@ public class ImageViewerViewModelTests
     }
 
     [Fact]
-    public void WhenTheCollectionIsClearedThenTheResetIsIgnoredAndNoCloseIsRequested()
+    public void WhenTheCollectionIsClearedThenTheViewerClosesJustLikeRemovingTheLastItemWould()
     {
-        // Clear() raises Reset, not Remove — the handler only reacts to Remove,
-        // so the viewer keeps a stale current image and stays open.
+        // Clear() raises Reset, not Remove. The viewer must treat a Reset down to
+        // an empty collection exactly like removing the last item: drop the stale
+        // current image and request a close.
         var images = Collection("a", "b");
         using var vm = new ImageViewerViewModel(images, 0);
-        var a = images[0];
         var closeRequests = 0;
         vm.CloseRequested += (_, _) => closeRequests++;
 
         images.Clear();
 
-        closeRequests.Should().Be(0);
-        vm.CurrentImage.Should().BeSameAs(a);
+        closeRequests.Should().Be(1);
+        vm.CurrentImage.Should().BeNull();
+        vm.HasCurrentImage.Should().BeFalse();
+        vm.CurrentIndex.Should().Be(0);
         vm.TotalCount.Should().Be(0);
+        vm.PositionText.Should().Be("0 / 0");
     }
 
     [Fact]
-    public void WhenAnImageIsAddedThenTheAddIsIgnoredByTheChangeHandler()
+    public void WhenAnImageIsAddedWhileTheViewerIsOpenThenCountsRefresh()
     {
         var images = Collection("a");
         using var vm = new ImageViewerViewModel(images, 0);
@@ -424,11 +453,114 @@ public class ImageViewerViewModelTests
         {
             if (e.PropertyName == nameof(ImageViewerViewModel.TotalCount)) totalCountNotifications++;
         };
+        vm.CanGoNext.Should().BeFalse();
 
         images.Add(Img("b"));
 
-        totalCountNotifications.Should().Be(0);
-        vm.TotalCount.Should().Be(2); // computed live, but never announced
+        totalCountNotifications.Should().BeGreaterThan(0);
+        vm.TotalCount.Should().Be(2);
+        vm.PositionText.Should().Be("1 / 2");
+        vm.CanGoNext.Should().BeTrue();
+        vm.NextCommand.CanExecute(null).Should().BeTrue();
+        // The current image itself is untouched by an unrelated addition.
+        vm.CurrentImage.Should().BeSameAs(images[0]);
+    }
+
+    [Fact]
+    public void WhenAResetLeavesTheCurrentImageInPlaceThenItIsKeptAndTheIndexIsReclamped()
+    {
+        var images = new ResettableCollection(Collection("a", "b", "c"));
+        using var vm = new ImageViewerViewModel(images, 2);
+        var c = images[2];
+        vm.CurrentImage.Should().BeSameAs(c);
+
+        // Bulk "reload" that happens to keep the current image but move it earlier.
+        var a = images[0];
+        images.ResetWith([a, c]);
+
+        vm.TotalCount.Should().Be(2);
+        vm.CurrentImage.Should().BeSameAs(c);
+        vm.CurrentIndex.Should().Be(1);
+        vm.PositionText.Should().Be("2 / 2");
+    }
+
+    [Fact]
+    public void WhenAResetRemovesTheCurrentImageThenTheIndexIsClampedToTheNearestValidPosition()
+    {
+        var images = new ResettableCollection(Collection("a", "b", "c"));
+        using var vm = new ImageViewerViewModel(images, 2);
+        var closeRequests = 0;
+        vm.CloseRequested += (_, _) => closeRequests++;
+
+        // Bulk "reload" that drops the current image entirely, leaving two others.
+        var a = images[0];
+        var b = images[1];
+        images.ResetWith([a, b]);
+
+        closeRequests.Should().Be(0);
+        vm.TotalCount.Should().Be(2);
+        vm.CurrentIndex.Should().Be(1);
+        vm.CurrentImage.Should().BeSameAs(b);
+    }
+
+    [Fact]
+    public void WhenAResetLeavesTheCollectionEmptyThenTheViewerCloses()
+    {
+        var images = new ResettableCollection(Collection("a"));
+        using var vm = new ImageViewerViewModel(images, 0);
+        var closeRequests = 0;
+        vm.CloseRequested += (_, _) => closeRequests++;
+
+        images.ResetWith([]);
+
+        closeRequests.Should().Be(1);
+        vm.CurrentImage.Should().BeNull();
+        vm.TotalCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void WhenADifferentImageIsReplacedThenTheCurrentImageIsUnaffected()
+    {
+        var images = Collection("a", "b", "c");
+        using var vm = new ImageViewerViewModel(images, 1);
+        var b = images[1];
+
+        images[2] = Img("d"); // Replace action on an item that isn't current
+
+        vm.CurrentImage.Should().BeSameAs(b);
+        vm.CurrentIndex.Should().Be(1);
+        vm.TotalCount.Should().Be(3);
+    }
+
+    [Fact]
+    public void WhenTheCurrentImageIsReplacedThenTheSlotsNewOccupantIsShown()
+    {
+        // The old reference is gone, so the resync clamps to the same index rather
+        // than jumping to a neighbor - the replacement item that now sits in that
+        // slot is what gets shown, same as landing on whatever fills a vacated slot.
+        var images = Collection("a", "b", "c");
+        using var vm = new ImageViewerViewModel(images, 1);
+        var d = Img("d");
+
+        images[1] = d; // Replace action on the current item itself
+
+        vm.CurrentImage.Should().BeSameAs(d);
+        vm.CurrentIndex.Should().Be(1);
+        vm.TotalCount.Should().Be(3);
+    }
+
+    [Fact]
+    public void WhenTheCurrentImageIsMovedThenTheIndexFollowsItAndTheImageStays()
+    {
+        var images = Collection("a", "b", "c");
+        using var vm = new ImageViewerViewModel(images, 0);
+        var a = images[0];
+
+        images.Move(0, 2); // -> [b, c, a]
+
+        vm.CurrentImage.Should().BeSameAs(a);
+        vm.CurrentIndex.Should().Be(2);
+        vm.PositionText.Should().Be("3 / 3");
     }
 
     [Fact]

--- a/DiffusionNexus.UI/ViewModels/ImageViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/ImageViewerViewModel.cs
@@ -196,46 +196,69 @@ public partial class ImageViewerViewModel : ObservableObject, IDisposable
     }
 
     /// <summary>
-    /// Handles collection changes to properly update navigation when images are deleted.
+    /// Handles collection changes (Add/Remove/Replace/Move/Reset) by funnelling every
+    /// action through <see cref="ResyncToCollection"/> rather than patching state per
+    /// action. <see cref="ObservableCollection{T}.Clear"/> raises <c>Reset</c> (not
+    /// <c>Remove</c>) and plain additions raise <c>Add</c> — both used to fall through
+    /// this handler untouched, leaving the viewer holding a stale <see cref="CurrentImage"/>
+    /// and never closing when the dataset was cleared out from under it. Resyncing from
+    /// scratch on every action fixes that without having to reason about each
+    /// <see cref="NotifyCollectionChangedAction"/> independently: Replace/Move are handled
+    /// "for free" the same way (see <see cref="ResyncToCollection"/> for the details).
     /// </summary>
     private void OnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        => ResyncToCollection();
+
+    /// <summary>
+    /// Re-derives <see cref="CurrentIndex"/>, <see cref="TotalCount"/>, the validity of
+    /// <see cref="CurrentImage"/>, and the close condition from what <c>_allImages</c>
+    /// actually contains right now — instead of patching state based on which
+    /// <see cref="NotifyCollectionChangedAction"/> fired.
+    /// <para>
+    /// This intentionally does not special-case <c>Replace</c> or <c>Move</c>: a Replace
+    /// of the current image looks identical to a Remove-of-current to this method (the
+    /// old reference is simply no longer <c>Contains</c>-ed, so the index gets clamped),
+    /// a Replace of a different item is a no-op for the current image/index, and a Move
+    /// of the current image is picked up by the "still Contains, re-read IndexOf" branch.
+    /// </para>
+    /// </summary>
+    private void ResyncToCollection()
     {
-        if (e.Action == NotifyCollectionChangedAction.Remove)
+        OnPropertyChanged(nameof(TotalCount));
+        OnPropertyChanged(nameof(PositionText));
+        OnPropertyChanged(nameof(CanGoPrevious));
+        OnPropertyChanged(nameof(CanGoNext));
+
+        if (_allImages.Count == 0)
         {
-            // Collection has changed - update the UI
-            OnPropertyChanged(nameof(TotalCount));
-            OnPropertyChanged(nameof(PositionText));
-
-            if (_allImages.Count == 0)
-            {
-                // No more images - close the viewer
-                CurrentImage = null;
-                CurrentIndex = 0;
-                Close();
-                return;
-            }
-
-            // If the current image was removed, navigate to appropriate image
-            if (_currentImage is not null && !_allImages.Contains(_currentImage))
-            {
-                // Current image was deleted - navigate to next available
-                var newIndex = Math.Min(_currentIndex, _allImages.Count - 1);
-                NavigateTo(newIndex);
-            }
-            else if (_currentImage is not null)
-            {
-                // Current image still exists but index may have changed
-                var actualIndex = _allImages.IndexOf(_currentImage);
-                if (actualIndex >= 0 && actualIndex != _currentIndex)
-                {
-                    CurrentIndex = actualIndex;
-                }
-            }
-
-            // Update command states
-            ((RelayCommand)PreviousCommand).NotifyCanExecuteChanged();
-            ((RelayCommand)NextCommand).NotifyCanExecuteChanged();
+            // No images left - close the viewer, just like removing the last item does.
+            CurrentImage = null;
+            CurrentIndex = 0;
+            IsFavorite = false;
+            Close();
         }
+        else if (_currentImage is not null && _allImages.Contains(_currentImage))
+        {
+            // The current image is still present, possibly at a new position (Move,
+            // or a Reset/Replace elsewhere in the collection shifted it).
+            var actualIndex = _allImages.IndexOf(_currentImage);
+            if (actualIndex != _currentIndex)
+            {
+                CurrentIndex = actualIndex;
+            }
+        }
+        else
+        {
+            // The current image is gone (removed/replaced), or there wasn't one yet
+            // (collection went from empty to populated) - clamp to the nearest valid
+            // index and navigate there.
+            var newIndex = Math.Clamp(_currentIndex, 0, _allImages.Count - 1);
+            NavigateTo(newIndex);
+        }
+
+        // Update command states
+        ((RelayCommand)PreviousCommand).NotifyCanExecuteChanged();
+        ((RelayCommand)NextCommand).NotifyCanExecuteChanged();
     }
 
     /// <summary>Navigates to a specific index in the collection.</summary>


### PR DESCRIPTION
## Summary
`ImageViewerViewModel.OnCollectionChanged` only handled `Remove`. `ObservableCollection.Clear()` raises `Reset` and additions raise `Add` — both fell straight through. Clearing the dataset wholesale (reload, dataset switch, overview navigation) left an open viewer holding a `CurrentImage` no longer in the dataset, stale `PositionText`/`TotalCount`, and no `CloseRequested` — while removing images one-by-one closed it correctly.

## Fix
All collection-change actions now funnel through a single `ResyncToCollection()` that re-derives everything from current state instead of per-action patching:
- empty collection → `Close()` (so `Clear()` now behaves exactly like removing the last item),
- current image survived → index re-resolved to its new position,
- current image gone → index clamped to the nearest valid slot,
- counts/`CanGoNext`/`CanGoPrevious`/`PositionText` always refreshed (fixes stale counts on `Add`).

`Replace`/`Move` deliberately get no special-casing — they flow through the same resync, and Replace-of-current shows the slot's new occupant, the only behavior consistent with how Remove-of-current already worked (review adjudicated this explicitly).

Production call-graph verified in review: the dataset views' `Clear()` calls hit exactly the reported scenario; the generation gallery passes a decoupled snapshot; the single `CloseRequested` subscriber (`Window.Close()`) can't recurse into the resync.

## Tests
- 7 deliberately-pinned buggy assertions in `ImageViewerViewModelTests` flipped (RED → GREEN), plus new cases: Clear-closes, Add-refreshes-counts, Reset-with-survivors (via a `ResettableCollection` helper — a scenario plain `Clear()` can't produce), Replace/Move semantics.
- Focused: ImageViewerViewModelTests 58/58. Full unit suite: 2965/2966 (sole failure is the pre-existing #444 disk-space test issue, fixed in PR #445).
- Task-reviewed (spec + quality): approved. Three harmless Minors noted for a future polish pass: no early-return after `Close()` in the empty branch, no reentrancy guard on the resync choke point (safe with today's single subscriber), and a benign double property-notification pattern.

Fixes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)