### PR TITLE
fix: Diffusion Nexus Core workload never downloads/detects its Civitai LoRAs (develop)

### DIFF
--- a/DiffusionNexus.Tests/InstallerManager/PipelineAssetInstallerTests.cs
+++ b/DiffusionNexus.Tests/InstallerManager/PipelineAssetInstallerTests.cs
@@ -1,0 +1,246 @@
+using DiffusionNexus.Civitai;
+using DiffusionNexus.Civitai.Models;
+using DiffusionNexus.Domain.Services;
+using DiffusionNexus.UI.Models.Pipelines;
+using DiffusionNexus.UI.Services;
+using DiffusionNexus.UI.Services.Diffusion;
+using DiffusionNexus.UI.Services.Pipelines;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace DiffusionNexus.Tests.InstallerManager;
+
+/// <summary>
+/// Regression tests for the "Installer Manager → Diffusion Nexus Core → workload does not
+/// download its LoRAs" bug: Civitai LoRA downloads never wrote a <c>.civitai.info</c> sidecar,
+/// so the readiness check (which matches LoRAs primarily by sidecar modelId) reported them
+/// missing forever, while re-installing early-returned on the existing weights file without
+/// downloading or healing anything.
+/// </summary>
+public sealed class PipelineAssetInstallerTests : IDisposable
+{
+    private readonly string _root;
+    private readonly Mock<IDownloadCoordinator> _coordinator = new();
+    private readonly Mock<ICivitaiClient> _civitai = new();
+    private readonly Mock<IAppSettingsService> _settings = new();
+
+    public PipelineAssetInstallerTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "dn-pipeline-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(_root, "loras"));
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    private PipelineAssetInstaller CreateInstaller()
+    {
+        return new PipelineAssetInstaller(
+            _coordinator.Object,
+            _civitai.Object,
+            new LoraDownloadService(null, null, null),
+            _settings.Object,
+            new LocalDiffusionBackendProvider(new Mock<IServiceProvider>().Object));
+    }
+
+    private static PipelineManifest ManifestWithLora(int modelId, string expectedFileName, string name = "Test LoRA")
+        => new()
+        {
+            Id = "test-pipeline",
+            Title = "Test Pipeline",
+            Assets =
+            [
+                new PipelineAsset
+                {
+                    Name = name,
+                    Kind = PipelineAssetKind.Lora,
+                    TargetSubfolder = "loras",
+                    ExpectedFileName = expectedFileName,
+                    CivitaiModelId = modelId,
+                },
+            ],
+        };
+
+    private static CivitaiModel CivitaiModelWithFile(int versionId, string fileName, int modelId = 0)
+        => new()
+        {
+            Id = 1934100,
+            Name = "Anime2Real",
+            ModelVersions =
+            [
+                new CivitaiModelVersion
+                {
+                    Id = versionId,
+                    // Deliberately 0 by default: nested versions in /api/v1/models/{id}
+                    // responses do not always carry the parent modelId.
+                    ModelId = modelId,
+                    Name = "Klein9B",
+                    Files =
+                    [
+                        new CivitaiModelFile
+                        {
+                            Id = 1,
+                            Name = fileName,
+                            Primary = true,
+                            DownloadUrl = $"https://civitai.com/api/download/models/{versionId}",
+                        },
+                    ],
+                },
+            ],
+        };
+
+    // ── Bug precondition (characterization): why the sidecar is required ──
+
+    [Fact]
+    public void BuildReadiness_DoesNotDetectLora_WhenWeightsExistWithoutSidecar()
+    {
+        // The real Civitai filename shares no substring with the manifest hint
+        // (e.g. hint "anime2real" vs file "A2R_Klein_Standard.safetensors").
+        File.WriteAllBytes(Path.Combine(_root, "loras", "A2R_Klein_Standard.safetensors"), [0x1]);
+
+        var readiness = PipelineAssetInstaller.BuildReadiness(
+            ManifestWithLora(1934100, "anime2real"), [_root]);
+
+        readiness.Assets.Should().ContainSingle().Which.IsPresent.Should().BeFalse(
+            "without a sidecar, neither the modelId scan nor the filename hint can match the file");
+    }
+
+    // ── The fix: sidecar written on download makes the LoRA detectable ──
+
+    [Fact]
+    public void WriteCivitaiInfoSidecar_MakesLoraDetectable_ByReadiness()
+    {
+        var weights = Path.Combine(_root, "loras", "A2R_Klein_Standard.safetensors");
+        File.WriteAllBytes(weights, [0x1]);
+        var version = CivitaiModelWithFile(2674717, "A2R_Klein_Standard.safetensors").ModelVersions[0];
+
+        PipelineAssetInstaller.WriteCivitaiInfoSidecar(weights, version, 1934100);
+
+        var readiness = PipelineAssetInstaller.BuildReadiness(
+            ManifestWithLora(1934100, "anime2real"), [_root]);
+
+        readiness.IsComplete.Should().BeTrue();
+        readiness.Assets[0].ResolvedFileName.Should().Be("A2R_Klein_Standard.safetensors");
+    }
+
+    [Fact]
+    public void WriteCivitaiInfoSidecar_WritesManifestModelId_WhenVersionLacksModelId()
+    {
+        var weights = Path.Combine(_root, "loras", "A2R_Klein_Standard.safetensors");
+        File.WriteAllBytes(weights, [0x1]);
+        var version = CivitaiModelWithFile(2674717, "A2R_Klein_Standard.safetensors", modelId: 0).ModelVersions[0];
+
+        PipelineAssetInstaller.WriteCivitaiInfoSidecar(weights, version, 1934100);
+
+        var sidecar = Path.Combine(_root, "loras", "A2R_Klein_Standard.civitai.info");
+        File.Exists(sidecar).Should().BeTrue();
+        File.ReadAllText(sidecar).Should().Contain("\"modelId\": 1934100");
+    }
+
+    [Fact]
+    public void BuildReadiness_ReportsLoraMissing_WhenSidecarExistsButWeightsWereDeleted()
+    {
+        var weights = Path.Combine(_root, "loras", "A2R_Klein_Standard.safetensors");
+        File.WriteAllBytes(weights, [0x1]);
+        var version = CivitaiModelWithFile(2674717, "A2R_Klein_Standard.safetensors").ModelVersions[0];
+        PipelineAssetInstaller.WriteCivitaiInfoSidecar(weights, version, 1934100);
+        File.Delete(weights);
+
+        var readiness = PipelineAssetInstaller.BuildReadiness(
+            ManifestWithLora(1934100, "anime2real"), [_root]);
+
+        readiness.Assets.Should().ContainSingle().Which.IsPresent.Should().BeFalse(
+            "a sidecar without its weights file must not count as installed");
+    }
+
+    // ── Self-heal: re-installing over existing weights writes the missing sidecar ──
+
+    [Fact]
+    public async Task InstallAssets_HealsMissingSidecar_WhenWeightsAlreadyExist()
+    {
+        // The user's stuck state: weights were downloaded previously (Civitai filename),
+        // no sidecar → readiness says missing → Install runs again.
+        var weights = Path.Combine(_root, "loras", "A2R_Klein_Standard.safetensors");
+        File.WriteAllBytes(weights, [0x1]);
+
+        _civitai.Setup(c => c.GetModelAsync(1934100, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CivitaiModelWithFile(2674717, "A2R_Klein_Standard.safetensors"));
+
+        var installer = CreateInstaller();
+        var manifest = ManifestWithLora(1934100, "anime2real");
+
+        var errors = await installer.InstallAssetsAsync(
+            manifest, ["Test LoRA"], _root, vramGb: 0, hfToken: null, civitaiKey: null, CancellationToken.None);
+
+        errors.Should().BeEmpty();
+        _coordinator.Verify(
+            c => c.EnqueueAsync(It.IsAny<string>(),
+                It.IsAny<Func<IProgress<DownloadTaskProgress>, CancellationToken, Task<bool>>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the weights already exist, so nothing should be re-downloaded");
+
+        PipelineAssetInstaller.BuildReadiness(manifest, [_root]).IsComplete.Should().BeTrue(
+            "re-installing must heal the missing sidecar so the asset stops showing as missing");
+    }
+
+    // ── Per-asset isolation: one failing asset must not abort the rest ──
+
+    [Fact]
+    public async Task InstallAssets_ContinuesWithRemainingAssets_WhenOneDownloadFails()
+    {
+        var manifest = new PipelineManifest
+        {
+            Id = "test-pipeline",
+            Title = "Test Pipeline",
+            Assets =
+            [
+                new PipelineAsset
+                {
+                    Name = "Gated LoRA",
+                    Kind = PipelineAssetKind.Lora,
+                    TargetSubfolder = "loras",
+                    ExpectedFileName = "gated",
+                    CivitaiModelId = 2343188,
+                },
+                new PipelineAsset
+                {
+                    Name = "Public LoRA",
+                    Kind = PipelineAssetKind.Lora,
+                    TargetSubfolder = "loras",
+                    ExpectedFileName = "public",
+                    CivitaiModelId = 1934100,
+                },
+            ],
+        };
+
+        _civitai.Setup(c => c.GetModelAsync(2343188, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CivitaiModelWithFile(2635669, "Gated.safetensors"));
+        _civitai.Setup(c => c.GetModelAsync(1934100, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CivitaiModelWithFile(2674717, "Public.safetensors"));
+
+        var enqueued = new List<string>();
+        _coordinator.Setup(c => c.EnqueueAsync(It.IsAny<string>(),
+                It.IsAny<Func<IProgress<DownloadTaskProgress>, CancellationToken, Task<bool>>>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, Func<IProgress<DownloadTaskProgress>, CancellationToken, Task<bool>>, CancellationToken>(
+                (name, _, _) => enqueued.Add(name))
+            // Simulate the download failing (e.g. HTTP 401 because no Civitai API key is configured).
+            .ReturnsAsync(false);
+
+        var installer = CreateInstaller();
+
+        var errors = await installer.InstallAssetsAsync(
+            manifest, ["Gated LoRA", "Public LoRA"], _root, vramGb: 0, hfToken: null, civitaiKey: null,
+            CancellationToken.None);
+
+        enqueued.Should().HaveCount(2,
+            "a failure on the first asset must not prevent the remaining assets from being attempted");
+        errors.Should().HaveCount(2);
+        errors[0].Should().StartWith("Gated LoRA:");
+        errors[1].Should().StartWith("Public LoRA:");
+    }
+}

--- a/DiffusionNexus.UI/Services/Pipelines/PipelineAssetInstaller.cs
+++ b/DiffusionNexus.UI/Services/Pipelines/PipelineAssetInstaller.cs
@@ -4,10 +4,12 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using DiffusionNexus.Civitai;
+using DiffusionNexus.Civitai.Models;
 using DiffusionNexus.Domain.Services;
 using DiffusionNexus.Domain.Services.UnifiedLogging;
 using DiffusionNexus.Installer.SDK.Models.Entities;
@@ -113,6 +115,35 @@ public sealed class PipelineAssetInstaller : IPipelineAssetInstaller, IDisposabl
         var hfToken = await _settings.GetHuggingfaceApiKeyAsync(cancellationToken).ConfigureAwait(false);
         var civitaiKey = await _settings.GetCivitaiApiKeyAsync(cancellationToken).ConfigureAwait(false);
 
+        var errors = await InstallAssetsAsync(
+            manifest, missing, downloadRoot, vramGb, hfToken, civitaiKey, cancellationToken).ConfigureAwait(false);
+
+        if (errors.Count > 0)
+            throw new InvalidOperationException(string.Join(Environment.NewLine, errors));
+
+        var afterRoots = await _backendProvider.GetComfyUiModelsRootsAsync(cancellationToken).ConfigureAwait(false);
+        return await ComputeReadinessAsync(manifest, afterRoots, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Downloads every asset named in <paramref name="missingAssetNames"/>. A failure on one
+    /// asset is collected and the remaining assets are still attempted — one gated Civitai LoRA
+    /// (e.g. HTTP 401 without an API key) must not abort the rest of the workload install.
+    /// </summary>
+    /// <returns>One error line per failed asset; empty when everything succeeded.</returns>
+    internal async Task<IReadOnlyList<string>> InstallAssetsAsync(
+        PipelineManifest manifest,
+        IReadOnlyCollection<string> missingAssetNames,
+        string downloadRoot,
+        int vramGb,
+        string? hfToken,
+        string? civitaiKey,
+        CancellationToken cancellationToken)
+    {
+        var missing = missingAssetNames as ISet<string>
+            ?? missingAssetNames.ToHashSet(StringComparer.Ordinal);
+        var errors = new List<string>();
+
         foreach (var asset in manifest.Assets)
         {
             if (!missing.Contains(asset.Name))
@@ -120,17 +151,30 @@ public sealed class PipelineAssetInstaller : IPipelineAssetInstaller, IDisposabl
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            var targetDir = Path.Combine(downloadRoot, asset.TargetSubfolder);
-            Directory.CreateDirectory(targetDir);
+            try
+            {
+                var targetDir = Path.Combine(downloadRoot, asset.TargetSubfolder);
+                Directory.CreateDirectory(targetDir);
 
-            if (asset.Kind == PipelineAssetKind.Lora && asset.CivitaiModelId is int modelId)
-                await InstallCivitaiLoraAsync(asset, modelId, targetDir, civitaiKey, cancellationToken).ConfigureAwait(false);
-            else
-                await InstallHuggingFaceAssetAsync(asset, targetDir, vramGb, hfToken, cancellationToken).ConfigureAwait(false);
+                if (asset.Kind == PipelineAssetKind.Lora && asset.CivitaiModelId is int modelId)
+                    await InstallCivitaiLoraAsync(asset, modelId, targetDir, civitaiKey, cancellationToken).ConfigureAwait(false);
+                else
+                    await InstallHuggingFaceAssetAsync(asset, targetDir, vramGb, hfToken, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Pipeline asset install failed for {Asset}", asset.Name);
+                errors.Add(ex.Message.StartsWith(asset.Name + ":", StringComparison.Ordinal)
+                    ? ex.Message
+                    : $"{asset.Name}: {ex.Message}");
+            }
         }
 
-        var afterRoots = await _backendProvider.GetComfyUiModelsRootsAsync(cancellationToken).ConfigureAwait(false);
-        return await ComputeReadinessAsync(manifest, afterRoots, cancellationToken).ConfigureAwait(false);
+        return errors;
     }
 
     /// <inheritdoc />
@@ -140,9 +184,7 @@ public sealed class PipelineAssetInstaller : IPipelineAssetInstaller, IDisposabl
         foreach (var root in roots)
         {
             var hit = FindLoraByCivitaiModelId(root, civitaiModelId);
-            // FindLoraByCivitaiModelId may return the sidecar path when no weights file sits beside it;
-            // for inference we need the actual .safetensors.
-            if (hit is not null && hit.EndsWith(".safetensors", StringComparison.OrdinalIgnoreCase))
+            if (hit is not null)
                 return hit;
         }
         return null;
@@ -165,7 +207,7 @@ public sealed class PipelineAssetInstaller : IPipelineAssetInstaller, IDisposabl
         return null;
     }
 
-    private static PipelineReadiness BuildReadiness(PipelineManifest manifest, IReadOnlyList<string> roots)
+    internal static PipelineReadiness BuildReadiness(PipelineManifest manifest, IReadOnlyList<string> roots)
     {
         var states = new List<PipelineAssetState>(manifest.Assets.Count);
 
@@ -343,7 +385,13 @@ public sealed class PipelineAssetInstaller : IPipelineAssetInstaller, IDisposabl
         var fileName = primary?.Name ?? $"civitai_{modelId}_{version.Id}.safetensors";
         var target = Path.Combine(targetDir, fileName);
         if (File.Exists(target))
+        {
+            // Self-heal: builds that pre-date the sidecar write left the weights undetectable,
+            // so the asset showed as missing forever while re-installs bailed out right here.
+            if (!File.Exists(Path.ChangeExtension(target, ".civitai.info")))
+                WriteCivitaiInfoSidecar(target, version, modelId);
             return;
+        }
 
         var earlyAccess = version.EarlyAccessTimeFrame > 0
             || string.Equals(version.Availability, "EarlyAccess", StringComparison.OrdinalIgnoreCase);
@@ -379,8 +427,37 @@ public sealed class PipelineAssetInstaller : IPipelineAssetInstaller, IDisposabl
             throw new InvalidOperationException(lastError ?? $"{asset.Name}: download failed.{hint}");
         }
 
+        // Link the file to its Civitai model so the readiness check (sidecar modelId scan)
+        // and the run screen's LoRA lookup can find it again.
+        WriteCivitaiInfoSidecar(target, version, modelId);
+
         _unifiedLogger?.Info(LogCategory.Download, "Pipelines", $"Downloaded {fileName} for pipeline LoRA '{asset.Name}'.");
     }
+
+    /// <summary>
+    /// Writes the <c>.civitai.info</c> sidecar next to a downloaded LoRA weights file. The
+    /// sidecar is how the app links a file on disk back to its Civitai model — without it,
+    /// <see cref="FindLoraByCivitaiModelId"/> (and therefore the workload readiness check and
+    /// the pipeline run screen) can never recognise the download. <paramref name="modelId"/>
+    /// is stamped into the payload because versions nested in <c>/api/v1/models/{id}</c>
+    /// responses do not always carry their parent model id. Best-effort: a sidecar write
+    /// failure must never fail the download itself.
+    /// </summary>
+    internal static void WriteCivitaiInfoSidecar(string weightsPath, CivitaiModelVersion version, int modelId)
+    {
+        try
+        {
+            var payload = version.ModelId == modelId ? version : version with { ModelId = modelId };
+            var json = JsonSerializer.Serialize(payload, SidecarJsonOptions);
+            File.WriteAllText(Path.ChangeExtension(weightsPath, ".civitai.info"), json);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warning(ex, "Failed to write .civitai.info sidecar next to {Weights}", weightsPath);
+        }
+    }
+
+    private static readonly JsonSerializerOptions SidecarJsonOptions = new() { WriteIndented = true };
 
     // ── Disk checks ────────────────────────────────────────────────────────────
 
@@ -449,7 +526,9 @@ public sealed class PipelineAssetInstaller : IPipelineAssetInstaller, IDisposabl
     /// <summary>
     /// Finds a LoRA previously downloaded from the given Civitai model by scanning for a
     /// <c>*.civitai.info</c> sidecar containing <c>"modelId": &lt;id&gt;</c>. Returns the matching
-    /// weights file (same base name + <c>.safetensors</c>) when present, else the sidecar path.
+    /// weights file (same base name + <c>.safetensors</c>), or <c>null</c> when no sidecar
+    /// matches — a sidecar whose weights file was deleted does not count, otherwise the
+    /// readiness check would report an uninstallable LoRA as present.
     /// </summary>
     private static string? FindLoraByCivitaiModelId(string root, int modelId)
     {
@@ -470,9 +549,9 @@ public sealed class PipelineAssetInstaller : IPipelineAssetInstaller, IDisposabl
                 if (!Regex.IsMatch(text, pattern))
                     continue;
 
-                var baseName = sidecar[..^".civitai.info".Length];
-                var weights = baseName + ".safetensors";
-                return File.Exists(weights) ? weights : sidecar;
+                var weights = sidecar[..^".civitai.info".Length] + ".safetensors";
+                if (File.Exists(weights))
+                    return weights;
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
Develop-side twin of #475 (same branch, same commit) — the affected pipeline files are byte-identical on `main` and `develop`, so this applies cleanly to both. See #475 for the full root-cause analysis and fix description.

Summary: Civitai LoRA downloads never wrote a `.civitai.info` sidecar, so Diffusion Nexus Core workload readiness never detected them and repeated Install clicks silently no-opped on `File.Exists`; additionally one failing (gated) LoRA aborted all remaining asset downloads. Fixed with sidecar write + self-heal + per-asset error isolation, TDD tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)