### PR TITLE
Fix DownloadCoordinator.MaxConcurrent live-swap permit leak and over-release

### DIFF
--- a/DiffusionNexus.Infrastructure/Services/DownloadCoordinator.cs
+++ b/DiffusionNexus.Infrastructure/Services/DownloadCoordinator.cs
@@ -29,19 +29,39 @@ public sealed class DownloadCoordinator : IDownloadCoordinator, IDisposable
     }
 
     private int _maxConcurrent = 3;
+
+    /// <summary>
+    /// Maximum number of downloads the coordinator admits concurrently. Setting this swaps in a
+    /// fresh <see cref="SemaphoreSlim"/> sized to the new value.
+    /// <para>
+    /// <see cref="EnqueueAsync"/> captures the current semaphore into a local once, before
+    /// <c>WaitAsync</c>, and releases through that same local — so an in-flight download always
+    /// finishes its wait/release pair on the instance it started with, even if this setter swaps
+    /// <c>_slots</c> mid-flight.
+    /// </para>
+    /// <para>
+    /// Trade-off (accepted, not a bug): during a swap window the total number of simultaneously
+    /// active downloads can transiently exceed the newly configured limit — old in-flight
+    /// downloads keep running under the old semaphore's permits while new admissions are governed
+    /// by the new one. The invariant this class guarantees is "no semaphore instance is ever
+    /// over-released", not "the global active count is capped at every instant during a resize".
+    /// </para>
+    /// </summary>
     public int MaxConcurrent
     {
         get => _maxConcurrent;
         set
         {
-            // Resizing live: swap the semaphore. Already-in-flight downloads
-            // hold permits from the previous instance and will release back
-            // into it via captured local — we just lose tracking, but since
-            // the semaphore is single-instance-only owned by the coordinator
-            // we accept the leak for the rare resize case.
             if (value < 1) throw new ArgumentOutOfRangeException(nameof(value), "MaxConcurrent must be ≥ 1.");
             if (value == _maxConcurrent) return;
             _maxConcurrent = value;
+
+            // Deliberately NOT disposing the swapped-out semaphore: in-flight downloads captured
+            // it into a local (see EnqueueAsync) and will Release() it later; disposing it here
+            // would make that Release() throw ObjectDisposedException. This class never
+            // materializes AvailableWaitHandle, so SemaphoreSlim.Dispose() has nothing
+            // load-bearing to clean up — letting the old instance be GC'd once the last
+            // in-flight holder releases it is simpler and safe.
             _slots = new SemaphoreSlim(value, value);
             RaiseStateChanged();
         }
@@ -95,12 +115,18 @@ public sealed class DownloadCoordinator : IDownloadCoordinator, IDisposable
         var success = false;
         var slotAcquired = false;
 
+        // Capture the semaphore instance once, before waiting on it. MaxConcurrent's setter can
+        // swap the _slots field concurrently; capturing here guarantees this download's wait and
+        // its eventual release always target the SAME instance, even if a resize happens while
+        // this download is in flight (issue #467).
+        var slots = _slots;
+
         try
         {
             // Cancelling a queued task wakes us right back up; the resulting
             // OperationCanceledException is caught below and the status flips
             // to Cancelled before we ever consume a semaphore slot.
-            await _slots.WaitAsync(linkedCts.Token).ConfigureAwait(false);
+            await slots.WaitAsync(linkedCts.Token).ConfigureAwait(false);
             slotAcquired = true;
 
             // Promote to active. The state-change notification covers both the
@@ -138,7 +164,7 @@ public sealed class DownloadCoordinator : IDownloadCoordinator, IDisposable
         }
         finally
         {
-            if (slotAcquired) _slots.Release();
+            if (slotAcquired) slots.Release();
             // Remove from the tracked list so the UI list doesn't grow
             // unbounded. The unified console keeps a permanent log entry
             // via the activity log so users still see the completion event.
@@ -233,6 +259,11 @@ public sealed class DownloadCoordinator : IDownloadCoordinator, IDisposable
     {
         if (_disposed) return;
         _disposed = true;
+
+        // Only the CURRENT _slots is disposed here — that's fine by the same reasoning as the
+        // MaxConcurrent setter: any already-swapped-out (old) instance was never captured by this
+        // method, and in-flight downloads on the current instance are expected to have completed
+        // before the coordinator itself is disposed.
         _slots.Dispose();
     }
 

--- a/DiffusionNexus.Tests/Infrastructure/DownloadCoordinatorTests.cs
+++ b/DiffusionNexus.Tests/Infrastructure/DownloadCoordinatorTests.cs
@@ -6,8 +6,9 @@ namespace DiffusionNexus.Tests.Infrastructure;
 
 /// <summary>
 /// Covers <see cref="DownloadCoordinator"/> (issue #443): semaphore-gated FIFO admission, per-task
-/// cancellation, the activity-log aggregation shim, and the known-sharp live semaphore swap in the
-/// <c>MaxConcurrent</c> setter.
+/// cancellation, the activity-log aggregation shim, and the live semaphore swap in the
+/// <c>MaxConcurrent</c> setter (issue #467: capture-at-acquisition so in-flight downloads always
+/// wait/release on the same semaphore instance, even across a resize).
 ///
 /// All concurrency is driven deterministically with <see cref="TaskCompletionSource"/> gates (the
 /// idiom used by <c>ComfyUIUpdateServiceTests</c>) — no <c>Thread.Sleep</c> races. Every wait is
@@ -216,12 +217,15 @@ public class DownloadCoordinatorTests
     }
 
     [Fact]
-    public async Task MaxConcurrent_LiveSwap_LeaksTheInFlightPermit_AndOverAdmits()
+    public async Task MaxConcurrent_LiveSwap_RaisingLimit_OldInFlightTaskReleasesToOwnSemaphore_DrainsCleanly()
     {
-        // KNOWN SHARP EDGE (the setter's own comment: "we accept the leak"). Raising the limit while a
-        // download is in flight swaps in a brand-new semaphore with a FULL set of permits — it has no
-        // knowledge of the still-running download holding a permit on the discarded instance. So the
-        // total number of simultaneously-active downloads can exceed MaxConcurrent right after a resize.
+        // Raising the limit while a download is in flight swaps in a brand-new semaphore. The
+        // FIX: EnqueueAsync captures the semaphore instance into a local once, before WaitAsync,
+        // and releases through that SAME local — so A's release goes back to the OLD semaphore
+        // it acquired from, never into the new one. Total active count can still transiently
+        // exceed the new limit while A (old semaphore) overlaps B/C (new semaphore) during the
+        // swap window — that is accepted, documented behavior (see the MaxConcurrent XML doc),
+        // not a leak: nothing throws and nothing is double-counted on any single instance.
         using var coordinator = new DownloadCoordinator { MaxConcurrent = 1 };
         var startedA = new TaskCompletionSource();
         var releaseA = new TaskCompletionSource();
@@ -239,16 +243,90 @@ public class DownloadCoordinatorTests
         var c = coordinator.EnqueueAsync("C", Gated(startedC, releaseC.Task));
         await Task.WhenAll(startedB.Task, startedC.Task).WaitAsync(Timeout);
 
-        coordinator.Active.Should().HaveCount(3, "A (old semaphore) + B + C (new semaphore) all run — above the limit of 2");
+        coordinator.Active.Should().HaveCount(3, "A (old semaphore) overlaps B + C (new semaphore) during the swap window — accepted, transient");
 
-        // Draining also exposes the second half of the bug: the finally releases into the *field*
-        // semaphore (the new one), not the instance each task acquired from, so the surplus release
-        // pushes the new semaphore past its max count.
         releaseA.SetResult();
         releaseB.SetResult();
         releaseC.SetResult();
-        var drain = async () => await Task.WhenAll(a, b, c).WaitAsync(Timeout);
-        await drain.Should().ThrowAsync<SemaphoreFullException>();
+
+        // Fixed behavior: nothing throws, nothing leaks — each task's release lands on the
+        // instance it acquired from.
+        var results = await Task.WhenAll(a, b, c).WaitAsync(Timeout);
+        results.Should().AllSatisfy(r => r.Should().BeTrue());
+
+        // Post-swap: new admissions are governed strictly by the new limit (2 concurrent).
+        var startedD = new TaskCompletionSource();
+        var releaseD = new TaskCompletionSource();
+        var startedE = new TaskCompletionSource();
+        var releaseE = new TaskCompletionSource();
+        var startedF = new TaskCompletionSource();
+        var releaseF = new TaskCompletionSource();
+
+        var d = coordinator.EnqueueAsync("D", Gated(startedD, releaseD.Task));
+        var e = coordinator.EnqueueAsync("E", Gated(startedE, releaseE.Task));
+        await Task.WhenAll(startedD.Task, startedE.Task).WaitAsync(Timeout);
+
+        var f = coordinator.EnqueueAsync("F", Gated(startedF, releaseF.Task));
+        coordinator.Active.Should().HaveCount(2, "the new limit of 2 governs steady-state admission after the swap");
+        coordinator.Queued.Select(t => t.Name).Should().Equal("F");
+
+        releaseD.SetResult();
+        await startedF.Task.WaitAsync(Timeout); // F is admitted only once D frees a permit on the new semaphore
+        releaseE.SetResult();
+        releaseF.SetResult();
+        (await Task.WhenAll(d, e, f).WaitAsync(Timeout)).Should().AllSatisfy(r => r.Should().BeTrue());
+    }
+
+    [Fact]
+    public async Task MaxConcurrent_LiveSwap_LoweringLimit_OldInFlightTasksDrainCleanly_NewAdmissionsRespectLoweredLimit()
+    {
+        // Lowering the limit while two downloads are in flight swaps in a smaller semaphore that
+        // starts fully available — it knows nothing about A/B's permits already held on the old
+        // instance. The FIX ensures A and B still release into the OLD semaphore they acquired
+        // from, so their completion must NOT free up a slot on the NEW (lowered) one; only C
+        // releasing does that. This is the sharpest regression signal for the bug: with the old
+        // field-based release, A/B's finally would erroneously admit D early (or overflow the
+        // new semaphore, depending on scheduling).
+        using var coordinator = new DownloadCoordinator { MaxConcurrent = 2 };
+        var startedA = new TaskCompletionSource();
+        var releaseA = new TaskCompletionSource();
+        var startedB = new TaskCompletionSource();
+        var releaseB = new TaskCompletionSource();
+
+        var a = coordinator.EnqueueAsync("A", Gated(startedA, releaseA.Task));
+        var b = coordinator.EnqueueAsync("B", Gated(startedB, releaseB.Task));
+        await Task.WhenAll(startedA.Task, startedB.Task).WaitAsync(Timeout); // A + B hold both old permits
+
+        coordinator.MaxConcurrent = 1;          // swaps in a fresh SemaphoreSlim(1, 1)
+
+        var startedC = new TaskCompletionSource();
+        var releaseC = new TaskCompletionSource();
+        var startedD = new TaskCompletionSource();
+        var releaseD = new TaskCompletionSource();
+
+        var c = coordinator.EnqueueAsync("C", Gated(startedC, releaseC.Task));
+        await startedC.Task.WaitAsync(Timeout); // C acquires the new semaphore's sole free permit
+
+        var d = coordinator.EnqueueAsync("D", Gated(startedD, releaseD.Task));
+
+        coordinator.Active.Should().HaveCount(3, "A+B (old semaphore) overlap C (new semaphore) — accepted, transient");
+        // D must wait: the new semaphore has only 1 permit and C already holds it.
+        coordinator.Queued.Select(t => t.Name).Should().Equal("D");
+
+        // Drain the old in-flight downloads. Fixed behavior: their release goes back to the OLD
+        // semaphore, never throws, and — critically — never frees a slot on the NEW one.
+        releaseA.SetResult();
+        releaseB.SetResult();
+        (await Task.WhenAll(a, b).WaitAsync(Timeout)).Should().AllSatisfy(r => r.Should().BeTrue());
+
+        startedD.Task.IsCompleted.Should().BeFalse("A/B releasing into the OLD semaphore must not admit D on the NEW one");
+
+        releaseC.SetResult();
+        (await c.WaitAsync(Timeout)).Should().BeTrue();
+        await startedD.Task.WaitAsync(Timeout); // only now — after C frees the new semaphore's single permit
+
+        releaseD.SetResult();
+        (await d.WaitAsync(Timeout)).Should().BeTrue();
     }
 
     // ── Activity-log aggregation shim (real ActivityLogService) ──


### PR DESCRIPTION
## What

Fixes the `DownloadCoordinator.MaxConcurrent` live-swap semaphore bug: `EnqueueAsync` acquired and released through the `_slots` **field**, so a task in flight during a resize leaked its permit on the old semaphore and released into the new already-full one → `SemaphoreFullException` on drain, plus over-admission during the swap window. The setter's own comment falsely claimed a "captured local" was already in use.

## Fix

- `EnqueueAsync` now reads `_slots` **exactly once** into a local before `WaitAsync`; both the wait and the `finally` release go through that captured instance — every path (success, exception, cancellation before/after acquisition) is internally consistent on one semaphore.
- Swapped-out semaphores are deliberately **not disposed** (in-flight holders still release into them; `SemaphoreSlim.Dispose` is only load-bearing when `AvailableWaitHandle` is materialized, which this class never does) — documented on the setter.
- Accepted, documented semantics: during a swap window total active downloads may transiently exceed a lowered limit; the invariant is that no semaphore instance is ever over-released.

## Tests

- Pinning test flipped: `MaxConcurrent_LiveSwap_LeaksTheInFlightPermit_AndOverAdmits` → `..._RaisingLimit_OldInFlightTaskReleasesToOwnSemaphore_DrainsCleanly` (RED on unfixed code, GREEN after).
- New `..._LoweringLimit_...` case: in-flight holders drain cleanly, old-instance releases do **not** admit new work early, post-swap concurrency equals the new limit.
- Both TCS-gated, deterministic — reviewer reran the coordinator file 3× (17/17 each) plus the full suite.

## Verification (implementer + reviewer independently)

- `dotnet build DiffusionNexus.sln -c Release` — 0 errors
- Unit suite: **3,253 / 3,253** (baseline 3,252 + 1 net new test)

Review: **Approved** (capable-tier concurrency review; zero Critical/Important findings).

Fixes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)
