### PR TITLE
Fix AnalysisRunStore prune: chronological ordering instead of lexicographic dd-MM-yyyy sort

### DIFF
--- a/DiffusionNexus.Service/Services/DatasetQuality/AnalysisRunStore.cs
+++ b/DiffusionNexus.Service/Services/DatasetQuality/AnalysisRunStore.cs
@@ -156,7 +156,10 @@ public class AnalysisRunStore
     /// <see cref="GetSortableTimestamp"/>), not by a plain string sort of the path (issue #468). The
     /// file name's <c>dd-MM-yyyy</c> prefix is day-first, so a lexicographic sort is NOT chronological
     /// across month/year boundaries — e.g. "01-08-2026…" sorts before "28-07-2026…" as a string despite
-    /// being later in time — which could delete recently-saved runs while keeping older ones.
+    /// being later in time — which could delete recently-saved runs while keeping older ones. Ties
+    /// (e.g. two runs saved within the same second) fall back to an ordinal compare of the full path,
+    /// purely to make the outcome deterministic — this secondary key is NOT chronological and must
+    /// never be promoted above the timestamp.
     /// </remarks>
     private static void PruneOldRuns(string runsDir)
     {
@@ -167,6 +170,7 @@ public class AnalysisRunStore
 
         var ordered = files
             .OrderByDescending(GetSortableTimestamp)
+            .ThenByDescending(f => f, StringComparer.Ordinal)
             .ToArray();
 
         foreach (var file in ordered.Skip(MaxRunsPerDataset))
@@ -194,9 +198,16 @@ public class AnalysisRunStore
     /// <para>
     /// The <c>*-run.json</c> glob can also match foreign files that don't fit the naming convention
     /// (e.g. a stray file dropped into the runs folder). Those fall back to
-    /// <see cref="File.GetLastWriteTimeUtc(string)"/> so an unparsable name can neither crash the prune
-    /// nor be silently preferred (or deprioritized) over real, parseable runs — it's ordered by its
-    /// actual last-write-time like any other file would be absent a name to parse.
+    /// <see cref="File.GetLastWriteTimeUtc(string)"/>, converted to LOCAL time via
+    /// <see cref="DateTime.ToLocalTime"/> so it lands in the same frame as the parsed branch above.
+    /// This conversion is required, not cosmetic: <see cref="DateTime"/> comparison ignores
+    /// <see cref="DateTime.Kind"/> and compares raw ticks, so leaving the fallback as raw UTC ticks
+    /// would silently misorder it against the parsed branch's local wall-clock ticks on any machine not
+    /// at UTC+0 (e.g. on UTC+2, a file genuinely written at local 15:30 has raw UTC ticks of 13:30,
+    /// which would incorrectly compare as OLDER than a parsed run stamped local 14:00). With the
+    /// conversion applied, an unparsable name can neither crash the prune nor be silently preferred (or
+    /// deprioritized) over real, parseable runs — it's ordered by its actual local last-write-time like
+    /// any other file would be absent a name to parse.
     /// </para>
     /// </remarks>
     private static DateTime GetSortableTimestamp(string filePath)
@@ -218,12 +229,17 @@ public class AnalysisRunStore
 
         try
         {
-            return File.GetLastWriteTimeUtc(filePath);
+            // GetLastWriteTimeUtc returns UTC; convert to local so its ticks are comparable to the
+            // parsed branch's local wall-clock ticks above (see the Kind-mismatch note in <remarks>).
+            return File.GetLastWriteTimeUtc(filePath).ToLocalTime();
         }
         catch (IOException)
         {
-            // File vanished or is otherwise inaccessible; treat as oldest so it's a prune candidate
-            // first rather than risk squatting on a slot ahead of a real run.
+            // A genuine I/O failure reading the last-write-time (e.g. a sharing violation) - NOT a
+            // missing file: GetLastWriteTimeUtc does not throw for a nonexistent path, it returns the
+            // 1601-01-01 UTC sentinel, which already sorts oldest on its own. Treat this failure case
+            // the same way (oldest) so it's a prune candidate first rather than risk squatting on a
+            // slot ahead of a real run.
             return DateTime.MinValue;
         }
     }

--- a/DiffusionNexus.Service/Services/DatasetQuality/AnalysisRunStore.cs
+++ b/DiffusionNexus.Service/Services/DatasetQuality/AnalysisRunStore.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using DiffusionNexus.Domain.Models;
@@ -24,6 +25,12 @@ public class AnalysisRunStore
     /// are automatically deleted after each save.
     /// </summary>
     private const int MaxRunsPerDataset = 50;
+
+    /// <summary>
+    /// The leading timestamp segment of a run file name (see <see cref="BuildFileName"/>). Shared by
+    /// the name-builder and the prune's chronological parser so the two never drift apart.
+    /// </summary>
+    private const string TimestampFormat = "dd-MM-yyyy-HH-mm-ss";
 
     private static readonly JsonSerializerOptions SerializerOptions = new()
     {
@@ -132,9 +139,10 @@ public class AnalysisRunStore
     /// </summary>
     private static string BuildFileName(DateTimeOffset timestamp, int version)
     {
-        // Use local time for human-readable file names
+        // Use local time for human-readable file names. Formatted with InvariantCulture: this app also
+        // runs under German locale, and culture-sensitive date formatting/parsing is a known trap here.
         var local = timestamp.ToLocalTime();
-        return $"{local:dd-MM-yyyy-HH-mm-ss}-Version-V{version}-run.json";
+        return $"{local.ToString(TimestampFormat, CultureInfo.InvariantCulture)}-Version-V{version}-run.json";
     }
 
     private static string GetRunsDirectory(string datasetFolderPath) =>
@@ -143,16 +151,25 @@ public class AnalysisRunStore
     /// <summary>
     /// Deletes the oldest run files when the total exceeds <see cref="MaxRunsPerDataset"/>.
     /// </summary>
+    /// <remarks>
+    /// Candidates are ordered by the timestamp PARSED from the file name (see
+    /// <see cref="GetSortableTimestamp"/>), not by a plain string sort of the path (issue #468). The
+    /// file name's <c>dd-MM-yyyy</c> prefix is day-first, so a lexicographic sort is NOT chronological
+    /// across month/year boundaries — e.g. "01-08-2026…" sorts before "28-07-2026…" as a string despite
+    /// being later in time — which could delete recently-saved runs while keeping older ones.
+    /// </remarks>
     private static void PruneOldRuns(string runsDir)
     {
-        var files = Directory.GetFiles(runsDir, "*-run.json")
-            .OrderByDescending(f => f)
-            .ToArray();
+        var files = Directory.GetFiles(runsDir, "*-run.json");
 
         if (files.Length <= MaxRunsPerDataset)
             return;
 
-        foreach (var file in files.Skip(MaxRunsPerDataset))
+        var ordered = files
+            .OrderByDescending(GetSortableTimestamp)
+            .ToArray();
+
+        foreach (var file in ordered.Skip(MaxRunsPerDataset))
         {
             try
             {
@@ -162,6 +179,52 @@ public class AnalysisRunStore
             {
                 // Best-effort cleanup; skip locked files
             }
+        }
+    }
+
+    /// <summary>
+    /// Resolves a comparable "age" for a run file so prune candidates can be ordered chronologically.
+    /// </summary>
+    /// <remarks>
+    /// Parses the leading <c>dd-MM-yyyy-HH-mm-ss</c> segment of the file NAME (not the full path) with
+    /// <see cref="CultureInfo.InvariantCulture"/> — this app also runs under German locale, where
+    /// culture-sensitive parsing is a known trap. The timestamps are local wall-clock values written
+    /// with <see cref="DateTimeStyles.None"/> (unspecified kind); only relative ordering matters here,
+    /// so a DST-ambiguous local time may mis-order within the repeated hour, which is accepted.
+    /// <para>
+    /// The <c>*-run.json</c> glob can also match foreign files that don't fit the naming convention
+    /// (e.g. a stray file dropped into the runs folder). Those fall back to
+    /// <see cref="File.GetLastWriteTimeUtc(string)"/> so an unparsable name can neither crash the prune
+    /// nor be silently preferred (or deprioritized) over real, parseable runs — it's ordered by its
+    /// actual last-write-time like any other file would be absent a name to parse.
+    /// </para>
+    /// </remarks>
+    private static DateTime GetSortableTimestamp(string filePath)
+    {
+        var name = Path.GetFileName(filePath);
+        if (name.Length >= TimestampFormat.Length)
+        {
+            var candidate = name[..TimestampFormat.Length];
+            if (DateTime.TryParseExact(
+                    candidate,
+                    TimestampFormat,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.None,
+                    out var parsed))
+            {
+                return parsed;
+            }
+        }
+
+        try
+        {
+            return File.GetLastWriteTimeUtc(filePath);
+        }
+        catch (IOException)
+        {
+            // File vanished or is otherwise inaccessible; treat as oldest so it's a prune candidate
+            // first rather than risk squatting on a slot ahead of a real run.
+            return DateTime.MinValue;
         }
     }
 }

--- a/DiffusionNexus.Tests/DatasetQuality/AnalysisRunStoreTests.cs
+++ b/DiffusionNexus.Tests/DatasetQuality/AnalysisRunStoreTests.cs
@@ -189,6 +189,64 @@ public class AnalysisRunStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task SaveAsync_PruneWithUnparsableFileName_RanksByLocalTime_NotRawUtcTicks()
+    {
+        // Regression: GetSortableTimestamp's parsed branch returns LOCAL wall-clock ticks
+        // (DateTimeKind.Unspecified). DateTime comparison ignores Kind and compares raw ticks, so the
+        // unparsable-name fallback (File.GetLastWriteTimeUtc) MUST be converted to local time before
+        // comparison - otherwise, on any machine away from UTC+0, a file genuinely written LATER can
+        // carry smaller raw UTC ticks than an earlier local-stamped run and be misranked as older (or
+        // vice versa on a negative-offset machine). This test only proves something away from UTC+0.
+        var neighborLocal = new DateTime(2026, 1, 10, 14, 0, 0, DateTimeKind.Local);
+        var offset = TimeZoneInfo.Local.GetUtcOffset(neighborLocal);
+        offset.Should().NotBe(TimeSpan.Zero, "the Kind-mismatch regression is only observable away from UTC+0; this machine is expected to run a non-UTC (German) locale");
+
+        // Nudge the unparsable file's TRUE local write time a few minutes to the "newer" side of the
+        // neighbor if the offset is positive, or the "older" side if negative - either way, by far less
+        // than the offset's magnitude, so an unconverted (raw UTC ticks) comparison would land it on
+        // the WRONG side of the neighbor once "offset" is baked into its raw ticks.
+        var gap = TimeSpan.FromMinutes(20);
+        var garbageIntendedLocal = offset > TimeSpan.Zero ? neighborLocal + gap : neighborLocal - gap;
+        var garbageIsTrulyNewer = garbageIntendedLocal > neighborLocal;
+
+        await _store.SaveAsync(_tempDir, MakeRecord(version: 1, new DateTimeOffset(neighborLocal)));
+
+        // 49 fillers, unambiguously newer than the neighbor/garbage pair (later calendar days) and
+        // never near the boundary being tested, so they always survive regardless of the bug.
+        for (int i = 0; i < 49; i++)
+            await _store.SaveAsync(_tempDir, MakeRecord(version: 100 + i, new DateTimeOffset(neighborLocal.AddDays(i + 1))));
+
+        var unparsablePath = Path.Combine(_runsDir, "not-a-timestamp-run.json");
+        await File.WriteAllTextAsync(unparsablePath, "{}");
+        // Store the UTC instant that corresponds to garbageIntendedLocal on THIS machine, so the test
+        // is self-consistent regardless of what the actual local offset is.
+        File.SetLastWriteTimeUtc(unparsablePath, garbageIntendedLocal.ToUniversalTime());
+
+        // An unambiguously ancient run (year 2000) is the mechanism that pushes the total to 52 and
+        // triggers a 2-file prune; it is always the single oldest of the 52 regardless of the bug, so
+        // it's dropped either way and isn't itself part of the assertion.
+        await _store.SaveAsync(_tempDir, MakeRecord(version: 999, new DateTimeOffset(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Local))));
+
+        var remaining = Directory.GetFiles(_runsDir, "*-run.json");
+        remaining.Should().HaveCount(50);
+
+        var names = remaining.Select(Path.GetFileName).ToList();
+        names.Should().NotContain(n => n!.EndsWith("-Version-V999-run.json"), "the year-2000 run is unambiguously the oldest of the 52 and must be pruned");
+        if (garbageIsTrulyNewer)
+        {
+            names.Should().Contain("not-a-timestamp-run.json", "the unparsable file's fallback, correctly normalized to local time, ranks it newer than the neighbor and it must survive");
+            names.Should().NotContain(n => n!.EndsWith("-Version-V1-run.json"), "the neighbor is genuinely older than the unparsable file's true local write time and must be pruned");
+        }
+        else
+        {
+            names.Should().NotContain("not-a-timestamp-run.json", "the unparsable file's fallback, correctly normalized to local time, ranks it older than the neighbor and it must be pruned");
+            names.Should().Contain(n => n!.EndsWith("-Version-V1-run.json"), "the neighbor is genuinely newer than the unparsable file's true local write time and must survive");
+        }
+        for (int i = 0; i < 49; i++)
+            names.Should().Contain(n => n!.EndsWith($"-Version-V{100 + i}-run.json"), $"filler {100 + i} is far newer than the pruned pair and must survive");
+    }
+
+    [Fact]
     public async Task SaveAsync_Exactly50Runs_PrunesNothing()
     {
         for (int s = 0; s < 50; s++)

--- a/DiffusionNexus.Tests/DatasetQuality/AnalysisRunStoreTests.cs
+++ b/DiffusionNexus.Tests/DatasetQuality/AnalysisRunStoreTests.cs
@@ -8,8 +8,9 @@ namespace DiffusionNexus.Tests.DatasetQuality;
 /// <summary>
 /// Covers <see cref="AnalysisRunStore"/> — JSON run persistence into a <c>.quality-runs</c> subfolder,
 /// plus the 50-file retention prune that DELETES user run files (issue #443). All I/O runs against a
-/// throwaway temp directory; the prune selection/ordering is pinned exactly, including its lexicographic
-/// (not chronological) file selection.
+/// throwaway temp directory; the prune selection is pinned to CHRONOLOGICAL order (issue #468 — a plain
+/// lexicographic sort on the dd-MM-yyyy-prefixed file name does not sort chronologically across
+/// month/year boundaries, e.g. "01-08-2026…" < "28-07-2026…" as strings despite being later in time).
 /// </summary>
 public class AnalysisRunStoreTests : IDisposable
 {
@@ -112,22 +113,79 @@ public class AnalysisRunStoreTests : IDisposable
     }
 
     [Fact]
-    public async Task SaveAsync_PrunesOldestBeyond50_KeepingNewest50()
+    public async Task SaveAsync_PrunesOldestBeyond50_KeepingNewest50_Chronologically()
     {
-        // Save 51 runs at the same day/hour/minute, differing only by second (00..50). Because the file
-        // name is dd-MM-yyyy-HH-mm-ss-…, differing only in the trailing seconds makes lexicographic
-        // (the prune's OrderByDescending(f => f)) order identical to chronological order here — so the
-        // second-00 run is both the oldest and the lexicographically smallest, and is the one deleted.
-        for (int s = 0; s <= 50; s++)
-            await _store.SaveAsync(_tempDir, MakeRecord(1, LocalSecond(s)));
+        // 51 runs, one per day, spanning Jan 15 -> Mar 6 2026 (crossing both a month and a year-day
+        // boundary). Version N is chronological rank N (1 = oldest), so this asserts pruning by actual
+        // elapsed time rather than by which saves happen to land on lexicographically-ordered file names.
+        var start = new DateTime(2026, 1, 15, 12, 0, 0, DateTimeKind.Local);
+        for (int i = 1; i <= 51; i++)
+            await _store.SaveAsync(_tempDir, MakeRecord(version: i, new DateTimeOffset(start.AddDays(i - 1))));
 
         var remaining = Directory.GetFiles(_runsDir, "*-run.json");
         remaining.Should().HaveCount(50);
 
         var names = remaining.Select(Path.GetFileName).ToList();
-        names.Should().NotContain(n => n!.Contains("-00-Version-V1-run.json"), "second-00 is the oldest and is pruned");
-        names.Should().Contain(n => n!.Contains("-01-Version-V1-run.json"), "second-01 is the new oldest kept");
-        names.Should().Contain(n => n!.Contains("-50-Version-V1-run.json"), "second-50 is the newest");
+        names.Should().NotContain(n => n!.EndsWith("-Version-V1-run.json"), "version 1 is the chronologically oldest of the 51 and must be pruned");
+        for (int i = 2; i <= 51; i++)
+            names.Should().Contain(n => n!.EndsWith($"-Version-V{i}-run.json"), $"version {i} is chronologically newer than the pruned oldest and must survive");
+    }
+
+    [Fact]
+    public async Task SaveAsync_PruneAcrossMonthBoundary_KeepsNewestRun_NotLexicographicallySmallest()
+    {
+        // 49 "filler" runs from Oct/Nov 2025, each using a day-of-month between 02 and 31 (never "01"),
+        // so none can tie with the Aug-1 run below on the file name's leading two digits.
+        for (int i = 0; i < 49; i++)
+        {
+            var day = 2 + (i % 30);
+            var month = 10 + (i / 30); // 10 (Oct) for i<30, 11 (Nov) for i>=30
+            await _store.SaveAsync(_tempDir, MakeRecord(version: 900 + i, LocalDateTime(2025, month, day)));
+        }
+
+        // The boundary pair: Jul 28 2026 (older) and Aug 1 2026 (newer). The file name's "dd" prefix
+        // resets from "28" to "01" across the month boundary, so "01-08-2026…" sorts lexicographically
+        // BEFORE "28-07-2026…" even though Aug 1 is later in time — the exact bug from issue #468.
+        await _store.SaveAsync(_tempDir, MakeRecord(version: 201, LocalDateTime(2026, 7, 28)));
+        await _store.SaveAsync(_tempDir, MakeRecord(version: 202, LocalDateTime(2026, 8, 1)));
+
+        var remaining = Directory.GetFiles(_runsDir, "*-run.json");
+        remaining.Should().HaveCount(50, "51 runs were saved and prune keeps only the newest 50");
+
+        var names = remaining.Select(Path.GetFileName).ToList();
+        names.Should().Contain(n => n!.EndsWith("-Version-V202-run.json"), "Aug 1 2026 is the single newest run and must survive despite sorting lexicographically smallest");
+        names.Should().Contain(n => n!.EndsWith("-Version-V201-run.json"), "Jul 28 2026 is also recent and must survive");
+        names.Should().NotContain(n => n!.EndsWith("-Version-V900-run.json"), "Oct 2 2025 is the chronologically oldest of all 51 and must be pruned");
+    }
+
+    [Fact]
+    public async Task SaveAsync_PruneWithUnparsableFileName_DoesNotCrash_AndFallsBackToLastWriteTime()
+    {
+        // 50 valid runs at seconds 00..49 (same day/hour/minute) - no prune yet (<=50 files).
+        for (int s = 0; s < 50; s++)
+            await _store.SaveAsync(_tempDir, MakeRecord(1, LocalSecond(s)));
+
+        // A foreign file that matches the "*-run.json" glob but does not fit the dd-MM-yyyy-HH-mm-ss
+        // naming convention. Back-date its last-write-time so it is unambiguously the OLDEST file
+        // present, exercising the documented fallback (File.GetLastWriteTimeUtc) for names that fail
+        // to parse - it must not crash the prune and must not be silently preferred over real runs.
+        var unparsablePath = Path.Combine(_runsDir, "not-a-timestamp-run.json");
+        await File.WriteAllTextAsync(unparsablePath, "{}");
+        File.SetLastWriteTimeUtc(unparsablePath, new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        // Saving one more valid run brings the total to 52 (50 + 1 garbage + 1 new), triggering a prune
+        // of 2 files.
+        var act = async () => await _store.SaveAsync(_tempDir, MakeRecord(1, LocalSecond(50)));
+        await act.Should().NotThrowAsync();
+
+        var remaining = Directory.GetFiles(_runsDir, "*-run.json");
+        remaining.Should().HaveCount(50);
+
+        var names = remaining.Select(Path.GetFileName).ToList();
+        names.Should().NotContain("not-a-timestamp-run.json", "the unparsable file falls back to last-write-time and, backdated to year 2000, is the oldest present and must be pruned");
+        names.Should().NotContain(n => n!.Contains("-00-Version-V1-run.json"), "second-00 is the next-oldest real run and must also be pruned");
+        names.Should().Contain(n => n!.Contains("-01-Version-V1-run.json"), "second-01 is the new oldest kept real run");
+        names.Should().Contain(n => n!.Contains("-50-Version-V1-run.json"), "second-50 is the newest real run");
     }
 
     [Fact]
@@ -143,6 +201,11 @@ public class AnalysisRunStoreTests : IDisposable
     // is a no-op and the produced file name is deterministic on any machine timezone.
     private static DateTimeOffset LocalSecond(int second)
         => new(new DateTime(2026, 1, 1, 12, 0, second, DateTimeKind.Local));
+
+    // Same idea as LocalSecond, but for an arbitrary calendar date (fixed noon local time) - used to
+    // build cross-month/cross-year timestamps for the chronological-prune tests.
+    private static DateTimeOffset LocalDateTime(int year, int month, int day)
+        => new(new DateTime(year, month, day, 12, 0, 0, DateTimeKind.Local));
 
     private static AnalysisRunRecord MakeRecord(int version, DateTimeOffset when) => new()
     {


### PR DESCRIPTION
## What

Fixes `AnalysisRunStore.PruneOldRuns` deleting the wrong "oldest" runs: it kept the newest 50 files via lexicographic `OrderByDescending(f => f)`, but filenames are day-first (`dd-MM-yyyy-HH-mm-ss-…`), so ordering was not chronological across day/month boundaries (e.g. `02-07-2026…` sorts after `01-08-2026…`) — recent runs could be pruned while older ones survived.

## Fix

- Prune now orders by the timestamp **parsed from the file name** (`TryParseExact`, `dd-MM-yyyy-HH-mm-ss`, `CultureInfo.InvariantCulture` — culture-explicit on this German-locale codebase). Filename format unchanged.
- Unparsable `*-run.json` names fall back to `File.GetLastWriteTimeUtc(...).ToLocalTime()` — normalized into the same local-wall-clock tick frame as the parsed branch (review caught that comparing raw UTC ticks against local ticks mis-ranked files within the UTC-offset window; reproduced, fixed, regression-tested with a close 20-minute offset rather than a masking year-2000 backdate).
- Same-second ties get a deterministic `StringComparer.Ordinal` secondary key (LINQ enumeration order is unguaranteed).
- Newest-50 / per-file `IOException` best-effort semantics preserved.

## Tests

- Old constrained pinning test flipped to assert chronological pruning outright (its timestamps had been deliberately chosen so lexical == chronological).
- New cases: cross-month-boundary disagreement (Jul-28 vs Aug-1), unparsable-name crash-safety + fallback ranking, and the DateTimeKind regression test. All RED on the unfixed code (fix-wave RED proven via temporary revert), GREEN after.

## Verification (implementer + reviewer independently)

- `dotnet build DiffusionNexus.sln -c Release` — 0 errors
- Unit suite: **3,255 / 3,255** (baseline 3,252 + 3 net-new tests across both commits)
- Reviewer independently derived the regression test's winter-offset math against the machine's real timezone data.

Review: round 1 **Needs fixes** (the Kind-mismatch finding + 2 minors) → fix wave → **Approved**, no new issues.

Fixes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)
