### PR TITLE
fix(service): propagate caller cancellation from ComfyUI readiness checks

### DIFF
--- a/DiffusionNexus.Domain/Services/ICaptioningBackend.cs
+++ b/DiffusionNexus.Domain/Services/ICaptioningBackend.cs
@@ -7,7 +7,7 @@ namespace DiffusionNexus.Domain.Services;
 public interface ICaptioningBackend
 {
     /// <summary>
-    /// Human-readable name of this backend (e.g. "Local Inference", "ComfyUI – Qwen3-VL").
+    /// Human-readable name of this backend (e.g. "Local Inference", "ComfyUI ï¿½ Qwen3-VL").
     /// </summary>
     string DisplayName { get; }
 
@@ -21,7 +21,7 @@ public interface ICaptioningBackend
     /// <summary>
     /// Non-blocking warnings discovered during <see cref="IsAvailableAsync"/>.
     /// Unlike <see cref="MissingRequirements"/>, warnings do not prevent the backend from
-    /// being used — they inform the user about conditions that may affect the first run
+    /// being used ï¿½ they inform the user about conditions that may affect the first run
     /// (e.g. a large model download that will happen on first execution).
     /// </summary>
     IReadOnlyList<string> Warnings { get; }
@@ -33,10 +33,14 @@ public interface ICaptioningBackend
     /// Implementations should populate <see cref="MissingRequirements"/> when returning <c>false</c>.
     /// </summary>
     /// <remarks>
-    /// Cancellation contract: a cancelled check must propagate as <see cref="OperationCanceledException"/>
-    /// rather than being reported through <see cref="MissingRequirements"/>. The caller cancelling
-    /// is not evidence the backend is unavailable, so implementations must rethrow instead of
-    /// mapping the exception onto a fabricated readiness failure (issue #434).
+    /// Cancellation contract: cancellation requested via the caller's token must propagate as
+    /// <see cref="OperationCanceledException"/> rather than being reported through
+    /// <see cref="MissingRequirements"/>. The caller cancelling is not evidence the backend is
+    /// unavailable, so implementations must rethrow when the caller's token requested the
+    /// cancellation, instead of mapping the exception onto a fabricated readiness failure. An
+    /// <see cref="OperationCanceledException"/> that does not originate from the caller's token
+    /// (e.g. an internal HTTP timeout) is not caller cancellation and must not be rethrown as one
+    /// (issue #434).
     /// </remarks>
     /// <param name="ct">Cancellation token.</param>
     /// <returns><c>true</c> if the backend can accept captioning requests.</returns>
@@ -49,7 +53,7 @@ public interface ICaptioningBackend
     /// <param name="prompt">The prompt/instruction to guide caption generation.</param>
     /// <param name="triggerWord">Optional token to prepend to the generated caption.</param>
     /// <param name="blacklistedWords">Words to remove from the generated caption.</param>
-    /// <param name="temperature">Inference temperature (0.0–2.0). Lower values are more deterministic.</param>
+    /// <param name="temperature">Inference temperature (0.0ï¿½2.0). Lower values are more deterministic.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The captioning result.</returns>
     Task<CaptioningResult> GenerateSingleCaptionAsync(

--- a/DiffusionNexus.Domain/Services/ICaptioningBackend.cs
+++ b/DiffusionNexus.Domain/Services/ICaptioningBackend.cs
@@ -32,6 +32,12 @@ public interface ICaptioningBackend
     /// For ComfyUI this means the server is reachable and all required custom nodes are installed.
     /// Implementations should populate <see cref="MissingRequirements"/> when returning <c>false</c>.
     /// </summary>
+    /// <remarks>
+    /// Cancellation contract: a cancelled check must propagate as <see cref="OperationCanceledException"/>
+    /// rather than being reported through <see cref="MissingRequirements"/>. The caller cancelling
+    /// is not evidence the backend is unavailable, so implementations must rethrow instead of
+    /// mapping the exception onto a fabricated readiness failure (issue #434).
+    /// </remarks>
     /// <param name="ct">Cancellation token.</param>
     /// <returns><c>true</c> if the backend can accept captioning requests.</returns>
     Task<bool> IsAvailableAsync(CancellationToken ct = default);

--- a/DiffusionNexus.Domain/Services/IFeatureBackend.cs
+++ b/DiffusionNexus.Domain/Services/IFeatureBackend.cs
@@ -21,10 +21,14 @@ public interface IFeatureBackend
     /// Checks whether the given feature is ready to execute on this backend.
     /// </summary>
     /// <remarks>
-    /// Cancellation contract: a cancelled check must propagate as <see cref="OperationCanceledException"/>
-    /// rather than being reported through <see cref="FeatureReadinessResult.MissingRequirements"/>.
-    /// The caller cancelling is not evidence the backend is unavailable, so implementations must
-    /// rethrow instead of mapping the exception onto a fabricated readiness failure (issue #434).
+    /// Cancellation contract: cancellation requested via the caller's token must propagate as
+    /// <see cref="OperationCanceledException"/> rather than being reported through
+    /// <see cref="FeatureReadinessResult.MissingRequirements"/>. The caller cancelling is not
+    /// evidence the backend is unavailable, so implementations must rethrow when the caller's
+    /// token requested the cancellation, instead of mapping the exception onto a fabricated
+    /// readiness failure. An <see cref="OperationCanceledException"/> that does not originate
+    /// from the caller's token (e.g. an internal HTTP timeout) is not caller cancellation and
+    /// must not be rethrown as one (issue #434).
     /// </remarks>
     /// <param name="feature">The feature to check.</param>
     /// <param name="ct">Cancellation token.</param>

--- a/DiffusionNexus.Domain/Services/IFeatureBackend.cs
+++ b/DiffusionNexus.Domain/Services/IFeatureBackend.cs
@@ -20,6 +20,12 @@ public interface IFeatureBackend
     /// <summary>
     /// Checks whether the given feature is ready to execute on this backend.
     /// </summary>
+    /// <remarks>
+    /// Cancellation contract: a cancelled check must propagate as <see cref="OperationCanceledException"/>
+    /// rather than being reported through <see cref="FeatureReadinessResult.MissingRequirements"/>.
+    /// The caller cancelling is not evidence the backend is unavailable, so implementations must
+    /// rethrow instead of mapping the exception onto a fabricated readiness failure (issue #434).
+    /// </remarks>
     /// <param name="feature">The feature to check.</param>
     /// <param name="ct">Cancellation token.</param>
     Task<FeatureReadinessResult> CheckFeatureAsync(Feature feature, CancellationToken ct = default);

--- a/DiffusionNexus.Domain/Services/IFeatureReadinessService.cs
+++ b/DiffusionNexus.Domain/Services/IFeatureReadinessService.cs
@@ -15,10 +15,11 @@ public interface IFeatureReadinessService
     /// selected backend.
     /// </summary>
     /// <remarks>
-    /// Cancellation contract: a cancelled check propagates as <see cref="OperationCanceledException"/>
-    /// rather than being reported through <see cref="FeatureReadinessResult.MissingRequirements"/>,
-    /// because this delegates straight to the resolved <see cref="IFeatureBackend.CheckFeatureAsync"/>
-    /// (issue #434).
+    /// Cancellation contract: cancellation requested via the caller's token propagates as
+    /// <see cref="OperationCanceledException"/> rather than being reported through
+    /// <see cref="FeatureReadinessResult.MissingRequirements"/>, because this delegates straight
+    /// to the resolved <see cref="IFeatureBackend.CheckFeatureAsync"/>, which carries the same
+    /// caller-token-only contract (issue #434).
     /// </remarks>
     Task<FeatureReadinessResult> CheckAsync(Feature feature, CancellationToken ct = default);
 

--- a/DiffusionNexus.Domain/Services/IFeatureReadinessService.cs
+++ b/DiffusionNexus.Domain/Services/IFeatureReadinessService.cs
@@ -14,6 +14,12 @@ public interface IFeatureReadinessService
     /// Checks whether <paramref name="feature"/> is ready to execute on its currently
     /// selected backend.
     /// </summary>
+    /// <remarks>
+    /// Cancellation contract: a cancelled check propagates as <see cref="OperationCanceledException"/>
+    /// rather than being reported through <see cref="FeatureReadinessResult.MissingRequirements"/>,
+    /// because this delegates straight to the resolved <see cref="IFeatureBackend.CheckFeatureAsync"/>
+    /// (issue #434).
+    /// </remarks>
     Task<FeatureReadinessResult> CheckAsync(Feature feature, CancellationToken ct = default);
 
     /// <summary>

--- a/DiffusionNexus.Inference/Abstractions/IDiffusionBackend.cs
+++ b/DiffusionNexus.Inference/Abstractions/IDiffusionBackend.cs
@@ -49,10 +49,14 @@ public interface IDiffusionBackend
     /// Implementations should populate <see cref="MissingRequirements"/> on a <c>false</c> result.
     /// </summary>
     /// <remarks>
-    /// Cancellation contract: a cancelled check must propagate as <see cref="OperationCanceledException"/>
-    /// rather than being reported through <see cref="MissingRequirements"/>. The caller cancelling
-    /// is not evidence the backend is unavailable, so implementations must rethrow instead of
-    /// mapping the exception onto a fabricated readiness failure (issue #434).
+    /// Cancellation contract: cancellation requested via the caller's token must propagate as
+    /// <see cref="OperationCanceledException"/> rather than being reported through
+    /// <see cref="MissingRequirements"/>. The caller cancelling is not evidence the backend is
+    /// unavailable, so implementations must rethrow when the caller's token requested the
+    /// cancellation, instead of mapping the exception onto a fabricated readiness failure. An
+    /// <see cref="OperationCanceledException"/> that does not originate from the caller's token
+    /// (e.g. an internal HTTP timeout) is not caller cancellation and must not be rethrown as one
+    /// (issue #434).
     /// </remarks>
     Task<bool> IsAvailableAsync(CancellationToken ct = default);
 

--- a/DiffusionNexus.Inference/Abstractions/IDiffusionBackend.cs
+++ b/DiffusionNexus.Inference/Abstractions/IDiffusionBackend.cs
@@ -48,6 +48,12 @@ public interface IDiffusionBackend
     /// Checks whether this diffusion backend is currently available and ready to generate.
     /// Implementations should populate <see cref="MissingRequirements"/> on a <c>false</c> result.
     /// </summary>
+    /// <remarks>
+    /// Cancellation contract: a cancelled check must propagate as <see cref="OperationCanceledException"/>
+    /// rather than being reported through <see cref="MissingRequirements"/>. The caller cancelling
+    /// is not evidence the backend is unavailable, so implementations must rethrow instead of
+    /// mapping the exception onto a fabricated readiness failure (issue #434).
+    /// </remarks>
     Task<bool> IsAvailableAsync(CancellationToken ct = default);
 
     /// <summary>

--- a/DiffusionNexus.Service/Services/ComfyUICaptioningBackend.cs
+++ b/DiffusionNexus.Service/Services/ComfyUICaptioningBackend.cs
@@ -59,6 +59,12 @@ public sealed class ComfyUICaptioningBackend : ICaptioningBackend
 
             return result.IsReady;
         }
+        catch (OperationCanceledException)
+        {
+            // Cancellation is the caller's business, not a backend availability problem - do not
+            // report it via MissingRequirements. Matches LocalInferenceFeatureBackend (#434).
+            throw;
+        }
         catch (Exception ex)
         {
             Logger.Warning(ex, "Unified readiness check failed for Captioning");

--- a/DiffusionNexus.Service/Services/ComfyUIFeatureBackend.cs
+++ b/DiffusionNexus.Service/Services/ComfyUIFeatureBackend.cs
@@ -170,15 +170,13 @@ public sealed class ComfyUIFeatureBackend : IFeatureBackend
             using var response = await httpClient.GetAsync($"{serverUrl}/system_stats", ct);
             return response.IsSuccessStatusCode;
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
-            // NOTE: HttpClient.Timeout also throws OperationCanceledException (a TaskCanceledException
-            // whose CancellationToken is an internal linked token, not necessarily `ct`), so a slow
-            // ComfyUI server can now surface as an unhandled cancellation instead of "server not
-            // reachable". LocalInferenceFeatureBackend rethrows every OperationCanceledException
-            // unconditionally with no such distinction, so this mirrors that discipline for
-            // consistency across IFeatureBackend implementations (#434) rather than special-casing
-            // the timeout here.
+            // Only rethrow when the caller's token requested the cancellation. HttpClient.Timeout
+            // also throws OperationCanceledException (a TaskCanceledException whose CancellationToken
+            // is an internal linked token, not `ct`), so a slow-but-reachable ComfyUI server must
+            // still fall through to "server not reachable" rather than being misreported as a
+            // cancelled check (#434).
             throw;
         }
         catch

--- a/DiffusionNexus.Service/Services/ComfyUIFeatureBackend.cs
+++ b/DiffusionNexus.Service/Services/ComfyUIFeatureBackend.cs
@@ -70,6 +70,12 @@ public sealed class ComfyUIFeatureBackend : IFeatureBackend
         {
             serverUrl = await GetServerUrlAsync(ct);
         }
+        catch (OperationCanceledException)
+        {
+            // Cancellation is the caller's business, not a backend availability problem - do not
+            // report it via MissingRequirements. Matches LocalInferenceFeatureBackend (#434).
+            throw;
+        }
         catch (Exception ex)
         {
             SerilogLogger.Debug(ex, "Failed to resolve ComfyUI server URL for feature {Feature}", feature);
@@ -163,6 +169,17 @@ public sealed class ComfyUIFeatureBackend : IFeatureBackend
             using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
             using var response = await httpClient.GetAsync($"{serverUrl}/system_stats", ct);
             return response.IsSuccessStatusCode;
+        }
+        catch (OperationCanceledException)
+        {
+            // NOTE: HttpClient.Timeout also throws OperationCanceledException (a TaskCanceledException
+            // whose CancellationToken is an internal linked token, not necessarily `ct`), so a slow
+            // ComfyUI server can now surface as an unhandled cancellation instead of "server not
+            // reachable". LocalInferenceFeatureBackend rethrows every OperationCanceledException
+            // unconditionally with no such distinction, so this mirrors that discipline for
+            // consistency across IFeatureBackend implementations (#434) rather than special-casing
+            // the timeout here.
+            throw;
         }
         catch
         {

--- a/DiffusionNexus.Tests/Service/Services/ComfyUICaptioningBackendTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/ComfyUICaptioningBackendTests.cs
@@ -202,7 +202,7 @@ public class ComfyUICaptioningBackendTests
     [Fact]
     public async Task WhenTheReadinessCheckIsCancelledThenTheCancellationPropagatesInsteadOfBecomingABlocker()
     {
-        // Cancellation is the caller's business, not a backend availability problem — swallowing
+        // Cancellation is the caller's business, not a backend availability problem -- swallowing
         // it into MissingRequirements would show the user a bogus "readiness check failed"
         // blocker every time they navigate away. Matches LocalInferenceFeatureBackend (#434).
         _readiness.Setup(r => r.CheckAsync(Feature.Captioning, It.IsAny<CancellationToken>()))

--- a/DiffusionNexus.Tests/Service/Services/ComfyUICaptioningBackendTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/ComfyUICaptioningBackendTests.cs
@@ -200,19 +200,18 @@ public class ComfyUICaptioningBackendTests
     }
 
     [Fact]
-    public async Task WhenTheReadinessCheckIsCancelledThenTheCancellationIsAlsoMappedNotRethrown()
+    public async Task WhenTheReadinessCheckIsCancelledThenTheCancellationPropagatesInsteadOfBecomingABlocker()
     {
-        // The catch-all deliberately has no OperationCanceledException escape hatch, so a
-        // cancelled check surfaces as "not available" rather than tearing down the caller.
+        // Cancellation is the caller's business, not a backend availability problem — swallowing
+        // it into MissingRequirements would show the user a bogus "readiness check failed"
+        // blocker every time they navigate away. Matches LocalInferenceFeatureBackend (#434).
         _readiness.Setup(r => r.CheckAsync(Feature.Captioning, It.IsAny<CancellationToken>()))
                   .ThrowsAsync(new OperationCanceledException("cancelled"));
         var backend = CreateBackend();
 
-        var available = await backend.IsAvailableAsync();
+        var act = async () => await backend.IsAvailableAsync();
 
-        available.Should().BeFalse();
-        backend.MissingRequirements.Should().ContainSingle()
-            .Which.Should().StartWith("Readiness check failed:");
+        await act.Should().ThrowAsync<OperationCanceledException>();
     }
 
     #endregion

--- a/DiffusionNexus.Tests/Service/Services/ComfyUIFeatureBackendTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/ComfyUIFeatureBackendTests.cs
@@ -129,6 +129,20 @@ public class ComfyUIFeatureBackendTests
         _workloadChecker.Verify(c => c.CheckAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    [Fact]
+    public async Task WhenSettingsLookupIsCancelledThenCancellationPropagatesInsteadOfBackendOffline()
+    {
+        // Same swallow pattern as #434's ComfyUICaptioningBackend bug, just one level down:
+        // a cancelled settings lookup must not be reported as "could not resolve server URL".
+        _settings.Setup(s => s.GetSettingsAsync(It.IsAny<CancellationToken>()))
+                 .ThrowsAsync(new OperationCanceledException("cancelled"));
+        var backend = CreateBackend();
+
+        var act = async () => await backend.CheckFeatureAsync(Feature.Captioning);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
     #endregion
 
     #region Installed-but-not-running (server offline)
@@ -150,6 +164,24 @@ public class ComfyUIFeatureBackendTests
         result.Endpoint.Should().Be(url);
         result.MissingRequirements.Should().ContainSingle()
             .Which.Should().Contain("not reachable").And.Contain(url);
+        _workloadChecker.Verify(c => c.CheckAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task WhenTheHealthCheckIsCancelledThenCancellationPropagatesInsteadOfServerOffline()
+    {
+        // IsServerOnlineAsync's bare catch used to swallow every exception from the live
+        // HttpClient.GetAsync call, including a caller-driven OperationCanceledException, and
+        // report it as "server not reachable". An already-cancelled token must instead surface
+        // as a genuine cancellation (#434).
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        GivenServerUrl(ClosedPortUrl());
+        var backend = CreateBackend();
+
+        var act = async () => await backend.CheckFeatureAsync(Feature.Captioning, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
         _workloadChecker.Verify(c => c.CheckAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 

--- a/DiffusionNexus.Tests/Service/Services/ComfyUIFeatureBackendTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/ComfyUIFeatureBackendTests.cs
@@ -186,6 +186,29 @@ public class ComfyUIFeatureBackendTests
     }
 
     [Fact]
+    public async Task WhenTheHealthCheckHttpClientTimesOutThenTheResultIsOfflineNotCancelled()
+    {
+        // IsServerOnlineAsync's HttpClient carries its own internal 5-second Timeout, completely
+        // independent of the caller's token. That internal timeout also throws
+        // OperationCanceledException (as a TaskCanceledException), so a filter that rethrows
+        // every OperationCanceledException unconditionally would misreport a slow-but-reachable
+        // server as "check cancelled" instead of "server not reachable". The caller's token here
+        // is never cancelled, so this must fall through to the ordinary offline result (#434).
+        using var server = new StallingLoopbackServer();
+        GivenServerUrl(server.Url);
+        GivenWorkloadSummary(fullyInstalled: true);
+        var backend = CreateBackend();
+
+        var result = await backend.CheckFeatureAsync(Feature.Captioning);
+
+        result.IsBackendOnline.Should().BeFalse();
+        result.IsReady.Should().BeFalse();
+        result.MissingRequirements.Should().ContainSingle()
+            .Which.Should().Contain("not reachable");
+        _workloadChecker.Verify(c => c.CheckAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
     public async Task WhenServerAnswersWithAnErrorStatusThenItCountsAsOffline()
     {
         using var server = new LoopbackHttpServer(statusCode: 500, reason: "Internal Server Error");
@@ -460,6 +483,73 @@ public class ComfyUIFeatureBackendTests
             catch
             {
                 // Client vanished or the server is shutting down.
+            }
+        }
+
+        public void Dispose()
+        {
+            _cts.Cancel();
+            try { _listener.Stop(); }
+            catch { /* already stopped */ }
+            _cts.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Loopback listener that accepts the TCP connection and drains the request head, but
+    /// deliberately never writes a response and never closes the connection. This is what
+    /// makes <see cref="HttpClient.Timeout"/> (not the caller's <see cref="CancellationToken"/>)
+    /// fire the cancellation, so tests can pin the distinction between an internal HTTP timeout
+    /// and caller-driven cancellation.
+    /// </summary>
+    private sealed class StallingLoopbackServer : IDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly CancellationTokenSource _cts = new();
+
+        public StallingLoopbackServer()
+        {
+            _listener = new TcpListener(IPAddress.Loopback, 0);
+            _listener.Start();
+            Url = $"http://127.0.0.1:{((IPEndPoint)_listener.LocalEndpoint).Port}";
+            _ = Task.Run(AcceptLoopAsync);
+        }
+
+        public string Url { get; }
+
+        private async Task AcceptLoopAsync()
+        {
+            try
+            {
+                while (!_cts.IsCancellationRequested)
+                {
+                    var client = await _listener.AcceptTcpClientAsync(_cts.Token);
+                    _ = Task.Run(() => HoldConnectionOpenAsync(client));
+                }
+            }
+            catch
+            {
+                // Listener stopped - expected on Dispose.
+            }
+        }
+
+        private async Task HoldConnectionOpenAsync(TcpClient client)
+        {
+            try
+            {
+                using (client)
+                {
+                    var scratch = new byte[4096];
+                    _ = await client.GetStream().ReadAsync(scratch, _cts.Token);
+
+                    // Never respond - hold the connection open until the client's own
+                    // HttpClient.Timeout gives up, or the test disposes the server.
+                    await Task.Delay(Timeout.Infinite, _cts.Token);
+                }
+            }
+            catch
+            {
+                // Client vanished (its HttpClient.Timeout fired) or the server is shutting down.
             }
         }
 


### PR DESCRIPTION
## Summary
`ComfyUICaptioningBackend`'s readiness check caught bare `Exception` — including `OperationCanceledException` — so a user cancelling (navigating away) made the backend report **"unavailable"** with a fabricated `MissingRequirements` entry ("Readiness check failed: The operation was canceled") instead of propagating the cancellation. Its sibling `LocalInferenceFeatureBackend` does the opposite, so two implementations of the same interface disagreed about what cancellation means.

## Fix
- `ComfyUICaptioningBackend.IsAvailableAsync` rethrows caller cancellation before the generic catch.
- Sibling audit (all 5 implementations read): found the same swallow **two levels deeper** in `ComfyUIFeatureBackend` — the actual production callee behind the captioning readiness chain — and fixed both of its catch sites. `StableDiffusionCppBackend` and `LocalInferenceCaptioningBackend` verified clean.
- **Timeout vs. cancel done right:** `IsServerOnlineAsync` uses a 5-second `HttpClient.Timeout`, whose expiry throws a `TaskCanceledException` that is NOT caller cancellation. That catch uses `when (ct.IsCancellationRequested)` — so a slow-but-reachable server still reports "not reachable" instead of a bogus "Check cancelled" (the review traced the full UI chain and confirmed the unconditional form would have shipped exactly the misreporting bug the SDK fixed in cb32239). Pinned by a regression test whose RED evidence was proven by temporarily reverting the filter.
- Cancellation contract now documented on all four readiness interface methods (`<remarks>`, ASCII-only): cancellation requested by the caller's token propagates as `OperationCanceledException` and must never be reported via `MissingRequirements`.

## Tests
- Pinned swallow-test flipped (RED→GREEN); new tests cover cancel-propagates and timeout-stays-offline on both backends (90 lines of new `ComfyUIFeatureBackendTests`).
- Focused: 42/42. Full unit suite: 2963/2963.
- Task-reviewed (spec + quality): initial review returned one Important (the timeout trade-off) with a prescribed fix; fix applied with RED/GREEN evidence and verified against the reviewer's own analysis.

Fixes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)