### PR TITLE
fix(service): single-pass model count rollup + unreadable-dir guard

### DIFF
--- a/DiffusionNexus.Service/Services/ModelDiscoveryService.cs
+++ b/DiffusionNexus.Service/Services/ModelDiscoveryService.cs
@@ -10,10 +10,40 @@ public class FolderNode
     public List<FolderNode> Children { get; } = new();
     public int ModelCount { get; set; }
     public bool IsExpanded { get; set; } = false;
+
+    /// <summary>
+    /// False when this folder (or one of its ancestors, while it was being scanned) could not be
+    /// enumerated - e.g. an access-denied ACL, a broken junction, or another filesystem error.
+    /// When false, <see cref="ModelCount"/> reflects 0 for the unreadable part of the tree rather
+    /// than the true (unknown) count, and no further descendants could be discovered.
+    /// </summary>
+    public bool IsAccessible { get; set; } = true;
 }
 
 public class ModelDiscoveryService
 {
+    private readonly Func<DirectoryInfo, DirectoryInfo[]> _getSubDirectories;
+    private readonly Func<string, SearchOption, IEnumerable<string>> _enumerateFiles;
+
+    public ModelDiscoveryService()
+        : this(dir => dir.GetDirectories(), (path, option) => Directory.EnumerateFiles(path, "*", option))
+    {
+    }
+
+    /// <summary>
+    /// Test-only seam (see DiffusionNexus.Tests, InternalsVisibleTo). Lets tests observe how many
+    /// times/how many files the enumeration primitives touch (efficiency regression guard), and
+    /// substitute a throwing delegate to simulate an unreadable directory (UnauthorizedAccessException,
+    /// broken junction, etc.) without needing real restricted ACLs on disk.
+    /// </summary>
+    internal ModelDiscoveryService(
+        Func<DirectoryInfo, DirectoryInfo[]> getSubDirectories,
+        Func<string, SearchOption, IEnumerable<string>> enumerateFiles)
+    {
+        _getSubDirectories = getSubDirectories ?? throw new ArgumentNullException(nameof(getSubDirectories));
+        _enumerateFiles = enumerateFiles ?? throw new ArgumentNullException(nameof(enumerateFiles));
+    }
+
     public FolderNode BuildFolderTree(string rootDirectory)
     {
         var rootDir = new DirectoryInfo(rootDirectory);
@@ -24,22 +54,54 @@ public class ModelDiscoveryService
 
     private void BuildNode(FolderNode node, DirectoryInfo dir)
     {
-        foreach (var subDir in dir.GetDirectories())
+        // Single-pass rollup (#435): count each directory's OWN files exactly once
+        // (TopDirectoryOnly) and add the child totals as recursion unwinds, instead of
+        // re-walking the entire subtree (AllDirectories) at every ancestor node.
+        DirectoryInfo[] subDirectories;
+        try
+        {
+            subDirectories = _getSubDirectories(dir);
+        }
+        catch (Exception ex) when (IsUnreadableDirectoryException(ex))
+        {
+            // Can't even list this directory's children - skip the subtree instead of
+            // aborting the whole scan. No children are added; ModelCount stays 0.
+            node.IsAccessible = false;
+            return;
+        }
+
+        var count = 0;
+        foreach (var subDir in subDirectories)
         {
             var child = new FolderNode { Name = subDir.Name, FullPath = subDir.FullName };
             BuildNode(child, subDir);
             node.Children.Add(child);
+            count += child.ModelCount;
         }
 
-        node.ModelCount = CountModels(dir.FullName);
+        try
+        {
+            count += CountModelsInThisFolderOnly(dir.FullName);
+        }
+        catch (Exception ex) when (IsUnreadableDirectoryException(ex))
+        {
+            // Subdirectories were listable but this directory's own files could not be read
+            // (e.g. a broken junction). Keep whatever children were already discovered; just
+            // don't contribute an unknown own-file count.
+            node.IsAccessible = false;
+        }
+
+        node.ModelCount = count;
     }
 
-    private int CountModels(string directory)
+    private int CountModelsInThisFolderOnly(string directory)
     {
-        return Directory
-            .EnumerateFiles(directory, "*", SearchOption.AllDirectories)
+        return _enumerateFiles(directory, SearchOption.TopDirectoryOnly)
             .Count(f => StaticFileTypes.ModelExtensions.Contains(Path.GetExtension(f), StringComparer.OrdinalIgnoreCase));
     }
+
+    private static bool IsUnreadableDirectoryException(Exception ex) =>
+        ex is UnauthorizedAccessException or DirectoryNotFoundException or IOException;
 
     public List<ModelClass> CollectModels(string rootDirectory)
     {

--- a/DiffusionNexus.Service/Services/ModelDiscoveryService.cs
+++ b/DiffusionNexus.Service/Services/ModelDiscoveryService.cs
@@ -12,10 +12,13 @@ public class FolderNode
     public bool IsExpanded { get; set; } = false;
 
     /// <summary>
-    /// False when this folder (or one of its ancestors, while it was being scanned) could not be
-    /// enumerated - e.g. an access-denied ACL, a broken junction, or another filesystem error.
-    /// When false, <see cref="ModelCount"/> reflects 0 for the unreadable part of the tree rather
-    /// than the true (unknown) count, and no further descendants could be discovered.
+    /// False only for the specific folder whose own enumeration failed - e.g. an access-denied
+    /// ACL, a broken junction, or another filesystem error. This is not propagated to ancestors:
+    /// a folder's own enumeration succeeding is independent of whether its descendants were
+    /// readable, so an ancestor node can be true (accessible) while still containing inaccessible
+    /// descendants further down the tree. When false, <see cref="ModelCount"/> reflects 0 for the
+    /// unreadable folder rather than the true (unknown) count, and no further descendants could be
+    /// discovered below it.
     /// </summary>
     public bool IsAccessible { get; set; } = true;
 }
@@ -100,8 +103,9 @@ public class ModelDiscoveryService
             .Count(f => StaticFileTypes.ModelExtensions.Contains(Path.GetExtension(f), StringComparer.OrdinalIgnoreCase));
     }
 
+    // DirectoryNotFoundException derives from IOException, so it is already covered here.
     private static bool IsUnreadableDirectoryException(Exception ex) =>
-        ex is UnauthorizedAccessException or DirectoryNotFoundException or IOException;
+        ex is UnauthorizedAccessException or IOException;
 
     public List<ModelClass> CollectModels(string rootDirectory)
     {

--- a/DiffusionNexus.Tests/Service/Services/ModelDiscoveryServiceTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/ModelDiscoveryServiceTests.cs
@@ -1,0 +1,259 @@
+using DiffusionNexus.Service.Helper;
+using DiffusionNexus.Service.Services;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.Service.Services;
+
+/// <summary>
+/// Covers issue #435: BuildFolderTree used to re-enumerate every subtree once per ancestor
+/// node (O(n x depth)), and had no guard against unreadable subdirectories aborting the whole
+/// scan. These tests pin the ModelCount rollup semantics (own files + all descendants), assert
+/// the fix touches each file exactly once (regression guard for the O(n x depth) blowup), and
+/// verify an inaccessible subtree is skipped rather than crashing the scan.
+/// </summary>
+public class ModelDiscoveryServiceTests : IDisposable
+{
+    private readonly string _root;
+
+    public ModelDiscoveryServiceTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "ModelDiscoveryServiceTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    void IDisposable.Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, true);
+        }
+    }
+
+    private static void CreateFiles(string directory, params string[] fileNames)
+    {
+        Directory.CreateDirectory(directory);
+        foreach (var name in fileNames)
+        {
+            File.WriteAllText(Path.Combine(directory, name), string.Empty);
+        }
+    }
+
+    // ---- ModelCount rollup semantics (pin correctness; these already pass against the
+    // unmodified implementation too, since the old AllDirectories-per-node approach happens to
+    // produce the right totals - just wastefully. Written first to lock in the contract before
+    // refactoring the counting strategy.) ----
+
+    [Fact]
+    public void BuildFolderTree_LeafFolderWithModelFiles_CountsOwnFilesOnly()
+    {
+        CreateFiles(_root, "a.safetensors", "b.pt", "notes.txt");
+
+        var node = new ModelDiscoveryService().BuildFolderTree(_root);
+
+        node.ModelCount.Should().Be(2);
+        node.Children.Should().BeEmpty();
+        node.IsAccessible.Should().BeTrue();
+    }
+
+    [Fact]
+    public void BuildFolderTree_ThreeLevelChain_RollsUpCountsFromLeafToRoot()
+    {
+        CreateFiles(_root, "root.ckpt", "root_readme.txt");
+        var child = Path.Combine(_root, "child");
+        CreateFiles(child, "child1.safetensors", "child2.pt");
+        var grandchild = Path.Combine(child, "grandchild");
+        CreateFiles(grandchild, "g1.pth", "g2.ckpt", "g3.safetensors");
+
+        var node = new ModelDiscoveryService().BuildFolderTree(_root);
+
+        node.ModelCount.Should().Be(6); // 1 own + 2 child + 3 grandchild
+        node.Children.Should().ContainSingle();
+        var childNode = node.Children.Single();
+        childNode.Name.Should().Be("child");
+        childNode.ModelCount.Should().Be(5); // 2 own + 3 grandchild
+
+        childNode.Children.Should().ContainSingle();
+        var grandchildNode = childNode.Children.Single();
+        grandchildNode.Name.Should().Be("grandchild");
+        grandchildNode.ModelCount.Should().Be(3);
+        grandchildNode.Children.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildFolderTree_SiblingSubtrees_SumIndependentlyWithoutLeaking()
+    {
+        CreateFiles(_root, "own.safetensors");
+        var subA = Path.Combine(_root, "A");
+        CreateFiles(subA, "a1.pt", "a2.pt");
+        var subB = Path.Combine(_root, "B");
+        CreateFiles(subB, "b1.ckpt", "b2.ckpt", "b3.ckpt");
+
+        var node = new ModelDiscoveryService().BuildFolderTree(_root);
+
+        node.ModelCount.Should().Be(6); // 1 + 2 + 3
+        node.Children.Should().HaveCount(2);
+        node.Children.Single(c => c.Name == "A").ModelCount.Should().Be(2);
+        node.Children.Single(c => c.Name == "B").ModelCount.Should().Be(3);
+    }
+
+    [Fact]
+    public void BuildFolderTree_EmptyDirectory_ReturnsZeroCountAndNoChildren()
+    {
+        var node = new ModelDiscoveryService().BuildFolderTree(_root);
+
+        node.ModelCount.Should().Be(0);
+        node.Children.Should().BeEmpty();
+        node.IsAccessible.Should().BeTrue();
+    }
+
+    [Fact]
+    public void BuildFolderTree_OnlyCountsRecognizedModelExtensions()
+    {
+        // One file per real model extension, driven off StaticFileTypes itself so this pins
+        // "whatever the current filter predicate is" rather than a hardcoded duplicate list.
+        var modelFiles = StaticFileTypes.ModelExtensions.Select((ext, i) => $"model{i}{ext}").ToArray();
+        CreateFiles(_root, modelFiles);
+        CreateFiles(_root, "notes.txt", "data.json", "cover.png", "workflow.yaml");
+
+        var node = new ModelDiscoveryService().BuildFolderTree(_root);
+
+        node.ModelCount.Should().Be(StaticFileTypes.ModelExtensions.Length);
+    }
+
+    [Fact]
+    public void BuildFolderTree_ExtensionMatchIsCaseInsensitive()
+    {
+        CreateFiles(_root, "Loud.SAFETENSORS", "quiet.PtH");
+
+        var node = new ModelDiscoveryService().BuildFolderTree(_root);
+
+        node.ModelCount.Should().Be(2);
+    }
+
+    // ---- Efficiency: each file must be touched exactly once across the whole build, not once
+    // per ancestor. TRUE RED before the fix: with the seam wired to the original AllDirectories
+    // strategy (one recursive re-scan per node), a 4-level chain with 1 file per level touched
+    // 10 file-entries (4+3+2+1) instead of the 4 actual files. After switching BuildNode to a
+    // single-pass rollup (TopDirectoryOnly + accumulate), this reports exactly 4. ----
+
+    [Fact]
+    public void BuildFolderTree_TouchesEachFileExactlyOnce_NotOncePerAncestor()
+    {
+        var level0 = _root;
+        var level1 = Path.Combine(level0, "L1");
+        var level2 = Path.Combine(level1, "L2");
+        var level3 = Path.Combine(level2, "L3");
+        CreateFiles(level0, "f0.safetensors");
+        CreateFiles(level1, "f1.safetensors");
+        CreateFiles(level2, "f2.safetensors");
+        CreateFiles(level3, "f3.safetensors");
+        const int totalActualFiles = 4;
+
+        var totalFilesTouched = 0;
+        var service = new ModelDiscoveryService(
+            dir => dir.GetDirectories(),
+            (path, option) =>
+            {
+                var results = Directory.EnumerateFiles(path, "*", option).ToArray();
+                totalFilesTouched += results.Length;
+                return results;
+            });
+
+        var node = service.BuildFolderTree(_root);
+
+        node.ModelCount.Should().Be(totalActualFiles);
+        totalFilesTouched.Should().Be(totalActualFiles,
+            "each file's directory should be enumerated exactly once, not once per ancestor node");
+    }
+
+    // ---- Unreadable subdirectory guard: TRUE RED before the fix - the original code had no
+    // try/catch anywhere, so any UnauthorizedAccessException/DirectoryNotFoundException/IOException
+    // raised while listing a subtree propagated out of BuildFolderTree and aborted the entire scan. ----
+
+    [Fact]
+    public void BuildFolderTree_SubdirectoryListingThrowsUnauthorizedAccess_SkipsSubtreeInsteadOfAborting()
+    {
+        CreateFiles(_root, "own.safetensors");
+        var accessible = Path.Combine(_root, "Accessible");
+        CreateFiles(accessible, "a1.pt", "a2.pt");
+        var restrictedPath = Path.Combine(_root, "Restricted");
+        Directory.CreateDirectory(restrictedPath); // exists on disk; enumeration is faked to fail
+
+        var service = new ModelDiscoveryService(
+            dir => dir.FullName == restrictedPath
+                ? throw new UnauthorizedAccessException("simulated access-denied subtree")
+                : dir.GetDirectories(),
+            (path, option) => Directory.EnumerateFiles(path, "*", option));
+
+        FolderNode? node = null;
+        Action act = () => node = service.BuildFolderTree(_root);
+
+        act.Should().NotThrow();
+        node!.ModelCount.Should().Be(3); // 1 own + 2 Accessible; Restricted contributes 0
+        node.IsAccessible.Should().BeTrue();
+
+        var accessibleNode = node.Children.Single(c => c.Name == "Accessible");
+        accessibleNode.ModelCount.Should().Be(2);
+        accessibleNode.IsAccessible.Should().BeTrue();
+
+        var restrictedNode = node.Children.Single(c => c.Name == "Restricted");
+        restrictedNode.ModelCount.Should().Be(0);
+        restrictedNode.IsAccessible.Should().BeFalse();
+        restrictedNode.Children.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildFolderTree_FileEnumerationThrowsDirectoryNotFound_SkipsOwnCountInsteadOfAborting()
+    {
+        // Simulates a broken junction/reparse point: listing subdirectories succeeds (or there are
+        // none), but reading the directory's own files fails.
+        CreateFiles(_root, "own.safetensors");
+        var brokenJunction = Path.Combine(_root, "BrokenJunction");
+        Directory.CreateDirectory(brokenJunction);
+
+        var service = new ModelDiscoveryService(
+            dir => dir.GetDirectories(),
+            (path, option) => path == brokenJunction
+                ? throw new DirectoryNotFoundException("simulated broken junction")
+                : Directory.EnumerateFiles(path, "*", option));
+
+        FolderNode? node = null;
+        Action act = () => node = service.BuildFolderTree(_root);
+
+        act.Should().NotThrow();
+        node!.ModelCount.Should().Be(1); // only the root's own file; BrokenJunction contributes 0
+        var brokenNode = node.Children.Single(c => c.Name == "BrokenJunction");
+        brokenNode.ModelCount.Should().Be(0);
+        brokenNode.IsAccessible.Should().BeFalse();
+    }
+
+    [Fact]
+    public void BuildFolderTree_RootItselfUnreadable_ReturnsInaccessibleRootWithoutThrowing()
+    {
+        var service = new ModelDiscoveryService(
+            dir => throw new UnauthorizedAccessException("simulated - root itself unreadable"),
+            (path, option) => Directory.EnumerateFiles(path, "*", option));
+
+        FolderNode? node = null;
+        Action act = () => node = service.BuildFolderTree(_root);
+
+        act.Should().NotThrow();
+        node!.ModelCount.Should().Be(0);
+        node.IsAccessible.Should().BeFalse();
+        node.Children.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildFolderTree_UnrelatedException_IsNotSwallowed()
+    {
+        // Guards against an overly broad catch: only filesystem-access-shaped exceptions should
+        // be treated as "skip this subtree"; anything else is a real bug and must propagate.
+        var service = new ModelDiscoveryService(
+            dir => throw new InvalidOperationException("not a filesystem access problem"),
+            (path, option) => Directory.EnumerateFiles(path, "*", option));
+
+        Action act = () => service.BuildFolderTree(_root);
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+}


### PR DESCRIPTION
## Summary
`ModelDiscoveryService.BuildNode` called `CountModels` (with `SearchOption.AllDirectories`) at **every** node while also recursing into every subtree — so a file at depth *d* was enumerated *d* times, an O(n × depth) filesystem blowup against exactly the kind of deep model/LoRA library where enumeration cost dominates (and a repo with a history of scan-related freezes, #397/#403). Additionally, one unreadable subdirectory (`UnauthorizedAccessException`) aborted the entire scan.

## Fix
- Single pass: each directory's own files counted once with `SearchOption.TopDirectoryOnly`; totals roll up as the recursion unwinds. `ModelCount` semantics identical (own + all descendants, each file visited exactly once); the model-extension filter predicate is byte-for-byte unchanged.
- Unreadable subtrees no longer abort the scan: the failing node stays in the tree with `ModelCount = 0` and a new `FolderNode.IsAccessible = false` marker (transparency over silent omission — safe because the service currently has zero consumers, verified by grep). Failure never propagates upward; siblings and ancestors are unaffected, and the XML doc states this explicitly.
- Internal constructor seam (existing `InternalsVisibleTo` idiom, no new plumbing) lets tests inject enumeration behavior; the public parameterless ctor delegates to real filesystem lambdas — no test hooks in release behavior.

## Tests
11 new tests (service previously had **zero**). True RED confirmed on 4 of them against the unmodified algorithm: an efficiency guard counting real enumeration touches (old algorithm: 10 touches on a 4-level chain; new: 4 — the reviewer independently reproduced both numbers by hand), plus three exception-guard tests that previously propagated unhandled.

- Focused: 11/11. Full unit suite: 2970/2971 (sole failure is the pre-existing #444 disk-space test issue, fixed in PR #445).
- Task-reviewed (spec + quality): approved — rollup hand-traced, per-node guard granularity verified, both review Minors (doc wording, redundant exception clause) fixed in a follow-up commit.

Fixes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)