### PR TITLE
feat(service): pure payload builder + HttpClient seam in ComfyUIWrapperService

### DIFF
--- a/DiffusionNexus.Service/Services/ComfyUIWrapperService.cs
+++ b/DiffusionNexus.Service/Services/ComfyUIWrapperService.cs
@@ -17,31 +17,93 @@ public sealed class ComfyUIWrapperService : IComfyUIWrapperService
     private const string Qwen3VlWorkflowFileName = "Assets/Workflows/Qwen-3VL-autocaption.json";
     private const string LoadImageNodeId = "100";
     private const string Qwen3VqaNodeId = "705";
+    private const string DefaultBaseUrl = "http://127.0.0.1:8188";
 
     private static readonly ILogger Logger = Log.ForContext<ComfyUIWrapperService>();
 
     private readonly HttpClient _httpClient;
+    private readonly bool _disposeHttpClient;
     private readonly string _baseUrl;
     private readonly string _clientId;
     private bool _disposed;
 
     /// <summary>
-    /// Creates a new ComfyUIWrapperService targeting the specified ComfyUI server.
+    /// Creates a new ComfyUIWrapperService targeting the specified ComfyUI server using an
+    /// internally-owned <see cref="HttpClient"/>.
     /// </summary>
     /// <param name="baseUrl">
     /// Base URL of the ComfyUI server (e.g. <c>http://127.0.0.1:8188</c>).
     /// </param>
-    public ComfyUIWrapperService(string baseUrl = "http://127.0.0.1:8188")
+    /// <remarks>
+    /// This convenience overload constructs (and owns) a default <see cref="HttpClient"/>
+    /// configured with a 10-minute timeout. It delegates to the
+    /// <see cref="ComfyUIWrapperService(HttpClient, string, bool)"/> seam so production call
+    /// sites remain unchanged while tests can inject a stub <see cref="HttpMessageHandler"/>.
+    /// </remarks>
+    public ComfyUIWrapperService(string baseUrl = DefaultBaseUrl)
+        : this(CreateDefaultHttpClient(baseUrl), baseUrl, disposeHttpClient: true)
     {
+    }
+
+    /// <summary>
+    /// Creates a new ComfyUIWrapperService driven by a caller-supplied <see cref="HttpClient"/>.
+    /// This is the testable seam: pass an <see cref="HttpClient"/> backed by a stub
+    /// <see cref="HttpMessageHandler"/> to exercise the HTTP paths without a live server.
+    /// </summary>
+    /// <param name="httpClient">The HTTP client used for all ComfyUI REST calls.</param>
+    /// <param name="baseUrl">
+    /// Base URL of the ComfyUI server. Still required even when <paramref name="httpClient"/>
+    /// is injected, because it derives the WebSocket URL and the image <c>/view</c> URLs.
+    /// </param>
+    /// <param name="disposeHttpClient">
+    /// When <c>true</c>, <see cref="Dispose"/> disposes <paramref name="httpClient"/>.
+    /// Defaults to <c>false</c> so externally-owned clients (e.g. from HttpClientFactory) survive.
+    /// </param>
+    public ComfyUIWrapperService(
+        HttpClient httpClient,
+        string baseUrl = DefaultBaseUrl,
+        bool disposeHttpClient = false)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
         ArgumentException.ThrowIfNullOrWhiteSpace(baseUrl);
 
         _baseUrl = baseUrl.TrimEnd('/');
         _clientId = Guid.NewGuid().ToString();
-        _httpClient = new HttpClient
+        _httpClient = httpClient;
+        _disposeHttpClient = disposeHttpClient;
+
+        TryConfigureBaseAddress(_httpClient, _baseUrl);
+    }
+
+    private static HttpClient CreateDefaultHttpClient(string baseUrl)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(baseUrl);
+
+        return new HttpClient
         {
-            BaseAddress = new Uri(_baseUrl),
+            BaseAddress = new Uri(baseUrl.TrimEnd('/')),
             Timeout = TimeSpan.FromMinutes(10) // VL models can be slow
         };
+    }
+
+    private static void TryConfigureBaseAddress(HttpClient client, string baseUrl)
+    {
+        // Relative request URIs (e.g. "/prompt") only resolve when a BaseAddress is set.
+        // An injected client may not have one; a default (or already-used) client will.
+        // HttpClient throws if BaseAddress is mutated after the first request, so guard it.
+        if (client.BaseAddress is not null)
+        {
+            return;
+        }
+
+        try
+        {
+            client.BaseAddress = new Uri(baseUrl);
+        }
+        catch (InvalidOperationException)
+        {
+            // Client has already been used - the caller owns the BaseAddress.
+        }
     }
 
     /// <inheritdoc />
@@ -89,39 +151,11 @@ public sealed class ComfyUIWrapperService : IComfyUIWrapperService
         var workflow = JsonNode.Parse(workflowText)
                        ?? throw new InvalidOperationException($"Failed to parse workflow JSON from {workflowJsonPath}.");
 
-        // Apply caller-supplied modifications to individual nodes
-        foreach (var (nodeId, modifier) in nodeModifiers)
-        {
-            var node = workflow[nodeId];
-            if (node is not null)
-            {
-                modifier(node);
-            }
-            else
-            {
-                Logger.Warning("Node {NodeId} not found in workflow; skipping modifier", nodeId);
-            }
-        }
-
-        var payload = new JsonObject
-        {
-            ["prompt"] = workflow,
-            ["client_id"] = _clientId,
-            ["extra_data"] = new JsonObject
-            {
-                ["extra_pnginfo"] = new JsonObject
-                {
-                    ["workflow"] = new JsonObject
-                    {
-                        // Required by comfyui_queue_manager plugin (qm_queue.py lines 221-222)
-                        ["workflow_name"] = "DiffusionNexus",
-                        ["id"] = _clientId,
-                        // Required by ShowText|pysssss node (show_text.py line 34)
-                        ["nodes"] = new JsonArray()
-                    }
-                }
-            }
-        };
+        var payload = BuildPromptPayload(
+            workflow,
+            nodeModifiers,
+            _clientId,
+            nodeId => Logger.Warning("Node {NodeId} not found in workflow; skipping modifier", nodeId));
 
         var content = new StringContent(
             payload.ToJsonString(),
@@ -171,40 +205,82 @@ public sealed class ComfyUIWrapperService : IComfyUIWrapperService
                 continue;
             }
 
-            var json = JsonNode.Parse(msg);
-            var type = json?["type"]?.GetValue<string>();
+            var parsed = ParseProgressMessage(msg, promptId);
 
-            Logger.Debug("WebSocket event: {EventType} for prompt {PromptId}", type, promptId);
+            Logger.Debug("WebSocket event: {EventType} for prompt {PromptId}", parsed.Type, promptId);
 
-            // Detect execution errors and propagate them
-            if (type is "execution_error")
+            switch (parsed.Action)
             {
-                var errorData = json?["data"];
-                var errorPromptId = errorData?["prompt_id"]?.GetValue<string>();
+                case ComfyUIProgressAction.Error:
+                    Logger.Error(
+                        "ComfyUI execution error in node {NodeType}: {Error}",
+                        parsed.ErrorNodeType,
+                        parsed.ErrorDetail);
+                    throw new InvalidOperationException(parsed.ExecutionErrorMessage);
+
+                case ComfyUIProgressAction.Completed:
+                    Logger.Information("Workflow execution completed for prompt {PromptId}", promptId);
+                    return;
+
+                case ComfyUIProgressAction.Report:
+                    progress?.Report(parsed.ReportText!);
+                    break;
+
+                case ComfyUIProgressAction.None:
+                default:
+                    if (parsed.QueueRemaining.HasValue)
+                    {
+                        Logger.Debug("Queue remaining: {QueueRemaining}", parsed.QueueRemaining.Value);
+                    }
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Pure parser for the ComfyUI WebSocket progress protocol. Given a single text frame and
+    /// the prompt being awaited, decides what the caller should do without performing any I/O.
+    /// Preserves the exact behavior of the previous inline loop, including which events are
+    /// ignored (unknown types, events for a different prompt, zero-max progress).
+    /// </summary>
+    /// <param name="message">The raw WebSocket text frame (a JSON document).</param>
+    /// <param name="promptId">The prompt ID currently being awaited.</param>
+    /// <returns>A <see cref="ComfyUIProgressMessage"/> describing the decoded event.</returns>
+    internal static ComfyUIProgressMessage ParseProgressMessage(string message, string promptId)
+    {
+        var json = JsonNode.Parse(message);
+        var type = json?["type"]?.GetValue<string>();
+
+        switch (type)
+        {
+            case "execution_error":
+            {
+                var data = json?["data"];
+                var errorPromptId = data?["prompt_id"]?.GetValue<string>();
                 if (errorPromptId == promptId)
                 {
-                    var nodeType = errorData?["node_type"]?.GetValue<string>() ?? "unknown";
-                    var errorMsg = errorData?["exception_message"]?.GetValue<string>() ?? "Unknown execution error";
-                    Logger.Error("ComfyUI execution error in node {NodeType}: {Error}", nodeType, errorMsg);
-                    throw new InvalidOperationException(
-                        $"ComfyUI workflow failed in node '{nodeType}': {errorMsg}");
+                    var nodeType = data?["node_type"]?.GetValue<string>() ?? "unknown";
+                    var detail = data?["exception_message"]?.GetValue<string>() ?? "Unknown execution error";
+                    return new ComfyUIProgressMessage(
+                        ComfyUIProgressAction.Error, type, ErrorNodeType: nodeType, ErrorDetail: detail);
                 }
+
+                return new ComfyUIProgressMessage(ComfyUIProgressAction.None, type);
             }
 
-            if (type is "executing")
+            case "executing":
             {
                 var data = json?["data"];
                 var nodeId = data?["node"]?.GetValue<string>();
                 var currentPromptId = data?["prompt_id"]?.GetValue<string>();
 
-                // node == null means execution finished for this prompt
+                // node == null means execution finished for this prompt.
                 if (nodeId is null && currentPromptId == promptId)
                 {
-                    Logger.Information("Workflow execution completed for prompt {PromptId}", promptId);
-                    return;
+                    return new ComfyUIProgressMessage(ComfyUIProgressAction.Completed, type);
                 }
 
-                // Report which node is currently executing
+                // Report which node is currently executing.
                 if (currentPromptId == promptId && nodeId is not null)
                 {
                     var nodeLabel = nodeId switch
@@ -213,34 +289,34 @@ public sealed class ComfyUIWrapperService : IComfyUIWrapperService
                         LoadImageNodeId => "Loading image...",
                         _ => $"Executing node {nodeId}..."
                     };
-                    progress?.Report(nodeLabel);
+                    return new ComfyUIProgressMessage(ComfyUIProgressAction.Report, type, ReportText: nodeLabel);
                 }
 
-                continue;
+                return new ComfyUIProgressMessage(ComfyUIProgressAction.None, type);
             }
 
-            // Forward progress events (e.g. model loading steps reported by ComfyUI)
-            if (type is "progress")
+            case "progress":
             {
                 var data = json?["data"];
                 var value = data?["value"]?.GetValue<int>() ?? 0;
                 var max = data?["max"]?.GetValue<int>() ?? 0;
                 if (max > 0)
                 {
-                    progress?.Report($"Progress: {value}/{max}");
+                    return new ComfyUIProgressMessage(
+                        ComfyUIProgressAction.Report, type, ReportText: $"Progress: {value}/{max}");
                 }
-                continue;
+
+                return new ComfyUIProgressMessage(ComfyUIProgressAction.None, type);
             }
 
-            // Forward status events
-            if (type is "status")
+            case "status":
             {
                 var queueRemaining = json?["data"]?["status"]?["exec_info"]?["queue_remaining"]?.GetValue<int>();
-                if (queueRemaining.HasValue)
-                {
-                    Logger.Debug("Queue remaining: {QueueRemaining}", queueRemaining.Value);
-                }
+                return new ComfyUIProgressMessage(ComfyUIProgressAction.None, type, QueueRemaining: queueRemaining);
             }
+
+            default:
+                return new ComfyUIProgressMessage(ComfyUIProgressAction.None, type);
         }
     }
 
@@ -294,22 +370,15 @@ public sealed class ComfyUIWrapperService : IComfyUIWrapperService
                    ?? throw new InvalidOperationException("ComfyUI returned an unparseable /history response.");
 
         var outputs = json[promptId]?["outputs"];
-        var comfyResult = new ComfyUIResult();
 
-        if (outputs is not JsonObject outputNodes)
+        if (outputs is not JsonObject)
         {
             Logger.Warning("No outputs found for prompt {PromptId}. Raw history: {History}",
                 promptId, historyText.Length > 2000 ? historyText[..2000] + "..." : historyText);
-            return comfyResult;
+            return new ComfyUIResult();
         }
 
-        foreach (var (nodeId, nodeOutput) in outputNodes)
-        {
-            Logger.Debug("Processing output for node {NodeId}: {Keys}",
-                nodeId, nodeOutput is JsonObject obj ? string.Join(", ", obj.Select(kv => kv.Key)) : "null");
-            ExtractTextOutputs(nodeOutput, comfyResult);
-            ExtractImageOutputs(nodeOutput, comfyResult);
-        }
+        var comfyResult = ParseHistoryOutputs(json, promptId, _baseUrl);
 
         if (comfyResult.Texts.Count == 0 && comfyResult.Images.Count == 0)
         {
@@ -539,11 +608,104 @@ public sealed class ComfyUIWrapperService : IComfyUIWrapperService
             return;
         }
 
-        _httpClient.Dispose();
+        if (_disposeHttpClient)
+        {
+            _httpClient.Dispose();
+        }
+
         _disposed = true;
     }
 
-    private void ExtractTextOutputs(JsonNode? nodeOutput, ComfyUIResult result)
+    /// <summary>
+    /// Pure builder for the ComfyUI <c>/prompt</c> request envelope. Applies the caller-supplied
+    /// per-node modifiers to the workflow, then wraps it in the exact JSON shape ComfyUI and its
+    /// plugins expect. Performs no I/O.
+    /// </summary>
+    /// <param name="workflow">The parsed API-format workflow (mutated in place by the modifiers).</param>
+    /// <param name="nodeModifiers">Node ID to mutation action. Missing nodes are skipped.</param>
+    /// <param name="clientId">The client ID; echoed as <c>client_id</c> and <c>extra_pnginfo.workflow.id</c>.</param>
+    /// <param name="onNodeNotFound">
+    /// Optional callback invoked with the node ID whenever a modifier targets a node absent from
+    /// the workflow. Kept as a callback so this function stays pure (the caller does the logging).
+    /// </param>
+    /// <returns>The <c>/prompt</c> payload envelope.</returns>
+    /// <remarks>
+    /// The <c>extra_data.extra_pnginfo.workflow</c> block encodes two <b>undocumented,
+    /// reverse-engineered</b> contracts. Changing these bytes will silently break queuing:
+    /// <list type="bullet">
+    /// <item><c>workflow_name</c> + <c>id</c> are required by the comfyui_queue_manager plugin
+    /// (qm_queue.py lines 221-222).</item>
+    /// <item><c>nodes</c> (an empty array) is required by the ShowText|pysssss node
+    /// (show_text.py line 34).</item>
+    /// </list>
+    /// </remarks>
+    internal static JsonObject BuildPromptPayload(
+        JsonNode workflow,
+        IReadOnlyDictionary<string, Action<JsonNode>> nodeModifiers,
+        string clientId,
+        Action<string>? onNodeNotFound = null)
+    {
+        // Apply caller-supplied modifications to individual nodes.
+        foreach (var (nodeId, modifier) in nodeModifiers)
+        {
+            var node = workflow[nodeId];
+            if (node is not null)
+            {
+                modifier(node);
+            }
+            else
+            {
+                onNodeNotFound?.Invoke(nodeId);
+            }
+        }
+
+        return new JsonObject
+        {
+            ["prompt"] = workflow,
+            ["client_id"] = clientId,
+            ["extra_data"] = new JsonObject
+            {
+                ["extra_pnginfo"] = new JsonObject
+                {
+                    ["workflow"] = new JsonObject
+                    {
+                        // Required by comfyui_queue_manager plugin (qm_queue.py lines 221-222)
+                        ["workflow_name"] = "DiffusionNexus",
+                        ["id"] = clientId,
+                        // Required by ShowText|pysssss node (show_text.py line 34)
+                        ["nodes"] = new JsonArray()
+                    }
+                }
+            }
+        };
+    }
+
+    /// <summary>
+    /// Pure parser for a ComfyUI <c>/history/{promptId}</c> document. Extracts all text and image
+    /// outputs for the given prompt into a <see cref="ComfyUIResult"/>. Performs no I/O.
+    /// </summary>
+    /// <param name="historyJson">The parsed <c>/history</c> response.</param>
+    /// <param name="promptId">The prompt whose outputs to extract.</param>
+    /// <param name="baseUrl">Base URL used to build image <c>/view</c> URLs.</param>
+    internal static ComfyUIResult ParseHistoryOutputs(JsonNode? historyJson, string promptId, string baseUrl)
+    {
+        var result = new ComfyUIResult();
+
+        if (historyJson?[promptId]?["outputs"] is not JsonObject outputNodes)
+        {
+            return result;
+        }
+
+        foreach (var (_, nodeOutput) in outputNodes)
+        {
+            ExtractTextOutputs(nodeOutput, result);
+            ExtractImageOutputs(nodeOutput, baseUrl, result);
+        }
+
+        return result;
+    }
+
+    internal static void ExtractTextOutputs(JsonNode? nodeOutput, ComfyUIResult result)
     {
         if (nodeOutput?["text"] is not JsonArray textArray)
         {
@@ -576,7 +738,7 @@ public sealed class ComfyUIWrapperService : IComfyUIWrapperService
         }
     }
 
-    private void ExtractImageOutputs(JsonNode? nodeOutput, ComfyUIResult result)
+    internal static void ExtractImageOutputs(JsonNode? nodeOutput, string baseUrl, ComfyUIResult result)
     {
         if (nodeOutput?["images"] is not JsonArray imageArray)
         {
@@ -603,7 +765,46 @@ public sealed class ComfyUIWrapperService : IComfyUIWrapperService
                 Filename: filename,
                 Subfolder: subfolder,
                 Type: type,
-                Url: $"{_baseUrl}/view?filename={Uri.EscapeDataString(filename)}&subfolder={Uri.EscapeDataString(subfolder)}&type={Uri.EscapeDataString(type)}"));
+                Url: $"{baseUrl}/view?filename={Uri.EscapeDataString(filename)}&subfolder={Uri.EscapeDataString(subfolder)}&type={Uri.EscapeDataString(type)}"));
         }
     }
+}
+
+/// <summary>
+/// The decoded meaning of a single ComfyUI WebSocket progress frame, produced by
+/// <see cref="ComfyUIWrapperService.ParseProgressMessage"/>.
+/// </summary>
+internal enum ComfyUIProgressAction
+{
+    /// <summary>Nothing to do (unknown type, an event for another prompt, idle status, etc.).</summary>
+    None = 0,
+
+    /// <summary>Report <see cref="ComfyUIProgressMessage.ReportText"/> to the progress reporter.</summary>
+    Report,
+
+    /// <summary>Execution finished for the awaited prompt; the wait should complete.</summary>
+    Completed,
+
+    /// <summary>An execution error occurred for the awaited prompt; the wait should throw.</summary>
+    Error
+}
+
+/// <summary>
+/// A decoded ComfyUI WebSocket progress frame. Immutable value describing what the caller
+/// should do, keeping <see cref="ComfyUIWrapperService.ParseProgressMessage"/> free of I/O.
+/// </summary>
+internal readonly record struct ComfyUIProgressMessage(
+    ComfyUIProgressAction Action,
+    string? Type = null,
+    string? ReportText = null,
+    string? ErrorNodeType = null,
+    string? ErrorDetail = null,
+    int? QueueRemaining = null)
+{
+    /// <summary>
+    /// The exception message to surface when <see cref="Action"/> is
+    /// <see cref="ComfyUIProgressAction.Error"/>. Preserves the historical wording exactly.
+    /// </summary>
+    public string ExecutionErrorMessage =>
+        $"ComfyUI workflow failed in node '{ErrorNodeType}': {ErrorDetail}";
 }

--- a/DiffusionNexus.Tests/Service/Services/ComfyUIWrapperServiceTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/ComfyUIWrapperServiceTests.cs
@@ -1,0 +1,592 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using DiffusionNexus.Domain.Services;
+using DiffusionNexus.Service.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace DiffusionNexus.Tests.Service.Services;
+
+/// <summary>
+/// Unit tests for <see cref="ComfyUIWrapperService"/>.
+///
+/// <para>
+/// This service underpins every ComfyUI feature (captioning, inpaint, upscale, outpaint)
+/// yet shipped with zero tests (issue #440). The highest-value logic is the
+/// workflow/payload envelope construction, which encodes <b>undocumented</b> contracts with
+/// the <c>comfyui_queue_manager</c> and <c>ShowText|pysssss</c> plugins: those exact JSON
+/// bytes ARE the spec. The tests below pin the byte shape so a silent contract drift fails
+/// loudly. WebSocket progress-protocol parsing and history/result parsing are pinned the
+/// same way, and the HTTP paths are driven through an injected fake handler
+/// (the <c>FakeHttpHandler</c> pattern from <c>CivitaiClientTests</c>).
+/// </para>
+/// </summary>
+public class ComfyUIWrapperServiceTests
+{
+    private const string BaseUrl = "http://127.0.0.1:8188";
+
+    // Node IDs are private consts on the service; mirror them here so the label-mapping
+    // contract is asserted against literal wire values, not against the implementation.
+    private const string LoadImageNodeId = "100";
+    private const string Qwen3VqaNodeId = "705";
+
+    private static (ComfyUIWrapperService sut, FakeHttpHandler handler) CreateService(
+        Func<HttpRequestMessage, HttpResponseMessage> responder,
+        string baseUrl = BaseUrl)
+    {
+        var handler = new FakeHttpHandler(responder);
+        var http = new HttpClient(handler);
+        return (new ComfyUIWrapperService(http, baseUrl, disposeHttpClient: true), handler);
+    }
+
+    private static HttpResponseMessage Json(HttpStatusCode status, string body) =>
+        new(status) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+    // ---------------------------------------------------------------------------------
+    // Item 1: BuildPromptPayload - the undocumented plugin-contract envelope (:106-124)
+    // ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void BuildPromptPayload_ProducesExactEnvelopeBytes()
+    {
+        var workflow = JsonNode.Parse("""{"100":{"inputs":{"image":"x.png"}}}""")!;
+
+        var payload = ComfyUIWrapperService.BuildPromptPayload(
+            workflow,
+            new Dictionary<string, Action<JsonNode>>(),
+            "cid-123");
+
+        // These exact bytes are the reverse-engineered contract with comfyui_queue_manager
+        // (workflow_name + id) and ShowText|pysssss (nodes[]). Do NOT loosen this assertion.
+        payload.ToJsonString().Should().Be(
+            "{\"prompt\":{\"100\":{\"inputs\":{\"image\":\"x.png\"}}}," +
+            "\"client_id\":\"cid-123\"," +
+            "\"extra_data\":{\"extra_pnginfo\":{\"workflow\":{" +
+            "\"workflow_name\":\"DiffusionNexus\"," +
+            "\"id\":\"cid-123\"," +
+            "\"nodes\":[]}}}}");
+    }
+
+    [Fact]
+    public void BuildPromptPayload_SetsPromptClientIdWorkflowNameAndNodes()
+    {
+        var workflow = JsonNode.Parse("""{"1":{"a":1}}""")!;
+
+        var payload = ComfyUIWrapperService.BuildPromptPayload(
+            workflow, new Dictionary<string, Action<JsonNode>>(), "the-client-id");
+
+        payload["prompt"]!["1"]!["a"]!.GetValue<int>().Should().Be(1);
+        payload["client_id"]!.GetValue<string>().Should().Be("the-client-id");
+
+        var inner = payload["extra_data"]!["extra_pnginfo"]!["workflow"]!;
+        inner["workflow_name"]!.GetValue<string>().Should().Be("DiffusionNexus");
+        inner["id"]!.GetValue<string>().Should().Be("the-client-id");
+        inner["nodes"].Should().BeOfType<JsonArray>();
+        ((JsonArray)inner["nodes"]!).Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void BuildPromptPayload_AppliesModifiersToMatchingNodes()
+    {
+        var workflow = JsonNode.Parse("""{"100":{"inputs":{"image":"old.png"}}}""")!;
+
+        var payload = ComfyUIWrapperService.BuildPromptPayload(
+            workflow,
+            new Dictionary<string, Action<JsonNode>>
+            {
+                ["100"] = n => n["inputs"]!["image"] = "new.png"
+            },
+            "cid");
+
+        payload["prompt"]!["100"]!["inputs"]!["image"]!.GetValue<string>().Should().Be("new.png");
+    }
+
+    [Fact]
+    public void BuildPromptPayload_MissingNode_SkipsModifierAndInvokesCallback()
+    {
+        var workflow = JsonNode.Parse("""{"100":{"inputs":{}}}""")!;
+        var notFound = new List<string>();
+
+        var payload = ComfyUIWrapperService.BuildPromptPayload(
+            workflow,
+            new Dictionary<string, Action<JsonNode>>
+            {
+                // Must NOT run because node 999 does not exist.
+                ["999"] = _ => throw new InvalidOperationException("modifier for missing node ran")
+            },
+            "cid",
+            notFound.Add);
+
+        notFound.Should().ContainSingle().Which.Should().Be("999");
+        payload.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void BuildPromptPayload_MissingNode_WithNoCallback_DoesNotThrow()
+    {
+        var workflow = JsonNode.Parse("""{"100":{}}""")!;
+
+        var act = () => ComfyUIWrapperService.BuildPromptPayload(
+            workflow,
+            new Dictionary<string, Action<JsonNode>> { ["nope"] = _ => { } },
+            "cid");
+
+        act.Should().NotThrow();
+    }
+
+    // ---------------------------------------------------------------------------------
+    // Item 3: ParseProgressMessage - WebSocket progress protocol (:147-281)
+    // ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void ParseProgressMessage_ExecutionError_MatchingPrompt_YieldsError()
+    {
+        const string json = """
+            {"type":"execution_error","data":{"prompt_id":"p1","node_type":"Qwen3_VQA","exception_message":"boom"}}
+            """;
+
+        var result = ComfyUIWrapperService.ParseProgressMessage(json, "p1");
+
+        result.Action.Should().Be(ComfyUIProgressAction.Error);
+        result.ErrorNodeType.Should().Be("Qwen3_VQA");
+        result.ErrorDetail.Should().Be("boom");
+        result.ExecutionErrorMessage.Should().Be("ComfyUI workflow failed in node 'Qwen3_VQA': boom");
+    }
+
+    [Fact]
+    public void ParseProgressMessage_ExecutionError_MissingFields_UsesDefaults()
+    {
+        const string json = """{"type":"execution_error","data":{"prompt_id":"p1"}}""";
+
+        var result = ComfyUIWrapperService.ParseProgressMessage(json, "p1");
+
+        result.Action.Should().Be(ComfyUIProgressAction.Error);
+        result.ErrorNodeType.Should().Be("unknown");
+        result.ErrorDetail.Should().Be("Unknown execution error");
+    }
+
+    [Fact]
+    public void ParseProgressMessage_ExecutionError_DifferentPrompt_Ignored()
+    {
+        const string json = """{"type":"execution_error","data":{"prompt_id":"other","node_type":"X","exception_message":"y"}}""";
+
+        var result = ComfyUIWrapperService.ParseProgressMessage(json, "p1");
+
+        result.Action.Should().Be(ComfyUIProgressAction.None);
+    }
+
+    [Fact]
+    public void ParseProgressMessage_Executing_NullNode_MatchingPrompt_IsCompleted()
+    {
+        const string json = """{"type":"executing","data":{"node":null,"prompt_id":"p1"}}""";
+
+        var result = ComfyUIWrapperService.ParseProgressMessage(json, "p1");
+
+        result.Action.Should().Be(ComfyUIProgressAction.Completed);
+    }
+
+    [Fact]
+    public void ParseProgressMessage_Executing_NullNode_DifferentPrompt_Ignored()
+    {
+        const string json = """{"type":"executing","data":{"node":null,"prompt_id":"other"}}""";
+
+        var result = ComfyUIWrapperService.ParseProgressMessage(json, "p1");
+
+        result.Action.Should().Be(ComfyUIProgressAction.None);
+    }
+
+    [Fact]
+    public void ParseProgressMessage_Executing_Qwen3VqaNode_ReportsInferenceLabel()
+    {
+        var json = "{\"type\":\"executing\",\"data\":{\"node\":\"" + Qwen3VqaNodeId + "\",\"prompt_id\":\"p1\"}}";
+
+        var result = ComfyUIWrapperService.ParseProgressMessage(json, "p1");
+
+        result.Action.Should().Be(ComfyUIProgressAction.Report);
+        result.ReportText.Should().Be("Running Qwen3-VL inference (first run may download the model...)");
+    }
+
+    [Fact]
+    public void ParseProgressMessage_Executing_LoadImageNode_ReportsLoadingLabel()
+    {
+        var json = "{\"type\":\"executing\",\"data\":{\"node\":\"" + LoadImageNodeId + "\",\"prompt_id\":\"p1\"}}";
+
+        var result = ComfyUIWrapperService.ParseProgressMessage(json, "p1");
+
+        result.Action.Should().Be(ComfyUIProgressAction.Report);
+        result.ReportText.Should().Be("Loading image...");
+    }
+
+    [Fact]
+    public void ParseProgressMessage_Executing_OtherNode_ReportsGenericLabel()
+    {
+        const string json = """{"type":"executing","data":{"node":"42","prompt_id":"p1"}}""";
+
+        var result = ComfyUIWrapperService.ParseProgressMessage(json, "p1");
+
+        result.Action.Should().Be(ComfyUIProgressAction.Report);
+        result.ReportText.Should().Be("Executing node 42...");
+    }
+
+    [Fact]
+    public void ParseProgressMessage_Executing_Node_DifferentPrompt_Ignored()
+    {
+        const string json = """{"type":"executing","data":{"node":"42","prompt_id":"other"}}""";
+
+        var result = ComfyUIWrapperService.ParseProgressMessage(json, "p1");
+
+        result.Action.Should().Be(ComfyUIProgressAction.None);
+    }
+
+    [Fact]
+    public void ParseProgressMessage_Progress_WithMax_ReportsProgress()
+    {
+        const string json = """{"type":"progress","data":{"value":3,"max":10}}""";
+
+        var result = ComfyUIWrapperService.ParseProgressMessage(json, "p1");
+
+        result.Action.Should().Be(ComfyUIProgressAction.Report);
+        result.ReportText.Should().Be("Progress: 3/10");
+    }
+
+    [Fact]
+    public void ParseProgressMessage_Progress_ZeroMax_Ignored()
+    {
+        const string json = """{"type":"progress","data":{"value":0,"max":0}}""";
+
+        var result = ComfyUIWrapperService.ParseProgressMessage(json, "p1");
+
+        result.Action.Should().Be(ComfyUIProgressAction.None);
+    }
+
+    [Fact]
+    public void ParseProgressMessage_Status_ExposesQueueRemaining()
+    {
+        const string json = """{"type":"status","data":{"status":{"exec_info":{"queue_remaining":4}}}}""";
+
+        var result = ComfyUIWrapperService.ParseProgressMessage(json, "p1");
+
+        result.Action.Should().Be(ComfyUIProgressAction.None);
+        result.QueueRemaining.Should().Be(4);
+    }
+
+    [Fact]
+    public void ParseProgressMessage_UnknownType_Ignored()
+    {
+        const string json = """{"type":"executed","data":{}}""";
+
+        var result = ComfyUIWrapperService.ParseProgressMessage(json, "p1");
+
+        result.Action.Should().Be(ComfyUIProgressAction.None);
+    }
+
+    [Fact]
+    public void ParseProgressMessage_JsonNullLiteral_Ignored()
+    {
+        var result = ComfyUIWrapperService.ParseProgressMessage("null", "p1");
+
+        result.Action.Should().Be(ComfyUIProgressAction.None);
+    }
+
+    [Fact]
+    public void ParseProgressMessage_MessageWithoutType_Ignored()
+    {
+        var result = ComfyUIWrapperService.ParseProgressMessage("""{"data":{}}""", "p1");
+
+        result.Action.Should().Be(ComfyUIProgressAction.None);
+    }
+
+    // ---------------------------------------------------------------------------------
+    // History / result parsing (:282+, ShowText nested-array + image URL contracts)
+    // ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void ExtractTextOutputs_FlatArray_AddsEachText()
+    {
+        var node = JsonNode.Parse("""{"text":["a","b"]}""");
+        var result = new ComfyUIResult();
+
+        ComfyUIWrapperService.ExtractTextOutputs(node, result);
+
+        result.Texts.Should().Equal("a", "b");
+    }
+
+    [Fact]
+    public void ExtractTextOutputs_NestedArray_UnwrapsShowTextPysssssContract()
+    {
+        // ShowText|pysssss with INPUT_IS_LIST/OUTPUT_IS_LIST wraps text as [["caption"]].
+        var node = JsonNode.Parse("""{"text":[["caption"]]}""");
+        var result = new ComfyUIResult();
+
+        ComfyUIWrapperService.ExtractTextOutputs(node, result);
+
+        result.Texts.Should().Equal("caption");
+    }
+
+    [Fact]
+    public void ExtractImageOutputs_BuildsEscapedViewUrl()
+    {
+        var node = JsonNode.Parse("""{"images":[{"filename":"a b.png","subfolder":"sub dir","type":"output"}]}""");
+        var result = new ComfyUIResult();
+
+        ComfyUIWrapperService.ExtractImageOutputs(node, BaseUrl, result);
+
+        result.Images.Should().ContainSingle();
+        var img = result.Images[0];
+        img.Filename.Should().Be("a b.png");
+        img.Subfolder.Should().Be("sub dir");
+        img.Type.Should().Be("output");
+        img.Url.Should().Be($"{BaseUrl}/view?filename=a%20b.png&subfolder=sub%20dir&type=output");
+    }
+
+    [Fact]
+    public void ExtractImageOutputs_MissingFilename_Skipped()
+    {
+        var node = JsonNode.Parse("""{"images":[{"subfolder":"s","type":"output"}]}""");
+        var result = new ComfyUIResult();
+
+        ComfyUIWrapperService.ExtractImageOutputs(node, BaseUrl, result);
+
+        result.Images.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseHistoryOutputs_ExtractsTextAndImages()
+    {
+        var history = JsonNode.Parse("""
+            {"p1":{"outputs":{
+                "9":{"text":[["hello"]]},
+                "10":{"images":[{"filename":"out.png","subfolder":"","type":"output"}]}
+            }}}
+            """);
+
+        var result = ComfyUIWrapperService.ParseHistoryOutputs(history, "p1", BaseUrl);
+
+        result.Texts.Should().Equal("hello");
+        result.Images.Should().ContainSingle();
+        result.Images[0].Filename.Should().Be("out.png");
+    }
+
+    [Fact]
+    public void ParseHistoryOutputs_NoOutputsForPrompt_ReturnsEmpty()
+    {
+        var history = JsonNode.Parse("""{"other":{"outputs":{}}}""");
+
+        var result = ComfyUIWrapperService.ParseHistoryOutputs(history, "p1", BaseUrl);
+
+        result.Texts.Should().BeEmpty();
+        result.Images.Should().BeEmpty();
+    }
+
+    // ---------------------------------------------------------------------------------
+    // Item 2: HttpClient constructor seam - HTTP paths driven by an injected handler
+    // ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void Ctor_NullHttpClient_Throws()
+    {
+        var act = () => new ComfyUIWrapperService((HttpClient)null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task UploadImageAsync_PostsToUploadEndpoint_ReturnsStoredName()
+    {
+        var tempImage = Path.GetTempFileName();
+        await File.WriteAllBytesAsync(tempImage, [1, 2, 3]);
+        var (sut, handler) = CreateService(_ => Json(HttpStatusCode.OK, """{"name":"stored.png"}"""));
+
+        try
+        {
+            using (sut)
+            {
+                var stored = await sut.UploadImageAsync(tempImage);
+                stored.Should().Be("stored.png");
+            }
+
+            handler.Requests.Should().ContainSingle();
+            handler.Requests[0].Method.Should().Be(HttpMethod.Post);
+            handler.Requests[0].RequestUri!.AbsolutePath.Should().Be("/upload/image");
+        }
+        finally
+        {
+            File.Delete(tempImage);
+        }
+    }
+
+    [Fact]
+    public async Task QueueWorkflowAsync_PostsPayloadToPrompt_ReturnsPromptId()
+    {
+        var workflowFile = Path.GetTempFileName();
+        await File.WriteAllTextAsync(workflowFile, """{"100":{"inputs":{"image":"x.png"}}}""");
+        string? capturedBody = null;
+        var (sut, handler) = CreateService(req =>
+        {
+            capturedBody = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+            return Json(HttpStatusCode.OK, """{"prompt_id":"pid-9"}""");
+        });
+
+        try
+        {
+            using (sut)
+            {
+                var promptId = await sut.QueueWorkflowAsync(
+                    workflowFile, new Dictionary<string, Action<JsonNode>>());
+                promptId.Should().Be("pid-9");
+            }
+
+            handler.Requests[0].RequestUri!.AbsolutePath.Should().Be("/prompt");
+            capturedBody.Should().Contain("\"workflow_name\":\"DiffusionNexus\"");
+            capturedBody.Should().Contain("\"nodes\":[]");
+        }
+        finally
+        {
+            File.Delete(workflowFile);
+        }
+    }
+
+    [Fact]
+    public async Task GetResultAsync_ParsesHistoryOutputs()
+    {
+        var (sut, handler) = CreateService(_ => Json(HttpStatusCode.OK, """
+            {"p1":{"outputs":{"9":{"text":[["caption"]]}}}}
+            """));
+
+        using (sut)
+        {
+            var result = await sut.GetResultAsync("p1");
+            result.Texts.Should().Equal("caption");
+        }
+
+        handler.Requests[0].RequestUri!.AbsolutePath.Should().Be("/history/p1");
+    }
+
+    [Fact]
+    public async Task DownloadImageAsync_GetsImageBytes()
+    {
+        var (sut, _) = CreateService(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent([9, 8, 7])
+        });
+
+        using (sut)
+        {
+            var image = new ComfyUIImage("f.png", "", "output", $"{BaseUrl}/view?filename=f.png");
+            var bytes = await sut.DownloadImageAsync(image);
+            bytes.Should().Equal(9, 8, 7);
+        }
+    }
+
+    [Fact]
+    public async Task GetInstalledNodeTypesAsync_ReturnsNodeKeys()
+    {
+        var (sut, handler) = CreateService(_ => Json(HttpStatusCode.OK,
+            """{"LoadImage":{},"Qwen3_VQA":{},"ShowText|pysssss":{}}"""));
+
+        using (sut)
+        {
+            var types = await sut.GetInstalledNodeTypesAsync();
+            types.Should().BeEquivalentTo("LoadImage", "Qwen3_VQA", "ShowText|pysssss");
+        }
+
+        handler.Requests[0].RequestUri!.AbsolutePath.Should().Be("/object_info");
+    }
+
+    [Fact]
+    public async Task CheckRequiredNodesAsync_ReturnsOnlyMissing()
+    {
+        var (sut, _) = CreateService(_ => Json(HttpStatusCode.OK, """{"LoadImage":{}}"""));
+
+        using (sut)
+        {
+            var missing = await sut.CheckRequiredNodesAsync(["LoadImage", "Qwen3_VQA"]);
+            missing.Should().Equal("Qwen3_VQA");
+        }
+    }
+
+    [Fact]
+    public async Task GetModelsInFolderAsync_NonSuccess_ReturnsEmpty()
+    {
+        var (sut, _) = CreateService(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
+
+        using (sut)
+        {
+            var models = await sut.GetModelsInFolderAsync("prompt_generator");
+            models.Should().BeEmpty();
+        }
+    }
+
+    [Fact]
+    public async Task GetModelsInFolderAsync_ReturnsModelNames()
+    {
+        var (sut, handler) = CreateService(_ => Json(HttpStatusCode.OK, """["a.safetensors","b.gguf"]"""));
+
+        using (sut)
+        {
+            var models = await sut.GetModelsInFolderAsync("prompt_generator");
+            models.Should().Equal("a.safetensors", "b.gguf");
+        }
+
+        handler.Requests[0].RequestUri!.AbsolutePath.Should().Be("/models/prompt_generator");
+    }
+
+    [Fact]
+    public async Task GetNodeInputOptionsAsync_ParsesFirstElementOptionList()
+    {
+        var (sut, _) = CreateService(_ => Json(HttpStatusCode.OK, """
+            {"Qwen3_VQA":{"input":{"required":{"model":[["m1","m2"],{}]}}}}
+            """));
+
+        using (sut)
+        {
+            var options = await sut.GetNodeInputOptionsAsync("Qwen3_VQA", "model");
+            options.Should().Equal("m1", "m2");
+        }
+    }
+
+    [Fact]
+    public void Dispose_DoesNotDisposeExternallyOwnedHttpClient()
+    {
+        var handler = new FakeHttpHandler(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        var http = new HttpClient(handler) { BaseAddress = new Uri(BaseUrl) };
+        var sut = new ComfyUIWrapperService(http, BaseUrl, disposeHttpClient: false);
+
+        sut.Dispose();
+
+        // If the HttpClient had been disposed, SendAsync would throw ObjectDisposedException.
+        var act = async () => await http.GetAsync("/object_info");
+        act.Should().NotThrowAsync<ObjectDisposedException>();
+
+        http.Dispose();
+    }
+
+    [Fact]
+    public void LegacyStringCtor_StillConstructs()
+    {
+        // Call sites like App.axaml.cs use `new ComfyUIWrapperService()`; that path must
+        // keep working and own its internal HttpClient.
+        using var sut = new ComfyUIWrapperService();
+        sut.Should().NotBeNull();
+    }
+
+    private sealed class FakeHttpHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+        public List<HttpRequestMessage> Requests { get; } = new();
+
+        public FakeHttpHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+        {
+            _responder = responder;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            return Task.FromResult(_responder(request));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
`ComfyUIWrapperService` (609 lines, 9 public methods, **0 tests**) sits underneath every ComfyUI feature — captioning, inpainting, upscale, outpaint. It constructed `new HttpClient` internally from a bare `string baseUrl`, opened raw WebSockets, and inlined the workflow-payload construction that encodes **undocumented, reverse-engineered contracts** with the `comfyui_queue_manager` and `ShowText|pysssss` plugins — shapes that would break silently the day those plugins change.

## Change (issue items 1–3; item 4 deferred as documented follow-up)
1. **`BuildPromptPayload` extracted as a pure function** — a line-for-line move of the inline builder (property names, insertion order, nesting, plugin-contract literals, `client_id` placement all identical — review verified zero drift). The undocumented plugin envelope is now pinned by a char-for-char `ToJsonString()` assertion: the current bytes ARE the spec, and any drift now fails a test instead of silently breaking four features.
2. **HttpClient/HttpMessageHandler ctor seam** — the legacy `string baseUrl` ctor delegates (call sites untouched; same BaseAddress + 10-min timeout) and ownership is explicit via `disposeHttpClient`: the service disposes only clients it created; injected clients survive (test-pinned). HTTP paths are now drivable by the repo's established `FakeHttpHandler` pattern.
3. **Pure WS/history parsing** — `ParseProgressMessage` maps the progress protocol 1:1 (review walked every branch: execution_error/executing/progress/status/unknown, identical ignore/complete/error rules and throw wording); `ParseHistoryOutputs` + text/image output extraction likewise pure and tested.

Item 4 (`IWebSocketFactory` + injected `ILogger`) deferred — documented in the report, nothing half-landed.

## Tests
38 new tests (service previously had 0): exact-envelope bytes, node-patching semantics, missing-node warning path, every WS message branch, history/result parsing, HttpClient disposal ownership. Full unit suite: **2998/2998**.
Task-reviewed (spec + quality, Opus): approved — all three drift risks (payload, WS parsing, HTTP ownership) verified clean branch-by-branch against the deleted code; the no-`[Obsolete]` judgment adjudicated correct (the legacy ctor is a live delegating overload, not a superseded duplicate).

## ⚠️ Before merge
**A live captioning or upscale smoke run against a real ComfyUI server is owed** — behavior is preserved by construction and test-pinned, but this service underpins every ComfyUI feature.

Fixes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)