### PR TITLE
test: Tier B coverage - 167 tests for the untested non-UI risk surface

### DIFF
--- a/DiffusionNexus.Tests/Civitai/CivitaiBaseModelCatalogTests.cs
+++ b/DiffusionNexus.Tests/Civitai/CivitaiBaseModelCatalogTests.cs
@@ -1,0 +1,380 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using DiffusionNexus.Civitai;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.Civitai;
+
+/// <summary>
+/// Covers the 4-tier fallback chain (memory -> disk TTL -> live GitHub fetch ->
+/// bundled snapshot) and the three TypeScript parsing strategies of
+/// <see cref="CivitaiBaseModelCatalog"/>. All HTTP goes through a fake handler;
+/// the catalog never touches the network here. Parsing is exercised through the
+/// public <see cref="CivitaiBaseModelCatalog.GetBaseModelsAsync"/> surface (the
+/// live-fetch tier) rather than the internal parser, so the tests pin real
+/// end-to-end behavior.
+/// </summary>
+/// <remarks>
+/// Note: <see cref="CivitaiBaseModelCatalog"/> exposes a <c>Dispose()</c> method
+/// but does not implement <see cref="IDisposable"/>, so it cannot be used in a
+/// <c>using</c> statement. Instances are registered for teardown instead.
+/// </remarks>
+public class CivitaiBaseModelCatalogTests : IDisposable
+{
+    // The class's real bundled snapshot has this many entries as of 2026-05.
+    // Pinning the exact count is intentional: a silent edit to the snapshot must
+    // trip a test, since the whole point of this class is to degrade *loudly*.
+    private const int BundledSnapshotCount = 86;
+
+    // --- New (2026) layout: baseModelRecords: BaseModelRecord[] = [ ... ] ---
+    private const string NewFormatTs = """
+        import { BaseModelRecord } from './types';
+
+        export const baseModelRecords: BaseModelRecord[] = [
+          { name: 'SD 1.5', type: 'sd1', description: 'legacy' },
+          { name: 'SDXL 1.0', type: 'sdxl' },
+          { name: "Flux.1 D", type: 'flux' },
+          { name: 'Pony', type: 'sdxl' },
+          { name: 'Illustrious', type: 'sdxl' },
+        ];
+
+        export const unrelated = 1;
+        """;
+
+    // --- Legacy flat array: baseModels = [ '...', "..." ] as const; ---
+    private const string LegacyArrayTs = """
+        export const baseModels = ['SD 1.4', 'SD 1.5', "SDXL 1.0", 'Pony'] as const;
+        """;
+
+    // --- Legacy Record: baseModelLicenses: Record<BaseModel, ...> = { ... }; ---
+    private const string LegacyLicensesTs = """
+        export const baseModelLicenses: Record<BaseModel, License | undefined> = {
+          'SD 1.4': license1,
+          'SD 1.5': license1,
+          "SDXL 1.0": license2,
+          Pony: license3,
+        };
+        """;
+
+    // --- Shape drift: records exist but the harvested field was renamed away. ---
+    private const string DriftedTs = """
+        export const baseModelRecords: BaseModelRecord[] = [
+          { label: 'SD 1.5', ecosystem: 'sd1' },
+          { label: 'SDXL 1.0', ecosystem: 'sdxl' },
+        ];
+        """;
+
+    // --- Duplicate record names to exercise order-preserving de-duplication. ---
+    private const string DuplicateNamesTs = """
+        export const baseModelRecords: BaseModelRecord[] = [
+          { name: 'SD 1.5' },
+          { name: 'SDXL 1.0' },
+          { name: 'SD 1.5' },
+        ];
+        """;
+
+    private readonly string _cacheDir;
+    private readonly List<CivitaiBaseModelCatalog> _catalogs = new();
+    private readonly List<HttpClient> _httpClients = new();
+
+    public CivitaiBaseModelCatalogTests()
+    {
+        _cacheDir = Path.Combine(Path.GetTempPath(), "CivitaiBaseModelCatalogTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_cacheDir);
+    }
+
+    public void Dispose()
+    {
+        foreach (var catalog in _catalogs)
+        {
+            try { catalog.Dispose(); } catch { /* ignore */ }
+        }
+        foreach (var http in _httpClients)
+        {
+            try { http.Dispose(); } catch { /* ignore */ }
+        }
+        try
+        {
+            if (Directory.Exists(_cacheDir))
+                Directory.Delete(_cacheDir, recursive: true);
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+    }
+
+    private string CacheFile => Path.Combine(_cacheDir, "civitai-base-models.json");
+
+    private void WriteDiskCache(params string[] models)
+    {
+        var payload = new { FetchedAtUtc = DateTime.UtcNow, BaseModels = models };
+        File.WriteAllText(CacheFile, JsonSerializer.Serialize(payload));
+    }
+
+    private (CivitaiBaseModelCatalog catalog, RecordingHandler handler, List<CivitaiBaseModelCatalogEventKind> events) Create(
+        Func<HttpRequestMessage, HttpResponseMessage> responder)
+    {
+        var handler = new RecordingHandler(responder);
+        var http = new HttpClient(handler);
+        var catalog = new CivitaiBaseModelCatalog(http, _cacheDir);
+        _httpClients.Add(http);
+        _catalogs.Add(catalog);
+
+        var events = new List<CivitaiBaseModelCatalogEventKind>();
+        catalog.StatusChanged += (_, e) => events.Add(e.Kind);
+        return (catalog, handler, events);
+    }
+
+    private static HttpResponseMessage Ts(string body) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "text/plain") };
+
+    // ---------------------------------------------------------------------
+    // Parsing strategies (through the live-fetch tier)
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task LiveFetch_NewFormat_ParsesRecordNames()
+    {
+        var (catalog, handler, events) = Create(_ => Ts(NewFormatTs));
+
+        var models = await catalog.GetBaseModelsAsync();
+
+        models.Should().Equal("SD 1.5", "SDXL 1.0", "Flux.1 D", "Pony", "Illustrious");
+        handler.Requests.Should().ContainSingle();
+        events.Should().Equal(
+            CivitaiBaseModelCatalogEventKind.FetchStarted,
+            CivitaiBaseModelCatalogEventKind.FetchSucceeded);
+    }
+
+    [Fact]
+    public async Task LiveFetch_LegacyFlatArray_ParsesArrayLiterals()
+    {
+        var (catalog, _, _) = Create(_ => Ts(LegacyArrayTs));
+
+        var models = await catalog.GetBaseModelsAsync();
+
+        models.Should().Equal("SD 1.4", "SD 1.5", "SDXL 1.0", "Pony");
+    }
+
+    [Fact]
+    public async Task LiveFetch_LegacyLicensesRecord_ParsesObjectKeys()
+    {
+        var (catalog, _, _) = Create(_ => Ts(LegacyLicensesTs));
+
+        var models = await catalog.GetBaseModelsAsync();
+
+        models.Should().Equal("SD 1.4", "SD 1.5", "SDXL 1.0", "Pony");
+    }
+
+    [Fact]
+    public async Task LiveFetch_DuplicateRecordNames_AreDedupedPreservingOrder()
+    {
+        var (catalog, _, _) = Create(_ => Ts(DuplicateNamesTs));
+
+        var models = await catalog.GetBaseModelsAsync();
+
+        models.Should().Equal("SD 1.5", "SDXL 1.0");
+    }
+
+    // ---------------------------------------------------------------------
+    // URL fallback within the live-fetch tier
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task LiveFetch_FirstUrlFails_FallsBackToSecondUrl()
+    {
+        var (catalog, handler, events) = Create(req =>
+            req.RequestUri!.AbsoluteUri.Contains("basemodel.constants.ts")
+                ? new HttpResponseMessage(HttpStatusCode.NotFound)
+                : Ts(LegacyArrayTs));
+
+        var models = await catalog.GetBaseModelsAsync();
+
+        models.Should().Equal("SD 1.4", "SD 1.5", "SDXL 1.0", "Pony");
+        handler.Requests.Should().HaveCount(2);
+        events.Should().Contain(CivitaiBaseModelCatalogEventKind.FetchSucceeded);
+    }
+
+    // ---------------------------------------------------------------------
+    // Bundled-snapshot fallback tier
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task ShapeDrift_NoParseableModels_FallsBackToBundledSnapshot()
+    {
+        // Upstream renamed the harvested field: the block still matches but yields
+        // nothing, so the catalog must degrade to the bundled snapshot, not crash.
+        var (catalog, handler, events) = Create(_ => Ts(DriftedTs));
+
+        var models = await catalog.GetBaseModelsAsync();
+
+        models.Should().HaveCount(BundledSnapshotCount);
+        models.Should().Contain(new[] { "SD 1.5", "SDXL 1.0", "Flux.2 Klein 9B", "Pony V7", "Upscaler" });
+        // Both candidate URLs are tried before giving up.
+        handler.Requests.Should().HaveCount(2);
+        events.Should().Contain(CivitaiBaseModelCatalogEventKind.FetchFailed)
+            .And.Contain(CivitaiBaseModelCatalogEventKind.UsedBundledFallback);
+    }
+
+    [Fact]
+    public async Task AllUrlsReturnServerError_FallsBackToBundledSnapshot()
+    {
+        var (catalog, handler, events) = Create(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
+        var models = await catalog.GetBaseModelsAsync();
+
+        models.Should().HaveCount(BundledSnapshotCount);
+        models.Should().OnlyHaveUniqueItems();
+        handler.Requests.Should().HaveCount(2);
+        events.Should().Contain(CivitaiBaseModelCatalogEventKind.UsedBundledFallback);
+    }
+
+    // ---------------------------------------------------------------------
+    // Disk-cache tier (TTL)
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task FreshDiskCache_IsUsedWithoutAnyHttpCall()
+    {
+        WriteDiskCache("Cached A", "Cached B");
+        // Handler would 500 if touched — proving no fetch happens.
+        var (catalog, handler, events) = Create(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
+        var models = await catalog.GetBaseModelsAsync();
+
+        models.Should().Equal("Cached A", "Cached B");
+        handler.Requests.Should().BeEmpty();
+        events.Should().Equal(CivitaiBaseModelCatalogEventKind.UsedDiskCache);
+    }
+
+    [Fact]
+    public async Task StaleDiskCache_IsBypassed_AndLiveFetchRuns()
+    {
+        WriteDiskCache("Stale A", "Stale B");
+        // TTL is 7 days; make the cache 8 days old.
+        File.SetLastWriteTimeUtc(CacheFile, DateTime.UtcNow.AddDays(-8));
+
+        var (catalog, handler, events) = Create(_ => Ts(NewFormatTs));
+
+        var models = await catalog.GetBaseModelsAsync();
+
+        models.Should().Equal("SD 1.5", "SDXL 1.0", "Flux.1 D", "Pony", "Illustrious");
+        models.Should().NotContain("Stale A");
+        handler.Requests.Should().ContainSingle();
+        events.Should().NotContain(CivitaiBaseModelCatalogEventKind.UsedDiskCache);
+        events.Should().Contain(CivitaiBaseModelCatalogEventKind.FetchSucceeded);
+    }
+
+    [Fact]
+    public async Task SuccessfulFetch_WritesDiskCache_ReadableByAFreshCatalog()
+    {
+        var (catalog, _, _) = Create(_ => Ts(NewFormatTs));
+        await catalog.GetBaseModelsAsync();
+
+        File.Exists(CacheFile).Should().BeTrue();
+
+        // A brand-new catalog over the same directory reads the persisted cache
+        // and must not perform any HTTP (handler 500s if touched).
+        var (catalog2, handler2, events2) = Create(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError));
+        var models = await catalog2.GetBaseModelsAsync();
+
+        models.Should().Equal("SD 1.5", "SDXL 1.0", "Flux.1 D", "Pony", "Illustrious");
+        handler2.Requests.Should().BeEmpty();
+        events2.Should().Equal(CivitaiBaseModelCatalogEventKind.UsedDiskCache);
+    }
+
+    // ---------------------------------------------------------------------
+    // Memory-cache tier & forceRefresh
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task SecondCall_ServedFromMemory_WithoutRefetching()
+    {
+        var (catalog, handler, _) = Create(_ => Ts(NewFormatTs));
+
+        var first = await catalog.GetBaseModelsAsync();
+        var second = await catalog.GetBaseModelsAsync();
+
+        second.Should().BeSameAs(first);
+        handler.Requests.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task ForceRefresh_BypassesMemoryCache_AndRefetches()
+    {
+        var (catalog, handler, _) = Create(_ => Ts(NewFormatTs));
+
+        await catalog.GetBaseModelsAsync();
+        await catalog.GetBaseModelsAsync(forceRefresh: true);
+
+        handler.Requests.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task ForceRefresh_BypassesFreshDiskCache_AndRefetches()
+    {
+        WriteDiskCache("Cached A", "Cached B");
+        var (catalog, handler, events) = Create(_ => Ts(LegacyArrayTs));
+
+        var models = await catalog.GetBaseModelsAsync(forceRefresh: true);
+
+        models.Should().Equal("SD 1.4", "SD 1.5", "SDXL 1.0", "Pony");
+        handler.Requests.Should().ContainSingle();
+        events.Should().NotContain(CivitaiBaseModelCatalogEventKind.UsedDiskCache);
+    }
+
+    // ---------------------------------------------------------------------
+    // Properties & cancellation
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void CacheFilePath_ResolvesInsideProvidedCacheDirectory()
+    {
+        var (catalog, _, _) = Create(_ => new HttpResponseMessage());
+
+        catalog.CacheFilePath.Should().Be(CacheFile);
+    }
+
+    [Fact]
+    public async Task CacheTimestampUtc_NullBeforeFetch_SetAfterSuccessfulFetch()
+    {
+        var (catalog, _, _) = Create(_ => Ts(NewFormatTs));
+
+        catalog.CacheTimestampUtc.Should().BeNull();
+
+        await catalog.GetBaseModelsAsync();
+
+        catalog.CacheTimestampUtc.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetBaseModelsAsync_WithAlreadyCancelledToken_Throws()
+    {
+        var (catalog, _, _) = Create(_ => Ts(NewFormatTs));
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = async () => await catalog.GetBaseModelsAsync(cancellationToken: cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+        public List<HttpRequestMessage> Requests { get; } = new();
+
+        public RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+        {
+            _responder = responder;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            return Task.FromResult(_responder(request));
+        }
+    }
+}

--- a/DiffusionNexus.Tests/Civitai/NextCursorJsonConverterTests.cs
+++ b/DiffusionNexus.Tests/Civitai/NextCursorJsonConverterTests.cs
@@ -1,0 +1,76 @@
+using System.Text.Json;
+using DiffusionNexus.Civitai.Models;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.Civitai;
+
+/// <summary>
+/// Pins <c>NextCursorJsonConverter</c> (internal) through the public
+/// <see cref="CivitaiPaginationMetadata.NextCursor"/> property it decorates.
+/// Civitai returns <c>nextCursor</c> as a JSON number on some endpoints and a
+/// string on others; the converter normalizes both to a string and is culture
+/// invariant (important: this suite runs on a German-locale machine, so a
+/// locale-dependent decimal separator would be caught here).
+/// </summary>
+public class NextCursorJsonConverterTests
+{
+    private static string? ReadCursor(string cursorJson)
+    {
+        var json = $$"""{ "totalItems": 0, "nextCursor": {{cursorJson}} }""";
+        return JsonSerializer.Deserialize<CivitaiPaginationMetadata>(json)!.NextCursor;
+    }
+
+    [Fact]
+    public void Read_StringCursor_ReturnedVerbatim()
+    {
+        ReadCursor("\"abc-123|xyz\"").Should().Be("abc-123|xyz");
+    }
+
+    [Fact]
+    public void Read_IntegerCursor_CoercedToString()
+    {
+        ReadCursor("482913").Should().Be("482913");
+    }
+
+    [Fact]
+    public void Read_LargeLongCursor_CoercedToString()
+    {
+        // Exceeds Int32; must go through the Int64 path, not overflow.
+        ReadCursor("9999999999").Should().Be("9999999999");
+    }
+
+    [Fact]
+    public void Read_NonIntegerNumberCursor_UsesInvariantDecimalPoint()
+    {
+        // Falls through to the double branch (G17, invariant). A German locale
+        // would render "1,5" — the converter must keep the invariant "1.5".
+        ReadCursor("1.5").Should().Be("1.5");
+    }
+
+    [Fact]
+    public void Read_NullCursor_ReturnsNull()
+    {
+        ReadCursor("null").Should().BeNull();
+    }
+
+    [Fact]
+    public void Read_MissingCursor_DefaultsToNull()
+    {
+        var json = """{ "totalItems": 0 }""";
+        JsonSerializer.Deserialize<CivitaiPaginationMetadata>(json)!.NextCursor.Should().BeNull();
+    }
+
+    [Fact]
+    public void Write_NonNull_EmitsString()
+    {
+        var meta = new CivitaiPaginationMetadata { NextCursor = "42" };
+        JsonSerializer.Serialize(meta).Should().Contain("\"nextCursor\":\"42\"");
+    }
+
+    [Fact]
+    public void Write_Null_EmitsNull()
+    {
+        var meta = new CivitaiPaginationMetadata { NextCursor = null };
+        JsonSerializer.Serialize(meta).Should().Contain("\"nextCursor\":null");
+    }
+}

--- a/DiffusionNexus.Tests/Civitai/TolerantEnumConverterTests.cs
+++ b/DiffusionNexus.Tests/Civitai/TolerantEnumConverterTests.cs
@@ -1,0 +1,123 @@
+using System.Text.Json;
+using DiffusionNexus.Civitai.Models;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.Civitai;
+
+/// <summary>
+/// Pins the malformed-input tolerance of <see cref="TolerantEnumConverter{T}"/>
+/// and <see cref="TolerantEnumConverterFactory"/>. The converters exist so that
+/// an unknown enum string from Civitai (they add values without warning) reads
+/// as <c>default(T)</c> instead of throwing and killing the whole response.
+/// </summary>
+public class TolerantEnumConverterTests
+{
+    private enum Color
+    {
+        Red = 0,
+        Green = 1,
+        Blue = 2,
+    }
+
+    private static JsonSerializerOptions Options()
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new TolerantEnumConverterFactory());
+        return options;
+    }
+
+    private static Color ReadColor(string json) =>
+        JsonSerializer.Deserialize<Color>(json, Options());
+
+    [Theory]
+    [InlineData("\"Green\"")]
+    [InlineData("\"green\"")]   // case-insensitive
+    [InlineData("\"GREEN\"")]
+    public void Read_ValidStringAnyCase_Parses(string json)
+    {
+        ReadColor(json).Should().Be(Color.Green);
+    }
+
+    [Fact]
+    public void Read_UnknownString_FallsBackToDefault()
+    {
+        ReadColor("\"Chartreuse\"").Should().Be(Color.Red);
+    }
+
+    [Fact]
+    public void Read_EmptyString_FallsBackToDefault()
+    {
+        ReadColor("\"\"").Should().Be(Color.Red);
+    }
+
+    [Fact]
+    public void Read_NullToken_FallsBackToDefault()
+    {
+        ReadColor("null").Should().Be(Color.Red);
+    }
+
+    [Fact]
+    public void Read_DefinedNumber_ReturnsEnumValue()
+    {
+        ReadColor("2").Should().Be(Color.Blue);
+    }
+
+    [Fact]
+    public void Read_UndefinedNumber_FallsBackToDefault()
+    {
+        ReadColor("99").Should().Be(Color.Red);
+    }
+
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("[]")]
+    [InlineData("true")]
+    public void Read_NonScalarOrBooleanToken_FallsBackToDefault(string json)
+    {
+        // The default switch arm skips the token and returns default(T).
+        ReadColor(json).Should().Be(Color.Red);
+    }
+
+    [Fact]
+    public void Write_EmitsEnumName()
+    {
+        var json = JsonSerializer.Serialize(Color.Blue, Options());
+        json.Should().Be("\"Blue\"");
+    }
+
+    [Theory]
+    [InlineData(typeof(Color), true)]
+    [InlineData(typeof(CivitaiModelType), true)]
+    [InlineData(typeof(int), false)]
+    [InlineData(typeof(string), false)]
+    public void Factory_CanConvert_OnlyEnums(Type type, bool expected)
+    {
+        new TolerantEnumConverterFactory().CanConvert(type).Should().Be(expected);
+    }
+
+    [Fact]
+    public void RealWorld_UnknownCivitaiModelType_DegradesToUnknown_KeepsRestOfPayload()
+    {
+        // CivitaiModelType is decorated with the tolerant factory. A brand-new
+        // upstream type must not blow up deserialization of the surrounding model.
+        const string json = """
+            { "id": 7, "name": "Fancy", "type": "SomeBrandNewType", "tags": ["anime"] }
+            """;
+
+        var model = JsonSerializer.Deserialize<CivitaiModel>(json);
+
+        model.Should().NotBeNull();
+        model!.Type.Should().Be(CivitaiModelType.Unknown);
+        model.Id.Should().Be(7);
+        model.Name.Should().Be("Fancy");
+        model.Tags.Should().ContainSingle().Which.Should().Be("anime");
+    }
+
+    [Fact]
+    public void RealWorld_KnownCivitaiModelType_Parses()
+    {
+        var model = JsonSerializer.Deserialize<CivitaiModel>("""{ "id": 1, "type": "LORA" }""");
+
+        model!.Type.Should().Be(CivitaiModelType.LORA);
+    }
+}

--- a/DiffusionNexus.Tests/DataAccess/Serialization/SerializerAdapterTests.cs
+++ b/DiffusionNexus.Tests/DataAccess/Serialization/SerializerAdapterTests.cs
@@ -1,0 +1,106 @@
+using DiffusionNexus.DataAccess.Infrastructure.Serialization;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.DataAccess.Serialization;
+
+/// <summary>
+/// First coverage of the previously-untested
+/// <c>DiffusionNexus.DataAccess.Infrastructure</c> serializer adapters. Both are
+/// thin wrappers around the framework serializers; these tests pin the
+/// round-trip contract and the culture-invariant number formatting (this suite
+/// runs on a German-locale machine, so a locale-dependent decimal separator
+/// would surface here).
+/// </summary>
+public class SerializerAdapterTests
+{
+    public class SampleDto
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public double Ratio { get; set; }
+    }
+
+    // ---------------------------------------------------------------------
+    // JSON
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void Json_Serialize_ProducesIndentedPayload()
+    {
+        ISerializer sut = new JsonSerializerAdapter();
+
+        var json = sut.Serialize(new SampleDto { Id = 1, Name = "x", Ratio = 1.5 });
+
+        // WriteIndented = true -> multi-line output.
+        json.Should().Contain("\n");
+        json.Should().Contain("\"Id\"").And.Contain("\"Name\"");
+    }
+
+    [Fact]
+    public void Json_Serialize_UsesInvariantDecimalPoint()
+    {
+        ISerializer sut = new JsonSerializerAdapter();
+
+        var json = sut.Serialize(new SampleDto { Ratio = 1.5 });
+
+        json.Should().Contain("1.5").And.NotContain("1,5");
+    }
+
+    [Fact]
+    public void Json_RoundTrip_PreservesValues()
+    {
+        ISerializer sut = new JsonSerializerAdapter();
+        var original = new SampleDto { Id = 7, Name = "round-trip", Ratio = 3.25 };
+
+        var restored = sut.Deserialize<SampleDto>(sut.Serialize(original));
+
+        restored.Should().BeEquivalentTo(original);
+    }
+
+    [Fact]
+    public void Json_Deserialize_ReadsExternalPayload()
+    {
+        ISerializer sut = new JsonSerializerAdapter();
+
+        var dto = sut.Deserialize<SampleDto>("""{ "Id": 5, "Name": "hi", "Ratio": 2.5 }""");
+
+        dto.Id.Should().Be(5);
+        dto.Name.Should().Be("hi");
+        dto.Ratio.Should().Be(2.5);
+    }
+
+    // ---------------------------------------------------------------------
+    // XML
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void Xml_Serialize_ContainsElementAndValues()
+    {
+        ISerializer sut = new XmlSerializerAdapter();
+
+        var xml = sut.Serialize(new SampleDto { Id = 9, Name = "node", Ratio = 1.5 });
+
+        xml.Should().Contain("<SampleDto");
+        xml.Should().Contain("<Name>node</Name>");
+        // XmlConvert is invariant -> decimal point, never a German comma.
+        xml.Should().Contain("<Ratio>1.5</Ratio>");
+    }
+
+    [Fact]
+    public void Xml_RoundTrip_PreservesValues()
+    {
+        ISerializer sut = new XmlSerializerAdapter();
+        var original = new SampleDto { Id = 11, Name = "xml round-trip", Ratio = 4.75 };
+
+        var restored = sut.Deserialize<SampleDto>(sut.Serialize(original));
+
+        restored.Should().BeEquivalentTo(original);
+    }
+
+    [Fact]
+    public void Adapters_ImplementISerializer()
+    {
+        new JsonSerializerAdapter().Should().BeAssignableTo<ISerializer>();
+        new XmlSerializerAdapter().Should().BeAssignableTo<ISerializer>();
+    }
+}

--- a/DiffusionNexus.Tests/DatasetQuality/AnalysisRunStoreTests.cs
+++ b/DiffusionNexus.Tests/DatasetQuality/AnalysisRunStoreTests.cs
@@ -1,0 +1,162 @@
+using DiffusionNexus.Domain.Enums;
+using DiffusionNexus.Domain.Models;
+using DiffusionNexus.Service.Services.DatasetQuality;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.DatasetQuality;
+
+/// <summary>
+/// Covers <see cref="AnalysisRunStore"/> — JSON run persistence into a <c>.quality-runs</c> subfolder,
+/// plus the 50-file retention prune that DELETES user run files (issue #443). All I/O runs against a
+/// throwaway temp directory; the prune selection/ordering is pinned exactly, including its lexicographic
+/// (not chronological) file selection.
+/// </summary>
+public class AnalysisRunStoreTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _runsDir;
+    private readonly AnalysisRunStore _store;
+
+    public AnalysisRunStoreTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"runstore_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _runsDir = Path.Combine(_tempDir, ".quality-runs");
+        _store = new AnalysisRunStore();
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch (IOException) { }
+    }
+
+    [Fact]
+    public async Task SaveAsync_WritesFileIntoRunsFolder_AndRoundTrips()
+    {
+        var record = MakeRecord(version: 3, LocalSecond(5));
+
+        var savedPath = await _store.SaveAsync(_tempDir, record);
+
+        File.Exists(savedPath).Should().BeTrue();
+        Path.GetDirectoryName(savedPath).Should().Be(_runsDir);
+        Path.GetFileName(savedPath).Should().EndWith("-Version-V3-run.json");
+
+        var loaded = await _store.LoadAllAsync(_tempDir);
+        loaded.Should().ContainSingle();
+        loaded[0].Version.Should().Be(3);
+        loaded[0].AnalyzedAtUtc.Should().Be(record.AnalyzedAtUtc);
+    }
+
+    [Fact]
+    public async Task SaveAsync_NullRecord_Throws()
+    {
+        var act = async () => await _store.SaveAsync(_tempDir, null!);
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task SaveAsync_EmptyDatasetPath_Throws()
+    {
+        var act = async () => await _store.SaveAsync("  ", MakeRecord(1, LocalSecond(0)));
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task LoadAllAsync_MissingFolder_ReturnsEmpty()
+    {
+        (await _store.LoadAllAsync(_tempDir)).Should().BeEmpty();
+        (await _store.LoadAllAsync("   ")).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task LoadAllAsync_OrdersByTimestampDescending()
+    {
+        await _store.SaveAsync(_tempDir, MakeRecord(1, LocalSecond(10)));
+        await _store.SaveAsync(_tempDir, MakeRecord(2, LocalSecond(30)));
+        await _store.SaveAsync(_tempDir, MakeRecord(3, LocalSecond(20)));
+
+        var loaded = await _store.LoadAllAsync(_tempDir);
+
+        loaded.Select(r => r.AnalyzedAtUtc).Should().BeInDescendingOrder();
+        loaded[0].Version.Should().Be(2); // second 30 is newest
+    }
+
+    [Fact]
+    public async Task LoadAllAsync_SkipsCorruptedFiles()
+    {
+        await _store.SaveAsync(_tempDir, MakeRecord(1, LocalSecond(5)));
+        await File.WriteAllTextAsync(Path.Combine(_runsDir, "garbage-run.json"), "{ this is not valid json");
+
+        var loaded = await _store.LoadAllAsync(_tempDir);
+
+        loaded.Should().ContainSingle().Which.Version.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Delete_RemovesMatchingFile_ByTimestampAndVersion()
+    {
+        var record = MakeRecord(7, LocalSecond(42));
+        await _store.SaveAsync(_tempDir, record);
+        Directory.GetFiles(_runsDir, "*-run.json").Should().ContainSingle();
+
+        _store.Delete(_tempDir, record);
+
+        Directory.GetFiles(_runsDir, "*-run.json").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Delete_NonExistentFile_DoesNotThrow()
+    {
+        var act = () => _store.Delete(_tempDir, MakeRecord(1, LocalSecond(0)));
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task SaveAsync_PrunesOldestBeyond50_KeepingNewest50()
+    {
+        // Save 51 runs at the same day/hour/minute, differing only by second (00..50). Because the file
+        // name is dd-MM-yyyy-HH-mm-ss-…, differing only in the trailing seconds makes lexicographic
+        // (the prune's OrderByDescending(f => f)) order identical to chronological order here — so the
+        // second-00 run is both the oldest and the lexicographically smallest, and is the one deleted.
+        for (int s = 0; s <= 50; s++)
+            await _store.SaveAsync(_tempDir, MakeRecord(1, LocalSecond(s)));
+
+        var remaining = Directory.GetFiles(_runsDir, "*-run.json");
+        remaining.Should().HaveCount(50);
+
+        var names = remaining.Select(Path.GetFileName).ToList();
+        names.Should().NotContain(n => n!.Contains("-00-Version-V1-run.json"), "second-00 is the oldest and is pruned");
+        names.Should().Contain(n => n!.Contains("-01-Version-V1-run.json"), "second-01 is the new oldest kept");
+        names.Should().Contain(n => n!.Contains("-50-Version-V1-run.json"), "second-50 is the newest");
+    }
+
+    [Fact]
+    public async Task SaveAsync_Exactly50Runs_PrunesNothing()
+    {
+        for (int s = 0; s < 50; s++)
+            await _store.SaveAsync(_tempDir, MakeRecord(1, LocalSecond(s)));
+
+        Directory.GetFiles(_runsDir, "*-run.json").Should().HaveCount(50);
+    }
+
+    // Builds a DateTimeOffset from a LOCAL wall-clock time so the store's ToLocalTime() file naming
+    // is a no-op and the produced file name is deterministic on any machine timezone.
+    private static DateTimeOffset LocalSecond(int second)
+        => new(new DateTime(2026, 1, 1, 12, 0, second, DateTimeKind.Local));
+
+    private static AnalysisRunRecord MakeRecord(int version, DateTimeOffset when) => new()
+    {
+        AnalyzedAtUtc = when,
+        Version = version,
+        DatasetLabel = $"Test — V{version}",
+        LoraType = LoraType.Character,
+        Summary = new AnalysisSummary
+        {
+            TotalCaptionFiles = 10,
+            TotalImageFiles = 10,
+            CountBySeverity = new Dictionary<IssueSeverity, int> { [IssueSeverity.Warning] = 2 },
+            ChecksRun = 5,
+            FixableIssueCount = 1
+        }
+    };
+}

--- a/DiffusionNexus.Tests/DatasetQuality/BlurDetectorTests.cs
+++ b/DiffusionNexus.Tests/DatasetQuality/BlurDetectorTests.cs
@@ -1,0 +1,202 @@
+using DiffusionNexus.Domain.Enums;
+using DiffusionNexus.Domain.Models;
+using DiffusionNexus.Service.Services.DatasetQuality.ImageAnalysis;
+using FluentAssertions;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace DiffusionNexus.Tests.DatasetQuality;
+
+/// <summary>
+/// Covers <see cref="BlurDetector"/> — the Laplacian-variance sharpness check. One of the two
+/// <c>IImageQualityCheck</c> implementations that had no tests (issue #443). Uses real, losslessly
+/// encoded PNGs synthesized with ImageSharp (the established pattern from the sibling
+/// <c>NoiseEstimatorTests</c>/<c>JpegArtifactDetectorTests</c>); a 1-px checkerboard has an
+/// exactly-computable Laplacian variance so the score bands are pinned deterministically.
+/// </summary>
+public class BlurDetectorTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly BlurDetector _detector;
+
+    public BlurDetectorTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"blur_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _detector = new BlurDetector();
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch (IOException) { }
+    }
+
+    [Fact]
+    public async Task WhenNoImages_ThenReturnsPerfectScore()
+    {
+        var result = await _detector.RunAsync([], MakeConfig());
+
+        result.Score.Should().Be(100);
+        result.Issues.Should().BeEmpty();
+        result.PerImageScores.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task WhenSharpImage_ThenHighScoreAndNoIssues()
+    {
+        // 1-px black/white checkerboard: every interior Laplacian is ±1020 → variance ≈ 1_040_400,
+        // far above the Warning threshold (300) → score ≈ 100, zero issues.
+        string path = CreateCheckerboard("sharp.png", 200, 200, 0, 255);
+        var images = new[] { new ImageFileInfo(path, 200, 200) };
+
+        var result = await _detector.RunAsync(images, MakeConfig());
+
+        result.Score.Should().BeGreaterThanOrEqualTo(95);
+        result.Issues.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task WhenFlatImage_ThenCriticalIssueAndLowScore()
+    {
+        // A uniform image has zero edge energy → Laplacian variance 0 (< CriticalThreshold 100).
+        string path = CreateUniform("flat.png", 200, 200, 128);
+        var images = new[] { new ImageFileInfo(path, 200, 200) };
+
+        var result = await _detector.RunAsync(images, MakeConfig());
+
+        result.Score.Should().BeLessThan(10);
+        result.Issues.Should().ContainSingle(i => i.Severity == IssueSeverity.Critical);
+        result.Issues.Single().AffectedFiles.Should().ContainSingle().Which.Should().Be(path);
+    }
+
+    [Fact]
+    public async Task WhenSoftImage_ThenWarningIssueButNotCritical()
+    {
+        // d=3 checkerboard → every interior Laplacian is ±12 → variance exactly 144,
+        // which lands in the Warning band (CriticalThreshold 100 ≤ 144 < WarningThreshold 300).
+        string path = CreateCheckerboard("soft.png", 200, 200, 126, 129);
+
+        // Guard the synthesis: if the variance drifts out of band the misclassification
+        // would silently pass, so assert the pinned value up front.
+        BlurDetector.ComputeLaplacianVariance(path).Should().BeApproximately(144.0, 0.5);
+
+        var images = new[] { new ImageFileInfo(path, 200, 200) };
+        var result = await _detector.RunAsync(images, MakeConfig());
+
+        result.Issues.Should().ContainSingle(i => i.Severity == IssueSeverity.Warning);
+        result.Issues.Should().NotContain(i => i.Severity == IssueSeverity.Critical);
+    }
+
+    [Fact]
+    public async Task WhenMixedImages_ThenPerImageScoresAveraged()
+    {
+        string sharp = CreateCheckerboard("mix_sharp.png", 200, 200, 0, 255);
+        string flat = CreateUniform("mix_flat.png", 200, 200, 128);
+        var images = new[]
+        {
+            new ImageFileInfo(sharp, 200, 200),
+            new ImageFileInfo(flat, 200, 200)
+        };
+
+        var result = await _detector.RunAsync(images, MakeConfig());
+
+        result.PerImageScores.Should().HaveCount(2);
+        result.Score.Should().BeApproximately(
+            Math.Round(result.PerImageScores.Average(s => s.Score), 1), 0.05);
+    }
+
+    [Fact]
+    public async Task WhenCancelled_ThenThrowsOperationCanceled()
+    {
+        string path = CreateUniform("cancel.png", 50, 50, 100);
+        var images = new[] { new ImageFileInfo(path, 50, 50) };
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = async () => await _detector.RunAsync(images, MakeConfig(), cancellationToken: cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    // ── ComputeLaplacianVariance (internal) ──
+
+    [Fact]
+    public void ComputeLaplacianVariance_UniformImage_IsZero()
+    {
+        string path = CreateUniform("uniform.png", 64, 64, 200);
+        BlurDetector.ComputeLaplacianVariance(path).Should().Be(0);
+    }
+
+    [Fact]
+    public void ComputeLaplacianVariance_HighContrastCheckerboard_IsLarge()
+    {
+        string path = CreateCheckerboard("hc.png", 64, 64, 0, 255);
+        BlurDetector.ComputeLaplacianVariance(path).Should().BeGreaterThan(300);
+    }
+
+    [Fact]
+    public void ComputeLaplacianVariance_ImageSmallerThan3px_ReturnsZero()
+    {
+        string path = CreateUniform("tiny.png", 2, 2, 255);
+        BlurDetector.ComputeLaplacianVariance(path).Should().Be(0);
+    }
+
+    // ── VarianceToScore (internal) — sigmoid mapping ──
+
+    [Theory]
+    [InlineData(0.0, 1.8)]      // 100/(1+e^4)
+    [InlineData(100.0, 11.9)]   // 100/(1+e^2)
+    [InlineData(200.0, 50.0)]   // sigmoid centre
+    [InlineData(300.0, 88.1)]   // 100/(1+e^-2)
+    public void VarianceToScore_MatchesSigmoid(double variance, double expected)
+    {
+        BlurDetector.VarianceToScore(variance).Should().BeApproximately(expected, 0.2);
+    }
+
+    [Fact]
+    public void VarianceToScore_IsMonotonicallyIncreasing()
+    {
+        double low = BlurDetector.VarianceToScore(50);
+        double mid = BlurDetector.VarianceToScore(200);
+        double high = BlurDetector.VarianceToScore(1000);
+        low.Should().BeLessThan(mid);
+        mid.Should().BeLessThan(high);
+        high.Should().BeLessThan(100);
+    }
+
+    private DatasetConfig MakeConfig() => new()
+    {
+        FolderPath = _tempDir,
+        LoraType = LoraType.Character
+    };
+
+    private string CreateUniform(string fileName, int width, int height, byte value)
+    {
+        string path = Path.Combine(_tempDir, fileName);
+        using var image = new Image<L8>(width, height, new L8(value));
+        image.SaveAsPng(path);
+        return path;
+    }
+
+    /// <summary>
+    /// 1-pixel checkerboard alternating <paramref name="a"/> / <paramref name="b"/> by pixel parity.
+    /// For a 1-px cell every orthogonal neighbour is the opposite value, so each interior Laplacian
+    /// equals ±4·|a−b| exactly, giving a deterministic variance independent of the platform.
+    /// </summary>
+    private string CreateCheckerboard(string fileName, int width, int height, byte a, byte b)
+    {
+        string path = Path.Combine(_tempDir, fileName);
+        using var image = new Image<L8>(width, height);
+        image.ProcessPixelRows(accessor =>
+        {
+            for (int y = 0; y < height; y++)
+            {
+                var row = accessor.GetRowSpan(y);
+                for (int x = 0; x < width; x++)
+                    row[x] = new L8(((x + y) & 1) == 0 ? a : b);
+            }
+        });
+        image.SaveAsPng(path);
+        return path;
+    }
+}

--- a/DiffusionNexus.Tests/DatasetQuality/ExposureAnalyzerTests.cs
+++ b/DiffusionNexus.Tests/DatasetQuality/ExposureAnalyzerTests.cs
@@ -1,0 +1,233 @@
+using DiffusionNexus.Domain.Enums;
+using DiffusionNexus.Domain.Models;
+using DiffusionNexus.Service.Services.DatasetQuality.ImageAnalysis;
+using FluentAssertions;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace DiffusionNexus.Tests.DatasetQuality;
+
+/// <summary>
+/// Covers <see cref="ExposureAnalyzer"/> — the luminance-histogram exposure check. The second of the
+/// two <c>IImageQualityCheck</c> implementations that had no tests (issue #443). Uses real lossless
+/// PNGs with fully controlled pixel values so the mean/stdDev/clip statistics are exact.
+/// </summary>
+public class ExposureAnalyzerTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly ExposureAnalyzer _analyzer;
+
+    public ExposureAnalyzerTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"exposure_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _analyzer = new ExposureAnalyzer();
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch (IOException) { }
+    }
+
+    [Fact]
+    public async Task WhenNoImages_ThenReturnsPerfectScore()
+    {
+        var result = await _analyzer.RunAsync([], MakeConfig());
+
+        result.Score.Should().Be(100);
+        result.Issues.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task WhenWellExposedGradient_ThenNoIssues()
+    {
+        // Full 0..255 horizontal ramp: mean ≈ 127.5 (ideal band), high stdDev (no low-DR flag),
+        // and only ~2.3% pixels clip at each end (< 15% warning thresholds).
+        string path = CreateHorizontalRamp("ramp.png", 256, 64);
+        var images = new[] { new ImageFileInfo(path, 256, 64) };
+
+        var result = await _analyzer.RunAsync(images, MakeConfig());
+
+        result.Issues.Should().BeEmpty();
+        result.Score.Should().BeGreaterThanOrEqualTo(80);
+    }
+
+    [Fact]
+    public async Task WhenSeverelyUnderexposed_ThenCriticalUnderexposedIssue()
+    {
+        string path = CreateUniform("dark.png", 128, 128, 20); // mean 20 < MeanCriticalLow (40)
+        var images = new[] { new ImageFileInfo(path, 128, 128) };
+
+        var result = await _analyzer.RunAsync(images, MakeConfig());
+
+        result.Issues.Should().Contain(i =>
+            i.Severity == IssueSeverity.Critical && i.Message.Contains("underexposed"));
+    }
+
+    [Fact]
+    public async Task WhenSeverelyOverexposed_ThenCriticalOverexposedIssue()
+    {
+        string path = CreateUniform("bright.png", 128, 128, 240); // mean 240 > MeanCriticalHigh (220)
+        var images = new[] { new ImageFileInfo(path, 128, 128) };
+
+        var result = await _analyzer.RunAsync(images, MakeConfig());
+
+        result.Issues.Should().Contain(i =>
+            i.Severity == IssueSeverity.Critical && i.Message.Contains("overexposed"));
+    }
+
+    [Fact]
+    public async Task WhenManyClippedHighlights_ThenHighlightWarning()
+    {
+        // 30% pure white (>= HighlightClipValue 250), 70% mid-grey → mean ≈ 146 (in range),
+        // highlight clip 30% (> 15% warning) but not critically over/under exposed.
+        string path = CreateColumnSplit("clip.png", 100, 100, 0.30, 255, 100);
+        var images = new[] { new ImageFileInfo(path, 100, 100) };
+
+        var result = await _analyzer.RunAsync(images, MakeConfig());
+
+        result.Issues.Should().Contain(i =>
+            i.Severity == IssueSeverity.Warning && i.Message.Contains("clipped highlights"));
+    }
+
+    [Fact]
+    public async Task WhenManyCrushedShadows_ThenShadowWarning()
+    {
+        // 30% pure black (<= ShadowCrushValue 5), 70% mid-grey → crushed shadows 30% (> 15%).
+        string path = CreateColumnSplit("crush.png", 100, 100, 0.30, 0, 150);
+        var images = new[] { new ImageFileInfo(path, 100, 100) };
+
+        var result = await _analyzer.RunAsync(images, MakeConfig());
+
+        result.Issues.Should().Contain(i =>
+            i.Severity == IssueSeverity.Warning && i.Message.Contains("crushed shadows"));
+    }
+
+    [Fact]
+    public async Task WhenFlatMidToneImage_ThenLowDynamicRangeInfo()
+    {
+        // Uniform mid-grey: mean 128 (ideal band, not critical), stdDev 0 (< LowDynamicRangeThreshold 30).
+        string path = CreateUniform("flat.png", 128, 128, 128);
+        var images = new[] { new ImageFileInfo(path, 128, 128) };
+
+        var result = await _analyzer.RunAsync(images, MakeConfig());
+
+        result.Issues.Should().Contain(i =>
+            i.Severity == IssueSeverity.Info && i.Message.Contains("low dynamic range"));
+    }
+
+    [Fact]
+    public async Task WhenCancelled_ThenThrowsOperationCanceled()
+    {
+        string path = CreateUniform("cancel.png", 32, 32, 128);
+        var images = new[] { new ImageFileInfo(path, 32, 32) };
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = async () => await _analyzer.RunAsync(images, MakeConfig(), cancellationToken: cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    // ── ComputeExposureStats (internal) ──
+
+    [Fact]
+    public void ComputeExposureStats_UniformImage_HasExactMeanAndZeroSpread()
+    {
+        string path = CreateUniform("stats.png", 64, 64, 128);
+
+        var stats = ExposureAnalyzer.ComputeExposureStats(path);
+
+        stats.Mean.Should().BeApproximately(128, 0.001);
+        stats.StdDev.Should().BeApproximately(0, 0.001);
+        stats.ClippedHighlightPercent.Should().Be(0);
+        stats.CrushedShadowPercent.Should().Be(0);
+    }
+
+    [Fact]
+    public void ComputeExposureStats_AllWhite_Is100PercentClipped()
+    {
+        string path = CreateUniform("white.png", 32, 32, 255);
+
+        var stats = ExposureAnalyzer.ComputeExposureStats(path);
+
+        stats.ClippedHighlightPercent.Should().BeApproximately(100, 0.001);
+        stats.CrushedShadowPercent.Should().Be(0);
+    }
+
+    // ── StatsToScore (internal) — brightness × clipping blend ──
+
+    [Theory]
+    [InlineData(128.0, 100.0)]  // ideal band, no clipping → full score
+    [InlineData(30.0, 40.0)]    // below MeanCriticalLow → meanScore 0, clipPenalty 100 → 0.6*0 + 0.4*100
+    [InlineData(230.0, 40.0)]   // above MeanCriticalHigh → same 40
+    [InlineData(60.0, 70.0)]    // halfway Critical→Ideal (meanScore 50) → 0.6*50 + 0.4*100
+    [InlineData(200.0, 70.0)]   // halfway Ideal→Critical (meanScore 50) → 70
+    public void StatsToScore_BrightnessComponent(double mean, double expected)
+    {
+        var stats = new ExposureAnalyzer.ExposureStats(mean, StdDev: 50, ClippedHighlightPercent: 0, CrushedShadowPercent: 0);
+        ExposureAnalyzer.StatsToScore(stats).Should().BeApproximately(expected, 0.1);
+    }
+
+    [Fact]
+    public void StatsToScore_ClippingReducesScore()
+    {
+        var clean = new ExposureAnalyzer.ExposureStats(128, 50, 0, 0);
+        var clipped = new ExposureAnalyzer.ExposureStats(128, 50, ClippedHighlightPercent: 20, CrushedShadowPercent: 10);
+
+        ExposureAnalyzer.StatsToScore(clipped).Should().BeLessThan(ExposureAnalyzer.StatsToScore(clean));
+    }
+
+    private DatasetConfig MakeConfig() => new()
+    {
+        FolderPath = _tempDir,
+        LoraType = LoraType.Character
+    };
+
+    private string CreateUniform(string fileName, int width, int height, byte value)
+    {
+        string path = Path.Combine(_tempDir, fileName);
+        using var image = new Image<L8>(width, height, new L8(value));
+        image.SaveAsPng(path);
+        return path;
+    }
+
+    private string CreateHorizontalRamp(string fileName, int width, int height)
+    {
+        string path = Path.Combine(_tempDir, fileName);
+        using var image = new Image<L8>(width, height);
+        image.ProcessPixelRows(accessor =>
+        {
+            for (int y = 0; y < height; y++)
+            {
+                var row = accessor.GetRowSpan(y);
+                for (int x = 0; x < width; x++)
+                    row[x] = new L8((byte)(x * 255 / Math.Max(width - 1, 1)));
+            }
+        });
+        image.SaveAsPng(path);
+        return path;
+    }
+
+    /// <summary>
+    /// Splits the image into a left band of <paramref name="leftFraction"/> columns at
+    /// <paramref name="leftValue"/> and the remainder at <paramref name="rightValue"/>.
+    /// </summary>
+    private string CreateColumnSplit(string fileName, int width, int height, double leftFraction, byte leftValue, byte rightValue)
+    {
+        string path = Path.Combine(_tempDir, fileName);
+        int splitCol = (int)Math.Round(width * leftFraction);
+        using var image = new Image<L8>(width, height);
+        image.ProcessPixelRows(accessor =>
+        {
+            for (int y = 0; y < height; y++)
+            {
+                var row = accessor.GetRowSpan(y);
+                for (int x = 0; x < width; x++)
+                    row[x] = new L8(x < splitCol ? leftValue : rightValue);
+            }
+        });
+        image.SaveAsPng(path);
+        return path;
+    }
+}

--- a/DiffusionNexus.Tests/DiffusionNexus.Tests.csproj
+++ b/DiffusionNexus.Tests/DiffusionNexus.Tests.csproj
@@ -38,6 +38,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DiffusionNexus.DataAccess\DiffusionNexus.DataAccess.csproj" />
+    <!-- Orphan project (not in the .sln and referenced by no production project);
+         referenced here so its serializer adapters can be covered (issue #443). -->
+    <ProjectReference Include="..\DiffusionNexus.DataAccess.Infrastructure\DiffusionNexus.DataAccess.Infrastructure.csproj" />
     <ProjectReference Include="..\DiffusionNexus.Service\DiffusionNexus.Service.csproj" />
     <ProjectReference Include="..\DiffusionNexus.UI\DiffusionNexus.UI.csproj" />
   </ItemGroup>

--- a/DiffusionNexus.Tests/Infrastructure/DownloadCoordinatorTests.cs
+++ b/DiffusionNexus.Tests/Infrastructure/DownloadCoordinatorTests.cs
@@ -1,0 +1,307 @@
+using DiffusionNexus.Domain.Services;
+using DiffusionNexus.Infrastructure.Services;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.Infrastructure;
+
+/// <summary>
+/// Covers <see cref="DownloadCoordinator"/> (issue #443): semaphore-gated FIFO admission, per-task
+/// cancellation, the activity-log aggregation shim, and the known-sharp live semaphore swap in the
+/// <c>MaxConcurrent</c> setter.
+///
+/// All concurrency is driven deterministically with <see cref="TaskCompletionSource"/> gates (the
+/// idiom used by <c>ComfyUIUpdateServiceTests</c>) — no <c>Thread.Sleep</c> races. Every wait is
+/// bounded by a timeout so a regression fails fast instead of hanging the suite.
+/// </summary>
+public class DownloadCoordinatorTests
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>Download action that signals <paramref name="started"/> then blocks on <paramref name="release"/>.</summary>
+    private static Func<IProgress<DownloadTaskProgress>, CancellationToken, Task<bool>> Gated(
+        TaskCompletionSource started, Task release, bool result = true)
+        => async (_, _) =>
+        {
+            started.TrySetResult();
+            await release.ConfigureAwait(false);
+            return result;
+        };
+
+    /// <summary>Download action that blocks until either released or its own token is cancelled.</summary>
+    private static Func<IProgress<DownloadTaskProgress>, CancellationToken, Task<bool>> GatedCancellable(
+        TaskCompletionSource started, Task release)
+        => async (_, ct) =>
+        {
+            started.TrySetResult();
+            await release.WaitAsync(ct).ConfigureAwait(false);
+            return true;
+        };
+
+    // ── Happy-path result mapping ──
+
+    [Fact]
+    public async Task Enqueue_SuccessfulDownload_ReturnsTrue_AndLeavesNoTrackedTasks()
+    {
+        using var coordinator = new DownloadCoordinator();
+        var stateChanges = 0;
+        coordinator.StateChanged += (_, _) => Interlocked.Increment(ref stateChanges);
+
+        var result = await coordinator.EnqueueAsync("model", (_, _) => Task.FromResult(true));
+
+        result.Should().BeTrue();
+        coordinator.All.Should().BeEmpty("completed tasks are removed from the tracked list");
+        stateChanges.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task Enqueue_ActionReturnsFalse_ReturnsFalse()
+    {
+        using var coordinator = new DownloadCoordinator();
+        var result = await coordinator.EnqueueAsync("model", (_, _) => Task.FromResult(false));
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Enqueue_ActionThrows_ReturnsFalse_WithoutPropagating()
+    {
+        using var coordinator = new DownloadCoordinator();
+        var result = await coordinator.EnqueueAsync("model",
+            (_, _) => throw new InvalidOperationException("boom"));
+        result.Should().BeFalse();
+        coordinator.All.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Enqueue_NullAction_Throws()
+    {
+        using var coordinator = new DownloadCoordinator();
+        var act = async () => await coordinator.EnqueueAsync("model", null!);
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    // ── Semaphore-gated FIFO admission ──
+
+    [Fact]
+    public async Task Enqueue_BeyondLimit_QueuesExcess_ExposingActiveAndQueuedSnapshots()
+    {
+        using var coordinator = new DownloadCoordinator { MaxConcurrent = 1 };
+        var startedA = new TaskCompletionSource();
+        var releaseA = new TaskCompletionSource();
+
+        var a = coordinator.EnqueueAsync("A", Gated(startedA, releaseA.Task));
+        await startedA.Task.WaitAsync(Timeout);
+
+        var b = coordinator.EnqueueAsync("B", (_, _) => Task.FromResult(true));
+
+        coordinator.Active.Select(t => t.Name).Should().Equal("A");
+        coordinator.Queued.Select(t => t.Name).Should().Equal("B");
+        coordinator.All.Select(t => t.Name).Should().Equal("A", "B");
+
+        releaseA.SetResult();
+        (await a.WaitAsync(Timeout)).Should().BeTrue();
+        (await b.WaitAsync(Timeout)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Admission_IsFifo_WhenSlotFrees()
+    {
+        using var coordinator = new DownloadCoordinator { MaxConcurrent = 1 };
+        var startedA = new TaskCompletionSource();
+        var releaseA = new TaskCompletionSource();
+        var startedB = new TaskCompletionSource();
+        var releaseB = new TaskCompletionSource();
+        var startedC = new TaskCompletionSource();
+        var releaseC = new TaskCompletionSource();
+
+        var a = coordinator.EnqueueAsync("A", Gated(startedA, releaseA.Task));
+        await startedA.Task.WaitAsync(Timeout);
+
+        var b = coordinator.EnqueueAsync("B", Gated(startedB, releaseB.Task));
+        var c = coordinator.EnqueueAsync("C", Gated(startedC, releaseC.Task));
+
+        // Free the single slot: the older-enqueued B must be admitted before C.
+        releaseA.SetResult();
+        await startedB.Task.WaitAsync(Timeout);
+        startedC.Task.IsCompleted.Should().BeFalse("C waits until B releases the slot (FIFO)");
+
+        releaseB.SetResult();
+        await startedC.Task.WaitAsync(Timeout);
+
+        releaseC.SetResult();
+        await Task.WhenAll(a, b, c).WaitAsync(Timeout);
+    }
+
+    // ── Cancellation ──
+
+    [Fact]
+    public async Task Cancel_QueuedTask_MarksCancelled_WithoutConsumingASlot()
+    {
+        using var coordinator = new DownloadCoordinator { MaxConcurrent = 1 };
+        var startedA = new TaskCompletionSource();
+        var releaseA = new TaskCompletionSource();
+        var startedB = new TaskCompletionSource();
+        var releaseB = new TaskCompletionSource();
+
+        var a = coordinator.EnqueueAsync("A", Gated(startedA, releaseA.Task));
+        await startedA.Task.WaitAsync(Timeout);
+
+        var b = coordinator.EnqueueAsync("B", Gated(startedB, releaseB.Task));
+        var queuedId = coordinator.Queued.Single().Id;
+
+        coordinator.Cancel(queuedId);
+
+        (await b.WaitAsync(Timeout)).Should().BeFalse("a cancelled queued task never runs");
+        startedB.Task.IsCompleted.Should().BeFalse("the cancelled task's action must never start");
+
+        releaseA.SetResult();
+        (await a.WaitAsync(Timeout)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Cancel_ActiveTask_SignalsToken_AndReportsFalse()
+    {
+        using var coordinator = new DownloadCoordinator { MaxConcurrent = 1 };
+        var startedA = new TaskCompletionSource();
+        var releaseA = new TaskCompletionSource(); // never released — cancellation must end it
+
+        var a = coordinator.EnqueueAsync("A", GatedCancellable(startedA, releaseA.Task));
+        await startedA.Task.WaitAsync(Timeout);
+
+        coordinator.Cancel(coordinator.Active.Single().Id);
+
+        (await a.WaitAsync(Timeout)).Should().BeFalse("a cancelled active download reports failure");
+    }
+
+    [Fact]
+    public void Cancel_UnknownId_IsNoOp()
+    {
+        using var coordinator = new DownloadCoordinator();
+        var act = () => coordinator.Cancel(Guid.NewGuid());
+        act.Should().NotThrow();
+    }
+
+    // ── MaxConcurrent setter ──
+
+    [Fact]
+    public void MaxConcurrent_BelowOne_Throws()
+    {
+        using var coordinator = new DownloadCoordinator();
+        var act = () => coordinator.MaxConcurrent = 0;
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void MaxConcurrent_SameValue_IsNoOp_AndDoesNotRaiseStateChanged()
+    {
+        using var coordinator = new DownloadCoordinator { MaxConcurrent = 3 };
+        var raised = 0;
+        coordinator.StateChanged += (_, _) => raised++;
+
+        coordinator.MaxConcurrent = 3;
+
+        raised.Should().Be(0);
+    }
+
+    [Fact]
+    public void MaxConcurrent_NewValue_RaisesStateChanged()
+    {
+        using var coordinator = new DownloadCoordinator { MaxConcurrent = 3 };
+        var raised = 0;
+        coordinator.StateChanged += (_, _) => raised++;
+
+        coordinator.MaxConcurrent = 5;
+
+        coordinator.MaxConcurrent.Should().Be(5);
+        raised.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task MaxConcurrent_LiveSwap_LeaksTheInFlightPermit_AndOverAdmits()
+    {
+        // KNOWN SHARP EDGE (the setter's own comment: "we accept the leak"). Raising the limit while a
+        // download is in flight swaps in a brand-new semaphore with a FULL set of permits — it has no
+        // knowledge of the still-running download holding a permit on the discarded instance. So the
+        // total number of simultaneously-active downloads can exceed MaxConcurrent right after a resize.
+        using var coordinator = new DownloadCoordinator { MaxConcurrent = 1 };
+        var startedA = new TaskCompletionSource();
+        var releaseA = new TaskCompletionSource();
+        var startedB = new TaskCompletionSource();
+        var releaseB = new TaskCompletionSource();
+        var startedC = new TaskCompletionSource();
+        var releaseC = new TaskCompletionSource();
+
+        var a = coordinator.EnqueueAsync("A", Gated(startedA, releaseA.Task));
+        await startedA.Task.WaitAsync(Timeout); // A holds the only permit of the original semaphore
+
+        coordinator.MaxConcurrent = 2;          // swaps in a fresh SemaphoreSlim(2, 2)
+
+        var b = coordinator.EnqueueAsync("B", Gated(startedB, releaseB.Task));
+        var c = coordinator.EnqueueAsync("C", Gated(startedC, releaseC.Task));
+        await Task.WhenAll(startedB.Task, startedC.Task).WaitAsync(Timeout);
+
+        coordinator.Active.Should().HaveCount(3, "A (old semaphore) + B + C (new semaphore) all run — above the limit of 2");
+
+        // Draining also exposes the second half of the bug: the finally releases into the *field*
+        // semaphore (the new one), not the instance each task acquired from, so the surplus release
+        // pushes the new semaphore past its max count.
+        releaseA.SetResult();
+        releaseB.SetResult();
+        releaseC.SetResult();
+        var drain = async () => await Task.WhenAll(a, b, c).WaitAsync(Timeout);
+        await drain.Should().ThrowAsync<SemaphoreFullException>();
+    }
+
+    // ── Activity-log aggregation shim (real ActivityLogService) ──
+
+    [Fact]
+    public async Task ActivityLog_SingleActiveDownload_ShowsItsName()
+    {
+        var log = new ActivityLogService();
+        using var coordinator = new DownloadCoordinator(log) { MaxConcurrent = 2 };
+        var startedA = new TaskCompletionSource();
+        var releaseA = new TaskCompletionSource();
+
+        var a = coordinator.EnqueueAsync("Model-A", Gated(startedA, releaseA.Task));
+        await startedA.Task.WaitAsync(Timeout);
+
+        log.IsDownloadInProgress.Should().BeTrue();
+        log.DownloadOperationName.Should().Be("Model-A");
+
+        releaseA.SetResult();
+        await a.WaitAsync(Timeout);
+    }
+
+    [Fact]
+    public async Task ActivityLog_TwoActiveDownloads_ShowAggregateSummary()
+    {
+        var log = new ActivityLogService();
+        using var coordinator = new DownloadCoordinator(log) { MaxConcurrent = 2 };
+        var startedA = new TaskCompletionSource();
+        var releaseA = new TaskCompletionSource();
+        var startedB = new TaskCompletionSource();
+        var releaseB = new TaskCompletionSource();
+
+        var a = coordinator.EnqueueAsync("Model-A", Gated(startedA, releaseA.Task));
+        await startedA.Task.WaitAsync(Timeout);
+        var b = coordinator.EnqueueAsync("Model-B", Gated(startedB, releaseB.Task));
+        await startedB.Task.WaitAsync(Timeout); // B's admission is the last activity-log update
+
+        log.DownloadOperationName.Should().Be("2 Downloads in progress");
+
+        releaseA.SetResult();
+        releaseB.SetResult();
+        await Task.WhenAll(a, b).WaitAsync(Timeout);
+    }
+
+    [Fact]
+    public async Task ActivityLog_WhenAllDownloadsComplete_ClosesTheDownloadSlot()
+    {
+        var log = new ActivityLogService();
+        using var coordinator = new DownloadCoordinator(log);
+
+        await coordinator.EnqueueAsync("Model-A", (_, _) => Task.FromResult(true)).WaitAsync(Timeout);
+
+        log.IsDownloadInProgress.Should().BeFalse();
+        log.DownloadOperationName.Should().BeNull();
+    }
+}

--- a/DiffusionNexus.Tests/LoraSort/Services/LocalFileMetadataProviderTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/Services/LocalFileMetadataProviderTests.cs
@@ -1,0 +1,216 @@
+using DiffusionNexus.Service.Classes;
+using DiffusionNexus.Service.Enums;
+using DiffusionNexus.Service.Services;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.LoraSort.Services;
+
+/// <summary>
+/// Direct coverage of <see cref="LocalFileMetadataProvider"/> — previously only
+/// exercised incidentally via <c>JsonInfoFileReaderServiceTests</c>. Pins the
+/// <c>.civitai.info</c>-over-<c>.json</c> precedence rule and the
+/// <c>modelId</c> String/Number coercion.
+/// </summary>
+public class LocalFileMetadataProviderTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly LocalFileMetadataProvider _sut = new();
+
+    public LocalFileMetadataProviderTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "LocalFileMetadataProviderTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_dir))
+                Directory.Delete(_dir, recursive: true);
+        }
+        catch
+        {
+            // best-effort
+        }
+    }
+
+    private string Write(string fileName, string content)
+    {
+        var path = Path.Combine(_dir, fileName);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    private string ModelFile()
+    {
+        // The sidecar-lookup key is derived from this file's base name ("model").
+        return Write("model.safetensors", string.Empty);
+    }
+
+    // ---------------------------------------------------------------------
+    // CanHandleAsync
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task CanHandleAsync_ExistingFile_True()
+    {
+        var path = ModelFile();
+        (await _sut.CanHandleAsync(path)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CanHandleAsync_MissingFile_False()
+    {
+        var path = Path.Combine(_dir, "nope.safetensors");
+        (await _sut.CanHandleAsync(path)).Should().BeFalse();
+    }
+
+    // ---------------------------------------------------------------------
+    // Precedence: .civitai.info wins over .json
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task CivitaiInfo_TakesPrecedenceOver_Json_WhenBothPresent()
+    {
+        var model = ModelFile();
+        Write("model.civitai.info", """{ "baseModel": "SD 1.5", "type": "LORA" }""");
+        Write("model.json", """{ "sd version": "Pony", "type": "Checkpoint" }""");
+
+        var result = await _sut.GetModelMetadataAsync(model);
+
+        // civitai.info values win; the .json file is not consulted at all.
+        result.DiffusionBaseModel.Should().Be("SD 1.5");
+        result.ModelType.Should().Be(DiffusionTypes.LORA);
+    }
+
+    [Fact]
+    public async Task JsonFile_UsedOnly_WhenNoCivitaiInfoPresent()
+    {
+        var model = ModelFile();
+        Write("model.json", """{ "sd version": "SD 1.5", "type": "LORA", "tags": ["character", "style"] }""");
+
+        var result = await _sut.GetModelMetadataAsync(model);
+
+        result.DiffusionBaseModel.Should().Be("SD 1.5");
+        result.ModelType.Should().Be(DiffusionTypes.LORA);
+        result.Tags.Should().Contain(new[] { "character", "style" });
+    }
+
+    // ---------------------------------------------------------------------
+    // modelId String/Number coercion (civitai.info)
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task ModelId_AsJsonNumber_CoercedToString()
+    {
+        var model = ModelFile();
+        Write("model.civitai.info", """{ "modelId": 789 }""");
+
+        var result = await _sut.GetModelMetadataAsync(model);
+
+        result.ModelId.Should().Be("789");
+    }
+
+    [Fact]
+    public async Task ModelId_AsJsonString_KeptAsString()
+    {
+        var model = ModelFile();
+        Write("model.civitai.info", """{ "modelId": "789" }""");
+
+        var result = await _sut.GetModelMetadataAsync(model);
+
+        result.ModelId.Should().Be("789");
+    }
+
+    [Fact]
+    public async Task ModelId_AsUnsupportedKind_IsNull()
+    {
+        var model = ModelFile();
+        Write("model.civitai.info", """{ "modelId": true }""");
+
+        var result = await _sut.GetModelMetadataAsync(model);
+
+        result.ModelId.Should().BeNull();
+    }
+
+    // ---------------------------------------------------------------------
+    // Full civitai.info parse + tolerance
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task CivitaiInfo_FullPayload_PopulatesAllFields()
+    {
+        var model = ModelFile();
+        Write("model.civitai.info", """
+            {
+              "modelId": 123,
+              "baseModel": "SD 1.5",
+              "trainedWords": ["trigger", "word"],
+              "model": {
+                "name": "My Model",
+                "type": "LORA",
+                "tags": ["character"],
+                "nsfw": true
+              }
+            }
+            """);
+
+        var result = await _sut.GetModelMetadataAsync(model);
+
+        result.ModelId.Should().Be("123");
+        result.DiffusionBaseModel.Should().Be("SD 1.5");
+        result.TrainedWords.Should().Equal("trigger", "word");
+        result.ModelVersionName.Should().Be("My Model");
+        result.ModelType.Should().Be(DiffusionTypes.LORA);
+        result.Tags.Should().ContainSingle().Which.Should().Be("character");
+        result.Nsfw.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CivitaiInfo_TrainedWords_NonStringEntriesAreIgnored()
+    {
+        var model = ModelFile();
+        Write("model.civitai.info", """{ "trainedWords": ["keep", 42, null, "also"] }""");
+
+        var result = await _sut.GetModelMetadataAsync(model);
+
+        result.TrainedWords.Should().Equal("keep", "also");
+    }
+
+    // ---------------------------------------------------------------------
+    // No sidecar files
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task NoSidecarFiles_LeavesContentFieldsAtDefaults()
+    {
+        var model = ModelFile();
+
+        var result = await _sut.GetModelMetadataAsync(model);
+
+        result.DiffusionBaseModel.Should().Be("UNKNOWN");
+        result.ModelType.Should().Be(DiffusionTypes.UNASSIGNED);
+        result.ModelId.Should().BeNull();
+        result.Tags.Should().BeEmpty();
+        // The base file name is always captured.
+        result.SafeTensorFileName.Should().Be("model");
+        // NOTE: NoMetaData ends up false even with no sidecars, because
+        // SafeTensorFileName is itself a [MetadataField] and is always populated.
+        result.NoMetaData.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ProvidedModelInstance_IsMutatedAndReturned()
+    {
+        var model = ModelFile();
+        Write("model.civitai.info", """{ "baseModel": "SD 1.5" }""");
+        var existing = new ModelClass { SHA256Hash = "preserve-me" };
+
+        var result = await _sut.GetModelMetadataAsync(model, model: existing);
+
+        result.Should().BeSameAs(existing);
+        result.SHA256Hash.Should().Be("preserve-me");
+        result.DiffusionBaseModel.Should().Be("SD 1.5");
+    }
+}

--- a/DiffusionNexus.Tests/LoraSort/Services/TypedCivitaiMetadataProviderTests.cs
+++ b/DiffusionNexus.Tests/LoraSort/Services/TypedCivitaiMetadataProviderTests.cs
@@ -1,0 +1,289 @@
+using System.Net;
+using DiffusionNexus.Civitai;
+using DiffusionNexus.Civitai.Models;
+using DiffusionNexus.Service.Enums;
+using DiffusionNexus.Service.Services;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.LoraSort.Services;
+
+/// <summary>
+/// Coverage of <see cref="TypedCivitaiMetadataProvider"/>: SHA256 hashing of a
+/// real temp file, the Civitai-response -> <c>ModelClass</c> mapping, the
+/// CivitaiModelType -> DiffusionTypes switch, and the NoMetaData fallbacks
+/// (null version, HTTP 404). Uses a hand-rolled fake <see cref="ICivitaiClient"/>.
+/// </summary>
+public class TypedCivitaiMetadataProviderTests : IDisposable
+{
+    // SHA-256 of the ASCII bytes "hello" (well-known test vector).
+    private const string HelloSha256 = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+
+    private readonly string _dir;
+
+    public TypedCivitaiMetadataProviderTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "TypedCivitaiMetadataProviderTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_dir))
+                Directory.Delete(_dir, recursive: true);
+        }
+        catch
+        {
+            // best-effort
+        }
+    }
+
+    private string HelloFile()
+    {
+        var path = Path.Combine(_dir, "model.safetensors");
+        File.WriteAllBytes(path, "hello"u8.ToArray());
+        return path;
+    }
+
+    // ---------------------------------------------------------------------
+    // Construction & CanHandleAsync
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void Ctor_NullClient_Throws()
+    {
+        var act = () => new TypedCivitaiMetadataProvider(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Theory]
+    [InlineData("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", true)] // valid 64-hex
+    [InlineData("2CF24DBA5FB0A30E26E83B2AC5B9E29E1B161E5C1FA7425E73043362938B9824", true)] // upper hex
+    [InlineData("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b982", false)]  // 63 chars
+    [InlineData("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b98244", false)] // 65 chars
+    [InlineData("gcf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", false)]  // non-hex 'g'
+    public async Task CanHandleAsync_OnlyAccepts64CharHex(string identifier, bool expected)
+    {
+        var sut = new TypedCivitaiMetadataProvider(new FakeCivitaiClient());
+        (await sut.CanHandleAsync(identifier)).Should().Be(expected);
+    }
+
+    // ---------------------------------------------------------------------
+    // Hashing
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetModelMetadataAsync_ComputesSha256_AndLooksUpByThatHash()
+    {
+        var file = HelloFile();
+        var fake = new FakeCivitaiClient
+        {
+            OnGetVersionByHash = (_, _, _) => Task.FromResult<CivitaiModelVersion?>(null),
+        };
+        var sut = new TypedCivitaiMetadataProvider(fake);
+
+        var result = await sut.GetModelMetadataAsync(file);
+
+        result.SHA256Hash.Should().Be(HelloSha256);
+        fake.LastHash.Should().Be(HelloSha256);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task GetModelMetadataAsync_NullOrWhitespacePath_Throws(string? path)
+    {
+        var sut = new TypedCivitaiMetadataProvider(new FakeCivitaiClient());
+        var act = async () => await sut.GetModelMetadataAsync(path!);
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    // ---------------------------------------------------------------------
+    // Mapping
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetModelMetadataAsync_MapsVersionAndModelFields()
+    {
+        var file = HelloFile();
+        var fake = new FakeCivitaiClient
+        {
+            OnGetVersionByHash = (_, _, _) => Task.FromResult<CivitaiModelVersion?>(new CivitaiModelVersion
+            {
+                Id = 10,
+                ModelId = 42,
+                Name = "v1.0",
+                BaseModel = "SD 1.5",
+                TrainedWords = new[] { "trigger" },
+            }),
+            OnGetModel = (_, _, _) => Task.FromResult<CivitaiModel?>(new CivitaiModel
+            {
+                Id = 42,
+                Type = CivitaiModelType.LORA,
+                Tags = new[] { "character" },
+                Nsfw = true,
+            }),
+        };
+        var sut = new TypedCivitaiMetadataProvider(fake);
+
+        var result = await sut.GetModelMetadataAsync(file);
+
+        result.ModelId.Should().Be("42");
+        result.DiffusionBaseModel.Should().Be("SD 1.5");
+        result.ModelVersionName.Should().Be("v1.0");
+        result.TrainedWords.Should().Equal("trigger");
+        result.ModelType.Should().Be(DiffusionTypes.LORA);
+        result.Tags.Should().ContainSingle().Which.Should().Be("character");
+        result.CivitaiCategory.Should().Be(CivitaiBaseCategories.CHARACTER);
+        result.Nsfw.Should().BeTrue();
+        result.NoMetaData.Should().BeFalse();
+        fake.LastModelId.Should().Be(42);
+    }
+
+    [Theory]
+    [InlineData(CivitaiModelType.Checkpoint, DiffusionTypes.CHECKPOINT)]
+    [InlineData(CivitaiModelType.LORA, DiffusionTypes.LORA)]
+    [InlineData(CivitaiModelType.DoRA, DiffusionTypes.DORA)]
+    [InlineData(CivitaiModelType.LoCon, DiffusionTypes.LOCON)]
+    [InlineData(CivitaiModelType.VAE, DiffusionTypes.VAE)]
+    [InlineData(CivitaiModelType.Controlnet, DiffusionTypes.CONTROLNET)]
+    [InlineData(CivitaiModelType.Upscaler, DiffusionTypes.UPSCALER)]
+    [InlineData(CivitaiModelType.Other, DiffusionTypes.OTHER)]
+    [InlineData(CivitaiModelType.Unknown, DiffusionTypes.UNASSIGNED)]
+    public async Task GetModelMetadataAsync_MapsModelType(CivitaiModelType civitaiType, DiffusionTypes expected)
+    {
+        var file = HelloFile();
+        var fake = new FakeCivitaiClient
+        {
+            OnGetVersionByHash = (_, _, _) => Task.FromResult<CivitaiModelVersion?>(new CivitaiModelVersion { ModelId = 42 }),
+            OnGetModel = (_, _, _) => Task.FromResult<CivitaiModel?>(new CivitaiModel { Id = 42, Type = civitaiType }),
+        };
+        var sut = new TypedCivitaiMetadataProvider(fake);
+
+        var result = await sut.GetModelMetadataAsync(file);
+
+        result.ModelType.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task GetModelMetadataAsync_ZeroModelId_DoesNotFetchModel()
+    {
+        var file = HelloFile();
+        var fake = new FakeCivitaiClient
+        {
+            OnGetVersionByHash = (_, _, _) => Task.FromResult<CivitaiModelVersion?>(new CivitaiModelVersion { ModelId = 0, BaseModel = "SD 1.5" }),
+        };
+        var sut = new TypedCivitaiMetadataProvider(fake);
+
+        var result = await sut.GetModelMetadataAsync(file);
+
+        fake.GetModelCallCount.Should().Be(0);
+        result.ModelId.Should().BeNull();
+        result.ModelType.Should().Be(DiffusionTypes.UNASSIGNED);
+    }
+
+    // ---------------------------------------------------------------------
+    // NoMetaData fallbacks
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetModelMetadataAsync_NullVersion_SetsNoMetaData()
+    {
+        var file = HelloFile();
+        var fake = new FakeCivitaiClient
+        {
+            OnGetVersionByHash = (_, _, _) => Task.FromResult<CivitaiModelVersion?>(null),
+        };
+        var sut = new TypedCivitaiMetadataProvider(fake);
+
+        var result = await sut.GetModelMetadataAsync(file);
+
+        result.NoMetaData.Should().BeTrue();
+        fake.GetModelCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetModelMetadataAsync_Http404_SetsNoMetaData()
+    {
+        var file = HelloFile();
+        var fake = new FakeCivitaiClient
+        {
+            OnGetVersionByHash = (_, _, _) => throw new HttpRequestException("nope", null, HttpStatusCode.NotFound),
+        };
+        var sut = new TypedCivitaiMetadataProvider(fake);
+
+        var result = await sut.GetModelMetadataAsync(file);
+
+        result.NoMetaData.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetModelMetadataAsync_NonNotFoundHttpError_Propagates()
+    {
+        var file = HelloFile();
+        var fake = new FakeCivitaiClient
+        {
+            OnGetVersionByHash = (_, _, _) => throw new HttpRequestException("boom", null, HttpStatusCode.InternalServerError),
+        };
+        var sut = new TypedCivitaiMetadataProvider(fake);
+
+        var act = async () => await sut.GetModelMetadataAsync(file);
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+    }
+
+    [Fact]
+    public async Task GetModelMetadataAsync_ForwardsApiKey_ToClient()
+    {
+        var file = HelloFile();
+        var fake = new FakeCivitaiClient
+        {
+            OnGetVersionByHash = (_, _, _) => Task.FromResult<CivitaiModelVersion?>(null),
+        };
+        var sut = new TypedCivitaiMetadataProvider(fake, apiKey: "secret");
+
+        await sut.GetModelMetadataAsync(file);
+
+        fake.LastApiKey.Should().Be("secret");
+    }
+
+    /// <summary>Configurable fake; only the two consumed methods are wired.</summary>
+    private sealed class FakeCivitaiClient : ICivitaiClient
+    {
+        public Func<string, string?, CancellationToken, Task<CivitaiModelVersion?>>? OnGetVersionByHash;
+        public Func<int, string?, CancellationToken, Task<CivitaiModel?>>? OnGetModel;
+
+        public string? LastHash;
+        public string? LastApiKey;
+        public int? LastModelId;
+        public int GetModelCallCount;
+
+        public Task<CivitaiModelVersion?> GetModelVersionByHashAsync(string hash, string? apiKey = null, CancellationToken cancellationToken = default)
+        {
+            LastHash = hash;
+            LastApiKey = apiKey;
+            return OnGetVersionByHash!(hash, apiKey, cancellationToken);
+        }
+
+        public Task<CivitaiModel?> GetModelAsync(int modelId, string? apiKey = null, CancellationToken cancellationToken = default)
+        {
+            LastModelId = modelId;
+            GetModelCallCount++;
+            return OnGetModel!(modelId, apiKey, cancellationToken);
+        }
+
+        // Unused by the provider.
+        public Task<CivitaiPagedResponse<CivitaiModel>> GetModelsAsync(CivitaiModelsQuery? query = null, string? apiKey = null, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+        public Task<CivitaiModelVersion?> GetModelVersionAsync(int modelVersionId, string? apiKey = null, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+        public Task<CivitaiPagedResponse<CivitaiModelImage>> GetImagesAsync(CivitaiImagesQuery? query = null, string? apiKey = null, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+        public Task<CivitaiPagedResponse<CivitaiTag>> GetTagsAsync(int? limit = null, int? page = null, string? query = null, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+        public Task<CivitaiPagedResponse<CivitaiCreatorInfo>> GetCreatorsAsync(int? limit = null, int? page = null, string? query = null, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+    }
+}

--- a/DiffusionNexus.Tests/Services/DatasetBackupServiceTests.cs
+++ b/DiffusionNexus.Tests/Services/DatasetBackupServiceTests.cs
@@ -1,0 +1,330 @@
+using System.IO.Compression;
+using DiffusionNexus.Domain.Entities;
+using DiffusionNexus.Domain.Services;
+using DiffusionNexus.Service.Services;
+using FluentAssertions;
+using Moq;
+
+namespace DiffusionNexus.Tests.Services;
+
+/// <summary>
+/// Covers the untested half of <see cref="DatasetBackupService"/> (issue #443): real ZIP creation,
+/// the destructive restore (which wipes and repopulates the dataset folder), <c>MaxBackups</c>
+/// retention pruning (which deletes archive files), and the <c>_isOperationInProgress</c>
+/// re-entrancy guard.
+///
+/// DESTRUCTIVE-OP SAFETY: every test drives the service at throwaway temp directories created per
+/// test and deleted in <see cref="Dispose"/>. Restore only ever wipes a temp DatasetStoragePath;
+/// pruning only ever deletes DatasetBackup_*.zip files inside a temp backup folder.
+/// (The existing <c>DatasetBackupAnalysisTests</c> already covers <c>AnalyzeBackupAsync</c>.)
+/// </summary>
+public class DatasetBackupServiceTests : IDisposable
+{
+    private readonly string _root;
+
+    public DatasetBackupServiceTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), $"dsbackup_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch (IOException) { }
+    }
+
+    private static Mock<IAppSettingsService> SettingsReturning(AppSettings settings)
+    {
+        var mock = new Mock<IAppSettingsService>();
+        mock.Setup(s => s.GetSettingsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(settings);
+        return mock;
+    }
+
+    private string NewDir(string name)
+    {
+        var p = Path.Combine(_root, name);
+        Directory.CreateDirectory(p);
+        return p;
+    }
+
+    // ── Backup: ZIP creation ──
+
+    [Fact]
+    public async Task BackupDatasetsAsync_CreatesTimestampedZip_WithRelativePaths_AndReportsCounts()
+    {
+        var storage = NewDir("data");
+        var backupDir = NewDir("backups");
+        Directory.CreateDirectory(Path.Combine(storage, "char"));
+        await File.WriteAllTextAsync(Path.Combine(storage, "char", "img.txt"), "hello");   // 5 bytes
+        await File.WriteAllTextAsync(Path.Combine(storage, "root.txt"), "world!!");         // 7 bytes
+
+        var settings = new AppSettings { DatasetStoragePath = storage, AutoBackupLocation = backupDir, MaxBackups = 10 };
+        var settingsMock = SettingsReturning(settings);
+        var service = new DatasetBackupService(settingsMock.Object);
+
+        var result = await service.BackupDatasetsAsync();
+
+        result.Success.Should().BeTrue(result.ErrorMessage);
+        result.FilesBackedUp.Should().Be(2);
+        result.TotalSizeBytes.Should().Be(12);
+
+        var zips = Directory.GetFiles(backupDir, "DatasetBackup_*.zip");
+        zips.Should().ContainSingle();
+        Path.GetFileName(result.BackupPath!).Should().MatchRegex(@"^DatasetBackup_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.zip$");
+
+        using var archive = ZipFile.OpenRead(zips[0]);
+        var entryNames = archive.Entries.Select(e => e.FullName.Replace('\\', '/')).ToList();
+        entryNames.Should().BeEquivalentTo(new[] { "char/img.txt", "root.txt" });
+
+        settingsMock.Verify(s => s.UpdateLastBackupAtAsync(It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task BackupDatasetsAsync_RoundTripsThroughRestore_IntoAFreshFolder()
+    {
+        var storage = NewDir("src");
+        var backupDir = NewDir("backups");
+        Directory.CreateDirectory(Path.Combine(storage, "sub"));
+        await File.WriteAllTextAsync(Path.Combine(storage, "sub", "a.txt"), "alpha");
+        await File.WriteAllTextAsync(Path.Combine(storage, "b.png"), "PNGDATA");
+
+        var settings = new AppSettings { DatasetStoragePath = storage, AutoBackupLocation = backupDir, MaxBackups = 10 };
+        var service = new DatasetBackupService(SettingsReturning(settings).Object);
+
+        var backup = await service.BackupDatasetsAsync();
+        backup.Success.Should().BeTrue(backup.ErrorMessage);
+
+        // Restore into a fresh, empty folder by pointing DatasetStoragePath at it.
+        var restoreDir = NewDir("restored");
+        settings.DatasetStoragePath = restoreDir;
+
+        var restore = await service.RestoreBackupAsync(backup.BackupPath!);
+
+        restore.Success.Should().BeTrue(restore.ErrorMessage);
+        restore.FilesRestored.Should().Be(2);
+        (await File.ReadAllTextAsync(Path.Combine(restoreDir, "sub", "a.txt"))).Should().Be("alpha");
+        (await File.ReadAllTextAsync(Path.Combine(restoreDir, "b.png"))).Should().Be("PNGDATA");
+    }
+
+    [Fact]
+    public async Task BackupDatasetsAsync_WhenDatasetPathNotConfigured_Fails()
+    {
+        var settings = new AppSettings { DatasetStoragePath = null, AutoBackupLocation = NewDir("b"), MaxBackups = 10 };
+        var service = new DatasetBackupService(SettingsReturning(settings).Object);
+
+        var result = await service.BackupDatasetsAsync();
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("not configured");
+    }
+
+    [Fact]
+    public async Task BackupDatasetsAsync_WhenDatasetPathDoesNotExist_Fails()
+    {
+        var settings = new AppSettings
+        {
+            DatasetStoragePath = Path.Combine(_root, "missing"),
+            AutoBackupLocation = NewDir("b"),
+            MaxBackups = 10
+        };
+        var service = new DatasetBackupService(SettingsReturning(settings).Object);
+
+        var result = await service.BackupDatasetsAsync();
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("does not exist");
+    }
+
+    [Fact]
+    public async Task BackupDatasetsAsync_WhenBackupLocationNotConfigured_Fails()
+    {
+        var settings = new AppSettings { DatasetStoragePath = NewDir("data"), AutoBackupLocation = null, MaxBackups = 10 };
+        var service = new DatasetBackupService(SettingsReturning(settings).Object);
+
+        var result = await service.BackupDatasetsAsync();
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Backup location");
+    }
+
+    [Fact]
+    public async Task BackupDatasetsAsync_WhenCancelled_Fails_AndDeletesPartialArchive()
+    {
+        var storage = NewDir("data");
+        var backupDir = NewDir("backups");
+        await File.WriteAllTextAsync(Path.Combine(storage, "one.txt"), "x"); // ensures the file loop runs
+
+        var settings = new AppSettings { DatasetStoragePath = storage, AutoBackupLocation = backupDir, MaxBackups = 10 };
+        var service = new DatasetBackupService(SettingsReturning(settings).Object);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var result = await service.BackupDatasetsAsync(cancellationToken: cts.Token);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("cancelled");
+        Directory.GetFiles(backupDir, "DatasetBackup_*.zip").Should().BeEmpty("the partial archive must be cleaned up");
+    }
+
+    // ── MaxBackups retention pruning (deletes archive files) ──
+
+    [Fact]
+    public async Task BackupDatasetsAsync_PrunesOldestArchives_KeepingNewestMaxBackups()
+    {
+        var storage = NewDir("data");
+        var backupDir = NewDir("backups");
+        await File.WriteAllTextAsync(Path.Combine(storage, "f.txt"), "content");
+
+        // Three pre-existing archives; old0 is oldest by CreationTimeUtc (the prune's sort key).
+        var now = DateTime.UtcNow;
+        for (var i = 0; i < 3; i++)
+        {
+            var p = Path.Combine(backupDir, $"DatasetBackup_old{i}.zip");
+            await File.WriteAllTextAsync(p, "x");
+            File.SetCreationTimeUtc(p, now.AddHours(-10 + i));
+        }
+
+        var settings = new AppSettings { DatasetStoragePath = storage, AutoBackupLocation = backupDir, MaxBackups = 3 };
+        var service = new DatasetBackupService(SettingsReturning(settings).Object);
+
+        var result = await service.BackupDatasetsAsync();
+
+        result.Success.Should().BeTrue(result.ErrorMessage);
+        var remaining = Directory.GetFiles(backupDir, "DatasetBackup_*.zip").Select(Path.GetFileName).ToList();
+        remaining.Should().HaveCount(3, "count is capped at MaxBackups after the new archive is added");
+        remaining.Should().NotContain("DatasetBackup_old0.zip", "the single oldest archive is pruned");
+        remaining.Should().Contain("DatasetBackup_old1.zip");
+        remaining.Should().Contain("DatasetBackup_old2.zip");
+        remaining.Should().Contain(Path.GetFileName(result.BackupPath));
+    }
+
+    [Fact]
+    public async Task BackupDatasetsAsync_WhenMaxBackupsZero_PruningIsDisabled()
+    {
+        var storage = NewDir("data");
+        var backupDir = NewDir("backups");
+        await File.WriteAllTextAsync(Path.Combine(storage, "f.txt"), "content");
+        for (var i = 0; i < 2; i++)
+            await File.WriteAllTextAsync(Path.Combine(backupDir, $"DatasetBackup_old{i}.zip"), "x");
+
+        var settings = new AppSettings { DatasetStoragePath = storage, AutoBackupLocation = backupDir, MaxBackups = 0 };
+        var service = new DatasetBackupService(SettingsReturning(settings).Object);
+
+        var result = await service.BackupDatasetsAsync();
+
+        result.Success.Should().BeTrue(result.ErrorMessage);
+        Directory.GetFiles(backupDir, "DatasetBackup_*.zip").Should().HaveCount(3, "MaxBackups <= 0 disables pruning");
+    }
+
+    // ── Restore: destructive replace ──
+
+    [Fact]
+    public async Task RestoreBackupAsync_WipesExistingContents_ThenExtractsArchive()
+    {
+        // Existing (soon-to-be-destroyed) contents in the throwaway target folder.
+        var target = NewDir("target");
+        Directory.CreateDirectory(Path.Combine(target, "oldsub"));
+        await File.WriteAllTextAsync(Path.Combine(target, "oldsub", "old.txt"), "OLD");
+        await File.WriteAllTextAsync(Path.Combine(target, "oldroot.txt"), "OLDROOT");
+
+        // Independent archive with different contents.
+        var staging = NewDir("staging");
+        Directory.CreateDirectory(Path.Combine(staging, "newsub"));
+        await File.WriteAllTextAsync(Path.Combine(staging, "newsub", "new.txt"), "NEW");
+        await File.WriteAllTextAsync(Path.Combine(staging, "newroot.txt"), "NEWROOT");
+        var zip = Path.Combine(_root, "DatasetBackup_x.zip");
+        ZipFile.CreateFromDirectory(staging, zip);
+
+        var settings = new AppSettings { DatasetStoragePath = target, AutoBackupLocation = NewDir("b"), MaxBackups = 10 };
+        var service = new DatasetBackupService(SettingsReturning(settings).Object);
+
+        var result = await service.RestoreBackupAsync(zip);
+
+        result.Success.Should().BeTrue(result.ErrorMessage);
+        result.FilesRestored.Should().Be(2);
+        Directory.Exists(Path.Combine(target, "oldsub")).Should().BeFalse("old subfolders are wiped");
+        File.Exists(Path.Combine(target, "oldroot.txt")).Should().BeFalse("old root files are wiped");
+        (await File.ReadAllTextAsync(Path.Combine(target, "newsub", "new.txt"))).Should().Be("NEW");
+        (await File.ReadAllTextAsync(Path.Combine(target, "newroot.txt"))).Should().Be("NEWROOT");
+    }
+
+    [Fact]
+    public async Task RestoreBackupAsync_NullPath_Throws()
+    {
+        var service = new DatasetBackupService(SettingsReturning(new AppSettings()).Object);
+        var act = async () => await service.RestoreBackupAsync(null!);
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task RestoreBackupAsync_MissingArchive_Fails()
+    {
+        var service = new DatasetBackupService(SettingsReturning(new AppSettings { DatasetStoragePath = NewDir("d") }).Object);
+
+        var result = await service.RestoreBackupAsync(Path.Combine(_root, "nope.zip"));
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("not found");
+    }
+
+    [Fact]
+    public async Task RestoreBackupAsync_WhenDatasetPathNotConfigured_Fails()
+    {
+        var zip = Path.Combine(_root, "DatasetBackup_empty.zip");
+        ZipFile.CreateFromDirectory(NewDir("emptysrc"), zip);
+        var service = new DatasetBackupService(SettingsReturning(new AppSettings { DatasetStoragePath = null }).Object);
+
+        var result = await service.RestoreBackupAsync(zip);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("not configured");
+    }
+
+    // ── Re-entrancy guard (_isOperationInProgress) ──
+
+    [Fact]
+    public async Task BackupDatasetsAsync_WhileAnotherOperationInProgress_Fails()
+    {
+        // Park the first backup at its very first await (GetSettingsAsync) so the guard is set but the
+        // operation has not completed, then fire a second one deterministically.
+        var gate = new TaskCompletionSource<AppSettings>();
+        var mock = new Mock<IAppSettingsService>();
+        mock.Setup(s => s.GetSettingsAsync(It.IsAny<CancellationToken>())).Returns(gate.Task);
+        var service = new DatasetBackupService(mock.Object);
+
+        var first = service.BackupDatasetsAsync();
+        service.IsOperationInProgress.Should().BeTrue("the guard is set synchronously before the first await");
+
+        var second = await service.BackupDatasetsAsync();
+        second.Success.Should().BeFalse();
+        second.ErrorMessage.Should().Contain("already in progress");
+
+        // Release the first with an invalid config so it fails fast and clears the guard.
+        gate.SetResult(new AppSettings { DatasetStoragePath = null });
+        (await first).Success.Should().BeFalse();
+        service.IsOperationInProgress.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RestoreBackupAsync_WhileBackupInProgress_Fails()
+    {
+        var gate = new TaskCompletionSource<AppSettings>();
+        var mock = new Mock<IAppSettingsService>();
+        mock.Setup(s => s.GetSettingsAsync(It.IsAny<CancellationToken>())).Returns(gate.Task);
+        var service = new DatasetBackupService(mock.Object);
+
+        var backup = service.BackupDatasetsAsync();
+        service.IsOperationInProgress.Should().BeTrue();
+
+        // A real, existing archive — proves the guard is checked BEFORE the file-exists check.
+        var zip = Path.Combine(_root, "DatasetBackup_r.zip");
+        ZipFile.CreateFromDirectory(NewDir("rsrc"), zip);
+
+        var restore = await service.RestoreBackupAsync(zip);
+        restore.Success.Should().BeFalse();
+        restore.ErrorMessage.Should().Contain("already in progress");
+
+        gate.SetResult(new AppSettings { DatasetStoragePath = null });
+        await backup;
+    }
+}

--- a/DiffusionNexus.Tests/Services/OnnxModelManagerTests.cs
+++ b/DiffusionNexus.Tests/Services/OnnxModelManagerTests.cs
@@ -1,0 +1,257 @@
+using System.Net;
+using DiffusionNexus.Domain.Services;
+using DiffusionNexus.Service.Services;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.Services;
+
+/// <summary>
+/// Covers <see cref="OnnxModelManager"/> (issue #443): status thresholds, the download state machine,
+/// temp-file → move behaviour, cleanup on failure, and the in-progress guard. Driven entirely through
+/// the injected HttpClient seam with a fake handler — no network.
+///
+/// Two production WARTS are pinned as-is (NOT fixed): the constructor performs I/O
+/// (<c>Directory.CreateDirectory</c>) and mutates the injected <c>HttpClient.Timeout</c>. See the two
+/// dedicated tests below.
+/// </summary>
+public class OnnxModelManagerTests : IDisposable
+{
+    private readonly string _root;
+
+    public OnnxModelManagerTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), $"onnx_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch (IOException) { }
+    }
+
+    private string Models(string name) => Path.Combine(_root, name);
+
+    // ── Constructor warts (pinned, deliberately not fixed) ──
+
+    [Fact]
+    public void Constructor_CreatesModelsDirectory_AsASideEffect()
+    {
+        // WART: the ctor does filesystem I/O. Pinned so a refactor that removes the side effect is a
+        // conscious, visible change.
+        var dir = Models("brand-new");
+        Directory.Exists(dir).Should().BeFalse();
+
+        _ = new OnnxModelManager(dir, new HttpClient(new FakeHttpHandler(_ => Ok([]))));
+
+        Directory.Exists(dir).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Constructor_MutatesInjectedHttpClientTimeout()
+    {
+        // WART: the ctor reaches into the caller-owned HttpClient and overwrites its Timeout. Pinned.
+        var http = new HttpClient(new FakeHttpHandler(_ => Ok([])));
+        http.Timeout = TimeSpan.FromSeconds(5);
+
+        _ = new OnnxModelManager(Models("m"), http);
+
+        http.Timeout.Should().Be(TimeSpan.FromMinutes(30));
+    }
+
+    // ── Path composition ──
+
+    [Fact]
+    public void ModelPaths_AreComposedFromBasePath()
+    {
+        var basePath = Models("models");
+        var mgr = new OnnxModelManager(basePath, new HttpClient(new FakeHttpHandler(_ => Ok([]))));
+
+        mgr.Rmbg14ModelPath.Should().Be(Path.Combine(basePath, "rmbg-1.4.onnx"));
+        mgr.UltraSharp4xModelPath.Should().Be(Path.Combine(basePath, "4x-UltraSharp.onnx"));
+    }
+
+    // ── Status thresholds ──
+
+    [Fact]
+    public void GetRmbg14Status_ReflectsFilePresenceAndSize()
+    {
+        var basePath = Models("m");
+        var mgr = new OnnxModelManager(basePath, new HttpClient(new FakeHttpHandler(_ => Ok([]))));
+
+        mgr.GetRmbg14Status().Should().Be(ModelStatus.NotDownloaded);
+
+        WriteFileOfSize(mgr.Rmbg14ModelPath, 149_000_000); // just under the 150MB floor
+        mgr.GetRmbg14Status().Should().Be(ModelStatus.Corrupted);
+
+        WriteFileOfSize(mgr.Rmbg14ModelPath, 150_000_000);
+        mgr.GetRmbg14Status().Should().Be(ModelStatus.Ready);
+    }
+
+    [Fact]
+    public void GetUltraSharp4xStatus_ReflectsFilePresenceAndSize()
+    {
+        var basePath = Models("m");
+        var mgr = new OnnxModelManager(basePath, new HttpClient(new FakeHttpHandler(_ => Ok([]))));
+
+        mgr.GetUltraSharp4xStatus().Should().Be(ModelStatus.NotDownloaded);
+
+        WriteFileOfSize(mgr.UltraSharp4xModelPath, 59_000_000); // just under the 60MB floor
+        mgr.GetUltraSharp4xStatus().Should().Be(ModelStatus.Corrupted);
+
+        WriteFileOfSize(mgr.UltraSharp4xModelPath, 60_000_000);
+        mgr.GetUltraSharp4xStatus().Should().Be(ModelStatus.Ready);
+    }
+
+    // ── Download state machine ──
+
+    [Fact]
+    public async Task Download_Success_WritesFinalFile_LeavesNoTempFile_AndReturnsTrue()
+    {
+        var content = RandomBytes(4096);
+        var handler = new FakeHttpHandler(_ => Ok(content));
+        var mgr = new OnnxModelManager(Models("m"), new HttpClient(handler));
+        var progress = new RecordingProgress<ModelDownloadProgress>();
+
+        var ok = await mgr.DownloadRmbg14ModelAsync(progress);
+
+        ok.Should().BeTrue();
+        File.Exists(mgr.Rmbg14ModelPath).Should().BeTrue();
+        (await File.ReadAllBytesAsync(mgr.Rmbg14ModelPath)).Should().Equal(content);
+        File.Exists(mgr.Rmbg14ModelPath + ".download").Should().BeFalse("the temp file is moved to the final path");
+        progress.Items.Should().Contain(p => p.Status == "Download complete");
+        handler.CallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Download_OverwritesExistingDestinationFile()
+    {
+        var mgr = new OnnxModelManager(Models("m"), new HttpClient(new FakeHttpHandler(_ => Ok(RandomBytes(2048)))));
+        await File.WriteAllTextAsync(mgr.Rmbg14ModelPath, "stale-and-corrupt"); // small → Corrupted, not Ready
+
+        var ok = await mgr.DownloadRmbg14ModelAsync();
+
+        ok.Should().BeTrue();
+        (await File.ReadAllBytesAsync(mgr.Rmbg14ModelPath)).Length.Should().Be(2048);
+    }
+
+    [Fact]
+    public async Task Download_WhenModelAlreadyReady_ShortCircuits_WithoutHttp()
+    {
+        var handler = new FakeHttpHandler(_ => Ok(RandomBytes(16)));
+        var mgr = new OnnxModelManager(Models("m"), new HttpClient(handler));
+        WriteFileOfSize(mgr.Rmbg14ModelPath, 150_000_000); // already Ready
+
+        var progress = new RecordingProgress<ModelDownloadProgress>();
+        var ok = await mgr.DownloadRmbg14ModelAsync(progress);
+
+        ok.Should().BeTrue();
+        handler.CallCount.Should().Be(0, "a ready model must not trigger a download");
+        progress.Items.Should().Contain(p => p.Status == "Model already downloaded");
+    }
+
+    [Fact]
+    public async Task Download_HttpFailure_ReturnsFalse_AndCleansUpTempFile()
+    {
+        var handler = new FakeHttpHandler(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
+        var mgr = new OnnxModelManager(Models("m"), new HttpClient(handler));
+
+        var ok = await mgr.DownloadRmbg14ModelAsync();
+
+        ok.Should().BeFalse();
+        File.Exists(mgr.Rmbg14ModelPath).Should().BeFalse();
+        File.Exists(mgr.Rmbg14ModelPath + ".download").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Download_WhenCancelled_ThrowsOperationCanceled_AndLeavesNoFiles()
+    {
+        var handler = new FakeHttpHandler(_ => Ok(RandomBytes(4096)));
+        var mgr = new OnnxModelManager(Models("m"), new HttpClient(handler));
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = async () => await mgr.DownloadRmbg14ModelAsync(cancellationToken: cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        File.Exists(mgr.Rmbg14ModelPath).Should().BeFalse();
+        File.Exists(mgr.Rmbg14ModelPath + ".download").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Download_WhileSameModelDownloadInProgress_SecondCallReturnsFalse()
+    {
+        // Gate the handler so the first download is parked mid-flight (guard set), then fire a second.
+        var gate = new TaskCompletionSource();
+        var handler = new FakeHttpHandler(_ => Ok(RandomBytes(4096)), gate.Task);
+        var mgr = new OnnxModelManager(Models("m"), new HttpClient(handler));
+
+        var first = mgr.DownloadRmbg14ModelAsync();          // parked at the gated GetAsync; guard set
+        mgr.GetRmbg14Status().Should().Be(ModelStatus.Downloading);
+
+        var second = await mgr.DownloadRmbg14ModelAsync();   // guard set → refused
+        second.Should().BeFalse();
+
+        gate.SetResult();
+        (await first).Should().BeTrue();
+    }
+
+    // ── Delete ──
+
+    [Fact]
+    public void Delete_RemovesFile_WhenPresent_AndIsNoOp_WhenAbsent()
+    {
+        var mgr = new OnnxModelManager(Models("m"), new HttpClient(new FakeHttpHandler(_ => Ok([]))));
+
+        var absent = () => mgr.DeleteRmbg14Model();
+        absent.Should().NotThrow();
+
+        WriteFileOfSize(mgr.Rmbg14ModelPath, 1024);
+        mgr.DeleteRmbg14Model();
+        File.Exists(mgr.Rmbg14ModelPath).Should().BeFalse();
+    }
+
+    // ── helpers ──
+
+    private static void WriteFileOfSize(string path, long length)
+    {
+        using var fs = File.Create(path);
+        fs.SetLength(length); // fast sparse allocation; FileInfo.Length reports the logical size
+    }
+
+    private static byte[] RandomBytes(int n)
+    {
+        var b = new byte[n];
+        new Random(1234).NextBytes(b);
+        return b;
+    }
+
+    private static HttpResponseMessage Ok(byte[] bytes)
+        => new(HttpStatusCode.OK) { Content = new ByteArrayContent(bytes) };
+
+    private sealed class RecordingProgress<T> : IProgress<T>
+    {
+        public List<T> Items { get; } = new();
+        public void Report(T value) { lock (Items) Items.Add(value); }
+    }
+
+    private sealed class FakeHttpHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _make;
+        private readonly Task _gate;
+        private int _callCount;
+        public int CallCount => Volatile.Read(ref _callCount);
+
+        public FakeHttpHandler(Func<HttpRequestMessage, HttpResponseMessage> make, Task? gate = null)
+        {
+            _make = make;
+            _gate = gate ?? Task.CompletedTask;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _callCount);
+            await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            return _make(request);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements #443: test coverage for the non-UI types that were testable **today** with zero production changes — the "pure omission" half of the #325 audit (Tier A was PR #428). 12 new test files, **167 new tests**, and exactly one non-test line changed (a test-only ProjectReference, see below). Suite: 3085 → **3252**.

## Coverage
**Cluster A (85):** `CivitaiBaseModelCatalog` — all fallback tiers (memory → disk TTL → live fetch → bundled snapshot) and all three TS-parsing strategies against real upstream fixtures plus a shape-drift fixture proving graceful degradation to the snapshot (the exact silent-degradation path the issue centered on), with a hard `BundledSnapshotCount` tripwire; `TolerantEnumConverter`/`Factory` + `NextCursorJsonConverter` (malformed-input tolerance paths); `LocalFileMetadataProvider` (.civitai.info vs .json precedence, modelId String/Number coercion); `TypedCivitaiMetadataProvider` (ModelClass mapping, NoMetaData fallback, real SHA-256); Json/Xml serializer adapters.

**Cluster B (82):** `DatasetBackupService` — real ZIP creation, destructive restore (wipe-then-extract), MaxBackups retention pruning, re-entrancy guard ordering; `OnnxModelManager` — download state machine, temp-file→move atomicity, cleanup on failure/cancel (ctor-I/O and injected-Timeout-mutation warts pinned as-is); `DownloadCoordinator` — TCS-gated deterministic FIFO/cancel/live-swap tests; `BlurDetector` + `ExposureAnalyzer` (the two uncovered quality checks, real synthesized images); `AnalysisRunStore` persistence + 50-file prune.

## Found along the way (pinned honestly, tracked, deliberately NOT fixed here per the issue's zero-refactor contract)
- https://github.com/Little-God1983/DiffusionNexus/issues/467 — `DownloadCoordinator.MaxConcurrent` live swap leaks the in-flight permit AND over-releases the new semaphore (`SemaphoreFullException` on drain; over-admission). The setter's own comment mis-describes its code. Review traced and confirmed.
- https://github.com/Little-God1983/DiffusionNexus/issues/468 — `AnalysisRunStore` prunes by lexicographic `dd-MM-yyyy...` filename sort → deletes the wrong "oldest" across days/months.
- https://github.com/Little-God1983/DiffusionNexus/issues/469 — `DiffusionNexus.DataAccess.Infrastructure` is orphaned (not in the .sln, zero production refs); its adapters are covered via a documented test-only ProjectReference pending an add-to-sln-or-delete decision.

## Verification
Full-solution Release build 0 errors; full unit suite **3252/3252** with hang guard (post develop merge-in). Whole-branch review (Opus): approved — zero-production-change verified from the diff stat, destructive-op tests confirmed temp-dir-confined, concurrency tests causality-based (no timing races), fallback/restore/atomicity tests verified non-tautological against the production code, locale-safe on a German-locale machine.

Fixes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)