### PR TITLE
chore: housekeeping - dead artifacts, duplicate FormatFileSize, CS0162

### DIFF
--- a/DiffusionNexus.Tests/ViewModels/FileConflictDialogViewModelTests.cs
+++ b/DiffusionNexus.Tests/ViewModels/FileConflictDialogViewModelTests.cs
@@ -429,7 +429,7 @@ public class FileConflictDialogViewModelTests
 
     #endregion
 
-    #region FormatFileSize (duplicated in FileConflictItem and NonConflictingFileItem)
+    #region FormatFileSize (shared via FileSizeFormatter, used by both FileConflictItem and NonConflictingFileItem)
 
     [Theory]
     [InlineData(0L, "0 B")]
@@ -442,36 +442,21 @@ public class FileConflictDialogViewModelTests
     [InlineData(1073741823L, "1024.0 MB")]
     [InlineData(1073741824L, "1.00 GB")]
     [InlineData(2147483648L, "2.00 GB")]
-    public void WhenFormattingConflictItemSizesThenUnitBoundariesAreRespected(long bytes, string expected)
+    public void WhenFormattingFileSizesThenUnitBoundariesAreRespected(long bytes, string expected)
     {
         WithInvariantCulture(() =>
         {
-            var item = new FileConflictItem
+            var conflictItem = new FileConflictItem
             {
                 ConflictingName = "a.png",
                 ExistingFileSize = bytes,
                 NewFileSize = bytes
             };
+            var nonConflictingItem = new NonConflictingFileItem { FileName = "a.png", FileSize = bytes };
 
-            item.ExistingFileSizeText.Should().Be(expected);
-            item.NewFileSizeText.Should().Be(expected);
-        });
-    }
-
-    [Theory]
-    [InlineData(0L, "0 B")]
-    [InlineData(1023L, "1023 B")]
-    [InlineData(1024L, "1.0 KB")]
-    [InlineData(1048575L, "1024.0 KB")]
-    [InlineData(1048576L, "1.0 MB")]
-    [InlineData(1073741823L, "1024.0 MB")]
-    [InlineData(1073741824L, "1.00 GB")]
-    public void WhenFormattingNonConflictingItemSizesThenTheDuplicateFormatterMatches(long bytes, string expected)
-    {
-        WithInvariantCulture(() =>
-        {
-            var item = new NonConflictingFileItem { FileName = "a.png", FileSize = bytes };
-            item.FileSizeText.Should().Be(expected);
+            conflictItem.ExistingFileSizeText.Should().Be(expected);
+            conflictItem.NewFileSizeText.Should().Be(expected);
+            nonConflictingItem.FileSizeText.Should().Be(expected);
         });
     }
 

--- a/DiffusionNexus.UI/App.axaml.cs
+++ b/DiffusionNexus.UI/App.axaml.cs
@@ -270,7 +270,16 @@ public partial class App : Application
             }
             else
             {
+                // DiffusionFeatureFlags.UseLocalDiffusionBackend is currently hardcoded to `true`
+                // (see its TODO(v2-backend-dropdown) doc comment — it's slated to become a runtime
+                // AppSettings option once the backend dropdown ships). While it's a const, the
+                // compiler proves this branch unreachable and reports CS0162; the branch itself is
+                // intentional — it's what keeps the "diffusion-engine" ready-check from hanging when
+                // the flag is flipped to `false` locally — so it's suppressed here rather than
+                // deleted.
+#pragma warning disable CS0162 // Unreachable code detected
                 startupProgress.Complete("diffusion-engine");
+#pragma warning restore CS0162
             }
         }
         catch (Exception ex)

--- a/DiffusionNexus.UI/Helpers/FileSizeFormatter.cs
+++ b/DiffusionNexus.UI/Helpers/FileSizeFormatter.cs
@@ -1,0 +1,30 @@
+namespace DiffusionNexus.UI.Helpers;
+
+/// <summary>
+/// Formats a byte count into a human-readable size string (B/KB/MB/GB).
+/// </summary>
+/// <remarks>
+/// Extracted from three byte-identical private copies (two in
+/// <c>FileConflictDialogViewModel.cs</c>, one in <c>BackupCompareDialog.axaml.cs</c>)
+/// found during the #442 housekeeping pass. There are other file-size formatters
+/// elsewhere in the codebase (e.g. <c>CivitaiDownloadQueue.FormatBytes</c>) with
+/// different rounding/precision rules; those are intentionally left alone since
+/// unifying them would change displayed text.
+/// </remarks>
+internal static class FileSizeFormatter
+{
+    /// <summary>
+    /// Formats <paramref name="bytes"/> as a size string.
+    /// Uses one decimal place for KB/MB and two for GB.
+    /// </summary>
+    public static string Format(long bytes)
+    {
+        if (bytes < 1024)
+            return $"{bytes} B";
+        if (bytes < 1024 * 1024)
+            return $"{bytes / 1024.0:F1} KB";
+        if (bytes < 1024 * 1024 * 1024)
+            return $"{bytes / (1024.0 * 1024.0):F1} MB";
+        return $"{bytes / (1024.0 * 1024.0 * 1024.0):F2} GB";
+    }
+}

--- a/DiffusionNexus.UI/Services/ImageMetadataParser.cs
+++ b/DiffusionNexus.UI/Services/ImageMetadataParser.cs
@@ -311,7 +311,6 @@ internal sealed partial class ImageMetadataParser
     {
         foreach (var match in LoraTagRegex().EnumerateMatches(prompt))
         {
-            var fullMatch = prompt.AsSpan(match.Index, match.Length);
             // Parse via the Regex object to get groups
             var regexMatch = LoraTagRegex().Match(prompt, match.Index, match.Length);
             if (!regexMatch.Success) continue;

--- a/DiffusionNexus.UI/ViewModels/FileConflictDialogViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/FileConflictDialogViewModel.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using Avalonia.Media.Imaging;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using DiffusionNexus.UI.Helpers;
 
 namespace DiffusionNexus.UI.ViewModels;
 
@@ -176,12 +177,12 @@ public sealed class FileConflictItem : INotifyPropertyChanged
     /// <summary>
     /// Formatted existing file size for display.
     /// </summary>
-    public string ExistingFileSizeText => FormatFileSize(ExistingFileSize);
+    public string ExistingFileSizeText => FileSizeFormatter.Format(ExistingFileSize);
 
     /// <summary>
     /// Formatted new file size for display.
     /// </summary>
-    public string NewFileSizeText => FormatFileSize(NewFileSize);
+    public string NewFileSizeText => FileSizeFormatter.Format(NewFileSize);
 
     /// <summary>
     /// Formatted existing creation date for display.
@@ -192,17 +193,6 @@ public sealed class FileConflictItem : INotifyPropertyChanged
     /// Formatted new creation date for display.
     /// </summary>
     public string NewCreationDateText => NewCreationDate.ToString("dd.MM.yyyy");
-
-    private static string FormatFileSize(long bytes)
-    {
-        if (bytes < 1024)
-            return $"{bytes} B";
-        if (bytes < 1024 * 1024)
-            return $"{bytes / 1024.0:F1} KB";
-        if (bytes < 1024 * 1024 * 1024)
-            return $"{bytes / (1024.0 * 1024.0):F1} MB";
-        return $"{bytes / (1024.0 * 1024.0 * 1024.0):F2} GB";
-    }
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -261,18 +251,7 @@ public sealed class NonConflictingFileItem
     /// <summary>
     /// Formatted file size for display.
     /// </summary>
-    public string FileSizeText => FormatFileSize(FileSize);
-
-    private static string FormatFileSize(long bytes)
-    {
-        if (bytes < 1024)
-            return $"{bytes} B";
-        if (bytes < 1024 * 1024)
-            return $"{bytes / 1024.0:F1} KB";
-        if (bytes < 1024 * 1024 * 1024)
-            return $"{bytes / (1024.0 * 1024.0):F1} MB";
-        return $"{bytes / (1024.0 * 1024.0 * 1024.0):F2} GB";
-    }
+    public string FileSizeText => FileSizeFormatter.Format(FileSize);
 }
 
 /// <summary>

--- a/DiffusionNexus.UI/Views/Dialogs/BackupCompareDialog.axaml.cs
+++ b/DiffusionNexus.UI/Views/Dialogs/BackupCompareDialog.axaml.cs
@@ -1,6 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
+using DiffusionNexus.UI.Helpers;
 using DiffusionNexus.UI.Services;
 
 namespace DiffusionNexus.UI.Views.Dialogs;
@@ -62,22 +63,8 @@ public partial class BackupCompareDialog : Window
     public int CurrentCaptions => _currentStats?.CaptionCount ?? 0;
     public int BackupCaptions => _backupStats?.CaptionCount ?? 0;
 
-    public string CurrentSizeText => FormatSize(_currentStats?.TotalSizeBytes ?? 0);
-    public string BackupSizeText => FormatSize(_backupStats?.TotalSizeBytes ?? 0);
-
-    /// <summary>
-    /// Formats bytes as a human-readable string (KB, MB, GB).
-    /// </summary>
-    private static string FormatSize(long bytes)
-    {
-        if (bytes < 1024)
-            return $"{bytes} B";
-        if (bytes < 1024 * 1024)
-            return $"{bytes / 1024.0:F1} KB";
-        if (bytes < 1024 * 1024 * 1024)
-            return $"{bytes / (1024.0 * 1024.0):F1} MB";
-        return $"{bytes / (1024.0 * 1024.0 * 1024.0):F2} GB";
-    }
+    public string CurrentSizeText => FileSizeFormatter.Format(_currentStats?.TotalSizeBytes ?? 0);
+    public string BackupSizeText => FileSizeFormatter.Format(_backupStats?.TotalSizeBytes ?? 0);
 
     private void OnRestoreClick(object? sender, RoutedEventArgs e)
     {


### PR DESCRIPTION
## Summary
The four housekeeping items from #442, each verified rather than blind-applied.

1. **Dead `DiffusionNexus.LocalDiffusion/` folder** — was fully untracked (stale `bin`/`obj` only, `.gitignore` already covers both), so it was deleted directly from the working machine; nothing to commit. Recorded here for the audit trail.
2. **`FormatFileSize` duplication** — the two byte-identical copies in `FileConflictDialogViewModel` plus a third identical copy found in `BackupCompareDialog.axaml.cs` collapsed into `DiffusionNexus.UI/Helpers/FileSizeFormatter` (review verified all three deleted bodies textually identical and the helper reproduces them exactly, negative-value fallthrough included). The full inventory found **16** byte-formatting implementations in **4 distinct families** — the other 3 families (different rounding/precision → different UI text) were deliberately left untouched and are listed in the review record as future candidates. The duplicated boundary-table tests collapsed 17→10 rows; coverage on `NonConflictingFileItem` actually increased (three sizes the old table never hit).
3. **Dead local in `ImageMetadataParser` (~:314)** — investigated per the issue's warning: genuinely dead (assigned, never referenced; the next line independently re-derives the same range for the capture groups actually used). Deleted.
4. **CS0162 in App.axaml.cs (:273)** — investigated, NOT deleted: the "unreachable" `else` belongs to `DiffusionFeatureFlags.UseLocalDiffusionBackend`, whose `TODO(v2-backend-dropdown)` says it becomes a runtime setting. Review traced the consequence: delete the else and the day the flag flips, the `"diffusion-engine"` startup check would sit Pending forever and **hang the startup overlay**. Suppressed with a narrowly-scoped `#pragma warning disable/restore` + explanatory comment instead.

## Verification
Focused 43/43; full unit suite **3082/3082** (baseline 3089 − exactly the 7 duplicate test rows, accounting reviewer-verified); full-solution Release build **clean — CS0162 gone**, zero behavior change (all four production hunks walked in review).
Task-reviewed (spec + quality): approved; both judgment calls (suppress-vs-delete, third-file scope widen) independently confirmed correct.

Fixes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)