### PR TITLE
fix(ui): shared HttpClient for detail-view thumbnail downloads

### DIFF
--- a/DiffusionNexus.Tests/ViewModels/ModelDetailViewModelTests.cs
+++ b/DiffusionNexus.Tests/ViewModels/ModelDetailViewModelTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using DiffusionNexus.Civitai;
 using DiffusionNexus.Domain.Services;
 using DiffusionNexus.Domain.Services.UnifiedLogging;
@@ -79,5 +80,23 @@ public class ModelDetailViewModelTests
         await vm.CopyTriggerWordsCommand.ExecuteAsync(null);
 
         clipboard.Copied.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CivitaiThumbnailDownloadsShareASingleStaticHttpClient()
+    {
+        // #460: LoadCivitaiThumbnailAsync used to create a fresh `new HttpClient()` per
+        // download — the same per-call-client anti-pattern that produced the tile's
+        // documented socket-exhaustion incident (TIME_WAIT accumulation -> OOM after ~100
+        // downloads; see ModelTileViewModelTests.ThumbnailDownloadsShareASingleStaticHttpClient).
+        // Assert the fix mirrors the tile's `s_thumbnailClient` pattern: one shared,
+        // readonly static client instead of a per-call instance.
+        var field = typeof(ModelDetailViewModel).GetField(
+            "s_civitaiThumbnailClient", BindingFlags.NonPublic | BindingFlags.Static);
+
+        field.Should().NotBeNull("Civitai thumbnail downloads must reuse one shared HttpClient");
+        field!.IsInitOnly.Should().BeTrue("the shared client must be readonly so it can't be swapped per-call");
+        field.FieldType.Should().Be<HttpClient>();
+        field.GetValue(null).Should().NotBeNull();
     }
 }

--- a/DiffusionNexus.UI/ViewModels/ModelDetailViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/ModelDetailViewModel.cs
@@ -56,6 +56,18 @@ public partial class ModelDetailViewModel : ViewModelBase
     /// </summary>
     private CancellationTokenSource? _detailThumbnailCts;
 
+    /// <summary>
+    /// Shared HttpClient for Civitai version-thumbnail downloads (see
+    /// <see cref="LoadCivitaiThumbnailAsync"/>). Reusing a single instance avoids the
+    /// socket exhaustion (TIME_WAIT accumulation) that a fresh <c>new HttpClient()</c> per
+    /// call caused on the tile thumbnail path — mirrors <c>ModelTileViewModel</c>'s
+    /// <c>s_thumbnailClient</c> pattern (issue #460).
+    /// </summary>
+    private static readonly HttpClient s_civitaiThumbnailClient = new()
+    {
+        Timeout = TimeSpan.FromSeconds(15)
+    };
+
     #region Observable Properties
 
     /// <summary>
@@ -1455,8 +1467,7 @@ public partial class ModelDetailViewModel : ViewModelBase
 
         try
         {
-            using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
-            var data = await httpClient.GetByteArrayAsync(image.Url, ct);
+            var data = await s_civitaiThumbnailClient.GetByteArrayAsync(image.Url, ct);
             if (data.Length == 0) return;
 
             ct.ThrowIfCancellationRequested();


### PR DESCRIPTION
## Summary
`ModelDetailViewModel.LoadCivitaiThumbnailAsync` (the issue named it `DownloadCivitaiThumbnailAsync`; review confirmed this is the only per-call-client thumbnail site in the file) created a `new HttpClient` per call — the same anti-pattern behind the tile view's documented socket-exhaustion incident.

## Fix
Shared `private static readonly HttpClient s_civitaiThumbnailClient` with the **exact** old configuration (15s timeout, no headers — deliberately not copying the tile client's 60s/User-Agent config; review verified zero drift). The field serves only this path. Structural pin test mirrors the tile's assertion-for-assertion.

**Why no behavioral wiring test:** the shared client is process-wide static state and this test project runs xUnit's default cross-class parallelism — a reflection-swap of the static field to a fake handler would be a genuine flakiness risk (the initially-recorded Avalonia-decode rationale was imprecise; this is the accurate reason, per review).

## Also noted (not in scope)
`ModelDetailViewModel.DownloadFileAsync` (~line 409) still builds a per-call client — but it's a 2-hour-timeout streaming model-file downloader with redirect/auth-retry config and one-at-a-time usage, a genuinely different lifetime shape from per-thumbnail chatter. Left for a deliberate decision rather than smuggled in.

## Tests
Focused 4/4; full unit suite **3090/3090** (+1 structural pin); full-solution Release build 0 errors/0 warnings.
Task-reviewed (spec + quality): approved — call-site correctness, config parity, and out-of-scope grep all independently verified.

Fixes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)