### PR TITLE
fix(ui): recover mojibake and cp1252-corrupt characters across the codebase

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,11 +5,3 @@ root = true
 
 [*]
 charset = utf-8
-end_of_line = crlf
-insert_final_newline = true
-
-[*.{cs,csx}]
-charset = utf-8
-
-[*.{md,json,yml,yaml,xml,axaml,csproj,sln}]
-charset = utf-8

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig: https://editorconfig.org
+# Recurrence prevention for issue #441 (U+FFFD mojibake from a lossy save):
+# pin UTF-8 so editors/tools stop guessing the encoding of source files.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = crlf
+insert_final_newline = true
+
+[*.{cs,csx}]
+charset = utf-8
+
+[*.{md,json,yml,yaml,xml,axaml,csproj,sln}]
+charset = utf-8

--- a/DiffusionNexus.Domain/Services/ICaptioningBackend.cs
+++ b/DiffusionNexus.Domain/Services/ICaptioningBackend.cs
@@ -7,7 +7,7 @@ namespace DiffusionNexus.Domain.Services;
 public interface ICaptioningBackend
 {
     /// <summary>
-    /// Human-readable name of this backend (e.g. "Local Inference", "ComfyUI – Qwen3-VL").
+    /// Human-readable name of this backend (e.g. "Local Inference", "ComfyUI - Qwen3-VL").
     /// </summary>
     string DisplayName { get; }
 
@@ -21,7 +21,7 @@ public interface ICaptioningBackend
     /// <summary>
     /// Non-blocking warnings discovered during <see cref="IsAvailableAsync"/>.
     /// Unlike <see cref="MissingRequirements"/>, warnings do not prevent the backend from
-    /// being used — they inform the user about conditions that may affect the first run
+    /// being used - they inform the user about conditions that may affect the first run
     /// (e.g. a large model download that will happen on first execution).
     /// </summary>
     IReadOnlyList<string> Warnings { get; }
@@ -43,7 +43,7 @@ public interface ICaptioningBackend
     /// <param name="prompt">The prompt/instruction to guide caption generation.</param>
     /// <param name="triggerWord">Optional token to prepend to the generated caption.</param>
     /// <param name="blacklistedWords">Words to remove from the generated caption.</param>
-    /// <param name="temperature">Inference temperature (0.0–2.0). Lower values are more deterministic.</param>
+    /// <param name="temperature">Inference temperature (0.0-2.0). Lower values are more deterministic.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The captioning result.</returns>
     Task<CaptioningResult> GenerateSingleCaptionAsync(

--- a/DiffusionNexus.Domain/Services/IComfyUIWrapperService.cs
+++ b/DiffusionNexus.Domain/Services/IComfyUIWrapperService.cs
@@ -93,7 +93,7 @@ public interface IComfyUIWrapperService : IDisposable
     /// </summary>
     /// <param name="imagePath">Absolute path to the image file on disk (must be accessible by the ComfyUI server).</param>
     /// <param name="prompt">The captioning prompt to send to the model.</param>
-    /// <param name="temperature">Inference temperature (0.0–2.0). Lower values are more deterministic.</param>
+    /// <param name="temperature">Inference temperature (0.0-2.0). Lower values are more deterministic.</param>
     /// <param name="progress">Optional progress reporter that receives WebSocket event messages.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The generated caption text, or <c>null</c> if no text was returned.</returns>

--- a/DiffusionNexus.Domain/Utilities/BaseModelDisplayMapper.cs
+++ b/DiffusionNexus.Domain/Utilities/BaseModelDisplayMapper.cs
@@ -192,6 +192,6 @@ public static class BaseModelDisplayMapper
             return value;
         }
 
-        return value[..(maxLength - 1)] + "…";
+        return value[..(maxLength - 1)] + "\u2026";
     }
 }

--- a/DiffusionNexus.Service/Services/ComfyUICaptioningBackend.cs
+++ b/DiffusionNexus.Service/Services/ComfyUICaptioningBackend.cs
@@ -31,7 +31,7 @@ public sealed class ComfyUICaptioningBackend : ICaptioningBackend
     }
 
     /// <inheritdoc />
-    public string DisplayName => "ComfyUI � Qwen3-VL";
+    public string DisplayName => "ComfyUI \u2014 Qwen3-VL";
 
     /// <inheritdoc />
     public IReadOnlyList<string> MissingRequirements { get; private set; } = [];

--- a/DiffusionNexus.Tests/ImageEditor/ImageEditorCoreInpaintBaseTests.cs
+++ b/DiffusionNexus.Tests/ImageEditor/ImageEditorCoreInpaintBaseTests.cs
@@ -34,7 +34,7 @@ public class ImageEditorCoreInpaintBaseTests : IDisposable
     [Fact]
     public void WhenResetToOriginal_InpaintBaseIsCleared()
     {
-        // Arrange — capture an inpaint base
+        // Arrange - capture an inpaint base
         _sut.SetInpaintBaseBitmap();
         _sut.HasInpaintBase.Should().BeTrue();
 
@@ -48,7 +48,7 @@ public class ImageEditorCoreInpaintBaseTests : IDisposable
     [Fact]
     public void WhenClear_InpaintBaseIsCleared()
     {
-        // Arrange — capture an inpaint base
+        // Arrange - capture an inpaint base
         _sut.SetInpaintBaseBitmap();
         _sut.HasInpaintBase.Should().BeTrue();
 

--- a/DiffusionNexus.Tests/ImageEditor/Services/EditorServiceFactoryTests.cs
+++ b/DiffusionNexus.Tests/ImageEditor/Services/EditorServiceFactoryTests.cs
@@ -28,7 +28,7 @@ public class EditorServiceFactoryTests
         // Act
         var services = EditorServiceFactory.Create();
 
-        // Assert — publish via viewport and verify event fires
+        // Assert - publish via viewport and verify event fires
         var raised = false;
         services.Viewport.Changed += (_, _) => raised = true;
         services.Viewport.ZoomIn();
@@ -42,10 +42,10 @@ public class EditorServiceFactoryTests
         var services1 = EditorServiceFactory.Create();
         var services2 = EditorServiceFactory.Create();
 
-        // Act — activate a tool on services1
+        // Act - activate a tool on services1
         services1.Tools.Activate(ToolIds.Crop);
 
-        // Assert — services2 is unaffected
+        // Assert - services2 is unaffected
         services2.Tools.ActiveToolId.Should().BeNull();
     }
 

--- a/DiffusionNexus.Tests/ImageEditor/Services/LayerManagerTests.cs
+++ b/DiffusionNexus.Tests/ImageEditor/Services/LayerManagerTests.cs
@@ -79,7 +79,7 @@ public class LayerManagerTests : IDisposable
         using var anotherBitmap = new SKBitmap(200, 200);
         _sut.EnableLayerMode(anotherBitmap, "Second");
 
-        // Assert — still has original dimensions
+        // Assert - still has original dimensions
         _sut.Width.Should().Be(100);
         _sut.Count.Should().Be(1);
     }
@@ -115,7 +115,7 @@ public class LayerManagerTests : IDisposable
         // Act
         _sut.EnableLayerMode(_testBitmap, "Background");
 
-        // Assert — LayerStack fires LayersChanged when a layer is added
+        // Assert - LayerStack fires LayersChanged when a layer is added
         raised.Should().BeTrue();
     }
 
@@ -624,7 +624,7 @@ public class LayerManagerTests : IDisposable
         var raised = false;
         _sut.ContentChanged += (_, _) => raised = true;
 
-        // Act — modify the layer content
+        // Act - modify the layer content
         _sut.ActiveLayer!.NotifyContentChanged();
 
         // Assert

--- a/DiffusionNexus.Tests/ImageEditor/Services/ViewportManagerTests.cs
+++ b/DiffusionNexus.Tests/ImageEditor/Services/ViewportManagerTests.cs
@@ -48,7 +48,7 @@ public class ViewportManagerTests
     [Fact]
     public void WhenZoomOut_ZoomLevelDecreases()
     {
-        // Arrange — start at 1.0 (default)
+        // Arrange - start at 1.0 (default)
         _sut.ZoomLevel = 1f;
 
         // Act
@@ -147,7 +147,7 @@ public class ViewportManagerTests
     [Fact]
     public void WhenPanInFitMode_OffsetNotChanged()
     {
-        // Arrange — fit mode is default
+        // Arrange - fit mode is default
         _sut.IsFitMode.Should().BeTrue();
 
         // Act

--- a/DiffusionNexus.Tests/Service/Services/ComfyUICaptioningBackendTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/ComfyUICaptioningBackendTests.cs
@@ -54,7 +54,9 @@ public class ComfyUICaptioningBackendTests
 
         backend.MissingRequirements.Should().BeEmpty();
         backend.Warnings.Should().BeEmpty();
-        backend.DisplayName.Should().Contain("ComfyUI").And.Contain("Qwen3-VL");
+        // Full-string assertion (not just substrings) to pin the exact separator glyph -
+        // regression guard for issue #441 (U+FFFD mojibake in place of the em dash).
+        backend.DisplayName.Should().Be("ComfyUI \u2014 Qwen3-VL");
     }
 
     #endregion

--- a/DiffusionNexus.Tests/Services/ThumbnailOrchestratorTests.cs
+++ b/DiffusionNexus.Tests/Services/ThumbnailOrchestratorTests.cs
@@ -119,7 +119,7 @@ public class ThumbnailOrchestratorTests : IDisposable
         _orchestrator.SetActiveOwner(_ownerA);
         var requestTask = _orchestrator.RequestThumbnailAsync("slow.png", _ownerA);
 
-        // Switch active owner — this should NOT cancel ownerA's in-flight work
+        // Switch active owner - this should NOT cancel ownerA's in-flight work
         _orchestrator.SetActiveOwner(_ownerB);
 
         // The request should complete (not be cancelled)
@@ -263,7 +263,7 @@ public class ThumbnailOrchestratorTests : IDisposable
                 return null;
             });
 
-        // Act: start a request but don't await — just verify dispose doesn't throw
+        // Act: start a request but don't await - just verify dispose doesn't throw
         _ = _orchestrator.RequestThumbnailAsync("pending.png", _ownerA);
 
         var action = () => _orchestrator.Dispose();
@@ -276,7 +276,7 @@ public class ThumbnailOrchestratorTests : IDisposable
         var token1 = new ThumbnailOwnerToken("Test");
         var token2 = new ThumbnailOwnerToken("Test");
 
-        // Same name but different instances — should NOT be equal (reference equality)
+        // Same name but different instances - should NOT be equal (reference equality)
         token1.Should().NotBeSameAs(token2);
     }
 

--- a/DiffusionNexus.UI/App.axaml.cs
+++ b/DiffusionNexus.UI/App.axaml.cs
@@ -1650,11 +1650,11 @@ public partial class App : Application
                 Serilog.Log.Information("LoadStartupData: {Phase} finished at +{End}ms ({Duration}ms total)", name, sw.ElapsedMilliseconds, sw.ElapsedMilliseconds - begin);
             }
 
-            // Disclaimer + settings must complete first � other modules depend on them.
+            // Disclaimer + settings must complete first - other modules depend on them.
             await Timed(sw, "disclaimer", () => mainViewModel.CheckDisclaimerStatusAsync());
             await Timed(sw, "settings", () => settingsVm.LoadCommand.ExecuteAsync(null));
 
-            // Remaining modules are independent � load in parallel.
+            // Remaining modules are independent - load in parallel.
             // NOTE: each command runs synchronously on the UI thread until its first
             // real await — the per-phase "synchronous head" stamps expose which load
             // is hogging the dispatcher.

--- a/DiffusionNexus.UI/Controls/ImageEditorControl.cs
+++ b/DiffusionNexus.UI/Controls/ImageEditorControl.cs
@@ -413,7 +413,7 @@ public class ImageEditorControl : Control
             if (!string.IsNullOrEmpty(newPath))
             {
                 // Skip redundant reload when binding restores the same path
-                // after a tab-switch reattach � the bitmap is still in memory.
+                // after a tab-switch reattach - the bitmap is still in memory.
                 if (_editorCore.HasImage &&
                     string.Equals(newPath, _editorCore.CurrentImagePath, StringComparison.OrdinalIgnoreCase))
                 {
@@ -945,14 +945,14 @@ public class ImageEditorControl : Control
 
     private void UpdateCursor(SKPoint point)
     {
-        // Inpaint tool uses a custom rendered brush cursor � hide the system cursor
+        // Inpaint tool uses a custom rendered brush cursor - hide the system cursor
         if (_isInpaintingToolActive)
         {
             Cursor = new Cursor(StandardCursorType.None);
             return;
         }
 
-        // Drawing tool uses a custom rendered brush cursor � hide the system cursor
+        // Drawing tool uses a custom rendered brush cursor - hide the system cursor
         if (_editorCore.DrawingTool.IsActive)
         {
             Cursor = new Cursor(StandardCursorType.None);

--- a/DiffusionNexus.UI/Converters/PathToBitmapConverter.cs
+++ b/DiffusionNexus.UI/Converters/PathToBitmapConverter.cs
@@ -10,7 +10,7 @@ namespace DiffusionNexus.UI.Converters;
 /// Converts a file path string to a Bitmap for display in Image controls.
 /// <para>
 /// <b>Sync-only:</b> This converter only returns cache hits or performs synchronous fallback loading.
-/// It does NOT fire async loads — ViewModels with a <c>Thumbnail</c> property should be bound
+/// It does NOT fire async loads - ViewModels with a <c>Thumbnail</c> property should be bound
 /// directly instead of using this converter for thumbnail-mode images.
 /// </para>
 /// <para>
@@ -53,7 +53,7 @@ public class PathToBitmapConverter : IValueConverter
             return LoadFullResolution(path);
         }
 
-        // Thumbnail mode: return from cache only — ViewModels handle async loading via their Thumbnail property
+        // Thumbnail mode: return from cache only - ViewModels handle async loading via their Thumbnail property
         if (ThumbnailOrchestrator is not null &&
             ThumbnailOrchestrator.TryGetCached(path, out var cached) &&
             cached is not null)

--- a/DiffusionNexus.UI/ImageEditor/ImageEditorCore.cs
+++ b/DiffusionNexus.UI/ImageEditor/ImageEditorCore.cs
@@ -22,11 +22,11 @@ public partial class ImageEditorCore : IDisposable
     private readonly object _bitmapLock = new();
     private SKRect _lastImageRect;
 
-    // Layer state � delegated to LayerManager when services are wired
+    // Layer state - delegated to LayerManager when services are wired
     private LayerStack? _layers => _services?.Layers.Stack;
     private bool _isLayerMode => _services?.Layers.IsLayerMode ?? false;
 
-    // Viewport state � delegated to ViewportManager when services are wired
+    // Viewport state - delegated to ViewportManager when services are wired
     private float _zoomLevel
     {
         get => _services?.Viewport.ZoomLevel ?? 1f;

--- a/DiffusionNexus.UI/ImageEditor/Services/IDocumentService.cs
+++ b/DiffusionNexus.UI/ImageEditor/Services/IDocumentService.cs
@@ -14,7 +14,7 @@ public interface IDocumentService
     /// <param name="bitmap">The bitmap to save.</param>
     /// <param name="filePath">Destination file path.</param>
     /// <param name="format">Image format.</param>
-    /// <param name="quality">Quality for lossy formats (0–100).</param>
+    /// <param name="quality">Quality for lossy formats (0-100).</param>
     /// <returns>True if saved successfully.</returns>
     bool Save(SKBitmap bitmap, string filePath, SKEncodedImageFormat format = SKEncodedImageFormat.Png, int quality = 95);
 

--- a/DiffusionNexus.UI/ImageEditor/Services/IViewportManager.cs
+++ b/DiffusionNexus.UI/ImageEditor/Services/IViewportManager.cs
@@ -13,7 +13,7 @@ public interface IViewportManager
     float ZoomLevel { get; set; }
 
     /// <summary>
-    /// Gets the zoom level as a percentage integer (10–1000).
+    /// Gets the zoom level as a percentage integer (10-1000).
     /// </summary>
     int ZoomPercentage { get; }
 

--- a/DiffusionNexus.UI/ImageEditor/Services/ViewportManager.cs
+++ b/DiffusionNexus.UI/ImageEditor/Services/ViewportManager.cs
@@ -2,7 +2,7 @@ namespace DiffusionNexus.UI.ImageEditor.Services;
 
 /// <summary>
 /// Manages viewport state: zoom, pan, fit mode.
-/// Single source of truth for zoom/pan — fires <see cref="Changed"/> on updates.
+/// Single source of truth for zoom/pan - fires <see cref="Changed"/> on updates.
 /// </summary>
 internal sealed class ViewportManager : IViewportManager
 {

--- a/DiffusionNexus.UI/ImageEditor/ShapeTool.cs
+++ b/DiffusionNexus.UI/ImageEditor/ShapeTool.cs
@@ -7,7 +7,7 @@ namespace DiffusionNexus.UI.ImageEditor;
 /// </summary>
 public enum ShapeToolPhase
 {
-    /// <summary>No shape is active � ready to draw a new one.</summary>
+    /// <summary>No shape is active - ready to draw a new one.</summary>
     Idle,
     /// <summary>User is dragging to create a new shape.</summary>
     Drawing,
@@ -26,9 +26,9 @@ public enum ShapeToolPhase
 /// </summary>
 public enum ShapeManipulationHandle
 {
-    /// <summary>No handle � click is outside the shape.</summary>
+    /// <summary>No handle - click is outside the shape.</summary>
     None,
-    /// <summary>Click is inside the shape body � drag to move.</summary>
+    /// <summary>Click is inside the shape body - drag to move.</summary>
     Body,
     /// <summary>Top-left corner resize handle.</summary>
     TopLeft,
@@ -436,7 +436,7 @@ public class ShapeTool
 
         if (handle == ShapeManipulationHandle.None)
         {
-            // Click outside � commit current shape and start a new one if inside image
+            // Click outside - commit current shape and start a new one if inside image
             CommitPlacedShape();
             if (_imageRect.Contains(screenPoint))
             {

--- a/DiffusionNexus.UI/Services/IThumbnailOrchestrator.cs
+++ b/DiffusionNexus.UI/Services/IThumbnailOrchestrator.cs
@@ -57,7 +57,7 @@ public sealed class ThumbnailOwnerToken
 /// </list>
 /// </para>
 /// <para>
-/// <b>TODO: Linux Implementation</b> — Verify that priority thread scheduling
+/// <b>TODO: Linux Implementation</b> - Verify that priority thread scheduling
 /// behaves identically on Linux; test under Wayland and X11 compositors.
 /// </para>
 /// </summary>

--- a/DiffusionNexus.UI/Services/ThumbnailOrchestrator.cs
+++ b/DiffusionNexus.UI/Services/ThumbnailOrchestrator.cs
@@ -19,10 +19,10 @@ internal sealed record ThumbnailRequest(
 /// <para>
 /// Wraps <see cref="IThumbnailService"/> and adds:
 /// <list type="bullet">
-/// <item>Priority queue — <see cref="ThumbnailPriority.Critical"/> requests are processed first.</item>
-/// <item>Active-owner boosting — the active view's requests are auto-promoted.</item>
-/// <item>Per-owner cancellation — switching views cancels the previous view's pending work.</item>
-/// <item>Concurrency control — limits parallel decode operations.</item>
+/// <item>Priority queue - <see cref="ThumbnailPriority.Critical"/> requests are processed first.</item>
+/// <item>Active-owner boosting - the active view's requests are auto-promoted.</item>
+/// <item>Per-owner cancellation - switching views cancels the previous view's pending work.</item>
+/// <item>Concurrency control - limits parallel decode operations.</item>
 /// </list>
 /// </para>
 /// <para>
@@ -30,7 +30,7 @@ internal sealed record ThumbnailRequest(
 /// Cache hits bypass the queue entirely for zero-latency returns.
 /// </para>
 /// <para>
-/// <b>TODO: Linux Implementation</b> — Profile queue throughput under X11/Wayland to ensure
+/// <b>TODO: Linux Implementation</b> - Profile queue throughput under X11/Wayland to ensure
 /// the priority processing loop does not starve the UI thread on single-core VMs.
 /// </para>
 /// </summary>
@@ -51,7 +51,7 @@ public sealed class ThumbnailOrchestrator : IThumbnailOrchestrator, IDisposable
     /// Creates a new ThumbnailOrchestrator.
     /// </summary>
     /// <param name="thumbnailService">The underlying thumbnail service for loading and caching.
-    /// The service owns concurrency throttling — the orchestrator does not add another semaphore.</param>
+    /// The service owns concurrency throttling - the orchestrator does not add another semaphore.</param>
     public ThumbnailOrchestrator(IThumbnailService thumbnailService)
     {
         ArgumentNullException.ThrowIfNull(thumbnailService);
@@ -124,7 +124,7 @@ public sealed class ThumbnailOrchestrator : IThumbnailOrchestrator, IDisposable
     public void SetActiveOwner(ThumbnailOwnerToken owner)
     {
         // Simply update the active owner. New requests from this owner will be boosted
-        // to Critical priority. We do NOT cancel the previous owner's in-flight work —
+        // to Critical priority. We do NOT cancel the previous owner's in-flight work -
         // completed loads populate the cache which benefits the user when switching back.
         _activeOwner = owner;
     }
@@ -194,7 +194,7 @@ public sealed class ThumbnailOrchestrator : IThumbnailOrchestrator, IDisposable
                 continue;
             }
 
-            // Dispatch to background — semaphore is acquired inside ProcessRequestAsync
+            // Dispatch to background - semaphore is acquired inside ProcessRequestAsync
             _ = ProcessRequestAsync(request);
         }
     }

--- a/DiffusionNexus.UI/ViewModels/ImageEditorViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/ImageEditorViewModel.cs
@@ -176,7 +176,7 @@ public partial class ImageEditorViewModel : ObservableObject
     }
 
     /// <summary>Formatted image dimensions for display.</summary>
-    public string ImageDimensions => HasImage ? $"{ImageWidth} � {ImageHeight}" : string.Empty;
+    public string ImageDimensions => HasImage ? $"{ImageWidth} \u00D7 {ImageHeight}" : string.Empty;
 
     /// <summary>Whether the crop tool is currently active.</summary>
     public bool IsCropToolActive
@@ -273,7 +273,7 @@ public partial class ImageEditorViewModel : ObservableObject
 
     /// <summary>Combined image info for display.</summary>
     public string ImageInfo => HasImage
-        ? $"Size: {ImageWidth} � {ImageHeight} px\nResolution: {ImageDpi} DPI\nFile: {FileSizeText}"
+        ? $"Size: {ImageWidth} \u00D7 {ImageHeight} px\nResolution: {ImageDpi} DPI\nFile: {FileSizeText}"
         : string.Empty;
 
     #endregion

--- a/DiffusionNexus.UI/ViewModels/Tabs/CaptioningTabViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/Tabs/CaptioningTabViewModel.cs
@@ -1315,7 +1315,7 @@ public partial class CaptioningTabViewModel : ViewModelBase, IDialogServiceAware
         }
         else
         {
-            StatusMessage = "Compare cancelled � the newly generated caption remains on disk.";
+            StatusMessage = "Compare cancelled \u2014 the newly generated caption remains on disk.";
         }
     }
 

--- a/EXAMPLE_EnhancedViewModel.cs
+++ b/EXAMPLE_EnhancedViewModel.cs
@@ -234,7 +234,7 @@ public partial class EnhancedLoraSortMainSettingsViewModel : ViewModelBase
                 options.ApiKey, 
                 useDatabase: UseDatabaseCache);
 
-            Log("Scanning…", LogSeverity.Info);
+            Log("Scanning\u2026", LogSeverity.Info);
             IsIndeterminate = true;
             var first = true;
             
@@ -247,7 +247,7 @@ public partial class EnhancedLoraSortMainSettingsViewModel : ViewModelBase
                         if (first)
                         {
                             IsIndeterminate = false;
-                            Log("Processing…", LogSeverity.Info);
+                            Log("Processing\u2026", LogSeverity.Info);
                             first = false;
                         }
                         Progress = report.Percentage.Value;
@@ -263,11 +263,11 @@ public partial class EnhancedLoraSortMainSettingsViewModel : ViewModelBase
             
             if (DeleteEmptySourceFolders)
             {
-                Log("Cleaning up empty folders…", LogSeverity.Info);
+                Log("Cleaning up empty folders\u2026", LogSeverity.Info);
                 await controllerService.DeleteEmptyDirectoriesAsync(BasePath!);
             }
             
-            Log("Finalising…", LogSeverity.Info);
+            Log("Finalising\u2026", LogSeverity.Info);
             
             // Refresh stats after processing
             await RefreshDatabaseStatsAsync();
@@ -279,7 +279,7 @@ public partial class EnhancedLoraSortMainSettingsViewModel : ViewModelBase
         catch (Exception ex)
         {
             Log($"Unexpected error: {ex.Message}", LogSeverity.Error);
-            await ShowDialog("Unexpected error – see log for details.", "Error");
+            await ShowDialog("Unexpected error \u2013 see log for details.", "Error");
         }
         finally
         {


### PR DESCRIPTION
## Summary
Seven files contained a literal U+FFFD replacement character where a dash was intended — including the user-visible captioning backend picker entry `"ComfyUI � Qwen3-VL"`. While fixing those, a strict-UTF8 decode scan of all 814 `.cs` files surfaced the same corruption family in a **second form**: 15 more files carried raw, never-transcoded cp1252 bytes (0x85/0x96/0x97 — ellipsis/en dash/em dash) that are invalid UTF-8.

## Fix (3 commits)
1. All U+FFFD occurrences replaced with the intended characters: string literals get `\uXXXX` escapes (`—` em dash, `–` en dash, `×` for dimension displays like `1920 × 1080`), comments/XML docs get plain ASCII — following the codebase's existing escape convention, since literal non-ASCII is what got corrupted in the first place. The `ComfyUI — Qwen3-VL` DisplayName test was tightened from substring to exact-string so this can't silently regress.
2. All 28 raw cp1252 stray bytes across the remaining 13 files recovered via cp1252 interpretation (the byte value itself disambiguates en vs em dash) and replaced under the same rules, using byte-level splicing that preserves each file's line endings exactly.
3. Recurrence prevention: new root `.editorconfig` scoped to exactly `charset = utf-8` (review-adjusted: no line-ending/final-newline rules that would churn existing files; note 76 files currently carry a BOM — 53 EF migrations + 23 scattered — and will be silently BOM-normalized on next touch, which is accepted).

Verification: strict-UTF8 decode of every `.cs` file in the repo now passes; U+FFFD grep returns zero. Review verified a byte-level sample of both corruption patterns against the base commit and walked every hunk to confirm no functional code changed anywhere (string/comment content only, plus the one authorized test tightening).

## Tests
- RED→GREEN on the exact-DisplayName assertion; 80/80 focused on the 5 touched test files.
- Full unit suite: 2959/2960 (sole failure is the pre-existing #444 disk-space test issue, fixed in PR #445).

**Merge note:** best merged early — several other open PRs touch files whose corrupt bytes this PR fixes (all conflicts would be one-line trivial).

Fixes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)