### PR TITLE
docs(service): codify the no-score-row contract in per-image quality aggregation

### DIFF
--- a/DiffusionNexus.Domain/Models/QualityScoreModels.cs
+++ b/DiffusionNexus.Domain/Models/QualityScoreModels.cs
@@ -71,8 +71,21 @@ public record PerImageQualitySummary
     public string? JpegDetail { get; init; }
 
     /// <summary>
-    /// Mean of all non-null score components. Returns NaN when no checks reported a score.
+    /// Mean of all non-null score components. Returns <see cref="double.NaN"/> when no
+    /// checks reported a score for this image.
     /// </summary>
+    /// <remarks>
+    /// NaN is a deliberate "no data" sentinel, not an error state — it is produced (by
+    /// design, issue #449) for images that were seen only by checks that
+    /// <c>PerImageQualityAggregator</c> intentionally ignores (Duplicate Detection, Color
+    /// Distribution) or by an unrecognized check name, and the row is kept rather than
+    /// dropped so the image still shows up in the Fixer grid. Callers must call
+    /// <see cref="double.IsNaN(double)"/> before treating this as a real score: do not
+    /// average, sum, or otherwise let it flow unguarded into arithmetic (NaN silently
+    /// propagates) and do not rely on direct comparisons (NaN comparisons are always
+    /// <see langword="false"/>). The canonical consumer is <c>ImageQualityAdvisor.Analyze</c>,
+    /// which maps NaN to a distinct "Unknown" verdict instead of banding a non-existent score.
+    /// </remarks>
     public double OverallScore
     {
         get

--- a/DiffusionNexus.Service/Services/DatasetQuality/PerImageQualityAggregator.cs
+++ b/DiffusionNexus.Service/Services/DatasetQuality/PerImageQualityAggregator.cs
@@ -8,6 +8,32 @@ namespace DiffusionNexus.Service.Services.DatasetQuality;
 /// check that ran into a single <see cref="PerImageQualitySummary"/> per image,
 /// keyed by absolute file path.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>No-score-row contract (issue #449):</b> an image is keyed into the result as soon
+/// as ANY check reports a <see cref="PerImageScore"/> for it — including checks that are
+/// intentionally ignored here (Duplicate Detection, Color Distribution; see
+/// <see cref="ApplyScore"/>) and any unrecognized/future check name that falls through
+/// the switch below. When none of the four scoring columns (Blur/Exposure/Noise/JPEG)
+/// end up populated for that image, the row is still returned rather than dropped: all
+/// four score columns are <see langword="null"/> and
+/// <see cref="PerImageQualitySummary.OverallScore"/> evaluates to
+/// <see cref="double.NaN"/>.
+/// </para>
+/// <para>
+/// This is a deliberate decision, not an accident. Suppressing the row would silently
+/// hide the image from the Image Quality Fixer grid, which is worse than showing an
+/// explicit "no score data" row for it. Callers MUST treat <c>OverallScore == NaN</c> as
+/// "no quality checks scored this image" — never as a real score of zero, and never
+/// let it flow unguarded into arithmetic (NaN silently propagates through sums/averages,
+/// and NaN comparisons are always <see langword="false"/>). The canonical consumer is
+/// <see cref="ImageQualityAdvisor.Analyze(PerImageQualitySummary)"/>, which maps NaN to
+/// the distinct <see cref="ImageQualityVerdict.Unknown"/> verdict ("No quality checks ran
+/// for this image") instead of trying to band a non-existent score. The Image Quality
+/// Fixer grid's sort likewise special-cases NaN so these rows land at the correct end
+/// regardless of sort direction, rather than participating in a NaN-corrupted ordering.
+/// </para>
+/// </remarks>
 public static class PerImageQualityAggregator
 {
     /// <summary>
@@ -17,7 +43,12 @@ public static class PerImageQualityAggregator
     /// their own dedicated fixers and are ignored here.
     /// </summary>
     /// <param name="results">All image check results from one analysis run.</param>
-    /// <returns>One summary per image, keyed by absolute file path (case-insensitive).</returns>
+    /// <returns>
+    /// One summary per image, keyed by absolute file path (case-insensitive). Includes
+    /// "no score data" rows (all-null columns, NaN <see cref="PerImageQualitySummary.OverallScore"/>)
+    /// for images seen only by ignored or unrecognized checks — see the type-level
+    /// remarks for the contract this implies for callers.
+    /// </returns>
     public static IReadOnlyDictionary<string, PerImageQualitySummary> Aggregate(
         IReadOnlyList<ImageCheckResult> results)
     {

--- a/DiffusionNexus.Tests/DatasetQuality/ImageQualityAdvisorTests.cs
+++ b/DiffusionNexus.Tests/DatasetQuality/ImageQualityAdvisorTests.cs
@@ -6,8 +6,11 @@ namespace DiffusionNexus.Tests.DatasetQuality;
 
 /// <summary>
 /// Unit tests for <see cref="ImageQualityAdvisor.Analyze"/>: verdict banding,
-/// which metrics become problems, the per-metric wording, the headline variants
-/// and the de-duplicated fix suggestions.
+/// which metrics become problems, the per-metric wording, the headline variants,
+/// the de-duplicated fix suggestions, and — in "Guard clauses" — the NaN
+/// <c>OverallScore</c> to <see cref="ImageQualityVerdict.Unknown"/> mapping that is the
+/// canonical consumer of the no-score-row contract on <c>PerImageQualityAggregator</c>
+/// (issue #449).
 /// </summary>
 public class ImageQualityAdvisorTests
 {
@@ -50,8 +53,15 @@ public class ImageQualityAdvisorTests
     [Fact]
     public void WhenNoChecksRanThenVerdictIsUnknownWithNoProblemsOrFixes()
     {
+        // Direct test of the NaN "no data" contract (issue #449): a summary with every
+        // column null has OverallScore == NaN (see PerImageQualitySummaryTests), and this
+        // is the canonical consumer that turns that NaN into the distinct Unknown verdict
+        // rather than trying to band a non-existent score. PerImageQualityAggregator
+        // deliberately keeps rows like this (images seen only by an ignored/unrecognized
+        // check) instead of dropping them, precisely so they reach this branch.
         var advice = ImageQualityAdvisor.Analyze(Summary());
 
+        double.IsNaN(Summary().OverallScore).Should().BeTrue("a summary with no columns set must produce the NaN sentinel");
         advice.Verdict.Should().Be(ImageQualityVerdict.Unknown);
         advice.Headline.Should().Be("No quality checks ran for this image.");
         advice.Problems.Should().BeEmpty();

--- a/DiffusionNexus.Tests/DatasetQuality/PerImageQualityAggregatorTests.cs
+++ b/DiffusionNexus.Tests/DatasetQuality/PerImageQualityAggregatorTests.cs
@@ -8,7 +8,8 @@ namespace DiffusionNexus.Tests.DatasetQuality;
 /// <summary>
 /// Unit tests for <see cref="PerImageQualityAggregator"/>: joining the per-image
 /// scores of several image checks into one summary per file, which checks map to
-/// which column, and the case-insensitive path keying.
+/// which column, the case-insensitive path keying, and the no-score-row contract for
+/// images seen only by ignored/unrecognized checks (issue #449).
 /// </summary>
 public class PerImageQualityAggregatorTests
 {
@@ -175,19 +176,28 @@ public class PerImageQualityAggregatorTests
 
     #endregion
 
-    #region Ignored checks
+    #region No-score-row contract (issue #449)
+
+    // These two tests pin the deliberate contract documented on PerImageQualityAggregator:
+    // an image seen only by an ignored/unrecognized check still gets a row — all four
+    // score columns null, OverallScore == NaN — instead of being dropped from the result.
+    // Dropping it would silently hide the image from the Image Quality Fixer grid, which
+    // is the exact scenario the contract exists to avoid. Both cases must stay aligned:
+    // if one is ever changed to suppress the row, the other must change too.
 
     [Theory]
     [InlineData(DuplicateDetector.CheckDisplayName)]
     [InlineData(ColorDistributionAnalyzer.CheckDisplayName)]
-    public void WhenCheckHasItsOwnFixerThenItProducesNoScoreColumns(string checkName)
+    public void WhenImageIsSeenOnlyByAnIgnoredCheckThenItStillGetsANoScoreRow(string checkName)
     {
         const string path = @"C:\ds\img.png";
         var results = new[] { Result(checkName, new PerImageScore(path, 5, "detail")) };
 
         var summaries = PerImageQualityAggregator.Aggregate(results);
 
-        // The image is still keyed (it was seen), but none of the four columns are filled.
+        // Contract: the image is still keyed (it was seen), but none of the four columns
+        // are filled and OverallScore is the NaN "no data" sentinel — not suppressed,
+        // not zero.
         summaries.Should().ContainSingle();
         var summary = summaries[path];
         summary.BlurScore.Should().BeNull();
@@ -198,15 +208,23 @@ public class PerImageQualityAggregatorTests
     }
 
     [Fact]
-    public void WhenUnknownCheckNameThenNoColumnIsPopulated()
+    public void WhenImageIsSeenOnlyByAnUnrecognizedCheckNameThenItStillGetsANoScoreRow()
     {
         const string path = @"C:\ds\img.png";
         var results = new[] { Result("Some Future Check", new PerImageScore(path, 5, "detail")) };
 
-        var summary = PerImageQualityAggregator.Aggregate(results)[path];
+        var summaries = PerImageQualityAggregator.Aggregate(results);
 
+        // Same contract as the ignored-check case above: a forward-compatible/unknown
+        // check name must not cause the image to vanish from the aggregate, and must not
+        // throw when accessed via the indexer.
+        summaries.Should().ContainSingle();
+        var summary = summaries[path];
         summary.BlurScore.Should().BeNull();
+        summary.ExposureScore.Should().BeNull();
+        summary.NoiseScore.Should().BeNull();
         summary.JpegScore.Should().BeNull();
+        double.IsNaN(summary.OverallScore).Should().BeTrue();
     }
 
     #endregion

--- a/DiffusionNexus.Tests/Domain/Models/PerImageQualitySummaryTests.cs
+++ b/DiffusionNexus.Tests/Domain/Models/PerImageQualitySummaryTests.cs
@@ -12,6 +12,9 @@ public class PerImageQualitySummaryTests
     [Fact]
     public void OverallScore_IsNaN_WhenNoChecksRan()
     {
+        // This is the NaN "no data" sentinel documented as a deliberate contract
+        // (issue #449): PerImageQualityAggregator keeps a row like this instead of
+        // dropping it, and ImageQualityAdvisor.Analyze maps it to the Unknown verdict.
         var summary = new PerImageQualitySummary { FilePath = "image.png" };
 
         double.IsNaN(summary.OverallScore).Should().BeTrue();


### PR DESCRIPTION
## Summary
Resolves the contract question from #449 (spun out of #432): what should `PerImageQualityAggregator` produce for an image seen only by ignored/score-less checks?

**Decision: keep the rows.** An ignored-check-only image stays in the aggregate as an explicit "no score data" row (all-null columns, `OverallScore == NaN`). Downstream already treats this deliberately — `ImageQualityAdvisor` maps NaN to a distinct `Unknown` verdict ("No quality checks ran for this image") and the Fixer grid sorts NaN rows to the correct end. Suppressing rows would silently hide images from the Fixer grid, which is strictly worse than an honest "no data" row.

## Change (docs + tests only — zero production behavior change, review-verified line-by-line)
- Contract documented in XML on `PerImageQualityAggregator` and `PerImageQualitySummary`: what a NaN row means, the consumer obligation to treat NaN as "no data", and the canonical consumer (`ImageQualityAdvisor.Analyze` → `Unknown`).
- The two previously-accidental pinned tests (ignored-check-only → NaN row; unknown-check-name → row without column) renamed and strengthened into deliberate contract tests, with comments noting they must change in tandem with any future contract revision.
- Advisor's NaN → `Unknown` behavior directly asserted.
- **NaN-consumer audit (every `OverallScore` reader): safe everywhere.** Fixer sort substitutes NaN with Min/MaxValue, score-color banding NaN-guards, and nothing averages summaries' `OverallScore` into a displayed aggregate — the two similarly-named computations in `ImageQualityTabViewModel` never consume the aggregator's output. Nothing needed fixing; the audit result is part of the record.

## Tests
Focused 54/54; full unit suite 3089/3089 (flat by design — assertions strengthened in-place, zero net new test methods, reviewer verified nothing was dropped); full-solution Release build 0 errors/0 warnings.
Task-reviewed (spec + quality): approved, zero findings.

Fixes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)