### PR TITLE
fix(tests): implement new IDialogService members in integration-test stub

### DIFF
--- a/DiffusionNexus.IntegrationTests/DatasetManagementIntegrationTests.cs
+++ b/DiffusionNexus.IntegrationTests/DatasetManagementIntegrationTests.cs
@@ -145,6 +145,18 @@ public class DatasetManagementIntegrationTests : IClassFixture<TestAppHost>
         public Task<ReplaceImageResult> ShowReplaceImageDialogAsync(DatasetImageViewModel originalImage) =>
             Task.FromResult(ReplaceImageResult.Cancelled());
 
+        public Task<LoraDeleteResult?> ShowSelectLoraVersionsToDeleteDialogAsync(
+            string displayName,
+            IEnumerable<ModelVersion> versions,
+            IReadOnlyList<Model> allGroupedModels) =>
+            Task.FromResult<LoraDeleteResult?>(null);
+
+        public Task<CivitaiTokenDialogResult> ShowCivitaiTokenDialogAsync() =>
+            Task.FromResult(new CivitaiTokenDialogResult(false, string.Empty));
+
+        public Task<AssignCivitaiIdsDialogResult> ShowAssignCivitaiIdsDialogAsync() =>
+            Task.FromResult(new AssignCivitaiIdsDialogResult(false, null, null));
+
         public Task<bool> ShowBackupCompareDialogAsync(BackupCompareData currentStats, BackupCompareData backupStats) =>
             Task.FromResult(false);
 


### PR DESCRIPTION
## Summary
Develop's CI build broke after merging PR #461 (issue #438): the dialog seam added three members to `IDialogService` (`ShowSelectLoraVersionsToDeleteDialogAsync`, `ShowCivitaiTokenDialogAsync`, `ShowAssignCivitaiIdsDialogAsync`), and `DiffusionNexus.IntegrationTests`' `StubDialogService` wasn't updated — CS0535 × 3.

Root cause of the escape: the sweep's local verification built and ran only `DiffusionNexus.Tests` (long-standing guidance to avoid full-solution `dotnet test` stalls), so the IntegrationTests project was never compiled locally; CI builds the entire solution.

## Fix
Three stub implementations returning the same cancelled/null defaults as every other member of the stub.

## Verification (full CI mirror this time)
- `dotnet build DiffusionNexus.sln -c Release`: 0 errors.
- IntegrationTests: 2/2. Unit suite: 3089/3089 (hang guard clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)