### PR TITLE
Fix develop CI: self-skip UTC-offset regression test on UTC+0 runners

### DIFF
--- a/DiffusionNexus.Tests/DatasetQuality/AnalysisRunStoreTests.cs
+++ b/DiffusionNexus.Tests/DatasetQuality/AnalysisRunStoreTests.cs
@@ -199,7 +199,14 @@ public class AnalysisRunStoreTests : IDisposable
         // vice versa on a negative-offset machine). This test only proves something away from UTC+0.
         var neighborLocal = new DateTime(2026, 1, 10, 14, 0, 0, DateTimeKind.Local);
         var offset = TimeZoneInfo.Local.GetUtcOffset(neighborLocal);
-        offset.Should().NotBe(TimeSpan.Zero, "the Kind-mismatch regression is only observable away from UTC+0; this machine is expected to run a non-UTC (German) locale");
+        if (offset == TimeSpan.Zero)
+        {
+            // At UTC+0, local wall-clock ticks equal raw UTC ticks, so the buggy (raw UTC) and the
+            // fixed (ToLocalTime-normalized) orderings are indistinguishable and this regression
+            // cannot be observed. GitHub Actions runners run at UTC+0 - self-skip there; the test
+            // still exercises the regression on any non-UTC dev machine.
+            return;
+        }
 
         // Nudge the unparsable file's TRUE local write time a few minutes to the "newer" side of the
         // neighbor if the offset is positive, or the "older" side if negative - either way, by far less


### PR DESCRIPTION
## What

Repairs the develop CI break introduced by PR #473: the new DateTimeKind regression test (`SaveAsync_PruneWithUnparsableFileName_RanksByLocalTime_NotRawUtcTicks`) hard-asserted a **non-zero local UTC offset**. That holds on the dev machines it was written and reviewed on (UTC+1/+2) but not on GitHub Actions runners, which run at **UTC+0** — the guard assertion itself failed.

## Fix

At UTC+0, local wall-clock ticks equal raw UTC ticks, so the buggy (raw UTC) and fixed (`ToLocalTime()`-normalized) orderings are genuinely indistinguishable — there is nothing for the test to observe. The guard is now a documented early return instead of an assertion: the test self-skips at UTC+0 and still exercises the regression on any non-UTC machine. Test-only change, 8 lines.

## Verification

- `dotnet build DiffusionNexus.sln -c Release` — 0 errors
- Full unit suite: **3,249 / 3,249** (exactly the post-#471/#472/#473 merged count)
- Focused `AnalysisRunStore` filter: 13/13

🤖 Generated with [Claude Code](https://claude.com/claude-code)
