### PR TITLE
feat(ui): remove App.Services locator from ModelTileViewModel and ModelDetailViewModel

### DIFF
--- a/DiffusionNexus.Tests/Helpers/ImmediateUiScheduler.cs
+++ b/DiffusionNexus.Tests/Helpers/ImmediateUiScheduler.cs
@@ -34,5 +34,11 @@ internal sealed class ImmediateUiScheduler : IUiScheduler
         return Task.CompletedTask;
     }
 
+    public Task InvokeAsync(Func<Task> action)
+    {
+        InvokeCount++;
+        return action();
+    }
+
     public bool IsOnUiThread => true;
 }

--- a/DiffusionNexus.Tests/ViewModels/ModelDetailViewModelTests.cs
+++ b/DiffusionNexus.Tests/ViewModels/ModelDetailViewModelTests.cs
@@ -1,0 +1,83 @@
+using DiffusionNexus.Civitai;
+using DiffusionNexus.Domain.Services;
+using DiffusionNexus.Domain.Services.UnifiedLogging;
+using DiffusionNexus.Installer.SDK.Shared.Services;
+using DiffusionNexus.UI.Services;
+using DiffusionNexus.UI.ViewModels;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace DiffusionNexus.Tests.ViewModels;
+
+/// <summary>
+/// Proves the #438 constructor-injection contract on <see cref="ModelDetailViewModel"/>:
+/// the VM is fully constructible in a unit test with mocks/fakes (it no longer reaches
+/// into the <c>App.Services</c> static locator), and the clipboard copy path routes
+/// through the injected <see cref="IClipboardService"/> seam instead of a live Avalonia
+/// <c>TopLevel</c>. No global Avalonia platform init is required (which would deadlock
+/// the suite).
+/// </summary>
+public class ModelDetailViewModelTests
+{
+    /// <summary>Records the text handed to the clipboard seam.</summary>
+    private sealed class RecordingClipboard : IClipboardService
+    {
+        public List<string> Copied { get; } = [];
+
+        public Task SetTextAsync(string text)
+        {
+            Copied.Add(text);
+            return Task.CompletedTask;
+        }
+    }
+
+    private static ModelDetailViewModel CreateVm(
+        IClipboardService? clipboard = null,
+        IUiScheduler? scheduler = null)
+        => new(
+            civitaiClient: new Mock<ICivitaiClient>().Object,
+            settingsService: new Mock<IAppSettingsService>().Object,
+            secureStorage: new Mock<ISecureStorage>().Object,
+            logger: new Mock<IUnifiedLogger>().Object,
+            baseModelCatalog: null,
+            scopeFactory: new Mock<IServiceScopeFactory>().Object,
+            dialogService: new Mock<IDialogService>().Object,
+            downloadService: null,
+            downloadCoordinator: new Mock<IDownloadCoordinator>().Object,
+            taskTracker: new Mock<ITaskTracker>().Object,
+            activityLog: new Mock<IActivityLogService>().Object,
+            clipboard: clipboard,
+            uiScheduler: scheduler ?? new Helpers.ImmediateUiScheduler());
+
+    [Fact]
+    public void ConstructorWithMocksDoesNotThrowAndNeedsNoLocator()
+    {
+        var act = () => CreateVm();
+        act.Should().NotThrow("the VM must be constructible with injected mocks, not App.Services");
+    }
+
+    [Fact]
+    public async Task CopyTriggerWordsRoutesThroughTheInjectedClipboard()
+    {
+        var clipboard = new RecordingClipboard();
+        var vm = CreateVm(clipboard);
+        vm.TriggerWordsDisplay = "40fy, 3d style, fortnite";
+
+        await vm.CopyTriggerWordsCommand.ExecuteAsync(null);
+
+        clipboard.Copied.Should().ContainSingle().Which.Should().Be("40fy, 3d style, fortnite");
+    }
+
+    [Fact]
+    public async Task CopyTriggerWordsWithNoTriggerWordsDoesNotTouchTheClipboard()
+    {
+        var clipboard = new RecordingClipboard();
+        var vm = CreateVm(clipboard);
+        vm.TriggerWordsDisplay = "   ";
+
+        await vm.CopyTriggerWordsCommand.ExecuteAsync(null);
+
+        clipboard.Copied.Should().BeEmpty();
+    }
+}

--- a/DiffusionNexus.Tests/ViewModels/ModelTileViewModelTests.cs
+++ b/DiffusionNexus.Tests/ViewModels/ModelTileViewModelTests.cs
@@ -1,0 +1,160 @@
+using System.Reflection;
+using DiffusionNexus.Domain.Entities;
+using DiffusionNexus.Domain.Enums;
+using DiffusionNexus.Domain.Services.UnifiedLogging;
+using DiffusionNexus.Installer.SDK.Shared.Services;
+using DiffusionNexus.UI.ViewModels;
+using FluentAssertions;
+using Moq;
+using SkiaSharp;
+
+namespace DiffusionNexus.Tests.ViewModels;
+
+/// <summary>
+/// #438 regression + seam tests for <see cref="ModelTileViewModel"/>. The tile is now
+/// constructed with an injected <see cref="ModelTileDependencies"/> bundle instead of
+/// reaching into the <c>App.Services</c> static locator, so it can be exercised with
+/// mocks/fakes. These tests also guard the two historical production incident sites the
+/// issue calls out:
+/// <list type="bullet">
+///   <item>socket exhaustion from a fresh <c>HttpClient</c> per thumbnail download —
+///   the tile must keep a single shared static client;</item>
+///   <item>OOM / DB bloat from oversized thumbnail BLOBs — <c>ResizeIfOversized</c> must
+///   cap images that exceed the byte limit.</item>
+/// </list>
+/// No Avalonia platform is initialised (which would deadlock the suite): the clipboard,
+/// scheduler and dialog boundaries are all faked, and the thumbnail-resize guard runs on
+/// SkiaSharp alone.
+/// </summary>
+public class ModelTileViewModelTests
+{
+    /// <summary>Records the text handed to the clipboard seam.</summary>
+    private sealed class RecordingClipboard : IClipboardService
+    {
+        public List<string> Copied { get; } = [];
+
+        public Task SetTextAsync(string text)
+        {
+            Copied.Add(text);
+            return Task.CompletedTask;
+        }
+    }
+
+    private static Model CreateLocalModel(string fileName, bool withCivitaiIds = false)
+    {
+        var model = new Model
+        {
+            Id = 7,
+            Name = "Local Only LoRA",
+            Type = ModelType.LORA,
+            CivitaiId = withCivitaiIds ? 555 : null,
+            CivitaiModelPageId = withCivitaiIds ? 555 : null,
+        };
+
+        var version = new ModelVersion
+        {
+            Id = 700,
+            Name = "v1.0",
+            BaseModelRaw = "Flux.1 D",
+            CivitaiId = withCivitaiIds ? 5550 : null,
+            Model = model,
+        };
+        version.Files.Add(new ModelFile { Id = 7000, FileName = fileName, IsPrimary = true, ModelVersion = version });
+        model.Versions.Add(version);
+        return model;
+    }
+
+    [Fact]
+    public void FromModelWithADependencyBundleConstructsWithoutTheLocator()
+    {
+        var deps = new ModelTileDependencies(
+            Logger: new Mock<IUnifiedLogger>().Object,
+            Clipboard: new RecordingClipboard());
+
+        var act = () => ModelTileViewModel.FromModel(CreateLocalModel("a.safetensors"), deps);
+
+        act.Should().NotThrow("the tile must be constructible with an injected bundle, not App.Services");
+    }
+
+    [Fact]
+    public void OpenOnCivitaiWithNoLinkWarnsThroughTheInjectedLogger()
+    {
+        // A local-only model (no Civitai id anywhere) has no page to open, so the command
+        // logs a warning. That it reaches the *injected* logger proves the locator is gone.
+        var logger = new Mock<IUnifiedLogger>();
+        var tile = ModelTileViewModel.FromModel(
+            CreateLocalModel("a.safetensors", withCivitaiIds: false),
+            new ModelTileDependencies(Logger: logger.Object));
+
+        tile.OpenOnCivitaiCommand.Execute(null);
+
+        logger.Verify(
+            l => l.Warn(It.IsAny<LogCategory>(), "OpenOnCivitai", It.IsAny<string>(), It.IsAny<string?>()),
+            Times.Once());
+    }
+
+    [Fact]
+    public async Task CopyFileNameRoutesThroughTheInjectedClipboard()
+    {
+        var clipboard = new RecordingClipboard();
+        var tile = ModelTileViewModel.FromModel(
+            CreateLocalModel("my_cool_lora.safetensors"),
+            new ModelTileDependencies(Clipboard: clipboard));
+
+        await tile.CopyFileNameCommand.ExecuteAsync(null);
+
+        clipboard.Copied.Should().ContainSingle().Which.Should().Be("my_cool_lora");
+    }
+
+    [Fact]
+    public void ThumbnailDownloadsShareASingleStaticHttpClient()
+    {
+        // Socket-exhaustion incident: a `new HttpClient()` per download accumulated
+        // TIME_WAIT sockets until OOM. The fix is one shared static client — assert the
+        // field is still there, static and readonly (single shared instance).
+        var field = typeof(ModelTileViewModel).GetField(
+            "s_thumbnailClient", BindingFlags.NonPublic | BindingFlags.Static);
+
+        field.Should().NotBeNull("thumbnail downloads must reuse one shared HttpClient");
+        field!.IsInitOnly.Should().BeTrue("the shared client must be readonly so it can't be swapped per-call");
+        field.FieldType.Should().Be<HttpClient>();
+        field.GetValue(null).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ResizeIfOversizedCapsAThumbnailThatExceedsTheByteLimit()
+    {
+        // OOM / DB-bloat incident: Civitai's CDN sometimes ignores width= and returns a
+        // full-resolution image (up to 25 MB seen in prod). ResizeIfOversized must shrink
+        // anything over the ~1 MB limit before it is persisted / decoded.
+        var oversized = CreateNoisyPng(1200, 1200);
+        oversized.Length.Should().BeGreaterThan(1_048_576, "the test input must exceed the resize threshold");
+
+        var method = typeof(ModelTileViewModel).GetMethod(
+            "ResizeIfOversized", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        var result = ((byte[] Data, string MimeType))method.Invoke(
+            null, [oversized, "image/png", null, "IncidentTest"])!;
+
+        result.Data.Length.Should().BeLessThan(oversized.Length, "the oversized thumbnail must be shrunk");
+        result.Data.Length.Should().BeLessThanOrEqualTo(1_048_576, "the resized thumbnail must fit under the cap");
+    }
+
+    /// <summary>
+    /// Builds a PNG of random noise so it does not compress away — a reliable way to get a
+    /// decodable image comfortably over the 1 MB resize threshold without any test asset.
+    /// </summary>
+    private static byte[] CreateNoisyPng(int width, int height)
+    {
+        var info = new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
+        using var bitmap = new SKBitmap(info);
+
+        var pixels = new byte[info.BytesSize];
+        new Random(42).NextBytes(pixels);
+        System.Runtime.InteropServices.Marshal.Copy(pixels, 0, bitmap.GetPixels(), pixels.Length);
+
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        return data.ToArray();
+    }
+}

--- a/DiffusionNexus.UI/App.axaml.cs
+++ b/DiffusionNexus.UI/App.axaml.cs
@@ -533,6 +533,9 @@ public partial class App : Application
         // UI-thread scheduler seam over Dispatcher.UIThread (testability; #437)
         services.AddSingleton<IUiScheduler, AvaloniaUiScheduler>();
 
+        // System-clipboard seam (testability; #438)
+        services.AddSingleton<IClipboardService, AvaloniaClipboardService>();
+
         // Thumbnail service for async image loading with LRU cache (singleton)
         services.AddSingleton<IThumbnailService, ThumbnailService>();
 

--- a/DiffusionNexus.UI/Services/AvaloniaClipboardService.cs
+++ b/DiffusionNexus.UI/Services/AvaloniaClipboardService.cs
@@ -1,0 +1,39 @@
+using Avalonia.Controls.ApplicationLifetimes;
+using DiffusionNexus.Installer.SDK.Shared.Services;
+
+namespace DiffusionNexus.UI.Services;
+
+/// <summary>
+/// Production <see cref="IClipboardService"/> — resolves the system clipboard
+/// from the desktop main window's <c>TopLevel</c> and delegates to it. Stateless,
+/// so a single shared <see cref="Instance"/> is used as the default for ViewModel
+/// constructors and the same type is registered as a DI singleton.
+/// <para>
+/// Reuses the shared <see cref="IClipboardService"/> contract from the Installer
+/// SDK (identical signature) rather than duplicating it in the UI project.
+/// </para>
+/// </summary>
+public sealed class AvaloniaClipboardService : IClipboardService
+{
+    /// <summary>
+    /// Shared instance used as the default when no clipboard service is injected
+    /// (keeps existing construction sites behaving identically).
+    /// </summary>
+    public static AvaloniaClipboardService Instance { get; } = new();
+
+    /// <inheritdoc/>
+    // TODO: Linux Implementation for clipboard access via a non-desktop TopLevel.
+    public async Task SetTextAsync(string text)
+    {
+        var topLevel = Avalonia.Application.Current?.ApplicationLifetime
+            is IClassicDesktopStyleApplicationLifetime desktop
+            ? desktop.MainWindow
+            : null;
+
+        var clipboard = topLevel?.Clipboard;
+        if (clipboard is not null)
+        {
+            await clipboard.SetTextAsync(text);
+        }
+    }
+}

--- a/DiffusionNexus.UI/Services/AvaloniaUiScheduler.cs
+++ b/DiffusionNexus.UI/Services/AvaloniaUiScheduler.cs
@@ -23,5 +23,8 @@ public sealed class AvaloniaUiScheduler : IUiScheduler
     public Task InvokeAsync(Action action) => Dispatcher.UIThread.InvokeAsync(action).GetTask();
 
     /// <inheritdoc/>
+    public Task InvokeAsync(Func<Task> action) => Dispatcher.UIThread.InvokeAsync(action);
+
+    /// <inheritdoc/>
     public bool IsOnUiThread => Dispatcher.UIThread.CheckAccess();
 }

--- a/DiffusionNexus.UI/Services/DialogService.cs
+++ b/DiffusionNexus.UI/Services/DialogService.cs
@@ -679,4 +679,46 @@ public class DialogService : IDialogService
         var tail = entries.Count <= 500 ? entries : entries.Skip(entries.Count - 500);
         return string.Join('\n', tail.Select(e => e.ToDisplayString()));
     }
+
+    public async Task<LoraDeleteResult?> ShowSelectLoraVersionsToDeleteDialogAsync(
+        string displayName,
+        IEnumerable<ModelVersion> versions,
+        IReadOnlyList<Model> allGroupedModels)
+    {
+        if (!Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
+        {
+            return await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
+                () => ShowSelectLoraVersionsToDeleteDialogAsync(displayName, versions, allGroupedModels));
+        }
+
+        var dialog = new SelectLoraVersionsToDeleteDialog()
+            .WithVersions(displayName, versions, allGroupedModels);
+
+        await dialog.ShowDialog(_window);
+        return dialog.Result;
+    }
+
+    public async Task<CivitaiTokenDialogResult> ShowCivitaiTokenDialogAsync()
+    {
+        if (!Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
+        {
+            return await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(ShowCivitaiTokenDialogAsync);
+        }
+
+        var dialog = new CivitaiTokenDialog();
+        await dialog.ShowDialog(_window);
+        return new CivitaiTokenDialogResult(dialog.IsSaved, dialog.TokenText);
+    }
+
+    public async Task<AssignCivitaiIdsDialogResult> ShowAssignCivitaiIdsDialogAsync()
+    {
+        if (!Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
+        {
+            return await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(ShowAssignCivitaiIdsDialogAsync);
+        }
+
+        var dialog = new AssignCivitaiIdsDialog();
+        await dialog.ShowDialog(_window);
+        return new AssignCivitaiIdsDialogResult(dialog.IsConfirmed, dialog.ResolvedModel, dialog.ResolvedVersion);
+    }
     }

--- a/DiffusionNexus.UI/Services/IDialogService.cs
+++ b/DiffusionNexus.UI/Services/IDialogService.cs
@@ -391,6 +391,33 @@ public interface IDialogService
     /// attached when the user submits a bug report (not for feedback/feature requests).
     /// </summary>
     Task ShowFeedbackDialogAsync();
+
+    /// <summary>
+    /// Shows the LoRA version delete picker for a grouped tile. Marshals to the UI
+    /// thread internally so it is safe to call from a background context.
+    /// </summary>
+    /// <param name="displayName">Model display name shown in the dialog title.</param>
+    /// <param name="versions">All versions across the grouped models.</param>
+    /// <param name="allGroupedModels">All model entities in the group (for DB removal).</param>
+    /// <returns>The delete result, or a cancelled result if the user backed out.</returns>
+    Task<LoraDeleteResult?> ShowSelectLoraVersionsToDeleteDialogAsync(
+        string displayName,
+        IEnumerable<Domain.Entities.ModelVersion> versions,
+        IReadOnlyList<Domain.Entities.Model> allGroupedModels);
+
+    /// <summary>
+    /// Shows the Civitai API-token prompt (used when a download needs a token that
+    /// is not yet configured). Marshals to the UI thread internally.
+    /// </summary>
+    /// <returns>Whether the user saved a validated token, plus the token text.</returns>
+    Task<CivitaiTokenDialogResult> ShowCivitaiTokenDialogAsync();
+
+    /// <summary>
+    /// Shows the manual "Assign Civitai IDs" dialog where the user pastes a URL or
+    /// enters Model/Version IDs. Marshals to the UI thread internally.
+    /// </summary>
+    /// <returns>Whether the user confirmed, plus the resolved Civitai model/version.</returns>
+    Task<AssignCivitaiIdsDialogResult> ShowAssignCivitaiIdsDialogAsync();
 }
 
 /// <summary>

--- a/DiffusionNexus.UI/Services/IUiScheduler.cs
+++ b/DiffusionNexus.UI/Services/IUiScheduler.cs
@@ -28,6 +28,14 @@ public interface IUiScheduler
     Task InvokeAsync(Action action);
 
     /// <summary>
+    /// Runs the asynchronous <paramref name="action"/> on the UI thread and
+    /// returns a task that completes when the inner task has finished. Maps to
+    /// <c>Dispatcher.UIThread.InvokeAsync(Func&lt;Task&gt;)</c>. Used where the
+    /// marshalled work is itself awaitable (e.g. reload-after-save flows).
+    /// </summary>
+    Task InvokeAsync(Func<Task> action);
+
+    /// <summary>
     /// Whether the calling thread is the UI thread. Maps to
     /// <c>Dispatcher.UIThread.CheckAccess()</c>.
     /// </summary>

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -2244,12 +2244,23 @@ public partial class LoraViewerViewModel : BusyViewModelBase
             DetailViewModel.MetadataDownloadRequested -= OnDetailMetadataDownloadRequested;
         }
 
+        // #438: the detail VM no longer reaches into App.Services — resolve the
+        // dependencies it previously fetched from the locator here and inject them.
+        var sp = App.Services;
         var detailVm = new ModelDetailViewModel(
             _civitaiClient,
             _settingsService,
             _secureStorage,
             _logger,
-            _baseModelCatalog);
+            _baseModelCatalog,
+            sp?.GetService<IServiceScopeFactory>(),
+            sp?.GetService<IDialogService>(),
+            sp?.GetService<LoraDownloadService>(),
+            sp?.GetService<IDownloadCoordinator>(),
+            sp?.GetService<ITaskTracker>(),
+            sp?.GetService<IActivityLogService>(),
+            sp?.GetService<DiffusionNexus.Installer.SDK.Shared.Services.IClipboardService>(),
+            sp?.GetService<IUiScheduler>());
 
         detailVm.CloseRequested += OnDetailCloseRequested;
         detailVm.DownloadCompleted += OnDetailDownloadCompleted;

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -505,8 +505,38 @@ public partial class LoraViewerViewModel : BusyViewModelBase
     /// tile with multiple version buttons.
     /// Delegates to <see cref="TileGroupingHelper"/> for testability.
     /// </summary>
-    private static List<ModelTileViewModel> GroupModelsIntoTiles(IReadOnlyList<Model> allModels)
-        => TileGroupingHelper.GroupModelsIntoTiles(allModels);
+    private List<ModelTileViewModel> GroupModelsIntoTiles(IReadOnlyList<Model> allModels)
+        => TileGroupingHelper.GroupModelsIntoTiles(allModels, BuildTileDependencies());
+
+    /// <summary>
+    /// Builds the dependency bundle each freshly-created <see cref="ModelTileViewModel"/>
+    /// is constructed with (#438). Resolves from <c>App.Services</c> here — the tile no
+    /// longer reaches into the locator itself. Returns an all-null bundle at design time
+    /// (no <c>App.Services</c>), which is exactly how the tile behaved before.
+    /// </summary>
+    private ModelTileDependencies BuildTileDependencies()
+    {
+        var sp = App.Services;
+        return new ModelTileDependencies(
+            Logger: _logger,
+            ScopeFactory: sp?.GetService<IServiceScopeFactory>(),
+            DialogService: TryResolveDialogService(sp),
+            VideoThumbnailService: sp?.GetService<IVideoThumbnailService>(),
+            Clipboard: sp?.GetService<DiffusionNexus.Installer.SDK.Shared.Services.IClipboardService>(),
+            UiScheduler: sp?.GetService<IUiScheduler>());
+    }
+
+    /// <summary>
+    /// Resolves <see cref="IDialogService"/> defensively: its DI factory throws when the
+    /// main window is not available yet. Tiles are normally built after the window exists,
+    /// but guarding keeps an early / design-time build from throwing — the tile just gets
+    /// a null dialog service (delete no-ops with a logged error) until the next rebuild.
+    /// </summary>
+    private static IDialogService? TryResolveDialogService(IServiceProvider? sp)
+    {
+        try { return sp?.GetService<IDialogService>(); }
+        catch { return null; }
+    }
 
     /// <summary>
     /// Download missing metadata from Civitai for models that were discovered locally.
@@ -756,8 +786,9 @@ public partial class LoraViewerViewModel : BusyViewModelBase
     /// map for that location so the version switcher and OpenFolder/Delete work
     /// correctly. Issue #380.
     /// </summary>
-    private static List<ModelTileViewModel> BuildPerLocationTiles(IReadOnlyList<InstalledModelFile> files)
+    private List<ModelTileViewModel> BuildPerLocationTiles(IReadOnlyList<InstalledModelFile> files)
     {
+        var dependencies = BuildTileDependencies();
         return files
             // Group by Civitai page so two Model rows that point at the same page (legacy
             // local-discovery duplicates) collapse into one tile; fall back to Model.Id
@@ -769,7 +800,7 @@ public partial class LoraViewerViewModel : BusyViewModelBase
             {
                 var models = g.Select(f => f.Model).DistinctBy(m => m.Id).ToList();
                 var versionFiles = g.Select(f => (f.Version, f.File)).ToList();
-                return ModelTileViewModel.FromModelInLocation(models, g.Key.SourceRoot, versionFiles);
+                return ModelTileViewModel.FromModelInLocation(models, g.Key.SourceRoot, versionFiles, dependencies);
             })
             .ToList();
     }

--- a/DiffusionNexus.UI/ViewModels/ModelDetailViewModel.Editing.cs
+++ b/DiffusionNexus.UI/ViewModels/ModelDetailViewModel.Editing.cs
@@ -105,7 +105,7 @@ public partial class ModelDetailViewModel
 
         try
         {
-            using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            using var scope = _scopeFactory!.CreateScope();
             var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
 
             var dbModel = await unitOfWork.Models.GetByIdWithIncludesAsync(model.Id);
@@ -203,7 +203,7 @@ public partial class ModelDetailViewModel
 
         try
         {
-            using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            using var scope = _scopeFactory!.CreateScope();
             var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
 
             var dbModel = await unitOfWork.Models.GetByIdWithIncludesAsync(model.Id);
@@ -330,7 +330,7 @@ public partial class ModelDetailViewModel
             labels = Array.Empty<string>();
         }
 
-        await Dispatcher.UIThread.InvokeAsync(() =>
+        await _uiScheduler.InvokeAsync(() =>
         {
             var current = ResolveCurrentBaseModelRaw();
 
@@ -419,7 +419,7 @@ public partial class ModelDetailViewModel
 
         try
         {
-            using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            using var scope = _scopeFactory!.CreateScope();
             var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
 
             var dbModel = await unitOfWork.Models.GetByIdWithIncludesAsync(localVersion.ModelId);
@@ -491,7 +491,7 @@ public partial class ModelDetailViewModel
 
         try
         {
-            using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            using var scope = _scopeFactory!.CreateScope();
             var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
 
             var dbModel = await unitOfWork.Models.GetByIdWithIncludesAsync(model.Id);
@@ -538,7 +538,7 @@ public partial class ModelDetailViewModel
 
         try
         {
-            using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            using var scope = _scopeFactory!.CreateScope();
             var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
 
             var dbModel = await unitOfWork.Models.GetByIdWithIncludesAsync(model.Id);
@@ -590,7 +590,7 @@ public partial class ModelDetailViewModel
 
         try
         {
-            using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            using var scope = _scopeFactory!.CreateScope();
             var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
 
             var dbModel = await unitOfWork.Models.GetByIdWithIncludesAsync(model.Id);
@@ -643,7 +643,7 @@ public partial class ModelDetailViewModel
 
         try
         {
-            using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            using var scope = _scopeFactory!.CreateScope();
             var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
 
             var dbModel = await unitOfWork.Models.GetByIdWithIncludesAsync(localVersion.ModelId);
@@ -700,8 +700,7 @@ public partial class ModelDetailViewModel
     [RelayCommand]
     private async Task UploadThumbnailAsync()
     {
-        var dialog = App.Services?.GetService<IDialogService>();
-        if (dialog is null) return;
+        if (_dialogService is null) return;
 
         var localVersion = SelectedVersionTab?.LocalVersion ?? SourceTile?.SelectedVersion;
         var model = SourceTile?.ModelEntity;
@@ -711,7 +710,7 @@ public partial class ModelDetailViewModel
             return;
         }
 
-        var path = await dialog.ShowOpenFileDialogAsync(
+        var path = await _dialogService.ShowOpenFileDialogAsync(
             "Choose thumbnail image",
             "*.png;*.jpg;*.jpeg;*.webp;*.bmp");
         if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
@@ -726,7 +725,7 @@ public partial class ModelDetailViewModel
                 return;
             }
 
-            using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            using var scope = _scopeFactory!.CreateScope();
             var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
 
             var dbModel = await unitOfWork.Models.GetByIdWithIncludesAsync(model.Id);
@@ -762,7 +761,7 @@ public partial class ModelDetailViewModel
             using (var ms = new MemoryStream(data))
             {
                 var bmp = new Bitmap(ms);
-                await Dispatcher.UIThread.InvokeAsync(() => ThumbnailImage = bmp);
+                await _uiScheduler.InvokeAsync(() => ThumbnailImage = bmp);
             }
 
             await PostSaveRefreshAsync(unitOfWork, model.Id);
@@ -999,21 +998,19 @@ public partial class ModelDetailViewModel
             return;
         }
 
-        var owner = (App.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow;
-        if (owner is null) return;
+        if (_dialogService is null) return;
 
-        var dialog = new AssignCivitaiIdsDialog();
-        await dialog.ShowDialog(owner);
+        var dialogResult = await _dialogService.ShowAssignCivitaiIdsDialogAsync();
 
-        if (!dialog.IsConfirmed || dialog.ResolvedModel is null)
+        if (!dialogResult.IsConfirmed || dialogResult.ResolvedModel is null)
             return;
 
-        var civitaiModel = dialog.ResolvedModel;
-        var civitaiVersion = dialog.ResolvedVersion ?? civitaiModel.ModelVersions.FirstOrDefault();
+        var civitaiModel = dialogResult.ResolvedModel;
+        var civitaiVersion = dialogResult.ResolvedVersion ?? civitaiModel.ModelVersions.FirstOrDefault();
 
         try
         {
-            using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            using var scope = _scopeFactory!.CreateScope();
             var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
 
             var dbModel = await unitOfWork.Models.GetByIdWithIncludesAsync(model.Id);
@@ -1189,7 +1186,7 @@ public partial class ModelDetailViewModel
             var refreshed = await unitOfWork.Models.GetByIdWithIncludesAsync(dbModel.Id);
             if (refreshed is not null && SourceTile is not null)
             {
-                await Dispatcher.UIThread.InvokeAsync(async () =>
+                await _uiScheduler.InvokeAsync(async () =>
                 {
                     SourceTile.RefreshModelData(refreshed);
                     await LoadAsync(SourceTile);
@@ -1255,7 +1252,7 @@ public partial class ModelDetailViewModel
 
         try
         {
-            using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            using var scope = _scopeFactory!.CreateScope();
             var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
 
             var dbModel = await unitOfWork.Models.GetByIdWithIncludesAsync(selectedVersion.ModelId);
@@ -1279,7 +1276,7 @@ public partial class ModelDetailViewModel
             var refreshed = await unitOfWork.Models.GetByIdWithIncludesAsync(dbModel.Id);
             if (refreshed is not null)
             {
-                await Dispatcher.UIThread.InvokeAsync(async () =>
+                await _uiScheduler.InvokeAsync(async () =>
                 {
                     tile.RefreshModelData(refreshed);
                     await LoadAsync(tile);
@@ -1317,7 +1314,7 @@ public partial class ModelDetailViewModel
 
         try
         {
-            using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            using var scope = _scopeFactory!.CreateScope();
             var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
 
             // A tile may group multiple Model rows (e.g. multiple versions of
@@ -1343,7 +1340,7 @@ public partial class ModelDetailViewModel
             _logger?.Info(LogCategory.General, "DeleteMetadata",
                 $"Deleted metadata for '{model.Name}' ({deleted} of {ids.Count} grouped model row(s)). Files on disk were not touched.");
 
-            await Dispatcher.UIThread.InvokeAsync(() =>
+            await _uiScheduler.InvokeAsync(() =>
             {
                 // Order matters and each step is required:
                 // 1. RaiseDeleted() — synchronously removes the tile from the
@@ -1382,7 +1379,7 @@ public partial class ModelDetailViewModel
         var refreshed = await unitOfWork.Models.GetByIdWithIncludesAsync(modelId);
         if (refreshed is null) return;
 
-        await Dispatcher.UIThread.InvokeAsync(() =>
+        await _uiScheduler.InvokeAsync(() =>
         {
             SourceTile?.RefreshModelData(refreshed);
             _ = LoadEditableTagsAsync();

--- a/DiffusionNexus.UI/ViewModels/ModelDetailViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/ModelDetailViewModel.cs
@@ -12,6 +12,7 @@ using DiffusionNexus.Domain.Enums;
 using DiffusionNexus.Domain.Services;
 using DiffusionNexus.Domain.Services.UnifiedLogging;
 using DiffusionNexus.Infrastructure;
+using DiffusionNexus.Installer.SDK.Shared.Services;
 using DiffusionNexus.UI.Helpers;
 using DiffusionNexus.UI.Services;
 using DiffusionNexus.UI.Views.Dialogs;
@@ -30,6 +31,19 @@ public partial class ModelDetailViewModel : ViewModelBase
     private readonly ISecureStorage? _secureStorage;
     private readonly IUnifiedLogger? _logger;
     private readonly ICivitaiBaseModelCatalog? _baseModelCatalog;
+
+    // #438: constructor-injected replacements for the former App.Services locator
+    // calls. Nullable services degrade gracefully (as the null-conditional locator
+    // calls did); the scheduler/clipboard fall back to shared production instances
+    // so design-time / demo construction keeps working.
+    private readonly IServiceScopeFactory? _scopeFactory;
+    private readonly IDialogService? _dialogService;
+    private readonly LoraDownloadService? _downloadService;
+    private readonly IDownloadCoordinator? _downloadCoordinator;
+    private readonly ITaskTracker? _taskTracker;
+    private readonly IActivityLogService? _activityLog;
+    private readonly IClipboardService _clipboard = AvaloniaClipboardService.Instance;
+    private readonly IUiScheduler _uiScheduler = AvaloniaUiScheduler.Instance;
 
     /// <summary>
     /// Cached Civitai model data from the initial API fetch.
@@ -209,20 +223,40 @@ public partial class ModelDetailViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Runtime constructor with DI.
+    /// Runtime constructor with DI. The parameters after <paramref name="baseModelCatalog"/>
+    /// are the dependencies the method bodies previously resolved from the
+    /// <c>App.Services</c> locator (#438); they are optional so existing construction
+    /// sites keep compiling, but the production site (<c>LoraViewerViewModel</c>)
+    /// passes them from DI.
     /// </summary>
     public ModelDetailViewModel(
         ICivitaiClient? civitaiClient,
         IAppSettingsService? settingsService,
         ISecureStorage? secureStorage,
         IUnifiedLogger? logger,
-        ICivitaiBaseModelCatalog? baseModelCatalog = null)
+        ICivitaiBaseModelCatalog? baseModelCatalog = null,
+        IServiceScopeFactory? scopeFactory = null,
+        IDialogService? dialogService = null,
+        LoraDownloadService? downloadService = null,
+        IDownloadCoordinator? downloadCoordinator = null,
+        ITaskTracker? taskTracker = null,
+        IActivityLogService? activityLog = null,
+        IClipboardService? clipboard = null,
+        IUiScheduler? uiScheduler = null)
     {
         _civitaiClient = civitaiClient;
         _settingsService = settingsService;
         _secureStorage = secureStorage;
         _logger = logger;
         _baseModelCatalog = baseModelCatalog;
+        _scopeFactory = scopeFactory;
+        _dialogService = dialogService;
+        _downloadService = downloadService;
+        _downloadCoordinator = downloadCoordinator;
+        _taskTracker = taskTracker;
+        _activityLog = activityLog;
+        _clipboard = clipboard ?? AvaloniaClipboardService.Instance;
+        _uiScheduler = uiScheduler ?? AvaloniaUiScheduler.Instance;
     }
 
     #endregion
@@ -341,10 +375,9 @@ public partial class ModelDetailViewModel : ViewModelBase
         }
 
         // Show download destination dialog
-        var dialogService = App.Services?.GetService<IDialogService>();
-        if (dialogService is null) return;
+        if (_dialogService is null) return;
 
-        var result = await dialogService.ShowDownloadLoraVersionDialogAsync(
+        var result = await _dialogService.ShowDownloadLoraVersionDialogAsync(
             ModelName, tab.CivitaiVersion, sourceFolders, CategoryDisplay);
 
         if (!result.Confirmed || string.IsNullOrWhiteSpace(result.TargetFolder))
@@ -372,13 +405,13 @@ public partial class ModelDetailViewModel : ViewModelBase
 
         try
         {
-            var downloadService = App.Services?.GetService<LoraDownloadService>();
+            var downloadService = _downloadService;
             if (downloadService is not null)
             {
                 // Route through IDownloadCoordinator so this aggregates with any
                 // other downloads in flight (Civitai queue, etc.) instead of stealing
                 // the single-slot activity-log progress.
-                var coordinator = App.Services?.GetService<IDownloadCoordinator>();
+                var coordinator = _downloadCoordinator;
                 var tcs = new TaskCompletionSource<bool>();
 
                 async Task<bool> RunAsync(IProgress<DownloadTaskProgress>? progress, CancellationToken ct)
@@ -390,12 +423,12 @@ public partial class ModelDetailViewModel : ViewModelBase
                         taskName,
                         reportProgress: (pct, msg) =>
                             progress?.Report(new DownloadTaskProgress((int)(pct * 100), msg)),
-                        completed: () => Dispatcher.UIThread.Post(async () =>
+                        completed: () => _uiScheduler.Post(async () =>
                         {
                             await RefreshAfterDownloadAsync(targetPath);
                             tcs.TrySetResult(true);
                         }),
-                        failed: () => Dispatcher.UIThread.Post(() =>
+                        failed: () => _uiScheduler.Post(() =>
                         {
                             tab.IsDownloading = false;
                             tcs.TrySetResult(false);
@@ -414,8 +447,8 @@ public partial class ModelDetailViewModel : ViewModelBase
                 return;
             }
 
-            var taskTracker = App.Services?.GetService<ITaskTracker>();
-            activityLog = App.Services?.GetService<IActivityLogService>();
+            var taskTracker = _taskTracker;
+            activityLog = _activityLog;
             taskHandle = taskTracker?.BeginTask(taskName, LogCategory.Download);
 
             activityLog?.StartDownloadProgress(taskName);
@@ -542,7 +575,7 @@ public partial class ModelDetailViewModel : ViewModelBase
         finally
         {
             taskHandle?.Dispose();
-            await Dispatcher.UIThread.InvokeAsync(() => tab.IsDownloading = false);
+            await _uiScheduler.InvokeAsync(() => tab.IsDownloading = false);
         }
     }
 
@@ -556,9 +589,9 @@ public partial class ModelDetailViewModel : ViewModelBase
         try
         {
             var sourceTile = SourceTile;
-            if (sourceTile is null) return;
+            if (sourceTile is null || _scopeFactory is null) return;
 
-            using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            using var scope = _scopeFactory.CreateScope();
             var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
 
             // Find the model that owns the file we just downloaded (targeted query, not full DB load)
@@ -571,7 +604,7 @@ public partial class ModelDetailViewModel : ViewModelBase
 
             if (refreshedModel is not null)
             {
-                await Dispatcher.UIThread.InvokeAsync(() =>
+                await _uiScheduler.InvokeAsync(() =>
                 {
                     sourceTile.RefreshModelData(refreshedModel);
 
@@ -642,15 +675,14 @@ public partial class ModelDetailViewModel : ViewModelBase
     {
         try
         {
-            var scopeFactory = App.Services?.GetService<IServiceScopeFactory>();
-            if (scopeFactory is null)
+            if (_scopeFactory is null)
             {
                 _logger?.Warn(LogCategory.Download, "LoraDownload",
                     "Cannot persist to database: IServiceScopeFactory not available");
                 return;
             }
 
-            using var scope = scopeFactory.CreateScope();
+            using var scope = _scopeFactory.CreateScope();
             var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
 
             // Skip if file is already tracked (e.g., from a prior DiscoverNewFilesAsync)
@@ -1227,7 +1259,7 @@ public partial class ModelDetailViewModel : ViewModelBase
             _logger?.Debug(LogCategory.Network, "LoraUpdateChecker",
                 $"Update check completed for '{tileName}' (trigger={LoraUpdateTriggerSource.DetailView}, civitaiId={modelId.Value}): remoteVersions={totalRemoteVersions} ({deltaText} vs previous {previousTotal})");
 
-            await Dispatcher.UIThread.InvokeAsync(() =>
+            await _uiScheduler.InvokeAsync(() =>
             {
                 // Refresh the tile's "+N" badge in-place without waiting for a reload.
                 tile.UpdateRemoteVersionCount(totalRemoteVersions, checkedAtUtc);
@@ -1286,10 +1318,9 @@ public partial class ModelDetailViewModel : ViewModelBase
             var modelIds = tile.GetAllModelIds();
             if (modelIds.Count == 0) return;
 
-            var scopeFactory = App.Services?.GetService<IServiceScopeFactory>();
-            if (scopeFactory is null) return;
+            if (_scopeFactory is null) return;
 
-            using var scope = scopeFactory.CreateScope();
+            using var scope = _scopeFactory.CreateScope();
             var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
 
             foreach (var id in modelIds)
@@ -1430,7 +1461,7 @@ public partial class ModelDetailViewModel : ViewModelBase
 
             ct.ThrowIfCancellationRequested();
 
-            await Dispatcher.UIThread.InvokeAsync(() =>
+            await _uiScheduler.InvokeAsync(() =>
             {
                 try
                 {
@@ -1459,9 +1490,10 @@ public partial class ModelDetailViewModel : ViewModelBase
     /// The injected <c>_settingsService</c> may hold a cached <see cref="AppSettings"/> entity from
     /// a long-lived DbContext that was loaded before the key was saved via the Settings view.
     /// </summary>
-    private static async Task<string?> GetApiKeyAsync()
+    private async Task<string?> GetApiKeyAsync()
     {
-        using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+        if (_scopeFactory is null) return null;
+        using var scope = _scopeFactory.CreateScope();
         var settingsService = scope.ServiceProvider.GetRequiredService<IAppSettingsService>();
         return await settingsService.GetCivitaiApiKeyAsync();
     }
@@ -1477,44 +1509,26 @@ public partial class ModelDetailViewModel : ViewModelBase
         if (!string.IsNullOrWhiteSpace(existingKey))
             return true;
 
-        // Show the token dialog on the UI thread
-        return await Dispatcher.UIThread.InvokeAsync(async () =>
+        if (_dialogService is null) return false;
+
+        // The dialog service marshals to the UI thread internally.
+        var result = await _dialogService.ShowCivitaiTokenDialogAsync();
+
+        if (!result.IsSaved || string.IsNullOrWhiteSpace(result.TokenText))
+            return false;
+
+        // Persist the token (encrypted) via the settings service
+        if (_settingsService is not null)
         {
-            var mainWindow = (App.Current?.ApplicationLifetime
-                as Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime)?.MainWindow;
-            if (mainWindow is null) return false;
-
-            var dialog = new CivitaiTokenDialog();
-            await dialog.ShowDialog(mainWindow);
-
-            if (!dialog.IsSaved || string.IsNullOrWhiteSpace(dialog.TokenText))
-                return false;
-
-            // Persist the token (encrypted) via the settings service
-            if (_settingsService is not null)
-            {
-                await _settingsService.SetCivitaiApiKeyAsync(dialog.TokenText);
-                _logger?.Info(LogCategory.General, "CivitaiToken",
-                    "Civitai API token saved from download prompt");
-            }
-
-            return true;
-        });
-    }
-
-    private static async Task CopyToClipboardAsync(string text)
-    {
-        var topLevel = Avalonia.Application.Current?.ApplicationLifetime
-            is Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop
-            ? desktop.MainWindow
-            : null;
-
-        var clipboard = topLevel?.Clipboard;
-        if (clipboard is not null)
-        {
-            await clipboard.SetTextAsync(text);
+            await _settingsService.SetCivitaiApiKeyAsync(result.TokenText);
+            _logger?.Info(LogCategory.General, "CivitaiToken",
+                "Civitai API token saved from download prompt");
         }
+
+        return true;
     }
+
+    private Task CopyToClipboardAsync(string text) => _clipboard.SetTextAsync(text);
 
     #endregion
 }

--- a/DiffusionNexus.UI/ViewModels/ModelTileDependencies.cs
+++ b/DiffusionNexus.UI/ViewModels/ModelTileDependencies.cs
@@ -1,0 +1,32 @@
+using DiffusionNexus.Domain.Services;
+using DiffusionNexus.Domain.Services.UnifiedLogging;
+using DiffusionNexus.Installer.SDK.Shared.Services;
+using DiffusionNexus.UI.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+/// <summary>
+/// Bundle of services a <see cref="ModelTileViewModel"/> needs, injected through
+/// its constructor and the static factory methods (#438). Previously each of these
+/// was fetched lazily from the <c>App.Services</c> static locator inside the tile's
+/// method bodies, which made the tile untestable. The parent view model builds one
+/// bundle from DI and threads it through <c>TileGroupingHelper</c> / the factories so
+/// every tile is constructed with real services; tests construct tiles with a bundle
+/// of fakes (or none, in which case the tile degrades exactly as the null-conditional
+/// locator calls used to).
+/// <para>
+/// All members are nullable and default to <c>null</c> so construction sites that
+/// cannot reach DI (design-time, demo data, grouping-logic unit tests) keep compiling
+/// and behaving as before. <see cref="ScopeFactory"/> is a singleton whose
+/// <c>CreateScope()</c> is still called per operation inside the tile — it is never
+/// captured as a scoped instance.
+/// </para>
+/// </summary>
+public sealed record ModelTileDependencies(
+    IUnifiedLogger? Logger = null,
+    IServiceScopeFactory? ScopeFactory = null,
+    IDialogService? DialogService = null,
+    IVideoThumbnailService? VideoThumbnailService = null,
+    IClipboardService? Clipboard = null,
+    IUiScheduler? UiScheduler = null);

--- a/DiffusionNexus.UI/ViewModels/ModelTileViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/ModelTileViewModel.cs
@@ -9,6 +9,7 @@ using DiffusionNexus.DataAccess.UnitOfWork;
 using DiffusionNexus.Domain.Entities;
 using DiffusionNexus.Domain.Services;
 using DiffusionNexus.Domain.Services.UnifiedLogging;
+using DiffusionNexus.Installer.SDK.Shared.Services;
 using DiffusionNexus.UI.Services;
 using DiffusionNexus.UI.Views.Dialogs;
 using Microsoft.EntityFrameworkCore;
@@ -23,6 +24,43 @@ namespace DiffusionNexus.UI.ViewModels;
 /// </summary>
 public partial class ModelTileViewModel : ViewModelBase
 {
+    // #438: constructor-injected replacements for the former App.Services locator
+    // calls woven through this file. Nullable services degrade exactly as the old
+    // null-conditional locator lookups did; the scheduler/clipboard fall back to
+    // shared production instances so design-time / demo / grouping-test construction
+    // (which pass no dependency bundle) keeps working. The scope factory is a
+    // singleton whose CreateScope() is still called per DB operation below.
+    private readonly IUnifiedLogger? _logger;
+    private readonly IServiceScopeFactory? _scopeFactory;
+    private readonly IDialogService? _dialogService;
+    private readonly IVideoThumbnailService? _videoThumbnailService;
+    private readonly IClipboardService _clipboard = AvaloniaClipboardService.Instance;
+    private readonly IUiScheduler _uiScheduler = AvaloniaUiScheduler.Instance;
+
+    /// <summary>
+    /// Design-time / demo constructor. Produces a tile with no backing services —
+    /// commands that need the database or dialogs no-op, and the clipboard/scheduler
+    /// use their shared production defaults.
+    /// </summary>
+    public ModelTileViewModel() { }
+
+    /// <summary>
+    /// Runtime constructor. <paramref name="dependencies"/> carries the services the
+    /// tile previously pulled from <c>App.Services</c> (#438); it is optional so the
+    /// static factory methods and grouping tests keep compiling.
+    /// </summary>
+    public ModelTileViewModel(ModelTileDependencies? dependencies)
+    {
+        if (dependencies is { } d)
+        {
+            _logger = d.Logger;
+            _scopeFactory = d.ScopeFactory;
+            _dialogService = d.DialogService;
+            _videoThumbnailService = d.VideoThumbnailService;
+            _clipboard = d.Clipboard ?? AvaloniaClipboardService.Instance;
+            _uiScheduler = d.UiScheduler ?? AvaloniaUiScheduler.Instance;
+        }
+    }
     /// <summary>
     /// Maximum thumbnail BLOB size (1 MB). Images exceeding this limit are resized
     /// down to <see cref="MaxThumbnailWidth"/> pixels wide before being persisted to
@@ -516,21 +554,9 @@ public partial class ModelTileViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Copies text to the system clipboard via the Avalonia TopLevel.
+    /// Copies text to the system clipboard via the injected clipboard seam.
     /// </summary>
-    private static async Task CopyToClipboardAsync(string text)
-    {
-        var topLevel = Avalonia.Application.Current?.ApplicationLifetime
-            is Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop
-            ? desktop.MainWindow
-            : null;
-
-        var clipboard = topLevel?.Clipboard;
-        if (clipboard is not null)
-        {
-            await clipboard.SetTextAsync(text);
-        }
-    }
+    private Task CopyToClipboardAsync(string text) => _clipboard.SetTextAsync(text);
 
     /// <summary>
     /// Open model on Civitai. Tries multiple ID sources to build the URL:
@@ -563,8 +589,7 @@ public partial class ModelTileViewModel : ViewModelBase
 
         if (url is null)
         {
-            var logger = App.Services?.GetService<IUnifiedLogger>();
-            logger?.Warn(LogCategory.General, "OpenOnCivitai",
+            _logger?.Warn(LogCategory.General, "OpenOnCivitai",
                 $"No Civitai link available for '{DisplayName}' — run 'Download Metadata' first to sync with Civitai.");
             return;
         }
@@ -606,8 +631,8 @@ public partial class ModelTileViewModel : ViewModelBase
     [RelayCommand]
     private async Task DeleteAsync()
     {
-        var logger = App.Services?.GetService<IUnifiedLogger>();
-        var dialogService = App.Services?.GetService<IDialogService>();
+        var logger = _logger;
+        var dialogService = _dialogService;
 
         if (dialogService is null)
         {
@@ -667,7 +692,7 @@ public partial class ModelTileViewModel : ViewModelBase
         {
             DeleteFilesFromDisk(logger, [path]);
 
-            using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            using var scope = _scopeFactory!.CreateScope();
             var dbContext = scope.ServiceProvider
                 .GetRequiredService<IDbContextFactory<DiffusionNexusCoreDbContext>>()
                 .CreateDbContext();
@@ -728,13 +753,9 @@ public partial class ModelTileViewModel : ViewModelBase
     /// </summary>
     private async Task DeleteWithVersionPickerAsync(IUnifiedLogger? logger)
     {
-        // Find the main window for ShowDialog
-        var lifetime = Avalonia.Application.Current?.ApplicationLifetime
-            as Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime;
-        var mainWindow = lifetime?.MainWindow;
-        if (mainWindow is null)
+        if (_dialogService is null)
         {
-            logger?.Error(LogCategory.General, "Delete", "Cannot find main window for dialog.");
+            logger?.Error(LogCategory.General, "Delete", "Dialog service unavailable — cannot show version picker.");
             return;
         }
 
@@ -742,12 +763,9 @@ public partial class ModelTileViewModel : ViewModelBase
             ? _allGroupedModels
             : ModelEntity is not null ? new List<Model> { ModelEntity } : [];
 
-        var dialog = new SelectLoraVersionsToDeleteDialog()
-            .WithVersions(DisplayName, Versions, allModels);
+        var result = await _dialogService.ShowSelectLoraVersionsToDeleteDialogAsync(
+            DisplayName, Versions, allModels);
 
-        await dialog.ShowDialog(mainWindow);
-
-        var result = dialog.Result;
         if (result is null || !result.Confirmed || result.SelectedItems.Count == 0)
             return;
 
@@ -863,7 +881,7 @@ public partial class ModelTileViewModel : ViewModelBase
             // Remove entire model entities from the database
             if (modelIds.Count > 0)
             {
-                using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+                using var scope = _scopeFactory!.CreateScope();
                 var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
 
                 foreach (var modelId in modelIds)
@@ -902,7 +920,7 @@ public partial class ModelTileViewModel : ViewModelBase
 
             if (versionIds.Count > 0)
             {
-                using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+                using var scope = _scopeFactory!.CreateScope();
                 var dbContext = scope.ServiceProvider.GetRequiredService<IDbContextFactory<DiffusionNexusCoreDbContext>>()
                     .CreateDbContext();
                 await using (dbContext)
@@ -1292,7 +1310,7 @@ public partial class ModelTileViewModel : ViewModelBase
             {
                 var bitmap = CreateTileBitmap(data);
                 if (ct.IsCancellationRequested) return;
-                Dispatcher.UIThread.Post(() =>
+                _uiScheduler.Post(() =>
                 {
                     if (ct.IsCancellationRequested) return;
                     ThumbnailImage = bitmap;
@@ -1373,7 +1391,7 @@ public partial class ModelTileViewModel : ViewModelBase
         try
         {
             await Task.Delay(ThumbnailSettleDelayMs, ct).ConfigureAwait(false);
-            using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            using var scope = _scopeFactory!.CreateScope();
             var unitOfWork = scope.ServiceProvider.GetRequiredService<DataAccess.UnitOfWork.IUnitOfWork>();
             var (data, mimeType) = await unitOfWork.Models
                 .GetImageThumbnailDataAsync(image.Id, ct)
@@ -1386,7 +1404,7 @@ public partial class ModelTileViewModel : ViewModelBase
                 // Gradual self-healing: resize legacy oversized BLOBs on first read
                 if (data.Length > MaxThumbnailBytes)
                 {
-                    var logger = App.Services?.GetService<IUnifiedLogger>();
+                    var logger = _logger;
                     var (resizedData, resizedMime) = ResizeIfOversized(
                         data, mimeType ?? "image/jpeg", logger, $"ImageId={image.Id}");
 
@@ -1407,7 +1425,7 @@ public partial class ModelTileViewModel : ViewModelBase
                 // assignment needs the UI thread.
                 var bitmap = CreateTileBitmap(data);
                 ct.ThrowIfCancellationRequested();
-                await Dispatcher.UIThread.InvokeAsync(() => ThumbnailImage = bitmap);
+                await _uiScheduler.InvokeAsync(() => ThumbnailImage = bitmap);
             }
             else
             {
@@ -1424,7 +1442,7 @@ public partial class ModelTileViewModel : ViewModelBase
         catch (OperationCanceledException) { }
         catch (Exception ex)
         {
-            var logger = App.Services?.GetService<IUnifiedLogger>();
+            var logger = _logger;
             logger?.Debug(LogCategory.General, "ThumbnailLazyLoad",
                 $"Failed to lazy-load thumbnail for image {image.Id}: {ex.Message}");
         }
@@ -1473,7 +1491,7 @@ public partial class ModelTileViewModel : ViewModelBase
 
             if (localImagePath is null) return;
 
-            var logger = App.Services?.GetService<IUnifiedLogger>();
+            var logger = _logger;
             logger?.Debug(LogCategory.General, "LocalPreview",
                 $"Found local preview for '{DisplayName}': {Path.GetFileName(localImagePath)}");
 
@@ -1510,7 +1528,7 @@ public partial class ModelTileViewModel : ViewModelBase
             {
                 try
                 {
-                    using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+                    using var scope = _scopeFactory!.CreateScope();
                     var dbContext = scope.ServiceProvider.GetRequiredService<DiffusionNexusCoreDbContext>();
 
                     var dbVersion = await dbContext.ModelVersions
@@ -1556,7 +1574,7 @@ public partial class ModelTileViewModel : ViewModelBase
             ct.ThrowIfCancellationRequested();
 
             // Display the thumbnail immediately
-            await Dispatcher.UIThread.InvokeAsync(() =>
+            await _uiScheduler.InvokeAsync(() =>
             {
                 try
                 {
@@ -1622,7 +1640,7 @@ public partial class ModelTileViewModel : ViewModelBase
 
             if (staticSibling is not null)
             {
-                var logger = App.Services?.GetService<IUnifiedLogger>();
+                var logger = _logger;
                 logger?.Debug(LogCategory.Network, "ThumbnailDownload",
                     $"Primary image for '{DisplayName}' is video — using static sibling (ImageId={staticSibling.Id})");
 
@@ -1640,7 +1658,7 @@ public partial class ModelTileViewModel : ViewModelBase
     /// </summary>
     private async Task DownloadThumbnailAsync(ModelImage image, CancellationToken ct = default)
     {
-        var logger = App.Services?.GetService<IUnifiedLogger>();
+        var logger = _logger;
         var isVideo = IsVideoPreview(image);
         var previewType = isVideo ? "video" : "image";
         var displayName = DisplayName;
@@ -1710,7 +1728,7 @@ public partial class ModelTileViewModel : ViewModelBase
             ct.ThrowIfCancellationRequested();
 
             // Display the downloaded thumbnail
-            await Dispatcher.UIThread.InvokeAsync(() =>
+            await _uiScheduler.InvokeAsync(() =>
             {
                 try
                 {
@@ -1744,7 +1762,7 @@ public partial class ModelTileViewModel : ViewModelBase
         }
         finally
         {
-            await Dispatcher.UIThread.InvokeAsync(() => IsLoading = false);
+            await _uiScheduler.InvokeAsync(() => IsLoading = false);
         }
     }
 
@@ -1786,11 +1804,11 @@ public partial class ModelTileViewModel : ViewModelBase
     /// The Civitai CDN does not serve static poster images for video URLs;
     /// the <c>/width=300</c> trick only works for image URLs.
     /// </summary>
-    private static async Task<(byte[] Data, string MimeType)> DownloadVideoThumbnailAsync(
+    private async Task<(byte[] Data, string MimeType)> DownloadVideoThumbnailAsync(
         string videoUrl, IUnifiedLogger? logger)
     {
         // FFmpeg frame extraction — the only reliable way to get a poster from a video URL
-        var videoThumbnailService = App.Services?.GetService<IVideoThumbnailService>();
+        var videoThumbnailService = _videoThumbnailService;
         if (videoThumbnailService is null)
         {
             logger?.Warn(LogCategory.General, "ThumbnailDownload",
@@ -2024,15 +2042,15 @@ public partial class ModelTileViewModel : ViewModelBase
     /// Persists downloaded thumbnail bytes to the database for a given ModelImage.
     /// Applies <see cref="ResizeIfOversized"/> as a safety net before writing to DB.
     /// </summary>
-    private static async Task PersistThumbnailAsync(int imageId, byte[] thumbnailData, string mimeType)
+    private async Task PersistThumbnailAsync(int imageId, byte[] thumbnailData, string mimeType)
     {
-        var logger = App.Services?.GetService<IUnifiedLogger>();
+        var logger = _logger;
         try
         {
             // Safety net: resize if somehow oversized bytes reach persist directly
             (thumbnailData, mimeType) = ResizeIfOversized(thumbnailData, mimeType, logger, $"ImageId={imageId}");
 
-            using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            using var scope = _scopeFactory!.CreateScope();
             var dbContext = scope.ServiceProvider.GetRequiredService<DataAccess.Data.DiffusionNexusCoreDbContext>();
             var dbImage = await dbContext.ModelImages.FindAsync(imageId);
             if (dbImage is not null)
@@ -2061,11 +2079,13 @@ public partial class ModelTileViewModel : ViewModelBase
     #region Factory Methods
 
     /// <summary>
-    /// Creates a ModelTileViewModel from a Model entity.
+    /// Creates a ModelTileViewModel from a Model entity. <paramref name="dependencies"/>
+    /// carries the services the tile needs at runtime (#438); pass <c>null</c> for
+    /// design-time / grouping-logic tests.
     /// </summary>
-    public static ModelTileViewModel FromModel(Model model)
+    public static ModelTileViewModel FromModel(Model model, ModelTileDependencies? dependencies = null)
     {
-        var vm = new ModelTileViewModel();
+        var vm = new ModelTileViewModel(dependencies);
         vm._allGroupedModels = [model];
         vm._allDatabaseModelIds = [model.Id];
         vm.ModelEntity = model;
@@ -2083,7 +2103,8 @@ public partial class ModelTileViewModel : ViewModelBase
     public static ModelTileViewModel FromModelInLocation(
         IReadOnlyList<Model> models,
         string rootPath,
-        IReadOnlyList<(ModelVersion Version, ModelFile File)> versionFiles)
+        IReadOnlyList<(ModelVersion Version, ModelFile File)> versionFiles,
+        ModelTileDependencies? dependencies = null)
     {
         var map = new Dictionary<int, ModelFile>(versionFiles.Count);
         foreach (var (version, file) in versionFiles)
@@ -2101,7 +2122,7 @@ public partial class ModelTileViewModel : ViewModelBase
             .ThenByDescending(m => m.LastSyncedAt)
             .First();
 
-        var vm = new ModelTileViewModel
+        var vm = new ModelTileViewModel(dependencies)
         {
             _allGroupedModels = models.ToList(),
             _allDatabaseModelIds = models.Select(m => m.Id).ToHashSet(),
@@ -2116,7 +2137,7 @@ public partial class ModelTileViewModel : ViewModelBase
     /// Creates a ModelTileViewModel from multiple Model entities that share the same Civitai page.
     /// Versions from all models are merged into a single tile.
     /// </summary>
-    public static ModelTileViewModel FromModelGroup(IReadOnlyList<Model> models)
+    public static ModelTileViewModel FromModelGroup(IReadOnlyList<Model> models, ModelTileDependencies? dependencies = null)
     {
         // Use the model with the richest data as the primary display model
         var primary = models
@@ -2125,7 +2146,7 @@ public partial class ModelTileViewModel : ViewModelBase
             .ThenByDescending(m => m.LastSyncedAt)
             .First();
 
-        var vm = new ModelTileViewModel();
+        var vm = new ModelTileViewModel(dependencies);
         vm._allGroupedModels = models.ToList();
         vm._allDatabaseModelIds = models.Select(m => m.Id).ToHashSet();
         vm.ModelEntity = primary;

--- a/DiffusionNexus.UI/ViewModels/TileGroupingHelper.cs
+++ b/DiffusionNexus.UI/ViewModels/TileGroupingHelper.cs
@@ -22,7 +22,9 @@ internal static class TileGroupingHelper
     /// Within each group, re-discovery duplicates (same filename) are collapsed — only the
     /// model with the richest metadata is kept per unique filename.
     /// </summary>
-    internal static List<ModelTileViewModel> GroupModelsIntoTiles(IReadOnlyList<Model> allModels)
+    internal static List<ModelTileViewModel> GroupModelsIntoTiles(
+        IReadOnlyList<Model> allModels,
+        ModelTileDependencies? dependencies = null)
     {
         var tiles = new List<ModelTileViewModel>();
 
@@ -44,8 +46,8 @@ internal static class TileGroupingHelper
                 consumed.Add(m.Id);
 
             var tile = deduped.Count == 1
-                ? ModelTileViewModel.FromModel(deduped[0])
-                : ModelTileViewModel.FromModelGroup(deduped);
+                ? ModelTileViewModel.FromModel(deduped[0], dependencies)
+                : ModelTileViewModel.FromModelGroup(deduped, dependencies);
 
             // Track every original DB id (incl. dropped duplicates) so destructive
             // ops like "Delete Metadata" don't leave orphan rows behind.
@@ -68,8 +70,8 @@ internal static class TileGroupingHelper
                 consumed.Add(m.Id);
 
             var tile = deduped.Count == 1
-                ? ModelTileViewModel.FromModel(deduped[0])
-                : ModelTileViewModel.FromModelGroup(deduped);
+                ? ModelTileViewModel.FromModel(deduped[0], dependencies)
+                : ModelTileViewModel.FromModelGroup(deduped, dependencies);
 
             tile.RegisterAdditionalDatabaseIds(groupModels.Select(m => m.Id));
 

--- a/DiffusionNexus.UI/Views/Dialogs/AssignCivitaiIdsDialog.axaml.cs
+++ b/DiffusionNexus.UI/Views/Dialogs/AssignCivitaiIdsDialog.axaml.cs
@@ -296,3 +296,15 @@ public partial class AssignCivitaiIdsDialog : Window
         Close(false);
     }
 }
+
+/// <summary>
+/// Result of the <see cref="AssignCivitaiIdsDialog"/> shown via
+/// <see cref="Services.IDialogService.ShowAssignCivitaiIdsDialogAsync"/>.
+/// </summary>
+/// <param name="IsConfirmed">True when the user confirmed the resolved model.</param>
+/// <param name="ResolvedModel">The Civitai model resolved from the URL/IDs, or null.</param>
+/// <param name="ResolvedVersion">The selected version, or the model's first version.</param>
+public readonly record struct AssignCivitaiIdsDialogResult(
+    bool IsConfirmed,
+    CivitaiModel? ResolvedModel,
+    CivitaiModelVersion? ResolvedVersion);

--- a/DiffusionNexus.UI/Views/Dialogs/CivitaiTokenDialog.axaml.cs
+++ b/DiffusionNexus.UI/Views/Dialogs/CivitaiTokenDialog.axaml.cs
@@ -163,3 +163,11 @@ public partial class CivitaiTokenDialog : Window
         }
     }
 }
+
+/// <summary>
+/// Result of the <see cref="CivitaiTokenDialog"/> shown via
+/// <see cref="Services.IDialogService.ShowCivitaiTokenDialogAsync"/>.
+/// </summary>
+/// <param name="IsSaved">True when the user saved a validated token.</param>
+/// <param name="TokenText">The entered token text (empty when cancelled).</param>
+public readonly record struct CivitaiTokenDialogResult(bool IsSaved, string TokenText);


### PR DESCRIPTION
## Summary
`ModelTileViewModel` (2189 lines, 11 bugfixes) resolved dependencies from the static `App.Services` locator at 10 call sites; `ModelDetailViewModel` (1520 lines, 9 bugfixes) had a clean constructor that its method bodies bypassed with locator calls anyway. The issue called them **permanently untestable** — no test could substitute a dependency — on the exact Civitai + database + thumbnail surface that produced the repo's worst production incidents (thumbnail-BLOB OOM, per-download HttpClient socket exhaustion). This PR makes both fully constructor-injected.

## Change (4 commits)
1. **Seams:** `AvaloniaClipboardService` (implements the SDK's existing single-method `IClipboardService` contract — no duplicate interface; identical logic and thread affinity to the old inline clipboard code), three dialog methods on a narrow seam (self-marshalling to the UI thread), and an `InvokeAsync(Func<Task>)` overload on `IUiScheduler`.
2. **ModelDetailViewModel:** every locator call routed through injected fields (`IServiceScopeFactory`, download/coordinator/tracker/logger services); the one production construction site passes all 8 deps from DI.
3. **ModelTileViewModel:** all locator sites replaced via an optional `ModelTileDependencies` record (defaults preserve the old null-conditional degradation exactly; the two live production sites resolve real services, the 10+ factory/demo/test sites keep compiling unchanged).
4. **Tests (8 new, both incident paths):** socket-exhaustion guard (shared `static readonly HttpClient` pinned), OOM path (`ResizeIfOversized` on genuine >1MB SkiaSharp bytes asserting the 1MB cap; targeted `GetImageThumbnailDataAsync`, no `GetAllWithIncludesAsync`), plus seam-proving VM construction tests with fakes — no global Avalonia init.

**Review adjudications (Opus, all upheld):** dialog resolution moved from per-click to tile-build — verified behavior-equivalent because MainWindow provably exists before any tile is built (module load is deferred for exactly that reason) and the dialog service is app-scoped, so both timings yield the identical instance; scoped-DB discipline preserved (`CreateScope()` still strictly per-operation inside `using`, nothing scoped captured as a field); every eager-resolution move preserves instance identity and lifetime (full table in the review).

## Found along the way (tracked, not smuggled in)
- https://github.com/Little-God1983/DiffusionNexus/issues/460 — pre-existing per-call `new HttpClient()` in `ModelDetailViewModel.DownloadCivitaiThumbnailAsync`, the same anti-pattern as the tile incident.
- `LoraViewerViewModel`'s own `App.Services` usage is outside this issue's scope (it is where child-VM deps are now explicitly resolved).

## Tests
Full unit suite: **3089/3089** in 11s, Release, `--blame-hang-timeout 180s`, no hang (baseline 3081 + 8 new). Zero `App.Services` / `App.Current` / `Dispatcher.UIThread` references remain in either VM (grep-verified; comments only).

## ⚠️ Before/after merge
Manual smoke of the model browser + detail view is owed — this rewires dependency resolution on the repo's highest-incident surface (downloads, thumbnails, delete/edit dialogs, clipboard).

Fixes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)