### PR TITLE
feat: Base Model Folders — configurable model storage registry with default target + workload download dropdown

### DIFF
--- a/DiffusionNexus.DataAccess/Configurations/AppSettingsConfiguration.cs
+++ b/DiffusionNexus.DataAccess/Configurations/AppSettingsConfiguration.cs
@@ -35,5 +35,10 @@ internal sealed class AppSettingsConfiguration : IEntityTypeConfiguration<AppSet
             .WithOne(g => g.AppSettings)
             .HasForeignKey(g => g.AppSettingsId)
             .OnDelete(DeleteBehavior.Cascade);
+
+        entity.HasMany(e => e.BaseModelFolders)
+            .WithOne(f => f.AppSettings)
+            .HasForeignKey(f => f.AppSettingsId)
+            .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/DiffusionNexus.DataAccess/Configurations/BaseModelFolderConfiguration.cs
+++ b/DiffusionNexus.DataAccess/Configurations/BaseModelFolderConfiguration.cs
@@ -1,0 +1,27 @@
+using DiffusionNexus.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DiffusionNexus.DataAccess.Configurations;
+
+internal sealed class BaseModelFolderConfiguration : IEntityTypeConfiguration<BaseModelFolder>
+{
+    public void Configure(EntityTypeBuilder<BaseModelFolder> entity)
+    {
+        entity.ToTable("BaseModelFolders");
+        entity.HasKey(e => e.Id);
+
+        // Indexes
+        entity.HasIndex(e => e.AppSettingsId);
+        entity.HasIndex(e => e.FolderPath);
+
+        // Properties
+        entity.Property(e => e.FolderPath).IsRequired().HasMaxLength(1000);
+
+        // The folder row survives removal of the installation it was registered for.
+        entity.HasOne(e => e.InstallerPackage)
+            .WithMany()
+            .HasForeignKey(e => e.InstallerPackageId)
+            .OnDelete(DeleteBehavior.SetNull);
+    }
+}

--- a/DiffusionNexus.DataAccess/Data/DiffusionNexusCoreDbContext.cs
+++ b/DiffusionNexus.DataAccess/Data/DiffusionNexusCoreDbContext.cs
@@ -59,6 +59,7 @@ public class DiffusionNexusCoreDbContext : DbContext
     /// <summary>Disclaimer acceptances.</summary>
     public DbSet<DisclaimerAcceptance> DisclaimerAcceptances => Set<DisclaimerAcceptance>();
     public DbSet<ImageGallery> ImageGalleries => Set<ImageGallery>();
+    public DbSet<BaseModelFolder> BaseModelFolders => Set<BaseModelFolder>();
 
     /// <summary>Installed packages (ComfyUI, A1111, etc.).</summary>
     public DbSet<InstallerPackage> InstallerPackages => Set<InstallerPackage>();

--- a/DiffusionNexus.DataAccess/Migrations/Core/20260726032421_AddBaseModelFolders.Designer.cs
+++ b/DiffusionNexus.DataAccess/Migrations/Core/20260726032421_AddBaseModelFolders.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DiffusionNexus.DataAccess.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DiffusionNexus.DataAccess.Migrations.Core
 {
     [DbContext(typeof(DiffusionNexusCoreDbContext))]
-    partial class DiffusionNexusCoreDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260726032421_AddBaseModelFolders")]
+    partial class AddBaseModelFolders
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.10");

--- a/DiffusionNexus.DataAccess/Migrations/Core/20260726032421_AddBaseModelFolders.cs
+++ b/DiffusionNexus.DataAccess/Migrations/Core/20260726032421_AddBaseModelFolders.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DiffusionNexus.DataAccess.Migrations.Core
+{
+    /// <inheritdoc />
+    public partial class AddBaseModelFolders : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "BaseModelFolders",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    AppSettingsId = table.Column<int>(type: "INTEGER", nullable: false),
+                    FolderPath = table.Column<string>(type: "TEXT", maxLength: 1000, nullable: false),
+                    IsEnabled = table.Column<bool>(type: "INTEGER", nullable: false),
+                    Order = table.Column<int>(type: "INTEGER", nullable: false),
+                    IsDefault = table.Column<bool>(type: "INTEGER", nullable: false),
+                    InstallerPackageId = table.Column<int>(type: "INTEGER", nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BaseModelFolders", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_BaseModelFolders_AppSettings_AppSettingsId",
+                        column: x => x.AppSettingsId,
+                        principalTable: "AppSettings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_BaseModelFolders_InstallerPackages_InstallerPackageId",
+                        column: x => x.InstallerPackageId,
+                        principalTable: "InstallerPackages",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BaseModelFolders_AppSettingsId",
+                table: "BaseModelFolders",
+                column: "AppSettingsId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BaseModelFolders_FolderPath",
+                table: "BaseModelFolders",
+                column: "FolderPath");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BaseModelFolders_InstallerPackageId",
+                table: "BaseModelFolders",
+                column: "InstallerPackageId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "BaseModelFolders");
+        }
+    }
+}

--- a/DiffusionNexus.DataAccess/Repositories/AppSettingsRepository.cs
+++ b/DiffusionNexus.DataAccess/Repositories/AppSettingsRepository.cs
@@ -21,6 +21,7 @@ internal sealed class AppSettingsRepository : RepositoryBase<AppSettings>, IAppS
             .Include(s => s.LoraSources.OrderBy(ls => ls.Order))
             .Include(s => s.DatasetCategories.OrderBy(c => c.Order))
             .Include(s => s.ImageGalleries.OrderBy(g => g.Order))
+            .Include(s => s.BaseModelFolders.OrderBy(f => f.Order))
             .FirstOrDefaultAsync(s => s.Id == 1, cancellationToken)
             .ConfigureAwait(false);
 
@@ -98,5 +99,19 @@ internal sealed class AppSettingsRepository : RepositoryBase<AppSettings>, IAppS
     public void RemoveImageGallery(ImageGallery gallery)
     {
         Context.ImageGalleries.Remove(gallery);
+    }
+
+    /// <inheritdoc />
+    public async Task AddBaseModelFolderAsync(BaseModelFolder folder, CancellationToken cancellationToken = default)
+    {
+        await Context.BaseModelFolders
+            .AddAsync(folder, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public void RemoveBaseModelFolder(BaseModelFolder folder)
+    {
+        Context.BaseModelFolders.Remove(folder);
     }
 }

--- a/DiffusionNexus.DataAccess/Repositories/Interfaces/IAppSettingsRepository.cs
+++ b/DiffusionNexus.DataAccess/Repositories/Interfaces/IAppSettingsRepository.cs
@@ -76,4 +76,17 @@ public interface IAppSettingsRepository : IRepository<AppSettings>
     /// </summary>
     /// <param name="gallery">The gallery to remove.</param>
     void RemoveImageGallery(ImageGallery gallery);
+
+    /// <summary>
+    /// Adds a base model folder.
+    /// </summary>
+    /// <param name="folder">The folder to add.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task AddBaseModelFolderAsync(BaseModelFolder folder, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes a base model folder.
+    /// </summary>
+    /// <param name="folder">The folder to remove.</param>
+    void RemoveBaseModelFolder(BaseModelFolder folder);
 }

--- a/DiffusionNexus.DataAccess/UnitOfWork/IUnitOfWork.cs
+++ b/DiffusionNexus.DataAccess/UnitOfWork/IUnitOfWork.cs
@@ -43,4 +43,13 @@ public interface IUnitOfWork : IDisposable, IAsyncDisposable
     /// Rolls back the current transaction.
     /// </summary>
     Task RollbackTransactionAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Evicts every tracked entity from this unit's identity map. A long-lived
+    /// context never sees row deletions made by another context otherwise — a
+    /// tracking re-query returns the stale graph including phantom children.
+    /// Call before a read that must reflect current database truth. Any tracked
+    /// entities previously handed out become detached.
+    /// </summary>
+    void ClearChangeTracker();
 }

--- a/DiffusionNexus.DataAccess/UnitOfWork/UnitOfWork.cs
+++ b/DiffusionNexus.DataAccess/UnitOfWork/UnitOfWork.cs
@@ -74,6 +74,9 @@ internal sealed class UnitOfWork : IUnitOfWork
     }
 
     /// <inheritdoc />
+    public void ClearChangeTracker() => _context.ChangeTracker.Clear();
+
+    /// <inheritdoc />
     public async Task BeginTransactionAsync(CancellationToken cancellationToken = default)
     {
         _transaction = await _context.Database

--- a/DiffusionNexus.Domain/Entities/AppSettings.cs
+++ b/DiffusionNexus.Domain/Entities/AppSettings.cs
@@ -41,6 +41,12 @@ public class AppSettings
     public ICollection<ImageGallery> ImageGalleries { get; set; } = new List<ImageGallery>();
 
     /// <summary>
+    /// Registered model storage roots (Base Model Folders) used by the
+    /// Diffusion Nexus Core for downloading and looking up models.
+    /// </summary>
+    public ICollection<BaseModelFolder> BaseModelFolders { get; set; } = new List<BaseModelFolder>();
+
+    /// <summary>
     /// Whether to show NSFW content by default.
     /// </summary>
     public bool ShowNsfw { get; set; }

--- a/DiffusionNexus.Domain/Entities/BaseModelFolder.cs
+++ b/DiffusionNexus.Domain/Entities/BaseModelFolder.cs
@@ -1,0 +1,44 @@
+namespace DiffusionNexus.Domain.Entities
+{
+    /// <summary>
+    /// A registered model storage root ("Base Model Folder") — a directory that contains
+    /// (or receives) the ComfyUI-style model subfolders (<c>diffusion_models/</c>,
+    /// <c>loras/</c>, <c>text_encoders/</c>, <c>vae/</c>, …). Rows are either added manually
+    /// in Settings or auto-registered when an installation is added in the Installer Manager.
+    /// The row flagged <see cref="IsDefault"/> is the default download target for
+    /// Diffusion Nexus Core workloads.
+    /// </summary>
+    public class BaseModelFolder : BaseEntity
+    {
+        /// <summary>Parent settings ID (singleton row, always 1).</summary>
+        public int AppSettingsId { get; set; }
+
+        /// <summary>Absolute path of the models root.</summary>
+        public string FolderPath { get; set; } = string.Empty;
+
+        /// <summary>Whether this folder participates in scanning and the download dropdown.</summary>
+        public bool IsEnabled { get; set; } = true;
+
+        /// <summary>Display + scan order.</summary>
+        public int Order { get; set; }
+
+        /// <summary>
+        /// Default download target marker. At most one row is default —
+        /// enforced by <c>AppSettingsService</c> on save, not by the database.
+        /// </summary>
+        public bool IsDefault { get; set; }
+
+        /// <summary>Navigation property to parent settings.</summary>
+        public AppSettings? AppSettings { get; set; }
+
+        /// <summary>
+        /// Optional FK to the installer package whose model folders were auto-registered.
+        /// Null for manually added folders; set to null when the package is removed
+        /// (the folder row survives as a user-owned entry).
+        /// </summary>
+        public int? InstallerPackageId { get; set; }
+
+        /// <summary>Navigation to the owning installer package (null for manual rows).</summary>
+        public InstallerPackage? InstallerPackage { get; set; }
+    }
+}

--- a/DiffusionNexus.Domain/Models/SettingsExportData.cs
+++ b/DiffusionNexus.Domain/Models/SettingsExportData.cs
@@ -42,6 +42,7 @@ public sealed record SettingsExportData
 
     public List<LoraSourceExport> LoraSources { get; init; } = [];
     public List<ImageGalleryExport> ImageGalleries { get; init; } = [];
+    public List<BaseModelFolderExport> BaseModelFolders { get; init; } = [];
     public bool ShowNsfw { get; init; }
     public bool GenerateVideoThumbnails { get; init; } = true;
     public bool ShowVideoPreview { get; init; }
@@ -108,6 +109,18 @@ public sealed record ImageGalleryExport
     public string FolderPath { get; init; } = string.Empty;
     public bool IsEnabled { get; init; } = true;
     public int Order { get; init; }
+}
+
+/// <summary>
+/// Exported Base Model Folder (model storage root). The installer-package link is
+/// machine-specific and intentionally not exported.
+/// </summary>
+public sealed record BaseModelFolderExport
+{
+    public string FolderPath { get; init; } = string.Empty;
+    public bool IsEnabled { get; init; } = true;
+    public int Order { get; init; }
+    public bool IsDefault { get; init; }
 }
 
 /// <summary>

--- a/DiffusionNexus.Domain/Services/IAppSettingsService.cs
+++ b/DiffusionNexus.Domain/Services/IAppSettingsService.cs
@@ -99,6 +99,23 @@ public interface IAppSettingsService
     /// </summary>
     Task SetFavoriteLoraSourceAsync(string? folderPath, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Gets all enabled Base Model Folders, ordered by <c>Order</c>.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IReadOnlyList<BaseModelFolder>> GetEnabledBaseModelFoldersAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Registers a Base Model Folder. Idempotent: when a row with the same path already
+    /// exists (case-insensitive) no duplicate is created; a non-null
+    /// <paramref name="installerPackageId"/> is linked onto the existing row.
+    /// Never sets the default flag.
+    /// </summary>
+    /// <param name="folderPath">Absolute path of the models root.</param>
+    /// <param name="installerPackageId">Owning installer package, when auto-registered.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task AddBaseModelFolderAsync(string folderPath, int? installerPackageId = null, CancellationToken cancellationToken = default);
+
     /// <summary>Gets the remembered feedback-reporter e-mail, or null if not set.</summary>
     Task<string?> GetFeedbackReporterEmailAsync(CancellationToken cancellationToken = default);
 

--- a/DiffusionNexus.Domain/Services/IAppSettingsService.cs
+++ b/DiffusionNexus.Domain/Services/IAppSettingsService.cs
@@ -114,7 +114,8 @@ public interface IAppSettingsService
     /// <param name="folderPath">Absolute path of the models root.</param>
     /// <param name="installerPackageId">Owning installer package, when auto-registered.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    Task AddBaseModelFolderAsync(string folderPath, int? installerPackageId = null, CancellationToken cancellationToken = default);
+    /// <returns><c>true</c> when a new row was inserted; <c>false</c> when the path already existed.</returns>
+    Task<bool> AddBaseModelFolderAsync(string folderPath, int? installerPackageId = null, CancellationToken cancellationToken = default);
 
     /// <summary>Gets the remembered feedback-reporter e-mail, or null if not set.</summary>
     Task<string?> GetFeedbackReporterEmailAsync(CancellationToken cancellationToken = default);

--- a/DiffusionNexus.IntegrationTests/DatasetManagementIntegrationTests.cs
+++ b/DiffusionNexus.IntegrationTests/DatasetManagementIntegrationTests.cs
@@ -220,6 +220,9 @@ public class DatasetManagementIntegrationTests : IClassFixture<TestAppHost>
         public Task<AddExistingInstallationResult> ShowAddExistingInstallationDialogAsync(string initialPath) =>
             Task.FromResult(AddExistingInstallationResult.Cancelled());
 
+        public Task<RemoveInstallationResult> ShowRemoveInstallationDialogAsync(RemoveInstallationPrompt prompt) =>
+            Task.FromResult(RemoveInstallationResult.Cancelled());
+
         public Task<AddExistingInstallationResult> ShowEditInstallationDialogAsync(
             string name, string installationPath, DiffusionNexus.Domain.Enums.InstallerType type,
             string executablePath, string outputFolderPath) =>

--- a/DiffusionNexus.Service/Services/AppSettingsService.cs
+++ b/DiffusionNexus.Service/Services/AppSettingsService.cs
@@ -23,6 +23,13 @@ public sealed class AppSettingsService : IAppSettingsService
     /// <inheritdoc />
     public async Task<AppSettings> GetSettingsAsync(CancellationToken cancellationToken = default)
     {
+        // Each consumer holds this service (and its context) for the app lifetime,
+        // while other components delete the same settings rows through their own
+        // contexts. EF's identity map never evicts those deletions, so without a
+        // reset every re-read returns phantom children — they reappear in the UI,
+        // keep being scanned, and poison the next save with a 0-row DELETE/UPDATE.
+        _unitOfWork.ClearChangeTracker();
+
         var settings = await _unitOfWork.AppSettings
             .GetSettingsWithIncludesAsync(cancellationToken)
             .ConfigureAwait(false);
@@ -145,6 +152,11 @@ public sealed class AppSettingsService : IAppSettingsService
         var incomingFolderData = settings.BaseModelFolders
             .Select(f => new { f.Id, f.FolderPath, f.IsEnabled, f.Order, f.IsDefault, f.InstallerPackageId })
             .ToList();
+
+        // Sync against database truth, not this context's identity map — rows
+        // deleted by another context would otherwise still sit in the tracked
+        // graph and turn the save into a failing 0-row DELETE/UPDATE.
+        _unitOfWork.ClearChangeTracker();
 
         var existingSettings = await _unitOfWork.AppSettings
             .GetSettingsWithIncludesAsync(cancellationToken)

--- a/DiffusionNexus.Service/Services/AppSettingsService.cs
+++ b/DiffusionNexus.Service/Services/AppSettingsService.cs
@@ -375,7 +375,7 @@ public sealed class AppSettingsService : IAppSettingsService
     }
 
     /// <inheritdoc />
-    public async Task AddBaseModelFolderAsync(string folderPath, int? installerPackageId = null, CancellationToken cancellationToken = default)
+    public async Task<bool> AddBaseModelFolderAsync(string folderPath, int? installerPackageId = null, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(folderPath);
 
@@ -392,7 +392,7 @@ public sealed class AppSettingsService : IAppSettingsService
                 existing.UpdatedAt = DateTimeOffset.UtcNow;
                 await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
             }
-            return;
+            return false;
         }
 
         var maxOrder = settings.BaseModelFolders.Any()
@@ -410,6 +410,7 @@ public sealed class AppSettingsService : IAppSettingsService
         }, cancellationToken).ConfigureAwait(false);
 
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return true;
     }
 
     /// <inheritdoc />

--- a/DiffusionNexus.Service/Services/AppSettingsService.cs
+++ b/DiffusionNexus.Service/Services/AppSettingsService.cs
@@ -1,3 +1,4 @@
+using DiffusionNexus.DataAccess.Exceptions;
 using DiffusionNexus.DataAccess.UnitOfWork;
 using DiffusionNexus.Domain.Entities;
 using DiffusionNexus.Domain.Services;
@@ -51,7 +52,120 @@ public sealed class AppSettingsService : IAppSettingsService
             await RemoveDuplicateCategoriesAsync(settings, cancellationToken).ConfigureAwait(false);
         }
 
+        settings = await RemoveDuplicateFolderRowsAsync(settings, cancellationToken).ConfigureAwait(false);
+
         return settings;
+    }
+
+    /// <summary>
+    /// Prunes folder rows that sit duplicated in the database (historical concurrent
+    /// startup saves) from the Generation Gallery, LoRA source, and Base Model Folder
+    /// lists — same self-healing idea as <see cref="RemoveDuplicateCategoriesAsync"/>.
+    /// The row worth keeping wins: ⭐ default, then installer-linked, then persisted.
+    /// </summary>
+    private async Task<AppSettings> RemoveDuplicateFolderRowsAsync(AppSettings settings, CancellationToken cancellationToken)
+    {
+        var removed =
+            PruneDuplicates(settings.LoraSources, s => s.FolderPath,
+                s => (s.Id > 0 ? 2 : 0) + (s.IsEnabled ? 1 : 0),
+                _unitOfWork.AppSettings.RemoveLoraSource)
+            + PruneDuplicates(settings.ImageGalleries, g => g.FolderPath,
+                g => (g.InstallerPackageId is not null ? 4 : 0) + (g.Id > 0 ? 2 : 0) + (g.IsEnabled ? 1 : 0),
+                _unitOfWork.AppSettings.RemoveImageGallery)
+            + PruneDuplicates(settings.BaseModelFolders, f => f.FolderPath,
+                f => (f.IsDefault ? 8 : 0) + (f.InstallerPackageId is not null ? 4 : 0) + (f.Id > 0 ? 2 : 0) + (f.IsEnabled ? 1 : 0),
+                _unitOfWork.AppSettings.RemoveBaseModelFolder);
+
+        if (removed == 0)
+        {
+            return settings;
+        }
+
+        try
+        {
+            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            return settings;
+        }
+        catch (ConcurrencyConflictException)
+        {
+            // Another context pruned the same duplicates first (0-row DELETE).
+            // Discard the poisoned entries and hand back a fresh read instead.
+            _unitOfWork.ClearChangeTracker();
+            return await _unitOfWork.AppSettings
+                .GetSettingsWithIncludesAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Removes all but the highest-scoring row per normalized folder path from both
+    /// the navigation collection and the context. Blank paths are left alone.
+    /// </summary>
+    private static int PruneDuplicates<T>(
+        ICollection<T> rows,
+        Func<T, string?> pathOf,
+        Func<T, int> keepScore,
+        Action<T> removeAction)
+    {
+        var duplicates = rows
+            .GroupBy(r => NormalizeFolderKey(pathOf(r)), StringComparer.OrdinalIgnoreCase)
+            .Where(g => g.Key.Length > 0 && g.Count() > 1)
+            .SelectMany(g => g.OrderByDescending(keepScore).Skip(1))
+            .ToList();
+
+        foreach (var duplicate in duplicates)
+        {
+            removeAction(duplicate);
+            rows.Remove(duplicate);
+        }
+
+        return duplicates.Count;
+    }
+
+    /// <summary>
+    /// Keeps only the highest-scoring entry per normalized folder path, preserving
+    /// the original order of the survivors. Blank paths are never merged.
+    /// </summary>
+    private static List<T> DedupeFolderRows<T>(List<T> rows, Func<T, string?> pathOf, Func<T, int> keepScore)
+    {
+        if (rows.Count < 2)
+        {
+            return rows;
+        }
+
+        return rows
+            .Select((row, index) => (Row: row, Index: index))
+            .GroupBy(x => NormalizeFolderKey(pathOf(x.Row)), StringComparer.OrdinalIgnoreCase)
+            .SelectMany(g => g.Key.Length == 0
+                ? g.AsEnumerable()
+                : new[] { g.OrderByDescending(x => keepScore(x.Row)).ThenBy(x => x.Index).First() })
+            .OrderBy(x => x.Index)
+            .Select(x => x.Row)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Comparison key for folder paths: full form when resolvable, trailing
+    /// separators trimmed. Case-insensitive comparison is the caller's job.
+    /// </summary>
+    private static string NormalizeFolderKey(string? path)
+    {
+        var trimmed = path?.Trim() ?? string.Empty;
+        if (trimmed.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            trimmed = Path.GetFullPath(trimmed);
+        }
+        catch (Exception)
+        {
+            // Invalid path characters — compare the raw string instead.
+        }
+
+        return Path.TrimEndingDirectorySeparator(trimmed);
     }
 
     /// <summary>
@@ -152,6 +266,14 @@ public sealed class AppSettingsService : IAppSettingsService
         var incomingFolderData = settings.BaseModelFolders
             .Select(f => new { f.Id, f.FolderPath, f.IsEnabled, f.Order, f.IsDefault, f.InstallerPackageId })
             .ToList();
+
+        // A folder must never appear twice in a list (case-insensitive, trailing
+        // separators ignored). Persisted rows outrank new ones so their FK links
+        // survive; the ⭐ default outranks everything.
+        incomingSourceData = DedupeFolderRows(incomingSourceData, d => d.FolderPath, d => d.Id > 0 ? 1 : 0);
+        incomingGalleryData = DedupeFolderRows(incomingGalleryData, d => d.FolderPath, d => d.Id > 0 ? 1 : 0);
+        incomingFolderData = DedupeFolderRows(incomingFolderData, d => d.FolderPath,
+            d => (d.IsDefault ? 4 : 0) + (d.InstallerPackageId is not null ? 2 : 0) + (d.Id > 0 ? 1 : 0));
 
         // Sync against database truth, not this context's identity map — rows
         // deleted by another context would otherwise still sit in the tracked

--- a/DiffusionNexus.Service/Services/AppSettingsService.cs
+++ b/DiffusionNexus.Service/Services/AppSettingsService.cs
@@ -122,6 +122,13 @@ public sealed class AppSettingsService : IAppSettingsService
             gallery.AppSettingsId = 1;
         }
 
+        var folderOrder = 0;
+        foreach (var folder in settings.BaseModelFolders)
+        {
+            folder.Order = folderOrder++;
+            folder.AppSettingsId = 1;
+        }
+
         // Capture incoming data before any tracking queries
         var incomingSourceData = settings.LoraSources
             .Select(s => new { s.Id, s.FolderPath, s.IsEnabled, s.Order })
@@ -133,6 +140,10 @@ public sealed class AppSettingsService : IAppSettingsService
 
         var incomingGalleryData = settings.ImageGalleries
             .Select(g => new { g.Id, g.FolderPath, g.IsEnabled, g.Order })
+            .ToList();
+
+        var incomingFolderData = settings.BaseModelFolders
+            .Select(f => new { f.Id, f.FolderPath, f.IsEnabled, f.Order, f.IsDefault, f.InstallerPackageId })
             .ToList();
 
         var existingSettings = await _unitOfWork.AppSettings
@@ -240,6 +251,41 @@ public sealed class AppSettingsService : IAppSettingsService
             _unitOfWork.AppSettings.RemoveImageGallery,
             async gallery => await _unitOfWork.AppSettings.AddImageGalleryAsync(gallery, cancellationToken).ConfigureAwait(false));
 
+        // Handle BaseModelFolders (remove deleted, update existing, add new)
+        SyncChildCollection(
+            existingSettings.BaseModelFolders,
+            incomingFolderData,
+            f => f.Id,
+            d => d.Id,
+            (existing, data) =>
+            {
+                existing.FolderPath = data.FolderPath;
+                existing.IsEnabled = data.IsEnabled;
+                existing.Order = data.Order;
+                existing.IsDefault = data.IsDefault;
+                existing.InstallerPackageId = data.InstallerPackageId;
+            },
+            data => new BaseModelFolder
+            {
+                AppSettingsId = 1,
+                FolderPath = data.FolderPath,
+                IsEnabled = data.IsEnabled,
+                Order = data.Order,
+                IsDefault = data.IsDefault,
+                InstallerPackageId = data.InstallerPackageId
+            },
+            _unitOfWork.AppSettings.RemoveBaseModelFolder,
+            async folder => await _unitOfWork.AppSettings.AddBaseModelFolderAsync(folder, cancellationToken).ConfigureAwait(false));
+
+        // Single-default invariant: at most one Base Model Folder may be the default.
+        // When several incoming rows are flagged, the last one (incoming order) wins.
+        var lastDefaultPath = incomingFolderData.LastOrDefault(d => d.IsDefault)?.FolderPath;
+        foreach (var folder in existingSettings.BaseModelFolders.Where(f => f.IsDefault))
+        {
+            if (!string.Equals(folder.FolderPath, lastDefaultPath, StringComparison.OrdinalIgnoreCase))
+                folder.IsDefault = false;
+        }
+
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
@@ -314,6 +360,54 @@ public sealed class AppSettingsService : IAppSettingsService
             ? null
             : _secureStorage.Encrypt(token);
         settings.UpdatedAt = DateTimeOffset.UtcNow;
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<BaseModelFolder>> GetEnabledBaseModelFoldersAsync(CancellationToken cancellationToken = default)
+    {
+        var settings = await GetSettingsAsync(cancellationToken).ConfigureAwait(false);
+        return settings.BaseModelFolders
+            .Where(f => f.IsEnabled && !string.IsNullOrWhiteSpace(f.FolderPath))
+            .OrderBy(f => f.Order)
+            .ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task AddBaseModelFolderAsync(string folderPath, int? installerPackageId = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(folderPath);
+
+        var settings = await GetSettingsAsync(cancellationToken).ConfigureAwait(false);
+
+        var existing = settings.BaseModelFolders.FirstOrDefault(f =>
+            string.Equals(f.FolderPath, folderPath, StringComparison.OrdinalIgnoreCase));
+
+        if (existing is not null)
+        {
+            if (installerPackageId is not null && existing.InstallerPackageId != installerPackageId)
+            {
+                existing.InstallerPackageId = installerPackageId;
+                existing.UpdatedAt = DateTimeOffset.UtcNow;
+                await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            }
+            return;
+        }
+
+        var maxOrder = settings.BaseModelFolders.Any()
+            ? settings.BaseModelFolders.Max(f => f.Order)
+            : -1;
+
+        await _unitOfWork.AppSettings.AddBaseModelFolderAsync(new BaseModelFolder
+        {
+            AppSettingsId = settings.Id,
+            FolderPath = folderPath,
+            IsEnabled = true,
+            IsDefault = false,
+            Order = maxOrder + 1,
+            InstallerPackageId = installerPackageId
+        }, cancellationToken).ConfigureAwait(false);
 
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }

--- a/DiffusionNexus.Service/Services/SettingsExportService.cs
+++ b/DiffusionNexus.Service/Services/SettingsExportService.cs
@@ -98,6 +98,18 @@ public sealed class SettingsExportService : ISettingsExportService
         }
 
         order = 0;
+        foreach (var f in settings.BaseModelFolders.OrderBy(x => x.Order))
+        {
+            export.BaseModelFolders.Add(new BaseModelFolderExport
+            {
+                FolderPath = f.FolderPath,
+                IsEnabled = f.IsEnabled,
+                IsDefault = f.IsDefault,
+                Order = order++
+            });
+        }
+
+        order = 0;
         foreach (var c in settings.DatasetCategories.OrderBy(x => x.Order))
         {
             export.DatasetCategories.Add(new DatasetCategoryExport
@@ -186,6 +198,18 @@ public sealed class SettingsExportService : ISettingsExportService
                 FolderPath = g.FolderPath,
                 IsEnabled = g.IsEnabled,
                 Order = g.Order
+            });
+        }
+
+        foreach (var f in export.BaseModelFolders.OrderBy(x => x.Order))
+        {
+            settings.BaseModelFolders.Add(new BaseModelFolder
+            {
+                AppSettingsId = 1,
+                FolderPath = f.FolderPath,
+                IsEnabled = f.IsEnabled,
+                IsDefault = f.IsDefault,
+                Order = f.Order
             });
         }
 

--- a/DiffusionNexus.Tests/DataAccess/Repositories/AppSettingsRepositoryTests.cs
+++ b/DiffusionNexus.Tests/DataAccess/Repositories/AppSettingsRepositoryTests.cs
@@ -220,6 +220,40 @@ public class AppSettingsRepositoryTests : IDisposable
         }
     }
 
+    [Fact]
+    public async Task WhenBaseModelFolderIsAddedThenItRoundTripsWithIncludes()
+    {
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+            await uow.AppSettings.GetSettingsWithIncludesAsync();
+            await uow.SaveChangesAsync();
+
+            await uow.AppSettings.AddBaseModelFolderAsync(new BaseModelFolder
+            {
+                AppSettingsId = 1,
+                FolderPath = @"D:\Models",
+                IsEnabled = true,
+                IsDefault = true,
+                Order = 0
+            });
+            await uow.SaveChangesAsync();
+        }
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+            var settings = await uow.AppSettings.GetSettingsWithIncludesAsync();
+
+            var folder = settings.BaseModelFolders.Should().ContainSingle().Subject;
+            folder.FolderPath.Should().Be(@"D:\Models");
+            folder.IsEnabled.Should().BeTrue();
+            folder.IsDefault.Should().BeTrue();
+            folder.InstallerPackageId.Should().BeNull();
+        }
+    }
+
     public void Dispose()
     {
         _serviceProvider.Dispose();

--- a/DiffusionNexus.Tests/InstallerManager/CoreWorkloadsViewModelTests.cs
+++ b/DiffusionNexus.Tests/InstallerManager/CoreWorkloadsViewModelTests.cs
@@ -1,0 +1,62 @@
+using DiffusionNexus.UI.Services.Diffusion;
+using DiffusionNexus.UI.ViewModels;
+using FluentAssertions;
+using Moq;
+
+namespace DiffusionNexus.Tests.InstallerManager;
+
+/// <summary>
+/// Covers the download-target dropdown of the Diffusion Nexus Core Workloads window:
+/// targets come from <see cref="IModelFolderCatalog"/>, the default is preselected,
+/// and the LocalAppData fallback is the only entry when nothing is configured.
+/// </summary>
+public sealed class CoreWorkloadsViewModelTests
+{
+    private readonly Mock<IModelFolderCatalog> _catalog = new();
+
+    private CoreWorkloadsViewModel CreateSut()
+    {
+        // Captioning tab VM is a hard ctor dependency; pipelines/installer stay null —
+        // LoadAsync skips pipeline rows but must still populate the dropdown.
+        var captioning = new CaptioningModelsDialogViewModel(
+            new DiffusionNexus.Inference.Captioning.CaptioningModelManager(),
+            new Mock<DiffusionNexus.Domain.Services.ICaptioningService>().Object,
+            downloadCoordinator: null,
+            optionsPicker: (_, _) => Task.FromResult<CaptioningDownloadChoice?>(null));
+        return new CoreWorkloadsViewModel(captioning, manifestProvider: null, installer: null, _catalog.Object);
+    }
+
+    [Fact]
+    public async Task Load_PopulatesDropdown_AndPreselectsTheDefault()
+    {
+        _catalog
+            .Setup(c => c.GetDownloadTargetsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new ModelFolderOption(@"D:\ModelsB", IsDefault: true, Exists: true),
+                new ModelFolderOption(@"D:\ModelsA", IsDefault: false, Exists: true),
+            ]);
+
+        var sut = CreateSut();
+        await sut.LoadCommand.ExecuteAsync(null);
+
+        sut.DownloadTargets.Select(t => t.Path).Should().Equal(@"D:\ModelsB", @"D:\ModelsA");
+        sut.SelectedDownloadTarget.Should().NotBeNull();
+        sut.SelectedDownloadTarget!.Path.Should().Be(@"D:\ModelsB");
+    }
+
+    [Fact]
+    public async Task Load_ShowsFallbackAsOnlyEntry_WhenCatalogReturnsFallbackOnly()
+    {
+        _catalog
+            .Setup(c => c.GetDownloadTargetsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new ModelFolderOption(ModelFolderCatalog.FallbackRoot, IsDefault: true, Exists: false)]);
+
+        var sut = CreateSut();
+        await sut.LoadCommand.ExecuteAsync(null);
+
+        var only = sut.DownloadTargets.Should().ContainSingle().Subject;
+        only.Path.Should().Be(ModelFolderCatalog.FallbackRoot);
+        sut.SelectedDownloadTarget.Should().Be(only);
+    }
+}

--- a/DiffusionNexus.Tests/InstallerManager/InstallationSettingsCleanupTests.cs
+++ b/DiffusionNexus.Tests/InstallerManager/InstallationSettingsCleanupTests.cs
@@ -1,0 +1,125 @@
+using DiffusionNexus.Domain.Entities;
+using DiffusionNexus.Domain.Enums;
+using DiffusionNexus.UI.Services;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.InstallerManager;
+
+/// <summary>
+/// Covers <see cref="InstallationSettingsCleanup"/> — resolving which settings rows
+/// (Generation Galleries, LoRA sources, Base Model Folders) belong to an installation
+/// that is being removed from the Installer Manager. Galleries and Base Model Folders
+/// are matched by their InstallerPackageId FK; LoRA sources have no FK and are matched
+/// by living underneath the installation path; Base Model Folders additionally match
+/// by path so manually re-added rows under the install are offered too.
+/// </summary>
+public sealed class InstallationSettingsCleanupTests
+{
+    private static InstallerPackage Package(int id = 5, string path = @"C:\AI\ComfyUI") => new()
+    {
+        Id = id,
+        Name = "ComfyUI",
+        InstallationPath = path,
+        ExecutablePath = "main.py",
+        Type = InstallerType.ComfyUI,
+    };
+
+    [Fact]
+    public void Resolve_MatchesGalleries_ByPackageLinkOnly()
+    {
+        var linked = new ImageGallery { Id = 1, FolderPath = @"D:\Output", InstallerPackageId = 5 };
+        var otherPackage = new ImageGallery { Id = 2, FolderPath = @"C:\AI\ComfyUI\output", InstallerPackageId = 9 };
+        var unlinked = new ImageGallery { Id = 3, FolderPath = @"C:\AI\ComfyUI\output2" };
+        var settings = new AppSettings { Id = 1, ImageGalleries = [linked, otherPackage, unlinked] };
+
+        var plan = InstallationSettingsCleanup.Resolve(settings, Package());
+
+        plan.Galleries.Should().ContainSingle().Which.Should().BeSameAs(linked,
+            "the FK is the ownership marker — a gallery merely located under the install path is not offered");
+    }
+
+    [Fact]
+    public void Resolve_MatchesLoraSources_UnderTheInstallationPath()
+    {
+        var inside = new LoraSource { Id = 1, FolderPath = @"C:\AI\ComfyUI\models\loras" };
+        var caseInsensitive = new LoraSource { Id = 2, FolderPath = @"c:\ai\comfyui\MODELS\Loras2\" };
+        var outside = new LoraSource { Id = 3, FolderPath = @"D:\Loras" };
+        var prefixNotFolder = new LoraSource { Id = 4, FolderPath = @"C:\AI\ComfyUI-Backup\loras" };
+        var settings = new AppSettings { Id = 1, LoraSources = [inside, caseInsensitive, outside, prefixNotFolder] };
+
+        var plan = InstallationSettingsCleanup.Resolve(settings, Package());
+
+        plan.LoraSources.Should().BeEquivalentTo(new[] { inside, caseInsensitive },
+            o => o.WithoutStrictOrdering(),
+            "\"C:\\AI\\ComfyUI-Backup\" is a sibling folder, not a subfolder of the installation");
+    }
+
+    [Fact]
+    public void Resolve_MatchesBaseModelFolders_ByOwnLinkOrUnclaimedPath()
+    {
+        var byLink = new BaseModelFolder { Id = 1, FolderPath = @"E:\ExtraModels", InstallerPackageId = 5 };
+        var byPath = new BaseModelFolder { Id = 2, FolderPath = @"C:\AI\ComfyUI\models" };
+        var unrelated = new BaseModelFolder { Id = 3, FolderPath = @"D:\Models", InstallerPackageId = 9 };
+        var otherOwnersRow = new BaseModelFolder { Id = 4, FolderPath = @"C:\AI\ComfyUI\models\shared", InstallerPackageId = 9 };
+        var settings = new AppSettings { Id = 1, BaseModelFolders = [byLink, byPath, unrelated, otherOwnersRow] };
+
+        var plan = InstallationSettingsCleanup.Resolve(settings, Package());
+
+        plan.BaseModelFolders.Should().BeEquivalentTo(new[] { byLink, byPath },
+            o => o.WithoutStrictOrdering(),
+            "a row registered for ANOTHER still-existing installation must never be swept, even under this install's path");
+    }
+
+    [Fact]
+    public void Resolve_KeepsBaseModelFolders_AnotherInstallationStillDiscovers()
+    {
+        // Install B's extra_model_paths.yaml points into this install's tree: the
+        // shared root must survive the removal (it would be resurrected by B's
+        // startup backfill anyway, making the dialog's promise a lie).
+        var shared = new BaseModelFolder { Id = 1, FolderPath = @"C:\AI\ComfyUI\models", InstallerPackageId = 5 };
+        var own = new BaseModelFolder { Id = 2, FolderPath = @"C:\AI\ComfyUI\models\extra", InstallerPackageId = 5 };
+        var settings = new AppSettings { Id = 1, BaseModelFolders = [shared, own] };
+
+        var plan = InstallationSettingsCleanup.Resolve(
+            settings,
+            Package(),
+            protectedRoots: [@"c:\ai\comfyui\MODELS\"]);
+
+        plan.BaseModelFolders.Should().BeEquivalentTo(new[] { own },
+            o => o.WithoutStrictOrdering(),
+            "protected roots are matched case-insensitively and separator-tolerantly");
+    }
+
+    [Fact]
+    public void Resolve_EmptySettings_YieldsEmptyPlan()
+    {
+        var plan = InstallationSettingsCleanup.Resolve(new AppSettings { Id = 1 }, Package());
+
+        plan.Galleries.Should().BeEmpty();
+        plan.LoraSources.Should().BeEmpty();
+        plan.BaseModelFolders.Should().BeEmpty();
+        plan.IsEmpty.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(@"C:\AI\ComfyUI", true)]
+    [InlineData(@"C:\AI\ComfyUI\", true)]
+    [InlineData(@"C:\AI\ComfyUI\models\loras", true)]
+    [InlineData(@"C:\AI\ComfyUI-Backup\loras", false)]
+    [InlineData(@"C:\AI", false)]
+    [InlineData(@"D:\Elsewhere", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void IsUnderInstallation_HandlesEdgeCases(string? candidate, bool expected)
+    {
+        InstallationSettingsCleanup.IsUnderInstallation(candidate, @"C:\AI\ComfyUI")
+            .Should().Be(expected);
+    }
+
+    [Fact]
+    public void IsUnderInstallation_ToleratesInvalidPaths()
+    {
+        InstallationSettingsCleanup.IsUnderInstallation("\0bad", @"C:\AI\ComfyUI").Should().BeFalse();
+        InstallationSettingsCleanup.IsUnderInstallation(@"C:\AI\ComfyUI\models", null).Should().BeFalse();
+    }
+}

--- a/DiffusionNexus.Tests/InstallerManager/InstallerManagerViewModelTests.cs
+++ b/DiffusionNexus.Tests/InstallerManager/InstallerManagerViewModelTests.cs
@@ -205,4 +205,177 @@ public class InstallerManagerViewModelTests
         vm.InstallerCards.First(c => c.Id == 2).IsDefault.Should().BeTrue("selected card should be marked as default");
         vm.InstallerCards.First(c => c.Id == 3).IsDefault.Should().BeTrue("Forge default should be unchanged");
     }
+
+    // ── Remove-installation flow (settings cleanup checkboxes) ──
+
+    private sealed class RemoveFlowHarness
+    {
+        public Mock<IDialogService> Dialog { get; } = new();
+        public Mock<IInstallerPackageRepository> PackageRepo { get; } = new();
+        public Mock<IAppSettingsRepository> AppSettingsRepo { get; } = new();
+        public Mock<IUnitOfWork> Uow { get; } = new();
+        public Mock<IDatasetEventAggregator> EventAggregator { get; } = new();
+        public InstallerPackage Package { get; }
+        public InstallerManagerViewModel Vm { get; }
+
+        public RemoveFlowHarness(AppSettings settings, string? installationPath = null)
+        {
+            Package = new InstallerPackage
+            {
+                Id = 5,
+                Name = "ComfyUI",
+                InstallationPath = installationPath ?? @"C:\AI\ComfyUI",
+                ExecutablePath = "main.py",
+                Type = InstallerType.ComfyUI,
+            };
+
+            PackageRepo.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync([Package]);
+            PackageRepo.Setup(r => r.GetByIdAsync(5, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Package);
+            AppSettingsRepo.Setup(r => r.GetSettingsWithIncludesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(settings);
+            Uow.Setup(u => u.InstallerPackages).Returns(PackageRepo.Object);
+            Uow.Setup(u => u.AppSettings).Returns(AppSettingsRepo.Object);
+            Uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+            Vm = new InstallerManagerViewModel(
+                Dialog.Object,
+                Uow.Object,
+                new PackageProcessManager(),
+                EventAggregator.Object,
+                new Mock<IConfigurationRepository>().Object,
+                new Mock<IConfigurationCheckerService>().Object,
+                new Mock<IWorkloadInstallService>().Object,
+                Enumerable.Empty<IInstallerUpdateService>(),
+                new Mock<IUnifiedLogger>().Object,
+                unitOfWorkFactory: () => Uow.Object);
+        }
+
+        public async Task<InstallerPackageCardViewModel> LoadCardAsync()
+        {
+            await Vm.LoadInstallationsCommand.ExecuteAsync(null);
+            return Vm.InstallerCards.First(c => c.Id == 5);
+        }
+    }
+
+    private static AppSettings SettingsWithLinkedRows() => new()
+    {
+        Id = 1,
+        ImageGalleries =
+        [
+            new ImageGallery { Id = 1, FolderPath = @"D:\Output", InstallerPackageId = 5 },
+            new ImageGallery { Id = 2, FolderPath = @"D:\Unrelated" },
+        ],
+        LoraSources =
+        [
+            new LoraSource { Id = 1, FolderPath = @"C:\AI\ComfyUI\models\loras" },
+            new LoraSource { Id = 2, FolderPath = @"D:\Loras" },
+        ],
+        BaseModelFolders =
+        [
+            new BaseModelFolder { Id = 1, FolderPath = @"C:\AI\ComfyUI\models", InstallerPackageId = 5 },
+            new BaseModelFolder { Id = 2, FolderPath = @"D:\Models" },
+        ],
+    };
+
+    [Fact]
+    public async Task RemoveInstallation_RemovesLinkedSettingsRows_WhenAllBoxesChecked()
+    {
+        var harness = new RemoveFlowHarness(SettingsWithLinkedRows());
+        RemoveInstallationPrompt? prompt = null;
+        harness.Dialog
+            .Setup(d => d.ShowRemoveInstallationDialogAsync(It.IsAny<RemoveInstallationPrompt>()))
+            .Callback<RemoveInstallationPrompt>(p => prompt = p)
+            .ReturnsAsync(new RemoveInstallationResult(true, true, true, true));
+
+        var card = await harness.LoadCardAsync();
+        await card.RemoveCommand.ExecuteAsync(null);
+
+        prompt.Should().NotBeNull();
+        prompt!.InstallationName.Should().Be("ComfyUI");
+        prompt.GalleryFolders.Should().BeEquivalentTo(@"D:\Output");
+        prompt.LoraSourceFolders.Should().BeEquivalentTo(@"C:\AI\ComfyUI\models\loras");
+        prompt.BaseModelFolders.Should().BeEquivalentTo(@"C:\AI\ComfyUI\models");
+
+        harness.AppSettingsRepo.Verify(r => r.RemoveImageGallery(
+            It.Is<ImageGallery>(g => g.Id == 1)), Times.Once);
+        harness.AppSettingsRepo.Verify(r => r.RemoveImageGallery(
+            It.Is<ImageGallery>(g => g.Id == 2)), Times.Never);
+        harness.AppSettingsRepo.Verify(r => r.RemoveLoraSource(
+            It.Is<LoraSource>(s => s.Id == 1)), Times.Once);
+        harness.AppSettingsRepo.Verify(r => r.RemoveBaseModelFolder(
+            It.Is<BaseModelFolder>(f => f.Id == 1)), Times.Once);
+        harness.PackageRepo.Verify(r => r.Remove(harness.Package), Times.Once);
+        harness.Uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        harness.EventAggregator.Verify(
+            e => e.PublishSettingsSaved(It.IsAny<SettingsSavedEventArgs>()), Times.Once);
+        harness.Vm.InstallerCards.Should().NotContain(card);
+    }
+
+    [Fact]
+    public async Task RemoveInstallation_KeepsSettingsRows_WhenBoxesUnchecked()
+    {
+        var harness = new RemoveFlowHarness(SettingsWithLinkedRows());
+        harness.Dialog
+            .Setup(d => d.ShowRemoveInstallationDialogAsync(It.IsAny<RemoveInstallationPrompt>()))
+            .ReturnsAsync(new RemoveInstallationResult(true, false, false, false));
+
+        var card = await harness.LoadCardAsync();
+        await card.RemoveCommand.ExecuteAsync(null);
+
+        harness.AppSettingsRepo.Verify(r => r.RemoveImageGallery(It.IsAny<ImageGallery>()), Times.Never);
+        harness.AppSettingsRepo.Verify(r => r.RemoveLoraSource(It.IsAny<LoraSource>()), Times.Never);
+        harness.AppSettingsRepo.Verify(r => r.RemoveBaseModelFolder(It.IsAny<BaseModelFolder>()), Times.Never);
+        harness.PackageRepo.Verify(r => r.Remove(harness.Package), Times.Once);
+        harness.EventAggregator.Verify(
+            e => e.PublishSettingsSaved(It.IsAny<SettingsSavedEventArgs>()), Times.Never);
+        harness.Vm.InstallerCards.Should().NotContain(card);
+    }
+
+    [Fact]
+    public async Task RemoveInstallation_Cancelled_RemovesNothing()
+    {
+        var harness = new RemoveFlowHarness(SettingsWithLinkedRows());
+        harness.Dialog
+            .Setup(d => d.ShowRemoveInstallationDialogAsync(It.IsAny<RemoveInstallationPrompt>()))
+            .ReturnsAsync(RemoveInstallationResult.Cancelled());
+
+        var card = await harness.LoadCardAsync();
+        await card.RemoveCommand.ExecuteAsync(null);
+
+        harness.PackageRepo.Verify(r => r.Remove(It.IsAny<InstallerPackage>()), Times.Never);
+        harness.Uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        harness.Vm.InstallerCards.Should().Contain(card);
+    }
+
+    [Fact]
+    public async Task DeleteFromDisk_RemovesLinkedSettingsRows_WithoutAsking()
+    {
+        // The deleted tree takes its folders with it — dead settings rows are
+        // cleaned up unconditionally (no checkboxes on this path).
+        var installPath = Path.Combine(Path.GetTempPath(), "dn-delete-test-" + Guid.NewGuid().ToString("N"));
+        var settings = new AppSettings
+        {
+            Id = 1,
+            ImageGalleries = [new ImageGallery { Id = 1, FolderPath = @"D:\Output", InstallerPackageId = 5 }],
+            LoraSources = [new LoraSource { Id = 1, FolderPath = Path.Combine(installPath, "models", "loras") }],
+            BaseModelFolders = [new BaseModelFolder { Id = 1, FolderPath = Path.Combine(installPath, "models"), InstallerPackageId = 5 }],
+        };
+        var harness = new RemoveFlowHarness(settings, installPath);
+        harness.Dialog
+            .Setup(d => d.ShowConfirmAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(true);
+
+        var card = await harness.LoadCardAsync();
+        await card.DeleteFromDiskCommand.ExecuteAsync(null);
+
+        harness.AppSettingsRepo.Verify(r => r.RemoveImageGallery(It.Is<ImageGallery>(g => g.Id == 1)), Times.Once);
+        harness.AppSettingsRepo.Verify(r => r.RemoveLoraSource(It.Is<LoraSource>(s => s.Id == 1)), Times.Once);
+        harness.AppSettingsRepo.Verify(r => r.RemoveBaseModelFolder(It.Is<BaseModelFolder>(f => f.Id == 1)), Times.Once);
+        harness.PackageRepo.Verify(r => r.Remove(harness.Package), Times.Once);
+        harness.EventAggregator.Verify(
+            e => e.PublishSettingsSaved(It.IsAny<SettingsSavedEventArgs>()), Times.Once);
+        harness.Vm.InstallerCards.Should().NotContain(card);
+    }
 }

--- a/DiffusionNexus.Tests/InstallerManager/PipelineAssetInstallerTests.cs
+++ b/DiffusionNexus.Tests/InstallerManager/PipelineAssetInstallerTests.cs
@@ -187,6 +187,57 @@ public sealed class PipelineAssetInstallerTests : IDisposable
             "re-installing must heal the missing sidecar so the asset stops showing as missing");
     }
 
+    // ── Explicit download root (Base Model Folders) ──
+
+    [Fact]
+    public async Task InstallMissing_DownloadsIntoThePassedRoot_NotTheFirstSearchRoot()
+    {
+        // Two candidate roots exist; the caller (workload-window dropdown) picked the second.
+        Directory.CreateDirectory(Path.Combine(_root, "first-root"));
+        var chosenRoot = Path.Combine(_root, "chosen-root");
+
+        _civitai.Setup(c => c.GetModelAsync(1934100, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CivitaiModelWithFile(2674717, "A2R_Klein_Standard.safetensors", modelId: 1934100));
+        _settings.Setup(s => s.GetHuggingfaceApiKeyAsync(It.IsAny<CancellationToken>())).ReturnsAsync((string?)null);
+        _settings.Setup(s => s.GetCivitaiApiKeyAsync(It.IsAny<CancellationToken>())).ReturnsAsync((string?)null);
+
+        // Simulate a successful download without invoking the real download delegate.
+        _coordinator.Setup(c => c.EnqueueAsync(It.IsAny<string>(),
+                It.IsAny<Func<IProgress<DownloadTaskProgress>, CancellationToken, Task<bool>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var installer = CreateInstaller();
+        var manifest = ManifestWithLora(1934100, "anime2real");
+
+        // New public contract: the caller chooses the download root explicitly —
+        // no ComfyUI installation is required at all.
+        await installer.InstallMissingAsync(manifest, vramGb: 0, chosenRoot, CancellationToken.None);
+
+        // The sidecar written after the (mocked) download proves which root received the files.
+        File.Exists(Path.Combine(chosenRoot, "loras", "A2R_Klein_Standard.civitai.info"))
+            .Should().BeTrue("assets must land in the explicitly chosen download root");
+        Directory.Exists(Path.Combine(_root, "first-root", "loras")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void BuildReadiness_FindsAssets_AcrossCatalogAndComfyRoots()
+    {
+        // Asset lives only in the second (ComfyUI) root — readiness must still see it.
+        var catalogRoot = Path.Combine(_root, "catalog-root");
+        Directory.CreateDirectory(Path.Combine(catalogRoot, "loras"));
+        var comfyRoot = _root; // fixture root already contains loras/ from the constructor
+        var weights = Path.Combine(comfyRoot, "loras", "A2R_Klein_Standard.safetensors");
+        File.WriteAllBytes(weights, [0x1]);
+        var version = CivitaiModelWithFile(2674717, "A2R_Klein_Standard.safetensors").ModelVersions[0];
+        PipelineAssetInstaller.WriteCivitaiInfoSidecar(weights, version, 1934100);
+
+        var readiness = PipelineAssetInstaller.BuildReadiness(
+            ManifestWithLora(1934100, "anime2real"), [catalogRoot, comfyRoot]);
+
+        readiness.IsComplete.Should().BeTrue();
+    }
+
     // ── Per-asset isolation: one failing asset must not abort the rest ──
 
     [Fact]

--- a/DiffusionNexus.Tests/Service/Services/AppSettingsServiceBaseModelFolderTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/AppSettingsServiceBaseModelFolderTests.cs
@@ -1,0 +1,186 @@
+using DiffusionNexus.DataAccess;
+using DiffusionNexus.DataAccess.UnitOfWork;
+using DiffusionNexus.Domain.Entities;
+using DiffusionNexus.Domain.Services;
+using DiffusionNexus.Service.Services;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace DiffusionNexus.Tests.Service.Services;
+
+/// <summary>
+/// Covers persistence of the Base Model Folders registry: collection sync through
+/// <see cref="AppSettingsService.SaveSettingsAsync"/>, the single-default invariant,
+/// and the idempotent targeted <c>AddBaseModelFolderAsync</c> used by auto-registration.
+/// </summary>
+public class AppSettingsServiceBaseModelFolderTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly ServiceProvider _serviceProvider;
+
+    public AppSettingsServiceBaseModelFolderTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var secureStorageMock = new Mock<ISecureStorage>();
+        secureStorageMock.Setup(s => s.Encrypt(It.IsAny<string?>())).Returns<string?>(v => v);
+        secureStorageMock.Setup(s => s.Decrypt(It.IsAny<string?>())).Returns<string?>(v => v);
+
+        var services = new ServiceCollection();
+        services.AddDataAccessLayer(options => options.UseSqlite(_connection));
+        services.AddSingleton(secureStorageMock.Object);
+        services.AddTransient<IAppSettingsService, AppSettingsService>();
+
+        _serviceProvider = services.BuildServiceProvider();
+
+        using var scope = _serviceProvider.CreateScope();
+        var context = scope.ServiceProvider
+            .GetRequiredService<DiffusionNexus.DataAccess.Data.DiffusionNexusCoreDbContext>();
+        context.Database.EnsureCreated();
+    }
+
+    private IAppSettingsService CreateService(IServiceScope scope)
+        => scope.ServiceProvider.GetRequiredService<IAppSettingsService>();
+
+    /// <summary>
+    /// Builds the detached snapshot shape the Settings page passes to
+    /// <see cref="IAppSettingsService.SaveSettingsAsync"/>.
+    /// </summary>
+    private static AppSettings Snapshot(params BaseModelFolder[] folders)
+        => new() { Id = 1, BaseModelFolders = folders.ToList() };
+
+    [Fact]
+    public async Task SaveSettings_AddsUpdatesAndRemovesBaseModelFolders()
+    {
+        // Add two rows.
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var service = CreateService(scope);
+            await service.SaveSettingsAsync(Snapshot(
+                new BaseModelFolder { FolderPath = @"D:\ModelsA", IsEnabled = true },
+                new BaseModelFolder { FolderPath = @"D:\ModelsB", IsEnabled = false }));
+        }
+
+        // Update one, remove the other (detached snapshot carrying the persisted Id).
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var service = CreateService(scope);
+            var settings = await service.GetSettingsAsync();
+            settings.BaseModelFolders.Should().HaveCount(2);
+            var keepId = settings.BaseModelFolders.First(f => f.FolderPath == @"D:\ModelsA").Id;
+
+            await service.SaveSettingsAsync(Snapshot(
+                new BaseModelFolder { Id = keepId, FolderPath = @"D:\ModelsA", IsEnabled = false }));
+        }
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var service = CreateService(scope);
+            var settings = await service.GetSettingsAsync();
+
+            var folder = settings.BaseModelFolders.Should().ContainSingle().Subject;
+            folder.FolderPath.Should().Be(@"D:\ModelsA");
+            folder.IsEnabled.Should().BeFalse();
+        }
+    }
+
+    [Fact]
+    public async Task SaveSettings_KeepsOnlyTheLastDefault_WhenMultipleRowsAreFlagged()
+    {
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var service = CreateService(scope);
+            await service.SaveSettingsAsync(Snapshot(
+                new BaseModelFolder { FolderPath = @"D:\First", IsDefault = true },
+                new BaseModelFolder { FolderPath = @"D:\Second", IsDefault = true }));
+        }
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var service = CreateService(scope);
+            var settings = await service.GetSettingsAsync();
+
+            settings.BaseModelFolders.Where(f => f.IsDefault)
+                .Should().ContainSingle()
+                .Which.FolderPath.Should().Be(@"D:\Second", "the last flagged row wins");
+        }
+    }
+
+    [Fact]
+    public async Task AddBaseModelFolder_IsIdempotentByPath_AndRelinksPackage()
+    {
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var service = CreateService(scope);
+            await service.AddBaseModelFolderAsync(@"D:\Shared\Models");
+            await service.AddBaseModelFolderAsync(@"d:\shared\MODELS", installerPackageId: null);
+        }
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            // Path comparison is case-insensitive: still one row.
+            var service = CreateService(scope);
+            var settings = await service.GetSettingsAsync();
+            settings.BaseModelFolders.Should().ContainSingle();
+        }
+
+        // Re-adding with a package id links the existing row instead of duplicating it.
+        int packageId;
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+            var package = new InstallerPackage { Name = "ComfyUI", InstallationPath = @"D:\Comfy", ExecutablePath = @"D:\Comfy\run.bat" };
+            await uow.InstallerPackages.AddAsync(package);
+            await uow.SaveChangesAsync();
+            packageId = package.Id;
+        }
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var service = CreateService(scope);
+            await service.AddBaseModelFolderAsync(@"D:\Shared\Models", packageId);
+        }
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var service = CreateService(scope);
+            var settings = await service.GetSettingsAsync();
+
+            var folder = settings.BaseModelFolders.Should().ContainSingle().Subject;
+            folder.InstallerPackageId.Should().Be(packageId);
+            folder.IsDefault.Should().BeFalse("auto-registration must never claim the default flag");
+        }
+    }
+
+    [Fact]
+    public async Task GetEnabledBaseModelFolders_ReturnsOnlyEnabled_InOrder()
+    {
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var service = CreateService(scope);
+            await service.SaveSettingsAsync(Snapshot(
+                new BaseModelFolder { FolderPath = @"D:\Zeta", IsEnabled = true },
+                new BaseModelFolder { FolderPath = @"D:\Off", IsEnabled = false },
+                new BaseModelFolder { FolderPath = @"D:\Alpha", IsEnabled = true }));
+        }
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var service = CreateService(scope);
+
+            var enabled = await service.GetEnabledBaseModelFoldersAsync();
+
+            enabled.Select(f => f.FolderPath).Should().Equal(@"D:\Zeta", @"D:\Alpha");
+        }
+    }
+
+    public void Dispose()
+    {
+        _serviceProvider.Dispose();
+        _connection.Dispose();
+    }
+}

--- a/DiffusionNexus.Tests/Service/Services/AppSettingsServiceBaseModelFolderTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/AppSettingsServiceBaseModelFolderTests.cs
@@ -116,8 +116,9 @@ public class AppSettingsServiceBaseModelFolderTests : IDisposable
         using (var scope = _serviceProvider.CreateScope())
         {
             var service = CreateService(scope);
-            await service.AddBaseModelFolderAsync(@"D:\Shared\Models");
-            await service.AddBaseModelFolderAsync(@"d:\shared\MODELS", installerPackageId: null);
+            (await service.AddBaseModelFolderAsync(@"D:\Shared\Models")).Should().BeTrue("a new row was inserted");
+            (await service.AddBaseModelFolderAsync(@"d:\shared\MODELS", installerPackageId: null))
+                .Should().BeFalse("the path already exists (case-insensitive)");
         }
 
         using (var scope = _serviceProvider.CreateScope())

--- a/DiffusionNexus.Tests/Service/Services/AppSettingsServiceCivitaiKeyTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/AppSettingsServiceCivitaiKeyTests.cs
@@ -75,16 +75,18 @@ public class AppSettingsServiceCivitaiKeyTests : IDisposable
     }
 
     [Fact]
-    public async Task WhenApiKeySavedInOneScopeThenStaleScopeDoesNotSeeUpdate()
+    public async Task WhenApiKeySavedInOneScope_LongLivedServiceSeesUpdate()
     {
-        // This test documents the root-cause behavior: a long-lived
-        // AppSettingsService (same DbContext) returns the stale cached entity.
-        // It is intentionally the inverse of the fix — proving the bug exists.
+        // Historically the inverse held (a long-lived AppSettingsService returned
+        // the stale cached entity, and this test pinned that bug). GetSettingsAsync
+        // now clears the change tracker before reading, so even a long-lived
+        // service always reflects database truth — updates AND deletions made by
+        // other contexts (see AppSettingsServiceStaleContextTests).
 
         // Arrange: read settings to populate the change tracker
         using var longLivedScope = _serviceProvider.CreateScope();
-        var staleService = longLivedScope.ServiceProvider.GetRequiredService<IAppSettingsService>();
-        await staleService.GetSettingsAsync();
+        var longLivedService = longLivedScope.ServiceProvider.GetRequiredService<IAppSettingsService>();
+        await longLivedService.GetSettingsAsync();
 
         // Act: save the key from a different scope
         using (var settingsScope = _serviceProvider.CreateScope())
@@ -93,9 +95,9 @@ public class AppSettingsServiceCivitaiKeyTests : IDisposable
             await settingsService.SetCivitaiApiKeyAsync("my-secret-key");
         }
 
-        // Assert: the stale service still returns null (cached tracked entity)
-        var staleKey = await staleService.GetCivitaiApiKeyAsync();
-        staleKey.Should().BeNull("EF Core returns the cached tracked entity, not the database value");
+        // Assert: the long-lived service reads the fresh value
+        var key = await longLivedService.GetCivitaiApiKeyAsync();
+        key.Should().Be("my-secret-key", "settings reads must reflect database truth, not the identity map");
     }
 
     public void Dispose()

--- a/DiffusionNexus.Tests/Service/Services/AppSettingsServiceDuplicateFolderTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/AppSettingsServiceDuplicateFolderTests.cs
@@ -1,0 +1,161 @@
+using DiffusionNexus.DataAccess;
+using DiffusionNexus.Domain.Entities;
+using DiffusionNexus.Domain.Services;
+using DiffusionNexus.Service.Services;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace DiffusionNexus.Tests.Service.Services;
+
+/// <summary>
+/// The three Settings folder lists (Generation Galleries, LoRA sources, Base Model
+/// Folders) must never contain the same folder twice. Duplicates are dropped when a
+/// snapshot is saved (case-insensitive, trailing-separator tolerant) and rows that
+/// already sit duplicated in the database — historical concurrent startup saves —
+/// are pruned on the next settings read, mirroring the existing category dedupe.
+/// </summary>
+public sealed class AppSettingsServiceDuplicateFolderTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly ServiceProvider _serviceProvider;
+
+    public AppSettingsServiceDuplicateFolderTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var secureStorageMock = new Mock<ISecureStorage>();
+        secureStorageMock.Setup(s => s.Encrypt(It.IsAny<string?>())).Returns<string?>(v => v);
+        secureStorageMock.Setup(s => s.Decrypt(It.IsAny<string?>())).Returns<string?>(v => v);
+
+        var services = new ServiceCollection();
+        services.AddDataAccessLayer(options => options.UseSqlite(_connection));
+        services.AddSingleton(secureStorageMock.Object);
+        services.AddTransient<IAppSettingsService, AppSettingsService>();
+
+        _serviceProvider = services.BuildServiceProvider();
+
+        using var scope = _serviceProvider.CreateScope();
+        var context = scope.ServiceProvider
+            .GetRequiredService<DiffusionNexus.DataAccess.Data.DiffusionNexusCoreDbContext>();
+        context.Database.EnsureCreated();
+    }
+
+    public void Dispose()
+    {
+        _serviceProvider.Dispose();
+        _connection.Dispose();
+    }
+
+    private IAppSettingsService CreateService(IServiceScope scope)
+        => scope.ServiceProvider.GetRequiredService<IAppSettingsService>();
+
+    private static AppSettings Snapshot(Action<AppSettings> mutate)
+    {
+        var settings = new AppSettings
+        {
+            Id = 1,
+            BackupDatasetImagesEnabled = false,
+            BackupDatabaseEnabled = false,
+        };
+        mutate(settings);
+        return settings;
+    }
+
+    [Fact]
+    public async Task SaveSettings_DropsDuplicateGalleryRows()
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var service = CreateService(scope);
+
+        await service.SaveSettingsAsync(Snapshot(s =>
+        {
+            s.ImageGalleries.Add(new ImageGallery { FolderPath = @"E:\AI\outputs", IsEnabled = true, Order = 0 });
+            s.ImageGalleries.Add(new ImageGallery { FolderPath = @"e:\ai\OUTPUTS\", IsEnabled = true, Order = 1 });
+        }));
+
+        var saved = await service.GetSettingsAsync();
+        saved.ImageGalleries.Should().ContainSingle()
+            .Which.FolderPath.Should().Be(@"E:\AI\outputs",
+                "the first occurrence wins; case and trailing separators do not make a path distinct");
+    }
+
+    [Fact]
+    public async Task SaveSettings_DropsDuplicateLoraSourceRows()
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var service = CreateService(scope);
+
+        await service.SaveSettingsAsync(Snapshot(s =>
+        {
+            s.LoraSources.Add(new LoraSource { FolderPath = @"D:\Models\Lora\", IsEnabled = true, Order = 0 });
+            s.LoraSources.Add(new LoraSource { FolderPath = @"D:\Models\Lora", IsEnabled = false, Order = 1 });
+        }));
+
+        var saved = await service.GetSettingsAsync();
+        saved.LoraSources.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task SaveSettings_DropsDuplicateBaseModelFolders_KeepingTheDefaultFlaggedRow()
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var service = CreateService(scope);
+
+        await service.SaveSettingsAsync(Snapshot(s =>
+        {
+            s.BaseModelFolders.Add(new BaseModelFolder { FolderPath = @"E:\AI\Models", IsEnabled = true, Order = 0 });
+            s.BaseModelFolders.Add(new BaseModelFolder { FolderPath = @"e:\ai\models", IsEnabled = true, IsDefault = true, Order = 1 });
+        }));
+
+        var saved = await service.GetSettingsAsync();
+        saved.BaseModelFolders.Should().ContainSingle()
+            .Which.IsDefault.Should().BeTrue("the ⭐ default row must survive the merge");
+    }
+
+    [Fact]
+    public async Task GetSettings_PrunesDuplicateRows_AlreadyInTheDatabase()
+    {
+        // Seed duplicates directly through the DbContext — exactly the state older
+        // app versions left behind (e.g. the outputs gallery registered twice).
+        using (var seedScope = _serviceProvider.CreateScope())
+        {
+            var service = CreateService(seedScope);
+            await service.GetSettingsAsync(); // ensure row Id=1 exists
+
+            var context = seedScope.ServiceProvider
+                .GetRequiredService<DiffusionNexus.DataAccess.Data.DiffusionNexusCoreDbContext>();
+            context.ImageGalleries.AddRange(
+                new ImageGallery { AppSettingsId = 1, FolderPath = @"E:\App\outputs", IsEnabled = true, Order = 0 },
+                new ImageGallery { AppSettingsId = 1, FolderPath = @"E:\App\outputs", IsEnabled = true, Order = 1 },
+                new ImageGallery { AppSettingsId = 1, FolderPath = @"E:\App\other", IsEnabled = true, Order = 2 });
+            context.LoraSources.AddRange(
+                new LoraSource { AppSettingsId = 1, FolderPath = @"D:\Loras", IsEnabled = true, Order = 0 },
+                new LoraSource { AppSettingsId = 1, FolderPath = @"d:\loras\", IsEnabled = true, Order = 1 });
+            context.BaseModelFolders.AddRange(
+                new BaseModelFolder { AppSettingsId = 1, FolderPath = @"E:\Models", IsEnabled = true, Order = 0 },
+                new BaseModelFolder { AppSettingsId = 1, FolderPath = @"E:\Models", IsEnabled = true, IsDefault = true, Order = 1 });
+            await context.SaveChangesAsync();
+        }
+
+        using var scope = _serviceProvider.CreateScope();
+        var service2 = CreateService(scope);
+        var settings = await service2.GetSettingsAsync();
+
+        settings.ImageGalleries.Select(g => g.FolderPath).Should().BeEquivalentTo(@"E:\App\outputs", @"E:\App\other");
+        settings.LoraSources.Should().ContainSingle();
+        settings.BaseModelFolders.Should().ContainSingle()
+            .Which.IsDefault.Should().BeTrue("the ⭐ default duplicate is the one worth keeping");
+
+        // And the database itself is cleaned, not just this context's view.
+        using var verifyScope = _serviceProvider.CreateScope();
+        var verifyContext = verifyScope.ServiceProvider
+            .GetRequiredService<DiffusionNexus.DataAccess.Data.DiffusionNexusCoreDbContext>();
+        (await verifyContext.ImageGalleries.CountAsync()).Should().Be(2);
+        (await verifyContext.LoraSources.CountAsync()).Should().Be(1);
+        (await verifyContext.BaseModelFolders.CountAsync()).Should().Be(1);
+    }
+}

--- a/DiffusionNexus.Tests/Service/Services/AppSettingsServiceStaleContextTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/AppSettingsServiceStaleContextTests.cs
@@ -1,0 +1,118 @@
+using DiffusionNexus.DataAccess;
+using DiffusionNexus.Domain.Entities;
+using DiffusionNexus.Domain.Services;
+using DiffusionNexus.Service.Services;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace DiffusionNexus.Tests.Service.Services;
+
+/// <summary>
+/// The app holds one long-lived DbContext per view model (each captures a transient
+/// <see cref="IAppSettingsService"/> at startup). EF's identity map never evicts
+/// entities deleted by ANOTHER context: a tracking re-query returns the stale graph
+/// including phantom children, so removed folders would reappear in the Settings UI,
+/// keep being scanned, and poison the next save with a 0-row DELETE/UPDATE
+/// (DbUpdateConcurrencyException). These tests pin the fix: every settings read
+/// clears the unit's change tracker first, so reads always reflect database truth.
+/// </summary>
+public sealed class AppSettingsServiceStaleContextTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly ServiceProvider _serviceProvider;
+
+    public AppSettingsServiceStaleContextTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var secureStorageMock = new Mock<ISecureStorage>();
+        secureStorageMock.Setup(s => s.Encrypt(It.IsAny<string?>())).Returns<string?>(v => v);
+        secureStorageMock.Setup(s => s.Decrypt(It.IsAny<string?>())).Returns<string?>(v => v);
+
+        var services = new ServiceCollection();
+        services.AddDataAccessLayer(options => options.UseSqlite(_connection));
+        services.AddSingleton(secureStorageMock.Object);
+        services.AddTransient<IAppSettingsService, AppSettingsService>();
+
+        _serviceProvider = services.BuildServiceProvider();
+
+        using var scope = _serviceProvider.CreateScope();
+        var context = scope.ServiceProvider
+            .GetRequiredService<DiffusionNexus.DataAccess.Data.DiffusionNexusCoreDbContext>();
+        context.Database.EnsureCreated();
+    }
+
+    public void Dispose()
+    {
+        _serviceProvider.Dispose();
+        _connection.Dispose();
+    }
+
+    /// <summary>Detached snapshot with backups disabled so SaveSettingsAsync never vetoes.</summary>
+    private static AppSettings Snapshot(Action<AppSettings>? mutate = null)
+    {
+        var settings = new AppSettings
+        {
+            Id = 1,
+            BackupDatasetImagesEnabled = false,
+            BackupDatabaseEnabled = false,
+        };
+        mutate?.Invoke(settings);
+        return settings;
+    }
+
+    [Fact]
+    public async Task GetSettingsAsync_DoesNotReturnRows_DeletedByAnotherContext()
+    {
+        // Long-lived service A tracks the settings graph (as every VM does at startup).
+        using var scopeA = _serviceProvider.CreateScope();
+        var serviceA = scopeA.ServiceProvider.GetRequiredService<IAppSettingsService>();
+        await serviceA.SaveSettingsAsync(Snapshot(s =>
+        {
+            s.LoraSources.Add(new LoraSource { FolderPath = @"D:\Loras", IsEnabled = true });
+            s.ImageGalleries.Add(new ImageGallery { FolderPath = @"D:\Output", IsEnabled = true });
+            s.BaseModelFolders.Add(new BaseModelFolder { FolderPath = @"D:\Models", IsEnabled = true });
+        }));
+        (await serviceA.GetSettingsAsync()).LoraSources.Should().ContainSingle();
+
+        // A different context (the Installer Manager's remove flow) deletes the rows.
+        using (var scopeB = _serviceProvider.CreateScope())
+        {
+            var serviceB = scopeB.ServiceProvider.GetRequiredService<IAppSettingsService>();
+            await serviceB.SaveSettingsAsync(Snapshot());
+        }
+
+        // Service A must see the deletion — no phantom rows from its identity map.
+        var reread = await serviceA.GetSettingsAsync();
+        reread.LoraSources.Should().BeEmpty("rows deleted by another context must not survive as phantoms");
+        reread.ImageGalleries.Should().BeEmpty();
+        reread.BaseModelFolders.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SaveSettingsAsync_Succeeds_AfterAnotherContextDeletedARow()
+    {
+        using var scopeA = _serviceProvider.CreateScope();
+        var serviceA = scopeA.ServiceProvider.GetRequiredService<IAppSettingsService>();
+        await serviceA.SaveSettingsAsync(Snapshot(s =>
+            s.LoraSources.Add(new LoraSource { FolderPath = @"D:\Loras", IsEnabled = true })));
+        var trackedId = (await serviceA.GetSettingsAsync()).LoraSources.Single().Id;
+
+        using (var scopeB = _serviceProvider.CreateScope())
+        {
+            var serviceB = scopeB.ServiceProvider.GetRequiredService<IAppSettingsService>();
+            await serviceB.SaveSettingsAsync(Snapshot());
+        }
+
+        // Saving unrelated changes must not replay a DELETE/UPDATE for the phantom
+        // (previously: DbUpdateConcurrencyException -> every save fails until restart).
+        var act = async () => await serviceA.SaveSettingsAsync(Snapshot(s => s.ShowNsfw = true));
+
+        await act.Should().NotThrowAsync();
+        (await serviceA.GetSettingsAsync()).LoraSources.Should().BeEmpty();
+    }
+}

--- a/DiffusionNexus.Tests/Service/Services/SettingsExportServiceTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/SettingsExportServiceTests.cs
@@ -47,6 +47,39 @@ public class SettingsExportServiceTests : IDisposable
         return path;
     }
 
+    [Fact]
+    public async Task BaseModelFoldersRoundTripThroughExportAndImport()
+    {
+        GivenCurrentSettings(new AppSettings
+        {
+            Id = 1,
+            BaseModelFolders =
+            [
+                new BaseModelFolder { FolderPath = @"D:\ModelsA", IsEnabled = true, Order = 0, IsDefault = false, InstallerPackageId = 7 },
+                new BaseModelFolder { FolderPath = @"E:\ModelsB", IsEnabled = false, Order = 1, IsDefault = true },
+            ],
+        });
+        var getSaved = GivenSaveIsCaptured();
+        var sut = CreateSut();
+        var path = PathFor("base-model-folders.json");
+
+        await sut.ExportAsync(path);
+        await sut.ImportAsync(path);
+
+        var saved = getSaved();
+        saved.Should().NotBeNull();
+        saved!.BaseModelFolders.Should().HaveCount(2);
+
+        var first = saved.BaseModelFolders.First(f => f.FolderPath == @"D:\ModelsA");
+        first.IsEnabled.Should().BeTrue();
+        first.IsDefault.Should().BeFalse();
+        first.InstallerPackageId.Should().BeNull("package links are machine-specific and must not be exported");
+
+        var second = saved.BaseModelFolders.First(f => f.FolderPath == @"E:\ModelsB");
+        second.IsEnabled.Should().BeFalse();
+        second.IsDefault.Should().BeTrue();
+    }
+
     private static AppSettings FullyPopulatedSettings() => new()
     {
         Id = 1,

--- a/DiffusionNexus.Tests/Services/BaseModelFolderRegistrarTests.cs
+++ b/DiffusionNexus.Tests/Services/BaseModelFolderRegistrarTests.cs
@@ -74,18 +74,26 @@ public sealed class BaseModelFolderRegistrarTests : IDisposable
     }
 
     [Fact]
-    public async Task RegisterPackageFolders_RegistersEachRoot_WithPackageLink()
+    public async Task RegisterPackageFolders_RegistersEachRoot_AndReportsHowManyWereNew()
     {
         var install = Dir("Forge");
         var modelsDir = Dir("Forge", "models");
         var settings = new Mock<IAppSettingsService>();
+        // First call inserts a new row, the second is a no-op (path already registered).
+        settings
+            .SetupSequence(s => s.AddBaseModelFolderAsync(modelsDir, 42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .ReturnsAsync(false);
         var sut = new BaseModelFolderRegistrar(settings.Object);
 
-        await sut.RegisterPackageFoldersAsync(Package(install, InstallerType.Forge, id: 42));
-        await sut.RegisterPackageFoldersAsync(Package(install, InstallerType.Forge, id: 42));
+        var firstAdded = await sut.RegisterPackageFoldersAsync(Package(install, InstallerType.Forge, id: 42));
+        var secondAdded = await sut.RegisterPackageFoldersAsync(Package(install, InstallerType.Forge, id: 42));
 
         // Idempotency lives in IAppSettingsService.AddBaseModelFolderAsync (path-unique);
-        // the registrar simply funnels every root through it with the package id.
+        // the registrar funnels every root through it and reports how many were new so
+        // callers know whether to announce a settings change (Settings page reload).
+        firstAdded.Should().Be(1);
+        secondAdded.Should().Be(0);
         settings.Verify(
             s => s.AddBaseModelFolderAsync(modelsDir, 42, It.IsAny<CancellationToken>()),
             Times.Exactly(2));
@@ -104,13 +112,15 @@ public sealed class BaseModelFolderRegistrarTests : IDisposable
 
         var sut = new BaseModelFolderRegistrar(settings.Object);
 
-        var act = async () => await sut.EnsureRegisteredAsync(
+        var added = 0;
+        var act = async () => added = await sut.EnsureRegisteredAsync(
         [
             Package(install, InstallerType.Forge, id: 1),
             Package(install, InstallerType.Forge, id: 2),
         ]);
 
         await act.Should().NotThrowAsync("startup backfill must never break app startup");
+        added.Should().Be(0, "failed registrations must not count as added");
         settings.Verify(
             s => s.AddBaseModelFolderAsync(modelsDir, It.IsAny<int?>(), It.IsAny<CancellationToken>()),
             Times.Exactly(2));

--- a/DiffusionNexus.Tests/Services/BaseModelFolderRegistrarTests.cs
+++ b/DiffusionNexus.Tests/Services/BaseModelFolderRegistrarTests.cs
@@ -1,0 +1,118 @@
+using DiffusionNexus.Domain.Entities;
+using DiffusionNexus.Domain.Enums;
+using DiffusionNexus.Domain.Services;
+using DiffusionNexus.UI.Services.Diffusion;
+using FluentAssertions;
+using Moq;
+
+namespace DiffusionNexus.Tests.Services;
+
+/// <summary>
+/// Covers <see cref="BaseModelFolderRegistrar"/>: which model roots get auto-registered
+/// per installation type (ComfyUI via ComfyUiPathDiscovery — including
+/// extra_model_paths.yaml roots — other types via their plain models/ folder),
+/// idempotency, and the package link.
+/// </summary>
+public sealed class BaseModelFolderRegistrarTests : IDisposable
+{
+    private readonly DirectoryInfo _tempDir = Directory.CreateTempSubdirectory("dn-bmf-registrar-");
+
+    public void Dispose()
+    {
+        try { _tempDir.Delete(recursive: true); } catch { /* best effort */ }
+    }
+
+    private string Dir(params string[] parts)
+    {
+        var path = Path.Combine([_tempDir.FullName, .. parts]);
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static InstallerPackage Package(string installPath, InstallerType type, int id = 5)
+        => new() { Id = id, Name = "Test", InstallationPath = installPath, ExecutablePath = "run.bat", Type = type };
+
+    [Fact]
+    public void ResolveModelRoots_ComfyUI_IncludesModelsDir_And_ExtraModelPathsYamlRoots()
+    {
+        // Manual ComfyUI layout: root contains main.py + models/.
+        var install = Dir("Comfy");
+        File.WriteAllText(Path.Combine(install, "main.py"), "# comfy");
+        var modelsDir = Dir("Comfy", "models");
+
+        // extra_model_paths.yaml declaring a shared library that exists.
+        var shared = Dir("SharedLibrary");
+        File.WriteAllText(Path.Combine(install, "extra_model_paths.yaml"),
+            $"library:\n  base_path: {shared}\n");
+
+        var roots = BaseModelFolderRegistrar.ResolveModelRoots(
+            Package(install, InstallerType.ComfyUI));
+
+        roots.Should().Contain(modelsDir);
+        roots.Should().Contain(shared, "extra_model_paths.yaml roots must be registered too");
+    }
+
+    [Fact]
+    public void ResolveModelRoots_NonComfyUI_ReturnsModelsSubfolder_WhenPresent()
+    {
+        var install = Dir("Forge");
+        var modelsDir = Dir("Forge", "models");
+
+        var roots = BaseModelFolderRegistrar.ResolveModelRoots(
+            Package(install, InstallerType.Forge));
+
+        roots.Should().Equal(modelsDir);
+    }
+
+    [Fact]
+    public void ResolveModelRoots_ReturnsEmpty_ForInvalidInstallationPath()
+    {
+        var roots = BaseModelFolderRegistrar.ResolveModelRoots(
+            Package(Path.Combine(_tempDir.FullName, "does-not-exist"), InstallerType.ComfyUI));
+
+        roots.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RegisterPackageFolders_RegistersEachRoot_WithPackageLink()
+    {
+        var install = Dir("Forge");
+        var modelsDir = Dir("Forge", "models");
+        var settings = new Mock<IAppSettingsService>();
+        var sut = new BaseModelFolderRegistrar(settings.Object);
+
+        await sut.RegisterPackageFoldersAsync(Package(install, InstallerType.Forge, id: 42));
+        await sut.RegisterPackageFoldersAsync(Package(install, InstallerType.Forge, id: 42));
+
+        // Idempotency lives in IAppSettingsService.AddBaseModelFolderAsync (path-unique);
+        // the registrar simply funnels every root through it with the package id.
+        settings.Verify(
+            s => s.AddBaseModelFolderAsync(modelsDir, 42, It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task EnsureRegistered_SwallowsFailures_AndProcessesAllPackages()
+    {
+        var install = Dir("Forge");
+        var modelsDir = Dir("Forge", "models");
+
+        var settings = new Mock<IAppSettingsService>();
+        settings
+            .Setup(s => s.AddBaseModelFolderAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("db down"));
+
+        var sut = new BaseModelFolderRegistrar(settings.Object);
+
+        var act = async () => await sut.EnsureRegisteredAsync(
+        [
+            Package(install, InstallerType.Forge, id: 1),
+            Package(install, InstallerType.Forge, id: 2),
+        ]);
+
+        await act.Should().NotThrowAsync("startup backfill must never break app startup");
+        settings.Verify(
+            s => s.AddBaseModelFolderAsync(modelsDir, It.IsAny<int?>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+}

--- a/DiffusionNexus.Tests/Services/ModelFolderCatalogTests.cs
+++ b/DiffusionNexus.Tests/Services/ModelFolderCatalogTests.cs
@@ -49,7 +49,7 @@ public sealed class ModelFolderCatalogTests : IDisposable
     }
 
     [Fact]
-    public async Task DownloadTargets_DefaultFolderFirst_ThenByOrder()
+    public async Task DownloadTargets_DefaultFolderFirst_ThenByOrder_ThenAppFolder()
     {
         var a = Dir("A");
         var b = Dir("B");
@@ -59,9 +59,22 @@ public sealed class ModelFolderCatalogTests : IDisposable
 
         var targets = await sut.GetDownloadTargetsAsync();
 
-        targets.Select(t => t.Path).Should().Equal(b, a);
+        targets.Select(t => t.Path).Should().Equal(b, a, ModelFolderCatalog.FallbackRoot);
         targets[0].IsDefault.Should().BeTrue();
         targets[1].IsDefault.Should().BeFalse();
+        targets[2].IsDefault.Should().BeFalse(
+            "the app folder is always selectable but only the default when nothing else exists");
+    }
+
+    [Fact]
+    public async Task DownloadTargets_DoNotDuplicateTheAppFolder_WhenItIsAlsoARegisteredRow()
+    {
+        var sut = CreateSut(
+            new BaseModelFolder { FolderPath = ModelFolderCatalog.FallbackRoot.ToUpperInvariant(), Order = 0 });
+
+        var targets = await sut.GetDownloadTargetsAsync();
+
+        targets.Should().ContainSingle();
     }
 
     [Fact]

--- a/DiffusionNexus.Tests/Services/ModelFolderCatalogTests.cs
+++ b/DiffusionNexus.Tests/Services/ModelFolderCatalogTests.cs
@@ -1,0 +1,120 @@
+using DiffusionNexus.Domain.Entities;
+using DiffusionNexus.Domain.Services;
+using DiffusionNexus.UI.Services.Diffusion;
+using FluentAssertions;
+using Moq;
+
+namespace DiffusionNexus.Tests.Services;
+
+/// <summary>
+/// Covers <see cref="ModelFolderCatalog"/>: download-target ordering (default first),
+/// the LocalAppData fallback when no Base Model Folders are configured, search-root
+/// dedupe/existence filtering, and the fallback on an uncreatable default.
+/// </summary>
+public sealed class ModelFolderCatalogTests : IDisposable
+{
+    private readonly DirectoryInfo _tempDir = Directory.CreateTempSubdirectory("dn-model-folder-catalog-");
+    private readonly Mock<IAppSettingsService> _settings = new();
+
+    public void Dispose()
+    {
+        try { _tempDir.Delete(recursive: true); } catch { /* best effort */ }
+    }
+
+    private string Dir(string name, bool create = true)
+    {
+        var path = Path.Combine(_tempDir.FullName, name);
+        if (create) Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private ModelFolderCatalog CreateSut(params BaseModelFolder[] enabledFolders)
+    {
+        _settings
+            .Setup(s => s.GetEnabledBaseModelFoldersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(enabledFolders.ToList());
+        return new ModelFolderCatalog(_settings.Object);
+    }
+
+    [Fact]
+    public async Task DownloadTargets_FallbackOnly_WhenNoFoldersConfigured()
+    {
+        var sut = CreateSut();
+
+        var targets = await sut.GetDownloadTargetsAsync();
+
+        var target = targets.Should().ContainSingle().Subject;
+        target.Path.Should().Be(ModelFolderCatalog.FallbackRoot);
+        target.IsDefault.Should().BeTrue("the fallback is the only choice, so it is the default");
+    }
+
+    [Fact]
+    public async Task DownloadTargets_DefaultFolderFirst_ThenByOrder()
+    {
+        var a = Dir("A");
+        var b = Dir("B");
+        var sut = CreateSut(
+            new BaseModelFolder { FolderPath = a, Order = 0 },
+            new BaseModelFolder { FolderPath = b, Order = 1, IsDefault = true });
+
+        var targets = await sut.GetDownloadTargetsAsync();
+
+        targets.Select(t => t.Path).Should().Equal(b, a);
+        targets[0].IsDefault.Should().BeTrue();
+        targets[1].IsDefault.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DownloadTargets_FirstEnabledIsDefault_WhenNoRowIsFlagged()
+    {
+        var a = Dir("A");
+        var b = Dir("B");
+        var sut = CreateSut(
+            new BaseModelFolder { FolderPath = a, Order = 0 },
+            new BaseModelFolder { FolderPath = b, Order = 1 });
+
+        var targets = await sut.GetDownloadTargetsAsync();
+
+        targets[0].Path.Should().Be(a);
+        targets[0].IsDefault.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetDefaultDownloadRoot_CreatesTheDirectory()
+    {
+        var missing = Dir("NotYetCreated", create: false);
+        var sut = CreateSut(new BaseModelFolder { FolderPath = missing, IsDefault = true });
+
+        var root = await sut.GetDefaultDownloadRootAsync();
+
+        root.Should().Be(missing);
+        Directory.Exists(missing).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetDefaultDownloadRoot_FallsBack_WhenDefaultIsUncreatable()
+    {
+        var invalid = Path.Combine(_tempDir.FullName, "bad\0path");
+        var sut = CreateSut(new BaseModelFolder { FolderPath = invalid, IsDefault = true });
+
+        var root = await sut.GetDefaultDownloadRootAsync();
+
+        root.Should().Be(ModelFolderCatalog.FallbackRoot);
+    }
+
+    [Fact]
+    public async Task SearchRoots_SkipMissingDirs_AndDedupeCaseInsensitively()
+    {
+        var a = Dir("A");
+        var missing = Dir("Gone", create: false);
+        var sut = CreateSut(
+            new BaseModelFolder { FolderPath = a, Order = 0 },
+            new BaseModelFolder { FolderPath = a.ToUpperInvariant(), Order = 1 },
+            new BaseModelFolder { FolderPath = missing, Order = 2 });
+
+        var roots = await sut.GetSearchRootsAsync();
+
+        roots.Should().ContainSingle(r => string.Equals(r, a, StringComparison.OrdinalIgnoreCase));
+        roots.Should().NotContain(missing);
+    }
+}

--- a/DiffusionNexus.Tests/ViewModels/SettingsFolderRowMissingTests.cs
+++ b/DiffusionNexus.Tests/ViewModels/SettingsFolderRowMissingTests.cs
@@ -1,3 +1,4 @@
+using DiffusionNexus.Domain.Entities;
 using DiffusionNexus.Domain.Services;
 using DiffusionNexus.UI.ViewModels;
 using FluentAssertions;
@@ -148,6 +149,35 @@ public sealed class SettingsFolderRowMissingTests : IDisposable
         await sut.RefreshFolderPresenceAsync();
 
         row.IsMissing.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task LoadCommand_FlagsMissingBaseModelFolders_ViaTheBackgroundScan()
+    {
+        // End-to-end through LoadAsync: rows are built from settings and the
+        // fire-and-forget presence scan must flag them — covers the wiring
+        // between load and RefreshFolderPresenceAsync for the base model list.
+        var settings = new AppSettings
+        {
+            Id = 1,
+            BaseModelFolders =
+            [
+                new BaseModelFolder { Id = 1, FolderPath = _existingDir, IsEnabled = true, Order = 0 },
+                new BaseModelFolder { Id = 2, FolderPath = _missingDir, IsEnabled = true, Order = 1 },
+            ],
+        };
+        var settingsService = new Mock<IAppSettingsService>();
+        settingsService
+            .Setup(s => s.GetSettingsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(settings);
+        var sut = new SettingsViewModel(settingsService.Object, new Mock<ISecureStorage>().Object);
+
+        await sut.LoadCommand.ExecuteAsync(null);
+
+        sut.BaseModelFolders.Should().HaveCount(2);
+        (await WaitForAsync(() => sut.BaseModelFolders[1].IsMissing)).Should().BeTrue(
+            "the load-time scan should flag the missing base model folder");
+        sut.BaseModelFolders[0].IsMissing.Should().BeFalse();
     }
 
     private static async Task<bool> WaitForAsync(Func<bool> condition)

--- a/DiffusionNexus.Tests/ViewModels/SettingsFolderRowMissingTests.cs
+++ b/DiffusionNexus.Tests/ViewModels/SettingsFolderRowMissingTests.cs
@@ -1,0 +1,163 @@
+using DiffusionNexus.Domain.Services;
+using DiffusionNexus.UI.ViewModels;
+using FluentAssertions;
+using Moq;
+
+namespace DiffusionNexus.Tests.ViewModels;
+
+/// <summary>
+/// Covers the ⚠ "folder not found on disk" indicator shared by the three Settings
+/// folder lists (LoRA Viewer sources, Generation Galleries, Base Model Folders).
+/// Presence is NEVER probed in the row's property setter — that would put blocking
+/// disk IO (seconds on an offline UNC share) on the UI thread per keystroke and on
+/// the startup-gating settings load. Instead the parent VM scans all rows off-thread
+/// via <see cref="SettingsViewModel.RefreshFolderPresenceAsync"/> (after load, on view
+/// attach) and debounced after row edits.
+/// </summary>
+public sealed class SettingsFolderRowMissingTests : IDisposable
+{
+    private readonly string _existingDir = Directory.CreateTempSubdirectory("dn-folder-row-").FullName;
+    private readonly string _missingDir = Path.Combine(Path.GetTempPath(), "dn-folder-row-missing-" + Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_existingDir, recursive: true); } catch { }
+    }
+
+    private static SettingsViewModel CreateSut() => new(
+        new Mock<IAppSettingsService>().Object,
+        new Mock<ISecureStorage>().Object);
+
+    // --- FolderRowPresence: the pure check --------------------------------------
+
+    [Fact]
+    public void Presence_FlagsMissing_WhenPathDoesNotExistOnDisk()
+    {
+        FolderRowPresence.IsMissing(_missingDir).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Presence_DoesNotFlag_WhenPathExists()
+    {
+        FolderRowPresence.IsMissing(_existingDir).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Presence_DoesNotFlag_EmptyPaths(string? emptyPath)
+    {
+        FolderRowPresence.IsMissing(emptyPath).Should().BeFalse();
+    }
+
+    // --- Row setters stay IO-free ------------------------------------------------
+
+    [Fact]
+    public void SettingAPath_DoesNotProbeTheDiskSynchronously()
+    {
+        // The badge appears only after an async presence scan — never from the
+        // setter itself (per-keystroke disk IO on the UI thread).
+        new LoraSourceViewModel { FolderPath = _missingDir }.IsMissing.Should().BeFalse();
+        new ImageGalleryViewModel { FolderPath = _missingDir }.IsMissing.Should().BeFalse();
+        new BaseModelFolderViewModel { FolderPath = _missingDir }.IsMissing.Should().BeFalse();
+    }
+
+    // --- The async scan ------------------------------------------------------------
+
+    [Fact]
+    public async Task RefreshFolderPresenceAsync_FlagsMissingRows_AcrossAllThreeLists()
+    {
+        var sut = CreateSut();
+        var lora = new LoraSourceViewModel { FolderPath = _missingDir };
+        var loraOk = new LoraSourceViewModel { FolderPath = _existingDir };
+        var gallery = new ImageGalleryViewModel { FolderPath = _missingDir };
+        var baseFolder = new BaseModelFolderViewModel { FolderPath = _missingDir };
+        var baseEmpty = new BaseModelFolderViewModel();
+        sut.LoraSources.Add(lora);
+        sut.LoraSources.Add(loraOk);
+        sut.ImageGallerySources.Add(gallery);
+        sut.BaseModelFolders.Add(baseFolder);
+        sut.BaseModelFolders.Add(baseEmpty);
+
+        await sut.RefreshFolderPresenceAsync();
+
+        lora.IsMissing.Should().BeTrue();
+        loraOk.IsMissing.Should().BeFalse();
+        gallery.IsMissing.Should().BeTrue();
+        baseFolder.IsMissing.Should().BeTrue();
+        baseEmpty.IsMissing.Should().BeFalse("a fresh row without a path must not warn");
+    }
+
+    [Fact]
+    public async Task RefreshFolderPresenceAsync_ClearsTheBadge_WhenTheFolderCameBack()
+    {
+        var sut = CreateSut();
+        var row = new BaseModelFolderViewModel { FolderPath = _existingDir, IsMissing = true };
+        sut.BaseModelFolders.Add(row);
+
+        await sut.RefreshFolderPresenceAsync();
+
+        row.IsMissing.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RefreshFolderPresenceAsync_SeesDiskChanges_SinceTheRowWasLoaded()
+    {
+        var vanishingDir = Directory.CreateTempSubdirectory("dn-folder-row-vanish-").FullName;
+        var sut = CreateSut();
+        var lora = new LoraSourceViewModel { FolderPath = vanishingDir };
+        var gallery = new ImageGalleryViewModel { FolderPath = vanishingDir };
+        var baseFolder = new BaseModelFolderViewModel { FolderPath = vanishingDir };
+        sut.LoraSources.Add(lora);
+        sut.ImageGallerySources.Add(gallery);
+        sut.BaseModelFolders.Add(baseFolder);
+
+        Directory.Delete(vanishingDir);
+        await sut.RefreshFolderPresenceAsync();
+
+        lora.IsMissing.Should().BeTrue();
+        gallery.IsMissing.Should().BeTrue();
+        baseFolder.IsMissing.Should().BeTrue();
+    }
+
+    // --- Debounced re-check after row edits ------------------------------------
+
+    [Fact]
+    public async Task EditingARowPath_RechecksPresence_AfterTheDebounce()
+    {
+        var sut = CreateSut();
+        sut.PresenceRefreshDebounce = TimeSpan.FromMilliseconds(20);
+        sut.AddBaseModelFolderCommand.Execute(null);
+        var row = sut.BaseModelFolders[0];
+
+        row.FolderPath = _missingDir;
+
+        (await WaitForAsync(() => row.IsMissing)).Should().BeTrue(
+            "the debounced scan should flag the missing folder shortly after the edit");
+    }
+
+    [Fact]
+    public async Task CorrectingARowPath_ClearsTheBadge_OnTheNextScan()
+    {
+        var sut = CreateSut();
+        var row = new LoraSourceViewModel { FolderPath = _missingDir, IsMissing = true };
+        sut.LoraSources.Add(row);
+
+        row.FolderPath = _existingDir;
+        await sut.RefreshFolderPresenceAsync();
+
+        row.IsMissing.Should().BeFalse();
+    }
+
+    private static async Task<bool> WaitForAsync(Func<bool> condition)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return true;
+            await Task.Delay(10);
+        }
+        return condition();
+    }
+}

--- a/DiffusionNexus.Tests/ViewModels/SettingsViewModelBaseModelFolderTests.cs
+++ b/DiffusionNexus.Tests/ViewModels/SettingsViewModelBaseModelFolderTests.cs
@@ -1,0 +1,126 @@
+using DiffusionNexus.Domain.Entities;
+using DiffusionNexus.Domain.Services;
+using DiffusionNexus.UI.ViewModels;
+using FluentAssertions;
+using Moq;
+
+namespace DiffusionNexus.Tests.ViewModels;
+
+/// <summary>
+/// Covers the "Base Model Folders" section of the Settings page: load mapping, the
+/// exclusive ⭐ default toggle, add/remove commands, and the save snapshot
+/// (including the pass-through of the installer-package link).
+/// </summary>
+public sealed class SettingsViewModelBaseModelFolderTests
+{
+    private readonly Mock<IAppSettingsService> _settingsService = new();
+    private AppSettings _stored = new() { Id = 1 };
+
+    private SettingsViewModel CreateSut()
+    {
+        _settingsService
+            .Setup(s => s.GetSettingsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _stored);
+
+        return new SettingsViewModel(
+            _settingsService.Object,
+            new Mock<ISecureStorage>().Object);
+    }
+
+    [Fact]
+    public async Task Load_MapsBaseModelFolderRows()
+    {
+        _stored = new AppSettings
+        {
+            Id = 1,
+            BaseModelFolders =
+            [
+                new BaseModelFolder { Id = 3, FolderPath = @"D:\ModelsA", IsEnabled = true, IsDefault = true, Order = 0, InstallerPackageId = 9 },
+                new BaseModelFolder { Id = 4, FolderPath = @"E:\ModelsB", IsEnabled = false, Order = 1 },
+            ],
+        };
+
+        var sut = CreateSut();
+        await sut.LoadCommand.ExecuteAsync(null);
+
+        sut.BaseModelFolders.Should().HaveCount(2);
+        sut.BaseModelFolders[0].FolderPath.Should().Be(@"D:\ModelsA");
+        sut.BaseModelFolders[0].IsDefault.Should().BeTrue();
+        sut.BaseModelFolders[0].InstallerPackageId.Should().Be(9);
+        sut.BaseModelFolders[1].IsEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SettingDefaultOnOneRow_ClearsTheOthers_AndFlagsChanges()
+    {
+        _stored = new AppSettings
+        {
+            Id = 1,
+            BaseModelFolders =
+            [
+                new BaseModelFolder { Id = 1, FolderPath = @"D:\A", IsDefault = true, Order = 0 },
+                new BaseModelFolder { Id = 2, FolderPath = @"D:\B", Order = 1 },
+            ],
+        };
+
+        var sut = CreateSut();
+        await sut.LoadCommand.ExecuteAsync(null);
+        sut.HasChanges = false;
+
+        sut.BaseModelFolders[1].IsDefault = true;
+
+        sut.BaseModelFolders[0].IsDefault.Should().BeFalse("only one folder can be the default");
+        sut.BaseModelFolders[1].IsDefault.Should().BeTrue();
+        sut.HasChanges.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AddAndRemoveCommands_MutateTheCollection_AndFlagChanges()
+    {
+        var sut = CreateSut();
+        await sut.LoadCommand.ExecuteAsync(null);
+        sut.HasChanges = false;
+
+        sut.AddBaseModelFolderCommand.Execute(null);
+        sut.BaseModelFolders.Should().ContainSingle();
+        sut.HasChanges.Should().BeTrue();
+
+        sut.RemoveBaseModelFolderCommand.Execute(sut.BaseModelFolders[0]);
+        sut.BaseModelFolders.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Save_SnapshotsRows_IncludingThePackageLink()
+    {
+        _stored = new AppSettings
+        {
+            Id = 1,
+            // Disable backups so SaveAsync's backup validation doesn't veto the save.
+            BackupDatabaseEnabled = false,
+            BackupDatasetImagesEnabled = false,
+            BaseModelFolders =
+            [
+                new BaseModelFolder { Id = 7, FolderPath = @"D:\Auto", IsEnabled = true, Order = 0, InstallerPackageId = 42 },
+            ],
+        };
+
+        AppSettings? saved = null;
+        _settingsService
+            .Setup(s => s.SaveSettingsAsync(It.IsAny<AppSettings>(), It.IsAny<CancellationToken>()))
+            .Callback<AppSettings, CancellationToken>((s, _) => saved = s)
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateSut();
+        await sut.LoadCommand.ExecuteAsync(null);
+        sut.BaseModelFolders[0].IsDefault = true;
+
+        await sut.SaveCommand.ExecuteAsync(null);
+
+        saved.Should().NotBeNull();
+        var folder = saved!.BaseModelFolders.Should().ContainSingle().Subject;
+        folder.Id.Should().Be(7);
+        folder.FolderPath.Should().Be(@"D:\Auto");
+        folder.IsDefault.Should().BeTrue();
+        folder.InstallerPackageId.Should().Be(42, "the auto-registration link must survive a settings save");
+    }
+}

--- a/DiffusionNexus.UI/App.axaml.cs
+++ b/DiffusionNexus.UI/App.axaml.cs
@@ -908,7 +908,11 @@ public partial class App : Application
             sp.GetService<ICaptioningService>(),
             sp.GetService<IActivityLogService>(),
             sp.GetService<IDownloadCoordinator>(),
-            sp.GetService<Services.Diffusion.BaseModelFolderRegistrar>()));
+            sp.GetService<Services.Diffusion.BaseModelFolderRegistrar>(),
+            // IUnitOfWork is transient: each factory call yields a fresh context for
+            // one destructive operation (remove / delete-from-disk), so those flows
+            // never act on — or poison — the VM's long-lived shared context.
+            unitOfWorkFactory: () => sp.GetRequiredService<IUnitOfWork>()));
         services.AddScoped<GenerationGalleryViewModel>(sp => new GenerationGalleryViewModel(
             sp.GetRequiredService<IAppSettingsService>(),
             sp.GetRequiredService<IDatasetEventAggregator>(),

--- a/DiffusionNexus.UI/App.axaml.cs
+++ b/DiffusionNexus.UI/App.axaml.cs
@@ -275,7 +275,16 @@ public partial class App : Application
                         var folderRegistrar = scope.ServiceProvider.GetRequiredService<DiffusionNexus.UI.Services.Diffusion.BaseModelFolderRegistrar>();
                         var uow = scope.ServiceProvider.GetRequiredService<DiffusionNexus.DataAccess.UnitOfWork.IUnitOfWork>();
                         var packages = await uow.InstallerPackages.GetAllAsync();
-                        await folderRegistrar.EnsureRegisteredAsync(packages);
+                        var added = await folderRegistrar.EnsureRegisteredAsync(packages);
+
+                        // The Settings page preloads its data before this backfill runs.
+                        // Announce the change so an already-loaded Settings VM reloads its
+                        // Base Model Folders list (same mechanism the gallery link uses).
+                        if (added > 0)
+                        {
+                            Services!.GetService<IDatasetEventAggregator>()
+                                ?.PublishSettingsSaved(new SettingsSavedEventArgs());
+                        }
                     }
                     catch (Exception ex)
                     {

--- a/DiffusionNexus.UI/App.axaml.cs
+++ b/DiffusionNexus.UI/App.axaml.cs
@@ -266,6 +266,21 @@ public partial class App : Application
                     {
                         Serilog.Log.Warning(ex, "OutputsFolderRegistrar failed during startup.");
                     }
+
+                    // Backfill Base Model Folders for already-registered installations so
+                    // existing users see their model roots without re-adding anything.
+                    try
+                    {
+                        using var scope = Services!.CreateScope();
+                        var folderRegistrar = scope.ServiceProvider.GetRequiredService<DiffusionNexus.UI.Services.Diffusion.BaseModelFolderRegistrar>();
+                        var uow = scope.ServiceProvider.GetRequiredService<DiffusionNexus.DataAccess.UnitOfWork.IUnitOfWork>();
+                        var packages = await uow.InstallerPackages.GetAllAsync();
+                        await folderRegistrar.EnsureRegisteredAsync(packages);
+                    }
+                    catch (Exception ex)
+                    {
+                        Serilog.Log.Warning(ex, "BaseModelFolderRegistrar backfill failed during startup.");
+                    }
                 });
             }
             else
@@ -608,6 +623,10 @@ public partial class App : Application
         services.AddScoped<DiffusionNexus.UI.Services.Diffusion.IModelFolderCatalog,
             DiffusionNexus.UI.Services.Diffusion.ModelFolderCatalog>();
 
+        // Auto-registers installation model folders (incl. extra_model_paths.yaml roots)
+        // as Base Model Folders — on package add and as startup backfill.
+        services.AddTransient<DiffusionNexus.UI.Services.Diffusion.BaseModelFolderRegistrar>();
+
         // GPU VRAM + system RAM monitor (reusable widget shown in the canvas and the Pipelines view).
         services.AddSingleton<IResourceMonitorService, ResourceMonitorService>();
         services.AddTransient<ResourceMonitorViewModel>();
@@ -879,7 +898,8 @@ public partial class App : Application
             sp.GetService<Inference.Captioning.CaptioningModelManager>(),
             sp.GetService<ICaptioningService>(),
             sp.GetService<IActivityLogService>(),
-            sp.GetService<IDownloadCoordinator>()));
+            sp.GetService<IDownloadCoordinator>(),
+            sp.GetService<Services.Diffusion.BaseModelFolderRegistrar>()));
         services.AddScoped<GenerationGalleryViewModel>(sp => new GenerationGalleryViewModel(
             sp.GetRequiredService<IAppSettingsService>(),
             sp.GetRequiredService<IDatasetEventAggregator>(),

--- a/DiffusionNexus.UI/App.axaml.cs
+++ b/DiffusionNexus.UI/App.axaml.cs
@@ -604,6 +604,10 @@ public partial class App : Application
         // Outputs folder registrar — ensures <exe-dir>/outputs/ is in the gallery list.
         services.AddTransient<DiffusionNexus.UI.Services.Diffusion.OutputsFolderRegistrar>();
 
+        // Base Model Folders: resolution authority for Core model download targets + search roots.
+        services.AddScoped<DiffusionNexus.UI.Services.Diffusion.IModelFolderCatalog,
+            DiffusionNexus.UI.Services.Diffusion.ModelFolderCatalog>();
+
         // GPU VRAM + system RAM monitor (reusable widget shown in the canvas and the Pipelines view).
         services.AddSingleton<IResourceMonitorService, ResourceMonitorService>();
         services.AddTransient<ResourceMonitorViewModel>();

--- a/DiffusionNexus.UI/DiffusionNexus.UI.csproj
+++ b/DiffusionNexus.UI/DiffusionNexus.UI.csproj
@@ -73,11 +73,11 @@
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="SkiaSharp" Version="3.119.4" />
     <PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.660" />
-    <PackageReference Include="DiffusionNexus.Installer.SDK.Models" Version="1.2.35" />
-    <PackageReference Include="DiffusionNexus.Installer.SDK.Services" Version="1.2.35" />
-    <PackageReference Include="DiffusionNexus.Installer.SDK.DataAccess" Version="1.2.35" />
-    <PackageReference Include="DiffusionNexus.Installer.SDK.Shared" Version="1.2.35" />
-    <PackageReference Include="DiffusionNexus.Installer.SDK.Database" Version="1.2.35" />
+    <PackageReference Include="DiffusionNexus.Installer.SDK.Models" Version="1.2.36" />
+    <PackageReference Include="DiffusionNexus.Installer.SDK.Services" Version="1.2.36" />
+    <PackageReference Include="DiffusionNexus.Installer.SDK.DataAccess" Version="1.2.36" />
+    <PackageReference Include="DiffusionNexus.Installer.SDK.Shared" Version="1.2.36" />
+    <PackageReference Include="DiffusionNexus.Installer.SDK.Database" Version="1.2.36" />
     <PackageReference Include="StableDiffusion.NET.Backend.Cuda12.Windows" Version="6.0.0" />
     <PackageReference Include="WeCantSpell.Hunspell" Version="7.0.1" />
     <!-- Pin transitive dependency to fix NU1903 (GHSA-xrw6-gwf8-vvr9) -->

--- a/DiffusionNexus.UI/Services/DialogService.cs
+++ b/DiffusionNexus.UI/Services/DialogService.cs
@@ -138,6 +138,15 @@ public class DialogService : IDialogService
         return dialog.Result;
     }
 
+    public async Task<RemoveInstallationResult> ShowRemoveInstallationDialogAsync(RemoveInstallationPrompt prompt)
+    {
+        var dialog = new RemoveInstallationDialog();
+        dialog.Configure(prompt);
+
+        await dialog.ShowDialog(_window);
+        return dialog.Result;
+    }
+
     public async Task<string?> ShowInputAsync(string title, string message, string? defaultValue = null)
     {
         var dialog = new TextInputDialog

--- a/DiffusionNexus.UI/Services/Diffusion/BaseModelFolderRegistrar.cs
+++ b/DiffusionNexus.UI/Services/Diffusion/BaseModelFolderRegistrar.cs
@@ -38,32 +38,45 @@ public sealed class BaseModelFolderRegistrar
     /// and package re-linking are handled by
     /// <see cref="IAppSettingsService.AddBaseModelFolderAsync(string, int?, CancellationToken)"/>.
     /// </summary>
-    public async Task RegisterPackageFoldersAsync(InstallerPackage package, CancellationToken cancellationToken = default)
+    /// <returns>How many folders were newly inserted (0 when everything already existed).</returns>
+    public async Task<int> RegisterPackageFoldersAsync(InstallerPackage package, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(package);
 
+        var added = 0;
         foreach (var root in ResolveModelRoots(package))
         {
-            await _settingsService
-                .AddBaseModelFolderAsync(root, package.Id, cancellationToken)
-                .ConfigureAwait(false);
-            Logger.Information("Registered base model folder {Root} for installation '{Name}'.", root, package.Name);
+            if (await _settingsService
+                    .AddBaseModelFolderAsync(root, package.Id, cancellationToken)
+                    .ConfigureAwait(false))
+            {
+                added++;
+                Logger.Information("Registered base model folder {Root} for installation '{Name}'.", root, package.Name);
+            }
         }
+
+        return added;
     }
 
     /// <summary>
     /// Startup backfill over all packages. Never throws — a registration failure must
     /// not block app startup.
     /// </summary>
-    public async Task EnsureRegisteredAsync(IEnumerable<InstallerPackage> packages, CancellationToken cancellationToken = default)
+    /// <returns>
+    /// How many folders were newly inserted across all packages. Callers should publish a
+    /// settings-saved notification when this is non-zero so an already-loaded Settings
+    /// page reloads its Base Model Folders list.
+    /// </returns>
+    public async Task<int> EnsureRegisteredAsync(IEnumerable<InstallerPackage> packages, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(packages);
 
+        var added = 0;
         foreach (var package in packages)
         {
             try
             {
-                await RegisterPackageFoldersAsync(package, cancellationToken).ConfigureAwait(false);
+                added += await RegisterPackageFoldersAsync(package, cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -74,6 +87,8 @@ public sealed class BaseModelFolderRegistrar
                 Logger.Warning(ex, "Failed to register base model folders for '{Name}'.", package.Name);
             }
         }
+
+        return added;
     }
 
     /// <summary>

--- a/DiffusionNexus.UI/Services/Diffusion/BaseModelFolderRegistrar.cs
+++ b/DiffusionNexus.UI/Services/Diffusion/BaseModelFolderRegistrar.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DiffusionNexus.Domain.Entities;
+using DiffusionNexus.Domain.Enums;
+using DiffusionNexus.Domain.Services;
+using Serilog;
+
+namespace DiffusionNexus.UI.Services.Diffusion;
+
+/// <summary>
+/// Auto-registers an installation's model folders as Base Model Folders — the same idea
+/// as the Generation Gallery link created for a package's output folder. ComfyUI installs
+/// contribute every root <see cref="ComfyUiPathDiscovery.EnumerateModelSearchPaths"/> finds
+/// (their own <c>models/</c>, every <c>extra_model_paths.yaml</c> root, and the portable
+/// sibling <c>models/</c>); other installer types contribute their plain
+/// <c>{InstallationPath}\models</c> folder when it exists.
+///
+/// Runs when a package is added in the Installer Manager and as an idempotent startup
+/// backfill for already-registered packages. Registration never claims the default flag.
+/// </summary>
+public sealed class BaseModelFolderRegistrar
+{
+    private static readonly ILogger Logger = Log.ForContext<BaseModelFolderRegistrar>();
+
+    private readonly IAppSettingsService _settingsService;
+
+    public BaseModelFolderRegistrar(IAppSettingsService settingsService)
+    {
+        _settingsService = settingsService ?? throw new ArgumentNullException(nameof(settingsService));
+    }
+
+    /// <summary>
+    /// Registers all model roots of one package. Idempotency (by path, case-insensitive)
+    /// and package re-linking are handled by
+    /// <see cref="IAppSettingsService.AddBaseModelFolderAsync(string, int?, CancellationToken)"/>.
+    /// </summary>
+    public async Task RegisterPackageFoldersAsync(InstallerPackage package, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(package);
+
+        foreach (var root in ResolveModelRoots(package))
+        {
+            await _settingsService
+                .AddBaseModelFolderAsync(root, package.Id, cancellationToken)
+                .ConfigureAwait(false);
+            Logger.Information("Registered base model folder {Root} for installation '{Name}'.", root, package.Name);
+        }
+    }
+
+    /// <summary>
+    /// Startup backfill over all packages. Never throws — a registration failure must
+    /// not block app startup.
+    /// </summary>
+    public async Task EnsureRegisteredAsync(IEnumerable<InstallerPackage> packages, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(packages);
+
+        foreach (var package in packages)
+        {
+            try
+            {
+                await RegisterPackageFoldersAsync(package, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(ex, "Failed to register base model folders for '{Name}'.", package.Name);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Resolves the model roots an installation contributes to the registry.
+    /// </summary>
+    internal static IReadOnlyList<string> ResolveModelRoots(InstallerPackage package)
+    {
+        if (string.IsNullOrWhiteSpace(package.InstallationPath) || !Directory.Exists(package.InstallationPath))
+        {
+            return [];
+        }
+
+        if (package.Type == InstallerType.ComfyUI)
+        {
+            return ComfyUiPathDiscovery.EnumerateModelSearchPaths(package.InstallationPath);
+        }
+
+        var modelsDir = Path.Combine(package.InstallationPath, "models");
+        return Directory.Exists(modelsDir) ? [modelsDir] : [];
+    }
+}

--- a/DiffusionNexus.UI/Services/Diffusion/IModelFolderCatalog.cs
+++ b/DiffusionNexus.UI/Services/Diffusion/IModelFolderCatalog.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DiffusionNexus.UI.Services.Diffusion;
+
+/// <summary>
+/// A selectable model storage root shown in download-target dropdowns.
+/// </summary>
+/// <param name="Path">Absolute folder path.</param>
+/// <param name="IsDefault">Whether this is the default download target.</param>
+/// <param name="Exists">Whether the directory currently exists on disk.</param>
+public sealed record ModelFolderOption(string Path, bool IsDefault, bool Exists)
+{
+    /// <summary>Dropdown display text.</summary>
+    public string Display => IsDefault ? $"{Path} (default)" : Path;
+}
+
+/// <summary>
+/// Resolution authority for the Base Model Folders registry: which folders a user can
+/// download Diffusion Nexus Core models into (and which one is the default), and which
+/// folders are scanned when looking models up. The registered ComfyUI installations'
+/// models folders are NOT part of this catalog — <c>LocalDiffusionBackendProvider</c>
+/// appends those separately so detection stays a superset of the pre-registry behavior.
+/// </summary>
+public interface IModelFolderCatalog
+{
+    /// <summary>
+    /// Dropdown items: enabled Base Model Folders with the default first; when none are
+    /// configured, exactly one entry — the LocalAppData fallback — flagged as default.
+    /// </summary>
+    Task<IReadOnlyList<ModelFolderOption>> GetDownloadTargetsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// The default download root (first download target). The directory is created on
+    /// demand; when creation fails the LocalAppData fallback is returned instead
+    /// (logged as a warning).
+    /// </summary>
+    Task<string> GetDefaultDownloadRootAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Folders to scan when looking up models: enabled Base Model Folders plus the
+    /// LocalAppData fallback — deduped case-insensitively, existing directories only.
+    /// </summary>
+    Task<IReadOnlyList<string>> GetSearchRootsAsync(CancellationToken cancellationToken = default);
+}

--- a/DiffusionNexus.UI/Services/Diffusion/LocalDiffusionBackendProvider.cs
+++ b/DiffusionNexus.UI/Services/Diffusion/LocalDiffusionBackendProvider.cs
@@ -82,10 +82,11 @@ public sealed class LocalDiffusionBackendProvider : IAsyncDisposable
         => _backend?.UnloadAllAsync(cancellationToken) ?? Task.CompletedTask;
 
     /// <summary>
-    /// Resolves the ComfyUI <c>models/</c> roots without constructing the (heavier) diffusion
-    /// backend or loading any native library. The first entry is the default ComfyUI installation
-    /// — the canonical download target for pipeline assets. Returns an empty list when no usable
-    /// ComfyUI installation is registered; callers should surface a friendly message in that case.
+    /// Resolves the model search roots without constructing the (heavier) diffusion backend or
+    /// loading any native library. Base Model Folders (including the LocalAppData fallback) come
+    /// first, followed by every registered ComfyUI installation's models roots. Download targets
+    /// are chosen via <see cref="IModelFolderCatalog"/>, not by position in this list. Returns an
+    /// empty list only when neither a base model folder nor a usable ComfyUI installation exists.
     /// </summary>
     public Task<IReadOnlyList<string>> GetComfyUiModelsRootsAsync(CancellationToken cancellationToken = default)
         => ResolveModelsRootsAsync(cancellationToken);
@@ -97,6 +98,25 @@ public sealed class LocalDiffusionBackendProvider : IAsyncDisposable
             // Use IUnitOfWork (same path as InstallerManagerViewModel). Repositories are NOT
             // registered directly in DI — they are only accessible through the Unit of Work.
             using var scope = _serviceProvider.CreateScope();
+
+            // Base Model Folders (incl. the LocalAppData fallback) come first: they are the
+            // preferred download targets, and prepending them here gives every consumer
+            // (pipeline readiness, LoRA lookups, local inference) the same superset view.
+            var catalogRoots = new List<string>();
+            try
+            {
+                var catalog = scope.ServiceProvider.GetRequiredService<IModelFolderCatalog>();
+                catalogRoots.AddRange(await catalog.GetSearchRootsAsync(ct).ConfigureAwait(false));
+                foreach (var root in catalogRoots)
+                {
+                    Logger.Information("Base model folder → models search root: {Root}", root);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(ex, "Failed to resolve base model folders; continuing with ComfyUI roots only.");
+            }
+
             var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
             var packages = await uow.InstallerPackages.GetAllAsync(ct).ConfigureAwait(false);
 
@@ -109,18 +129,18 @@ public sealed class LocalDiffusionBackendProvider : IAsyncDisposable
                 .ThenBy(p => p.Name)
                 .ToList();
 
-            if (comfyInstalls.Count == 0)
+            if (comfyInstalls.Count == 0 && catalogRoots.Count == 0)
             {
                 var typeCounts = packages.GroupBy(p => p.Type).Select(g => $"{g.Key}={g.Count()}").ToList();
                 Logger.Warning(
-                    "No ComfyUI installation found in database (looked for InstallerType.ComfyUI). " +
+                    "No base model folder and no ComfyUI installation found (looked for InstallerType.ComfyUI). " +
                     "Found: [{Types}]. The local diffusion backend uses the ComfyUI models folder layout " +
                     "but does NOT run ComfyUI — it generates locally on your GPU.",
                     string.Join(", ", typeCounts));
                 return [];
             }
 
-            var roots = new List<string>();
+            var roots = new List<string>(catalogRoots);
             foreach (var pkg in comfyInstalls)
             {
                 foreach (var root in ResolveRootsForPackage(pkg))

--- a/DiffusionNexus.UI/Services/Diffusion/ModelFolderCatalog.cs
+++ b/DiffusionNexus.UI/Services/Diffusion/ModelFolderCatalog.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DiffusionNexus.Domain.Services;
+using Serilog;
+
+namespace DiffusionNexus.UI.Services.Diffusion;
+
+/// <inheritdoc cref="IModelFolderCatalog"/>
+public sealed class ModelFolderCatalog : IModelFolderCatalog
+{
+    private static readonly ILogger Logger = Log.ForContext<ModelFolderCatalog>();
+
+    private readonly IAppSettingsService _settingsService;
+
+    /// <summary>
+    /// Built-in model storage root used when no Base Model Folder is configured:
+    /// <c>%LOCALAPPDATA%\DiffusionNexus\Models</c>.
+    /// </summary>
+    public static string FallbackRoot { get; } = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "DiffusionNexus", "Models");
+
+    public ModelFolderCatalog(IAppSettingsService settingsService)
+    {
+        _settingsService = settingsService ?? throw new ArgumentNullException(nameof(settingsService));
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<ModelFolderOption>> GetDownloadTargetsAsync(CancellationToken cancellationToken = default)
+    {
+        var folders = await _settingsService
+            .GetEnabledBaseModelFoldersAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (folders.Count == 0)
+        {
+            return [new ModelFolderOption(FallbackRoot, IsDefault: true, Directory.Exists(FallbackRoot))];
+        }
+
+        // Default first, then the remaining rows in their configured order.
+        // When no row is flagged, the first enabled row acts as the default.
+        var ordered = folders
+            .OrderByDescending(f => f.IsDefault)
+            .ThenBy(f => f.Order)
+            .ToList();
+
+        return ordered
+            .Select((f, index) => new ModelFolderOption(
+                f.FolderPath,
+                IsDefault: index == 0,
+                Directory.Exists(f.FolderPath)))
+            .ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task<string> GetDefaultDownloadRootAsync(CancellationToken cancellationToken = default)
+    {
+        var targets = await GetDownloadTargetsAsync(cancellationToken).ConfigureAwait(false);
+        var root = targets[0].Path;
+
+        try
+        {
+            Directory.CreateDirectory(root);
+            return root;
+        }
+        catch (Exception ex)
+        {
+            Logger.Warning(ex,
+                "Default model folder {Root} cannot be created — falling back to {Fallback}",
+                root, FallbackRoot);
+            Directory.CreateDirectory(FallbackRoot);
+            return FallbackRoot;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<string>> GetSearchRootsAsync(CancellationToken cancellationToken = default)
+    {
+        var folders = await _settingsService
+            .GetEnabledBaseModelFoldersAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var roots = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var path in folders.OrderByDescending(f => f.IsDefault).ThenBy(f => f.Order).Select(f => f.FolderPath)
+                     .Append(FallbackRoot))
+        {
+            if (string.IsNullOrWhiteSpace(path) || !seen.Add(path))
+                continue;
+
+            if (Directory.Exists(path))
+                roots.Add(path);
+        }
+
+        return roots;
+    }
+}

--- a/DiffusionNexus.UI/Services/Diffusion/ModelFolderCatalog.cs
+++ b/DiffusionNexus.UI/Services/Diffusion/ModelFolderCatalog.cs
@@ -48,12 +48,21 @@ public sealed class ModelFolderCatalog : IModelFolderCatalog
             .ThenBy(f => f.Order)
             .ToList();
 
-        return ordered
+        var targets = ordered
             .Select((f, index) => new ModelFolderOption(
                 f.FolderPath,
                 IsDefault: index == 0,
                 Directory.Exists(f.FolderPath)))
             .ToList();
+
+        // The app's own folder is always selectable, even when other folders are
+        // registered — it just never claims the default from a configured row.
+        if (!targets.Any(t => string.Equals(t.Path, FallbackRoot, StringComparison.OrdinalIgnoreCase)))
+        {
+            targets.Add(new ModelFolderOption(FallbackRoot, IsDefault: false, Directory.Exists(FallbackRoot)));
+        }
+
+        return targets;
     }
 
     /// <inheritdoc />

--- a/DiffusionNexus.UI/Services/IDialogService.cs
+++ b/DiffusionNexus.UI/Services/IDialogService.cs
@@ -324,6 +324,15 @@ public interface IDialogService
     Task<AddExistingInstallationResult> ShowAddExistingInstallationDialogAsync(string initialPath);
 
     /// <summary>
+    /// Shows the remove-installation confirmation with checkboxes offering to also
+    /// remove the settings folders linked to the installation (Generation Gallery,
+    /// LoRA sources, Base Model Folders).
+    /// </summary>
+    /// <param name="prompt">Installation name and its linked settings folders.</param>
+    /// <returns>The user's choice, or cancelled.</returns>
+    Task<RemoveInstallationResult> ShowRemoveInstallationDialogAsync(RemoveInstallationPrompt prompt);
+
+    /// <summary>
     /// Shows the installation dialog in edit mode with pre-filled values.
     /// </summary>
     Task<AddExistingInstallationResult> ShowEditInstallationDialogAsync(

--- a/DiffusionNexus.UI/Services/InstallationSettingsCleanup.cs
+++ b/DiffusionNexus.UI/Services/InstallationSettingsCleanup.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DiffusionNexus.Domain.Entities;
+
+namespace DiffusionNexus.UI.Services;
+
+/// <summary>
+/// Resolves which settings rows belong to an installation that is being removed from
+/// the Installer Manager, so the remove dialog can offer to clean them up:
+/// Generation Galleries are matched by their <c>InstallerPackageId</c> FK (the add flow
+/// always links them, and an output folder can live anywhere on disk); LoRA sources
+/// have no FK and are matched by living underneath the installation path; Base Model
+/// Folders match by this package's FK <em>or</em> by unclaimed path (FK null) — rows
+/// registered for a DIFFERENT installation are never swept, and neither are
+/// <paramref name="protectedRoots"/>: model roots another registered installation
+/// still discovers (their startup backfill would silently resurrect the row,
+/// contradicting the dialog's "no longer scanned" promise).
+/// </summary>
+public static class InstallationSettingsCleanup
+{
+    /// <summary>The settings rows associated with one installation.</summary>
+    public sealed record Plan(
+        IReadOnlyList<ImageGallery> Galleries,
+        IReadOnlyList<LoraSource> LoraSources,
+        IReadOnlyList<BaseModelFolder> BaseModelFolders)
+    {
+        /// <summary>True when the installation has no linked settings rows at all.</summary>
+        public bool IsEmpty => Galleries.Count == 0 && LoraSources.Count == 0 && BaseModelFolders.Count == 0;
+    }
+
+    /// <summary>Resolves the rows tied to <paramref name="package"/>.</summary>
+    /// <param name="settings">Settings graph including the three folder collections.</param>
+    /// <param name="package">The installation being removed.</param>
+    /// <param name="protectedRoots">
+    /// Model roots still discoverable from OTHER registered installations
+    /// (<see cref="Diffusion.BaseModelFolderRegistrar.ResolveModelRoots"/> over the
+    /// remaining packages); base folder rows on these paths are kept.
+    /// </param>
+    public static Plan Resolve(
+        AppSettings settings,
+        InstallerPackage package,
+        IReadOnlyCollection<string>? protectedRoots = null)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(package);
+
+        var protectedNormalized = (protectedRoots ?? [])
+            .Select(NormalizePath)
+            .Where(p => p is not null)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var galleries = settings.ImageGalleries
+            .Where(g => g.InstallerPackageId == package.Id)
+            .ToList();
+
+        var loraSources = settings.LoraSources
+            .Where(s => IsUnderInstallation(s.FolderPath, package.InstallationPath))
+            .ToList();
+
+        var baseModelFolders = settings.BaseModelFolders
+            .Where(f => f.InstallerPackageId == package.Id
+                        || (f.InstallerPackageId is null
+                            && IsUnderInstallation(f.FolderPath, package.InstallationPath)))
+            .Where(f => NormalizePath(f.FolderPath) is not { } normalized
+                        || !protectedNormalized.Contains(normalized))
+            .ToList();
+
+        return new Plan(galleries, loraSources, baseModelFolders);
+    }
+
+    /// <summary>Full, trailing-separator-free form of a path; null when invalid.</summary>
+    private static string? NormalizePath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            return Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// True when <paramref name="folderPath"/> equals or lies underneath
+    /// <paramref name="installationPath"/> (case-insensitive, separator-tolerant).
+    /// Invalid paths never match.
+    /// </summary>
+    internal static bool IsUnderInstallation(string? folderPath, string? installationPath)
+    {
+        if (string.IsNullOrWhiteSpace(folderPath) || string.IsNullOrWhiteSpace(installationPath))
+        {
+            return false;
+        }
+
+        string candidate;
+        string root;
+        try
+        {
+            candidate = Path.TrimEndingDirectorySeparator(Path.GetFullPath(folderPath));
+            root = Path.TrimEndingDirectorySeparator(Path.GetFullPath(installationPath));
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+
+        return candidate.Equals(root, StringComparison.OrdinalIgnoreCase)
+               || candidate.StartsWith(root + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)
+               || candidate.StartsWith(root + Path.AltDirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/DiffusionNexus.UI/Services/Pipelines/IPipelineAssetInstaller.cs
+++ b/DiffusionNexus.UI/Services/Pipelines/IPipelineAssetInstaller.cs
@@ -36,14 +36,17 @@ public interface IPipelineAssetInstaller
     Task<PipelineReadiness> CheckAsync(PipelineManifest manifest, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Downloads every currently-missing asset for <paramref name="manifest"/> into the primary
-    /// models root, selecting the diffusion-model variant that fits <paramref name="vramGb"/>.
+    /// Downloads every currently-missing asset for <paramref name="manifest"/> into
+    /// <paramref name="downloadRoot"/> (a Base Model Folder chosen by the caller — e.g. the
+    /// workload window's dropdown selection or <see cref="Diffusion.IModelFolderCatalog.GetDefaultDownloadRootAsync"/>),
+    /// selecting the diffusion-model variant that fits <paramref name="vramGb"/>.
     /// Each download is routed through the download coordinator (status-bar progress + cancel).
-    /// Returns the readiness re-computed (across all roots) after install.
+    /// Returns the readiness re-computed (across all search roots) after install.
     /// </summary>
     Task<PipelineReadiness> InstallMissingAsync(
         PipelineManifest manifest,
         int vramGb,
+        string downloadRoot,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/DiffusionNexus.UI/Services/Pipelines/PipelineAssetInstaller.cs
+++ b/DiffusionNexus.UI/Services/Pipelines/PipelineAssetInstaller.cs
@@ -95,23 +95,22 @@ public sealed class PipelineAssetInstaller : IPipelineAssetInstaller, IDisposabl
     public async Task<PipelineReadiness> InstallMissingAsync(
         PipelineManifest manifest,
         int vramGb,
+        string downloadRoot,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(manifest);
+        ArgumentException.ThrowIfNullOrWhiteSpace(downloadRoot);
 
+        // Existing copies anywhere in the search roots (Base Model Folders, the LocalAppData
+        // fallback, and every ComfyUI models tree) still count as present — only genuinely
+        // missing assets are downloaded, and they land in the caller-chosen root.
         var roots = await _backendProvider.GetComfyUiModelsRootsAsync(cancellationToken).ConfigureAwait(false);
-        if (roots.Count == 0)
-            throw new InvalidOperationException(
-                "No ComfyUI installation is registered, so there is no models folder to download into.");
 
         var before = await ComputeReadinessAsync(manifest, roots, cancellationToken).ConfigureAwait(false);
         var missing = before.Missing.Select(m => m.Name).ToHashSet(StringComparer.Ordinal);
         if (missing.Count == 0)
             return before;
 
-        // New downloads land in the primary (default) install's models tree; existing copies in
-        // other roots (e.g. an extra_model_paths library) are still detected by the check above.
-        var downloadRoot = roots[0];
         var hfToken = await _settings.GetHuggingfaceApiKeyAsync(cancellationToken).ConfigureAwait(false);
         var civitaiKey = await _settings.GetCivitaiApiKeyAsync(cancellationToken).ConfigureAwait(false);
 

--- a/DiffusionNexus.UI/Services/RemoveInstallationResult.cs
+++ b/DiffusionNexus.UI/Services/RemoveInstallationResult.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+namespace DiffusionNexus.UI.Services;
+
+/// <summary>
+/// Input for the remove-installation dialog: the installation's display name plus the
+/// settings folders linked to it (resolved via
+/// <see cref="InstallationSettingsCleanup.Resolve"/>). Empty lists disable the
+/// corresponding cleanup checkbox.
+/// </summary>
+public sealed record RemoveInstallationPrompt(
+    string InstallationName,
+    IReadOnlyList<string> GalleryFolders,
+    IReadOnlyList<string> LoraSourceFolders,
+    IReadOnlyList<string> BaseModelFolders);
+
+/// <summary>
+/// Result of the remove-installation dialog: whether the user confirmed the removal
+/// and which linked settings rows should be removed along with the installation.
+/// </summary>
+public sealed record RemoveInstallationResult(
+    bool Confirmed,
+    bool RemoveGalleries,
+    bool RemoveLoraSources,
+    bool RemoveBaseModelFolders)
+{
+    public static RemoveInstallationResult Cancelled() => new(false, false, false, false);
+}

--- a/DiffusionNexus.UI/ViewModels/CoreWorkloadsViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/CoreWorkloadsViewModel.cs
@@ -31,9 +31,23 @@ public partial class CoreWorkloadsViewModel : ViewModelBase
 
     private readonly IPipelineManifestProvider? _manifestProvider;
     private readonly IPipelineAssetInstaller? _installer;
+    private readonly Services.Diffusion.IModelFolderCatalog? _modelFolderCatalog;
 
     /// <summary>Pipeline workload rows shown on the "Pipelines" tab.</summary>
     public ObservableCollection<WorkloadItemViewModel> Pipelines { get; } = [];
+
+    /// <summary>
+    /// Selectable download targets (Base Model Folders; the LocalAppData fallback when
+    /// none are configured). Shown in the window's "Download to:" dropdown.
+    /// </summary>
+    public ObservableCollection<Services.Diffusion.ModelFolderOption> DownloadTargets { get; } = [];
+
+    /// <summary>
+    /// The download target chosen for installs started from this window. Per-window only —
+    /// changing it does not touch the ⭐ default in Settings.
+    /// </summary>
+    [ObservableProperty]
+    private Services.Diffusion.ModelFolderOption? _selectedDownloadTarget;
 
     /// <summary>Backing ViewModel for the "Captioning Models" tab.</summary>
     public CaptioningModelsDialogViewModel Captioning { get; }
@@ -44,17 +58,70 @@ public partial class CoreWorkloadsViewModel : ViewModelBase
     public CoreWorkloadsViewModel(
         CaptioningModelsDialogViewModel captioning,
         IPipelineManifestProvider? manifestProvider,
-        IPipelineAssetInstaller? installer)
+        IPipelineAssetInstaller? installer,
+        Services.Diffusion.IModelFolderCatalog? modelFolderCatalog = null)
     {
         Captioning = captioning ?? throw new ArgumentNullException(nameof(captioning));
         _manifestProvider = manifestProvider;
         _installer = installer;
+        _modelFolderCatalog = modelFolderCatalog;
+    }
+
+    /// <summary>
+    /// Fills the "Download to:" dropdown from the model folder catalog and preselects
+    /// the default target.
+    /// </summary>
+    private async Task LoadDownloadTargetsAsync()
+    {
+        if (_modelFolderCatalog is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var targets = await _modelFolderCatalog.GetDownloadTargetsAsync();
+
+            DownloadTargets.Clear();
+            foreach (var target in targets)
+            {
+                DownloadTargets.Add(target);
+            }
+
+            SelectedDownloadTarget = DownloadTargets.FirstOrDefault(t => t.IsDefault)
+                ?? DownloadTargets.FirstOrDefault();
+        }
+        catch (Exception ex)
+        {
+            Serilog.Log.Warning(ex, "Failed to load base model folder download targets.");
+        }
+    }
+
+    /// <summary>
+    /// Resolves the download root for pipeline installs: the window's dropdown selection
+    /// when available, else the catalog default, else the LocalAppData fallback.
+    /// </summary>
+    private async Task<string> ResolveDownloadRootAsync(CancellationToken ct)
+    {
+        if (SelectedDownloadTarget is { } selected)
+        {
+            return selected.Path;
+        }
+
+        if (_modelFolderCatalog is not null)
+        {
+            return await _modelFolderCatalog.GetDefaultDownloadRootAsync(ct);
+        }
+
+        return Services.Diffusion.ModelFolderCatalog.FallbackRoot;
     }
 
     /// <summary>Builds the pipeline rows and checks each one's on-disk readiness.</summary>
     [RelayCommand]
     private async Task LoadAsync()
     {
+        await LoadDownloadTargetsAsync();
+
         if (_manifestProvider is null || _installer is null)
         {
             return;
@@ -219,7 +286,8 @@ public partial class CoreWorkloadsViewModel : ViewModelBase
                 Message = $"Installing assets for {manifest.Title}… (download progress is shown in the status bar)"
             });
 
-            var result = await _installer.InstallMissingAsync(manifest, vramGb, ct);
+            var downloadRoot = await ResolveDownloadRootAsync(ct);
+            var result = await _installer.InstallMissingAsync(manifest, vramGb, downloadRoot, ct);
 
             foreach (var asset in result.Assets)
             {

--- a/DiffusionNexus.UI/ViewModels/InstallerManagerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/InstallerManagerViewModel.cs
@@ -35,6 +35,7 @@ public partial class InstallerManagerViewModel : ViewModelBase
     private readonly ICaptioningService? _captioningService;
     private readonly IActivityLogService? _activityLogService;
     private readonly IDownloadCoordinator? _downloadCoordinator;
+    private readonly Services.Diffusion.BaseModelFolderRegistrar? _baseModelFolderRegistrar;
 
     /// <summary>
     /// Raised when the unified console panel should be opened (e.g., during an update).
@@ -76,7 +77,8 @@ public partial class InstallerManagerViewModel : ViewModelBase
         DiffusionNexus.Inference.Captioning.CaptioningModelManager? captioningModelManager = null,
         ICaptioningService? captioningService = null,
         IActivityLogService? activityLogService = null,
-        IDownloadCoordinator? downloadCoordinator = null)
+        IDownloadCoordinator? downloadCoordinator = null,
+        Services.Diffusion.BaseModelFolderRegistrar? baseModelFolderRegistrar = null)
     {
         _dialogService = dialogService;
         _unitOfWork = unitOfWork;
@@ -91,6 +93,7 @@ public partial class InstallerManagerViewModel : ViewModelBase
         _captioningService = captioningService;
         _activityLogService = activityLogService;
         _downloadCoordinator = downloadCoordinator;
+        _baseModelFolderRegistrar = baseModelFolderRegistrar;
 
         InstallerCards.CollectionChanged += (_, _) => OnPropertyChanged(nameof(IsEmpty));
 
@@ -173,6 +176,14 @@ public partial class InstallerManagerViewModel : ViewModelBase
 
                 // Notify other components (Settings dialog, Generation Gallery) about the new gallery
                 _eventAggregator.PublishSettingsSaved(new SettingsSavedEventArgs());
+            }
+
+            // Register the installation's model folders as Base Model Folders
+            // (for ComfyUI this includes every extra_model_paths.yaml root).
+            // Non-fatal by design — EnsureRegisteredAsync logs and swallows failures.
+            if (_baseModelFolderRegistrar is not null)
+            {
+                await _baseModelFolderRegistrar.EnsureRegisteredAsync([package]);
             }
 
             var card = CreateCard(package);

--- a/DiffusionNexus.UI/ViewModels/InstallerManagerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/InstallerManagerViewModel.cs
@@ -181,9 +181,11 @@ public partial class InstallerManagerViewModel : ViewModelBase
             // Register the installation's model folders as Base Model Folders
             // (for ComfyUI this includes every extra_model_paths.yaml root).
             // Non-fatal by design — EnsureRegisteredAsync logs and swallows failures.
-            if (_baseModelFolderRegistrar is not null)
+            if (_baseModelFolderRegistrar is not null
+                && await _baseModelFolderRegistrar.EnsureRegisteredAsync([package]) > 0)
             {
-                await _baseModelFolderRegistrar.EnsureRegisteredAsync([package]);
+                // Let an open Settings page reload its Base Model Folders list.
+                _eventAggregator.PublishSettingsSaved(new SettingsSavedEventArgs());
             }
 
             var card = CreateCard(package);

--- a/DiffusionNexus.UI/ViewModels/InstallerManagerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/InstallerManagerViewModel.cs
@@ -640,7 +640,8 @@ public partial class InstallerManagerViewModel : ViewModelBase
             var coreVm = new CoreWorkloadsViewModel(
                 captioningVm,
                 App.Services?.GetService<Services.Pipelines.IPipelineManifestProvider>(),
-                App.Services?.GetService<Services.Pipelines.IPipelineAssetInstaller>());
+                App.Services?.GetService<Services.Pipelines.IPipelineAssetInstaller>(),
+                App.Services?.GetService<Services.Diffusion.IModelFolderCatalog>());
             await coreVm.LoadCommand.ExecuteAsync(null);
 
             var dialog = new Views.Dialogs.CoreWorkloadsDialog

--- a/DiffusionNexus.UI/ViewModels/InstallerManagerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/InstallerManagerViewModel.cs
@@ -24,6 +24,16 @@ public partial class InstallerManagerViewModel : ViewModelBase
 {
     private readonly IDialogService _dialogService;
     private readonly IUnitOfWork _unitOfWork;
+
+    /// <summary>
+    /// Creates a fresh unit of work (own DbContext) for one destructive operation.
+    /// The VM's shared <see cref="_unitOfWork"/> lives for the whole app session, so
+    /// its identity map goes stale (rows deleted/edited elsewhere linger) and a failed
+    /// save would leave poisoned Deleted-state entries that a later unrelated save
+    /// replays. Null in tests that pass only the shared instance.
+    /// </summary>
+    private readonly Func<IUnitOfWork>? _unitOfWorkFactory;
+
     private readonly PackageProcessManager _processManager;
     private readonly IDatasetEventAggregator _eventAggregator;
     private readonly IConfigurationRepository _configurationRepository;
@@ -78,10 +88,12 @@ public partial class InstallerManagerViewModel : ViewModelBase
         ICaptioningService? captioningService = null,
         IActivityLogService? activityLogService = null,
         IDownloadCoordinator? downloadCoordinator = null,
-        Services.Diffusion.BaseModelFolderRegistrar? baseModelFolderRegistrar = null)
+        Services.Diffusion.BaseModelFolderRegistrar? baseModelFolderRegistrar = null,
+        Func<IUnitOfWork>? unitOfWorkFactory = null)
     {
         _dialogService = dialogService;
         _unitOfWork = unitOfWork;
+        _unitOfWorkFactory = unitOfWorkFactory;
         _processManager = processManager;
         _eventAggregator = eventAggregator;
         _configurationRepository = configurationRepository;
@@ -355,6 +367,13 @@ public partial class InstallerManagerViewModel : ViewModelBase
         await _processManager.RestartAsync(card.Id);
     }
 
+    /// <summary>
+    /// Rents a unit of work for one destructive operation — fresh (owned, must be
+    /// disposed) when a factory is available, the shared instance otherwise.
+    /// </summary>
+    private (IUnitOfWork UnitOfWork, bool Owned) RentUnitOfWork() =>
+        _unitOfWorkFactory is null ? (_unitOfWork, false) : (_unitOfWorkFactory(), true);
+
     private async Task OnRemoveRequestedAsync(InstallerPackageCardViewModel card)
     {
         if (_processManager.IsRunning(card.Id))
@@ -363,34 +382,98 @@ public partial class InstallerManagerViewModel : ViewModelBase
             return;
         }
 
-        var confirmed = await _dialogService.ShowConfirmAsync(
-            "Remove Installation",
-            $"Remove \"{card.Name}\" from the Installer Manager?\n\nThis will NOT delete any files on disk.");
-
-        if (!confirmed) return;
-
+        var (unitOfWork, owned) = RentUnitOfWork();
         try
         {
-            var entity = await _unitOfWork.InstallerPackages.GetByIdAsync(card.Id);
-            if (entity is not null)
+            var entity = await unitOfWork.InstallerPackages.GetByIdAsync(card.Id);
+            if (entity is null)
             {
-                _unitOfWork.InstallerPackages.Remove(entity);
-                await _unitOfWork.SaveChangesAsync();
+                // Stale card without a DB row — nothing to clean up, just drop it.
+                InstallerCards.Remove(card);
+                return;
             }
 
-            InstallerCards.Remove(card);
+            // Model roots other registered installations still discover must never be
+            // offered for removal — their startup backfill would silently re-add them.
+            // ResolveModelRoots reads extra_model_paths.yaml files: keep it off the UI thread.
+            var allPackages = await unitOfWork.InstallerPackages.GetAllAsync();
+            var otherPackages = allPackages.Where(p => p.Id != entity.Id).ToList();
+            var protectedRoots = await Task.Run(() => otherPackages
+                .SelectMany(Services.Diffusion.BaseModelFolderRegistrar.ResolveModelRoots)
+                .ToList());
 
-            _unifiedLogger.Info(LogCategory.Installation, card.Name,
-                "Removed from Installer Manager. Files on disk were left untouched.");
+            // Resolve the settings folders tied to this installation so the dialog can
+            // offer to remove them too (galleries/base folders by FK, LoRA sources by path).
+            var settings = await unitOfWork.AppSettings.GetSettingsWithIncludesAsync();
+            var plan = InstallationSettingsCleanup.Resolve(settings, entity, protectedRoots);
 
-            _eventAggregator.PublishInstallerPackagesChanged(new InstallerPackagesChangedEventArgs());
+            var choice = await _dialogService.ShowRemoveInstallationDialogAsync(new RemoveInstallationPrompt(
+                card.Name,
+                plan.Galleries.Select(g => g.FolderPath).ToList(),
+                plan.LoraSources.Select(s => s.FolderPath).ToList(),
+                plan.BaseModelFolders.Select(f => f.FolderPath).ToList()));
+
+            if (!choice.Confirmed) return;
+
+            try
+            {
+                var removedFolders = 0;
+                if (choice.RemoveGalleries)
+                {
+                    foreach (var gallery in plan.Galleries)
+                    {
+                        unitOfWork.AppSettings.RemoveImageGallery(gallery);
+                        removedFolders++;
+                    }
+                }
+                if (choice.RemoveLoraSources)
+                {
+                    foreach (var source in plan.LoraSources)
+                    {
+                        unitOfWork.AppSettings.RemoveLoraSource(source);
+                        removedFolders++;
+                    }
+                }
+                if (choice.RemoveBaseModelFolders)
+                {
+                    foreach (var folder in plan.BaseModelFolders)
+                    {
+                        unitOfWork.AppSettings.RemoveBaseModelFolder(folder);
+                        removedFolders++;
+                    }
+                }
+
+                unitOfWork.InstallerPackages.Remove(entity);
+                await unitOfWork.SaveChangesAsync();
+
+                InstallerCards.Remove(card);
+
+                _unifiedLogger.Info(LogCategory.Installation, card.Name,
+                    removedFolders > 0
+                        ? $"Removed from Installer Manager together with {removedFolders} linked settings folder(s). Files on disk were left untouched."
+                        : "Removed from Installer Manager. Files on disk were left untouched.");
+
+                if (removedFolders > 0)
+                {
+                    // Let the Settings page / galleries / LoRA viewer reload their folder lists.
+                    _eventAggregator.PublishSettingsSaved(new SettingsSavedEventArgs());
+                }
+
+                _eventAggregator.PublishInstallerPackagesChanged(new InstallerPackagesChangedEventArgs());
+            }
+            catch (Exception ex)
+            {
+                Serilog.Log.Error(ex, "Failed to remove installation {Name}", card.Name);
+                _unifiedLogger.Error(LogCategory.Installation, card.Name,
+                    $"Failed to remove installation: {ex.Message}", ex);
+                await _dialogService.ShowMessageAsync("Error", $"Failed to remove installation: {ex.Message}");
+            }
         }
-        catch (Exception ex)
+        finally
         {
-            Serilog.Log.Error(ex, "Failed to remove installation {Name}", card.Name);
-            _unifiedLogger.Error(LogCategory.Installation, card.Name,
-                $"Failed to remove installation: {ex.Message}", ex);
-            await _dialogService.ShowMessageAsync("Error", $"Failed to remove installation: {ex.Message}");
+            // Owned = fresh context; disposing on failure also discards any staged
+            // deletes so no later unrelated save can replay them.
+            if (owned) unitOfWork.Dispose();
         }
     }
 
@@ -461,19 +544,44 @@ public partial class InstallerManagerViewModel : ViewModelBase
             "Delete from Disk",
             $"Are you sure you want to permanently delete \"{card.Name}\"?\n\n" +
             $"Path: {card.InstallationPath}\n\n" +
-            "This will delete the folder on your hard drive including models and generated images.\n\n" +
+            "This will delete the folder on your hard drive including models and generated images. " +
+            "Settings folders that live in it (gallery, LoRA sources, base model folders) are removed from the settings as well.\n\n" +
             "⚠ This action CANNOT be undone.");
 
         if (!confirmed) return;
 
+        var (unitOfWork, owned) = RentUnitOfWork();
         try
         {
-            // Remove from database first
-            var entity = await _unitOfWork.InstallerPackages.GetByIdAsync(card.Id);
+            // Remove from database first — including the settings rows tied to this
+            // installation: their folders cease to exist, so unlike the plain remove
+            // flow there is no choice to offer (dead rows would only linger as ⚠
+            // badges and dangling scan/download targets).
+            var removedFolders = 0;
+            var entity = await unitOfWork.InstallerPackages.GetByIdAsync(card.Id);
             if (entity is not null)
             {
-                _unitOfWork.InstallerPackages.Remove(entity);
-                await _unitOfWork.SaveChangesAsync();
+                var settings = await unitOfWork.AppSettings.GetSettingsWithIncludesAsync();
+                var plan = InstallationSettingsCleanup.Resolve(settings, entity);
+
+                foreach (var gallery in plan.Galleries)
+                {
+                    unitOfWork.AppSettings.RemoveImageGallery(gallery);
+                    removedFolders++;
+                }
+                foreach (var source in plan.LoraSources)
+                {
+                    unitOfWork.AppSettings.RemoveLoraSource(source);
+                    removedFolders++;
+                }
+                foreach (var folder in plan.BaseModelFolders)
+                {
+                    unitOfWork.AppSettings.RemoveBaseModelFolder(folder);
+                    removedFolders++;
+                }
+
+                unitOfWork.InstallerPackages.Remove(entity);
+                await unitOfWork.SaveChangesAsync();
             }
 
             InstallerCards.Remove(card);
@@ -487,7 +595,14 @@ public partial class InstallerManagerViewModel : ViewModelBase
             }
 
             _unifiedLogger.Info(LogCategory.Installation, card.Name,
-                $"Deleted installation and removed folder {card.InstallationPath}.");
+                removedFolders > 0
+                    ? $"Deleted installation, removed folder {card.InstallationPath} and {removedFolders} linked settings folder(s)."
+                    : $"Deleted installation and removed folder {card.InstallationPath}.");
+
+            if (removedFolders > 0)
+            {
+                _eventAggregator.PublishSettingsSaved(new SettingsSavedEventArgs());
+            }
 
             _eventAggregator.PublishInstallerPackagesChanged(new InstallerPackagesChangedEventArgs());
         }
@@ -497,6 +612,10 @@ public partial class InstallerManagerViewModel : ViewModelBase
             _unifiedLogger.Error(LogCategory.Installation, card.Name,
                 $"Failed to delete from disk: {ex.Message}", ex);
             await _dialogService.ShowMessageAsync("Error", $"Failed to delete: {ex.Message}\n\nSome files may have been partially removed.");
+        }
+        finally
+        {
+            if (owned) unitOfWork.Dispose();
         }
     }
 

--- a/DiffusionNexus.UI/ViewModels/PipelinesViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/PipelinesViewModel.cs
@@ -112,7 +112,7 @@ public partial class PipelinesViewModel : ViewModelBase
 
             if (root is null)
             {
-                SetStatus(tile, PipelineStatus.NotInstalled, "No ComfyUI install");
+                SetStatus(tile, PipelineStatus.NotInstalled, "No model folder yet");
                 continue;
             }
 
@@ -191,10 +191,10 @@ public partial class PipelinesViewModel : ViewModelBase
             var root = await _installer.ResolveModelsRootAsync();
             if (string.IsNullOrEmpty(root))
             {
-                await ShowMessageAsync("No ComfyUI installation",
-                    "Pipeline models live in a ComfyUI installation's models folder (which the local renderer also reads).\n\n" +
-                    "Add a ComfyUI installation in the Installer Manager first, then try again.");
-                SetStatus(tile, PipelineStatus.NotInstalled, "No ComfyUI install");
+                await ShowMessageAsync("No model folder",
+                    "Pipeline models live in a Base Model Folder (configurable in Settings) or a ComfyUI installation's models folder.\n\n" +
+                    "Install this workload's models via Installer Manager → Diffusion Nexus Core → Workloads, then try again.");
+                SetStatus(tile, PipelineStatus.NotInstalled, "No model folder yet");
                 return;
             }
 

--- a/DiffusionNexus.UI/ViewModels/SettingsViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/SettingsViewModel.cs
@@ -408,6 +408,9 @@ public partial class SettingsViewModel : BusyViewModelBase
 
         // Check ComfyUI server connectivity in the background
         _ = TestComfyUiConnectionAsync();
+
+        // Compute the ⚠ folder-presence badges off-thread; never gates startup.
+        _ = RefreshFolderPresenceAsync();
     }
 
     /// <summary>
@@ -485,6 +488,9 @@ public partial class SettingsViewModel : BusyViewModelBase
 
         // Reload Base Model Folders
         ReloadBaseModelFolders(settings);
+
+        // Re-check the ⚠ folder-presence badges off-thread.
+        _ = RefreshFolderPresenceAsync();
     }
 
     /// <summary>
@@ -512,6 +518,69 @@ public partial class SettingsViewModel : BusyViewModelBase
             folderVm.SourceChanged += OnBaseModelFolderChanged;
             folderVm.DefaultSelected += OnBaseModelFolderDefaultSelected;
             BaseModelFolders.Add(folderVm);
+        }
+    }
+
+    /// <summary>
+    /// Debounce for the presence re-check triggered by row edits (the path TextBoxes
+    /// update per keystroke). Internal so tests can shorten it.
+    /// </summary>
+    internal TimeSpan PresenceRefreshDebounce { get; set; } = TimeSpan.FromMilliseconds(500);
+
+    private CancellationTokenSource? _presenceRefreshCts;
+
+    /// <summary>
+    /// Re-checks disk presence (⚠ badge) for every folder row in the LoRA source,
+    /// Generation Gallery, and Base Model Folder lists. The <c>Directory.Exists</c>
+    /// probes run on the thread pool — a configured-but-offline network share blocks
+    /// for the SMB timeout (~20s per dead host), which must never stall the UI
+    /// thread. Runs after (re)load, each time the Settings view is shown, and
+    /// debounced after row edits.
+    /// </summary>
+    public async Task RefreshFolderPresenceAsync(CancellationToken cancellationToken = default)
+    {
+        var rows = LoraSources.Cast<IFolderPresenceRow>()
+            .Concat(ImageGallerySources)
+            .Concat(BaseModelFolders)
+            .ToList();
+        var paths = rows.Select(r => r.FolderPath).ToArray();
+
+        var missing = await Task.Run(
+            () => Array.ConvertAll(paths, FolderRowPresence.IsMissing),
+            cancellationToken);
+
+        // Back on the caller's (UI) context; rows removed meanwhile just get a
+        // harmless flag update on a detached object.
+        for (var i = 0; i < rows.Count; i++)
+        {
+            rows[i].IsMissing = missing[i];
+        }
+    }
+
+    /// <summary>
+    /// Debounced <see cref="RefreshFolderPresenceAsync"/>: row edits raise
+    /// SourceChanged per keystroke; only the last edit inside the debounce window
+    /// triggers a scan.
+    /// </summary>
+    private void SchedulePresenceRefresh()
+    {
+        _presenceRefreshCts?.Cancel();
+        _presenceRefreshCts?.Dispose();
+        var cts = new CancellationTokenSource();
+        _presenceRefreshCts = cts;
+        _ = DebouncedPresenceRefreshAsync(cts.Token);
+    }
+
+    private async Task DebouncedPresenceRefreshAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Task.Delay(PresenceRefreshDebounce, cancellationToken);
+            await RefreshFolderPresenceAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // Superseded by a newer edit.
         }
     }
 
@@ -1300,6 +1369,7 @@ public partial class SettingsViewModel : BusyViewModelBase
     private void OnLoraSourceChanged(object? sender, EventArgs e)
     {
         HasChanges = true;
+        SchedulePresenceRefresh();
     }
 
     /// <summary>
@@ -1342,11 +1412,13 @@ public partial class SettingsViewModel : BusyViewModelBase
     private void OnImageGalleryChanged(object? sender, EventArgs e)
     {
         HasChanges = true;
+        SchedulePresenceRefresh();
     }
 
     private void OnBaseModelFolderChanged(object? sender, EventArgs e)
     {
         HasChanges = true;
+        SchedulePresenceRefresh();
     }
 
     /// <summary>
@@ -1648,11 +1720,25 @@ public partial class DatasetCategoryViewModel : ObservableObject
 }
 
 /// <summary>
+/// A Settings folder row that shows the ⚠ missing-on-disk badge. Implemented by
+/// the LoRA source, Generation Gallery, and Base Model Folder row VMs so
+/// <see cref="SettingsViewModel.RefreshFolderPresenceAsync"/> can scan them uniformly.
+/// </summary>
+public interface IFolderPresenceRow
+{
+    /// <summary>Folder path configured for the row.</summary>
+    string? FolderPath { get; }
+
+    /// <summary>Badge state; set only by the parent's async presence scan.</summary>
+    bool IsMissing { get; set; }
+}
+
+/// <summary>
 /// ViewModel for a single Base Model Folder row (model storage root for the
 /// Diffusion Nexus Core). Mirrors <see cref="LoraSourceViewModel"/>: the ⭐ default
 /// flag is exclusive; the parent VM enforces it via <see cref="DefaultSelected"/>.
 /// </summary>
-public partial class BaseModelFolderViewModel : ObservableObject
+public partial class BaseModelFolderViewModel : ObservableObject, IFolderPresenceRow
 {
     /// <summary>Database ID (0 for new rows).</summary>
     public int Id { get; set; }
@@ -1675,6 +1761,14 @@ public partial class BaseModelFolderViewModel : ObservableObject
     [ObservableProperty]
     private bool _isDefault;
 
+    /// <summary>
+    /// True when a non-empty path does not exist on disk (⚠ badge in the row).
+    /// Set only by the parent VM's async presence scan — never computed in the
+    /// path setter, which would put blocking disk IO on the UI thread.
+    /// </summary>
+    [ObservableProperty]
+    private bool _isMissing;
+
     /// <summary>Raised on any property change so the parent flags unsaved changes.</summary>
     public event EventHandler? SourceChanged;
 
@@ -1693,7 +1787,7 @@ public partial class BaseModelFolderViewModel : ObservableObject
 /// <summary>
 /// ViewModel for a single LoRA source folder.
 /// </summary>
-public partial class LoraSourceViewModel : ObservableObject
+public partial class LoraSourceViewModel : ObservableObject, IFolderPresenceRow
 {
     /// <summary>
     /// Database ID (0 for new sources).
@@ -1722,6 +1816,14 @@ public partial class LoraSourceViewModel : ObservableObject
     private bool _isFavorite;
 
     /// <summary>
+    /// True when a non-empty path does not exist on disk (⚠ badge in the row).
+    /// Set only by the parent VM's async presence scan — never computed in the
+    /// path setter, which would put blocking disk IO on the UI thread.
+    /// </summary>
+    [ObservableProperty]
+    private bool _isMissing;
+
+    /// <summary>
     /// Event raised when any property changes (for parent to detect changes).
     /// </summary>
     public event EventHandler? SourceChanged;
@@ -1740,7 +1842,7 @@ public partial class LoraSourceViewModel : ObservableObject
         SourceChanged?.Invoke(this, EventArgs.Empty);
     }
 }
-public partial class ImageGalleryViewModel : ObservableObject
+public partial class ImageGalleryViewModel : ObservableObject, IFolderPresenceRow
 {
     /// <summary>
     /// Database ID (0 for new sources).
@@ -1760,10 +1862,30 @@ public partial class ImageGalleryViewModel : ObservableObject
     private bool _isEnabled = true;
 
     /// <summary>
+    /// True when a non-empty path does not exist on disk (⚠ badge in the row).
+    /// Set only by the parent VM's async presence scan — never computed in the
+    /// path setter, which would put blocking disk IO on the UI thread.
+    /// </summary>
+    [ObservableProperty]
+    private bool _isMissing;
+
+    /// <summary>
     /// Event raised when any property changes (for parent to detect changes).
     /// </summary>
     public event EventHandler? SourceChanged;
 
     partial void OnFolderPathChanged(string? value) => SourceChanged?.Invoke(this, EventArgs.Empty);
+
     partial void OnIsEnabledChanged(bool value) => SourceChanged?.Invoke(this, EventArgs.Empty);
+}
+
+/// <summary>
+/// Shared disk-presence check for the Settings folder rows (LoRA Viewer sources,
+/// Generation Galleries, Base Model Folders). An empty path is not "missing" —
+/// a freshly added row must not warn before the user entered anything.
+/// </summary>
+internal static class FolderRowPresence
+{
+    public static bool IsMissing(string? folderPath) =>
+        !string.IsNullOrWhiteSpace(folderPath) && !Directory.Exists(folderPath);
 }

--- a/DiffusionNexus.UI/ViewModels/SettingsViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/SettingsViewModel.cs
@@ -206,6 +206,12 @@ public partial class SettingsViewModel : BusyViewModelBase
     private ObservableCollection<ImageGalleryViewModel> _imageGallerySources = [];
 
     /// <summary>
+    /// Collection of Base Model Folders (model storage roots for the Diffusion Nexus Core).
+    /// </summary>
+    [ObservableProperty]
+    private ObservableCollection<BaseModelFolderViewModel> _baseModelFolders = [];
+
+    /// <summary>
     /// Collection of dataset categories.
     /// </summary>
     [ObservableProperty]
@@ -393,6 +399,9 @@ public partial class SettingsViewModel : BusyViewModelBase
                 ImageGallerySources.Add(sourceVm);
             }
 
+            // Map Base Model Folders
+            ReloadBaseModelFolders(settings);
+
             HasChanges = false;
             StatusMessage = null;
         }, "Loading settings...");
@@ -472,6 +481,37 @@ public partial class SettingsViewModel : BusyViewModelBase
             };
             sourceVm.SourceChanged += OnImageGalleryChanged;
             ImageGallerySources.Add(sourceVm);
+        }
+
+        // Reload Base Model Folders
+        ReloadBaseModelFolders(settings);
+    }
+
+    /// <summary>
+    /// (Re)builds the Base Model Folder rows from the given settings entity.
+    /// </summary>
+    private void ReloadBaseModelFolders(AppSettings settings)
+    {
+        foreach (var existing in BaseModelFolders)
+        {
+            existing.SourceChanged -= OnBaseModelFolderChanged;
+            existing.DefaultSelected -= OnBaseModelFolderDefaultSelected;
+        }
+        BaseModelFolders.Clear();
+
+        foreach (var folder in settings.BaseModelFolders.OrderBy(f => f.Order))
+        {
+            var folderVm = new BaseModelFolderViewModel
+            {
+                Id = folder.Id,
+                FolderPath = folder.FolderPath,
+                IsEnabled = folder.IsEnabled,
+                IsDefault = folder.IsDefault,
+                InstallerPackageId = folder.InstallerPackageId
+            };
+            folderVm.SourceChanged += OnBaseModelFolderChanged;
+            folderVm.DefaultSelected += OnBaseModelFolderDefaultSelected;
+            BaseModelFolders.Add(folderVm);
         }
     }
 
@@ -581,6 +621,22 @@ public partial class SettingsViewModel : BusyViewModelBase
                     FolderPath = sourceVm.FolderPath!,
                     IsEnabled = sourceVm.IsEnabled,
                     Order = galleryOrder++
+                });
+            }
+
+            // Map Base Model Folders (skip empty)
+            var folderOrder = 0;
+            foreach (var folderVm in BaseModelFolders.Where(f => !string.IsNullOrWhiteSpace(f.FolderPath)))
+            {
+                settings.BaseModelFolders.Add(new BaseModelFolder
+                {
+                    Id = folderVm.Id,
+                    AppSettingsId = 1,
+                    FolderPath = folderVm.FolderPath!,
+                    IsEnabled = folderVm.IsEnabled,
+                    IsDefault = folderVm.IsDefault,
+                    InstallerPackageId = folderVm.InstallerPackageId,
+                    Order = folderOrder++
                 });
             }
 
@@ -757,6 +813,53 @@ public partial class SettingsViewModel : BusyViewModelBase
         {
             source.SourceChanged -= OnImageGalleryChanged;
             ImageGallerySources.Remove(source);
+            HasChanges = true;
+        }
+    }
+
+    /// <summary>
+    /// Adds a new Base Model Folder row.
+    /// </summary>
+    [RelayCommand]
+    private void AddBaseModelFolder()
+    {
+        var folder = new BaseModelFolderViewModel { IsEnabled = true };
+        folder.SourceChanged += OnBaseModelFolderChanged;
+        folder.DefaultSelected += OnBaseModelFolderDefaultSelected;
+        BaseModelFolders.Add(folder);
+        HasChanges = true;
+    }
+
+    /// <summary>
+    /// Removes a Base Model Folder row.
+    /// </summary>
+    [RelayCommand]
+    private void RemoveBaseModelFolder(BaseModelFolderViewModel? folder)
+    {
+        if (folder is not null)
+        {
+            folder.SourceChanged -= OnBaseModelFolderChanged;
+            folder.DefaultSelected -= OnBaseModelFolderDefaultSelected;
+            BaseModelFolders.Remove(folder);
+            HasChanges = true;
+        }
+    }
+
+    /// <summary>
+    /// Browse for a Base Model Folder.
+    /// </summary>
+    [RelayCommand]
+    private async Task BrowseBaseModelFolderAsync(BaseModelFolderViewModel? folder)
+    {
+        if (folder is null || DialogService is null)
+        {
+            return;
+        }
+
+        var path = await DialogService.ShowOpenFolderDialogAsync("Select Base Model Folder");
+        if (!string.IsNullOrEmpty(path))
+        {
+            folder.FolderPath = path;
             HasChanges = true;
         }
     }
@@ -1241,6 +1344,26 @@ public partial class SettingsViewModel : BusyViewModelBase
         HasChanges = true;
     }
 
+    private void OnBaseModelFolderChanged(object? sender, EventArgs e)
+    {
+        HasChanges = true;
+    }
+
+    /// <summary>
+    /// Enforces the exclusive ⭐ default: when one Base Model Folder row is flagged,
+    /// every other row's flag is cleared.
+    /// </summary>
+    private void OnBaseModelFolderDefaultSelected(object? sender, EventArgs e)
+    {
+        foreach (var folder in BaseModelFolders)
+        {
+            if (!ReferenceEquals(folder, sender) && folder.IsDefault)
+            {
+                folder.IsDefault = false;
+            }
+        }
+    }
+
     partial void OnCivitaiApiKeyChanged(string? value) => HasChanges = true;
     partial void OnHuggingfaceApiKeyChanged(string? value) => HasChanges = true;
     partial void OnShowNsfwChanged(bool value) => HasChanges = true;
@@ -1522,6 +1645,49 @@ public partial class DatasetCategoryViewModel : ObservableObject
 
     partial void OnNameChanged(string? value) => CategoryChanged?.Invoke(this, EventArgs.Empty);
     partial void OnDescriptionChanged(string? value) => CategoryChanged?.Invoke(this, EventArgs.Empty);
+}
+
+/// <summary>
+/// ViewModel for a single Base Model Folder row (model storage root for the
+/// Diffusion Nexus Core). Mirrors <see cref="LoraSourceViewModel"/>: the ⭐ default
+/// flag is exclusive; the parent VM enforces it via <see cref="DefaultSelected"/>.
+/// </summary>
+public partial class BaseModelFolderViewModel : ObservableObject
+{
+    /// <summary>Database ID (0 for new rows).</summary>
+    public int Id { get; set; }
+
+    /// <summary>Installer package this folder was auto-registered for (null for manual rows).</summary>
+    public int? InstallerPackageId { get; set; }
+
+    /// <summary>Folder path.</summary>
+    [ObservableProperty]
+    private string? _folderPath;
+
+    /// <summary>Whether this folder participates in scanning and the download dropdown.</summary>
+    [ObservableProperty]
+    private bool _isEnabled = true;
+
+    /// <summary>
+    /// Default download target marker (⭐). Only one row can be the default;
+    /// the parent VM clears the others when this flips to true.
+    /// </summary>
+    [ObservableProperty]
+    private bool _isDefault;
+
+    /// <summary>Raised on any property change so the parent flags unsaved changes.</summary>
+    public event EventHandler? SourceChanged;
+
+    /// <summary>Raised when <see cref="IsDefault"/> flips to true.</summary>
+    public event EventHandler? DefaultSelected;
+
+    partial void OnFolderPathChanged(string? value) => SourceChanged?.Invoke(this, EventArgs.Empty);
+    partial void OnIsEnabledChanged(bool value) => SourceChanged?.Invoke(this, EventArgs.Empty);
+    partial void OnIsDefaultChanged(bool value)
+    {
+        if (value) DefaultSelected?.Invoke(this, EventArgs.Empty);
+        SourceChanged?.Invoke(this, EventArgs.Empty);
+    }
 }
 
 /// <summary>

--- a/DiffusionNexus.UI/Views/Dialogs/CoreWorkloadsDialog.axaml
+++ b/DiffusionNexus.UI/Views/Dialogs/CoreWorkloadsDialog.axaml
@@ -4,6 +4,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="using:DiffusionNexus.UI.ViewModels"
         xmlns:dialogs="using:DiffusionNexus.UI.Views.Dialogs"
+        xmlns:diffusion="using:DiffusionNexus.UI.Services.Diffusion"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="560"
         x:Class="DiffusionNexus.UI.Views.Dialogs.CoreWorkloadsDialog"
         x:DataType="vm:CoreWorkloadsViewModel"
@@ -36,8 +37,23 @@
     </Window.Styles>
 
     <Grid Margin="16" RowDefinitions="Auto,*,Auto">
-        <TextBlock Grid.Row="0" Text="Diffusion Nexus Core" FontSize="18" FontWeight="Bold"
-                   Foreground="White" Margin="0,0,0,8"/>
+        <Grid Grid.Row="0" ColumnDefinitions="Auto,*,Auto,Auto" Margin="0,0,0,8">
+            <TextBlock Grid.Column="0" Text="Diffusion Nexus Core" FontSize="18" FontWeight="Bold"
+                       Foreground="White" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="2" Text="Download to:" Foreground="#AAAAAA"
+                       VerticalAlignment="Center" Margin="16,0,8,0"
+                       ToolTip.Tip="Where models installed from this window are stored. Manage folders and the default in Settings → Base Model Folders."/>
+            <ComboBox Grid.Column="3" MinWidth="280" MaxWidth="360" VerticalAlignment="Center"
+                      ItemsSource="{Binding DownloadTargets}"
+                      SelectedItem="{Binding SelectedDownloadTarget}">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate x:DataType="diffusion:ModelFolderOption">
+                        <TextBlock Text="{Binding Display}" TextTrimming="CharacterEllipsis"
+                                   ToolTip.Tip="{Binding Path}"/>
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+        </Grid>
 
         <TabControl Grid.Row="1">
             <!-- Workflows tab -->

--- a/DiffusionNexus.UI/Views/Dialogs/RemoveInstallationDialog.axaml
+++ b/DiffusionNexus.UI/Views/Dialogs/RemoveInstallationDialog.axaml
@@ -1,0 +1,74 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="using:DiffusionNexus.UI.Views.Dialogs"
+        x:Class="DiffusionNexus.UI.Views.Dialogs.RemoveInstallationDialog"
+        x:DataType="local:RemoveInstallationDialog"
+        Title="Remove Installation"
+        Width="480"
+        MaxHeight="620"
+        SizeToContent="Height"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        Background="#2D2D30">
+
+  <StackPanel Margin="20" Spacing="12">
+
+    <!-- Message -->
+    <TextBlock Text="{Binding Message}"
+               TextWrapping="Wrap"
+               FontSize="14"
+               Foreground="White"/>
+
+    <!-- Linked settings cleanup. A ComfyUI install sharing model trees via
+         extra_model_paths.yaml can contribute a dozen long paths — the section
+         scrolls so the buttons below always stay reachable. -->
+    <StackPanel Spacing="6">
+      <TextBlock Text="Remove these from settings:"
+                 FontWeight="SemiBold"
+                 FontSize="13"
+                 Foreground="White"/>
+
+      <ScrollViewer MaxHeight="260" VerticalScrollBarVisibility="Auto">
+        <StackPanel Spacing="6">
+          <CheckBox IsChecked="{Binding RemoveGalleries, Mode=TwoWay}"
+                    IsEnabled="{Binding HasGalleries}">
+            <TextBlock Text="{Binding GalleryLabel}" TextWrapping="Wrap"/>
+          </CheckBox>
+
+          <CheckBox IsChecked="{Binding RemoveLoraSources, Mode=TwoWay}"
+                    IsEnabled="{Binding HasLoraSources}">
+            <TextBlock Text="{Binding LoraSourceLabel}" TextWrapping="Wrap"/>
+          </CheckBox>
+
+          <CheckBox IsChecked="{Binding RemoveBaseModelFolders, Mode=TwoWay}"
+                    IsEnabled="{Binding HasBaseModelFolders}">
+            <TextBlock Text="{Binding BaseModelFolderLabel}" TextWrapping="Wrap"/>
+          </CheckBox>
+        </StackPanel>
+      </ScrollViewer>
+    </StackPanel>
+
+    <!-- Consequence info -->
+    <Border Background="#3A3222" CornerRadius="4" Padding="10">
+      <TextBlock Text="Removed folders are no longer scanned by Diffusion Nexus — models and images stored in them can't be found in the future."
+                 TextWrapping="Wrap"
+                 FontSize="12"
+                 Foreground="#FBBF24"/>
+    </Border>
+
+    <!-- Buttons -->
+    <StackPanel Orientation="Horizontal"
+                HorizontalAlignment="Right"
+                Spacing="8">
+      <Button Content="Cancel"
+              Width="80"
+              Click="OnCancelClick"/>
+      <Button Content="Yes"
+              Width="80"
+              IsDefault="True"
+              Background="#D9534F"
+              Click="OnYesClick"/>
+    </StackPanel>
+
+  </StackPanel>
+</Window>

--- a/DiffusionNexus.UI/Views/Dialogs/RemoveInstallationDialog.axaml.cs
+++ b/DiffusionNexus.UI/Views/Dialogs/RemoveInstallationDialog.axaml.cs
@@ -1,0 +1,159 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using DiffusionNexus.UI.Services;
+
+namespace DiffusionNexus.UI.Views.Dialogs;
+
+/// <summary>
+/// Confirmation dialog for removing an installation from the Installer Manager,
+/// with checkboxes (checked by default) to also remove the settings folders linked
+/// to it. Checkboxes for which no folder exists are disabled and unchecked.
+/// Files on disk are never touched.
+/// </summary>
+public partial class RemoveInstallationDialog : Window
+{
+    public static readonly StyledProperty<string> MessageProperty =
+        AvaloniaProperty.Register<RemoveInstallationDialog, string>(nameof(Message), defaultValue: string.Empty);
+
+    public static readonly StyledProperty<string> GalleryLabelProperty =
+        AvaloniaProperty.Register<RemoveInstallationDialog, string>(nameof(GalleryLabel), defaultValue: string.Empty);
+
+    public static readonly StyledProperty<string> LoraSourceLabelProperty =
+        AvaloniaProperty.Register<RemoveInstallationDialog, string>(nameof(LoraSourceLabel), defaultValue: string.Empty);
+
+    public static readonly StyledProperty<string> BaseModelFolderLabelProperty =
+        AvaloniaProperty.Register<RemoveInstallationDialog, string>(nameof(BaseModelFolderLabel), defaultValue: string.Empty);
+
+    public static readonly StyledProperty<bool> HasGalleriesProperty =
+        AvaloniaProperty.Register<RemoveInstallationDialog, bool>(nameof(HasGalleries));
+
+    public static readonly StyledProperty<bool> HasLoraSourcesProperty =
+        AvaloniaProperty.Register<RemoveInstallationDialog, bool>(nameof(HasLoraSources));
+
+    public static readonly StyledProperty<bool> HasBaseModelFoldersProperty =
+        AvaloniaProperty.Register<RemoveInstallationDialog, bool>(nameof(HasBaseModelFolders));
+
+    public static readonly StyledProperty<bool> RemoveGalleriesProperty =
+        AvaloniaProperty.Register<RemoveInstallationDialog, bool>(nameof(RemoveGalleries));
+
+    public static readonly StyledProperty<bool> RemoveLoraSourcesProperty =
+        AvaloniaProperty.Register<RemoveInstallationDialog, bool>(nameof(RemoveLoraSources));
+
+    public static readonly StyledProperty<bool> RemoveBaseModelFoldersProperty =
+        AvaloniaProperty.Register<RemoveInstallationDialog, bool>(nameof(RemoveBaseModelFolders));
+
+    public RemoveInstallationDialog()
+    {
+        InitializeComponent();
+        DataContext = this;
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    public string Message
+    {
+        get => GetValue(MessageProperty);
+        set => SetValue(MessageProperty, value);
+    }
+
+    public string GalleryLabel
+    {
+        get => GetValue(GalleryLabelProperty);
+        set => SetValue(GalleryLabelProperty, value);
+    }
+
+    public string LoraSourceLabel
+    {
+        get => GetValue(LoraSourceLabelProperty);
+        set => SetValue(LoraSourceLabelProperty, value);
+    }
+
+    public string BaseModelFolderLabel
+    {
+        get => GetValue(BaseModelFolderLabelProperty);
+        set => SetValue(BaseModelFolderLabelProperty, value);
+    }
+
+    public bool HasGalleries
+    {
+        get => GetValue(HasGalleriesProperty);
+        set => SetValue(HasGalleriesProperty, value);
+    }
+
+    public bool HasLoraSources
+    {
+        get => GetValue(HasLoraSourcesProperty);
+        set => SetValue(HasLoraSourcesProperty, value);
+    }
+
+    public bool HasBaseModelFolders
+    {
+        get => GetValue(HasBaseModelFoldersProperty);
+        set => SetValue(HasBaseModelFoldersProperty, value);
+    }
+
+    public bool RemoveGalleries
+    {
+        get => GetValue(RemoveGalleriesProperty);
+        set => SetValue(RemoveGalleriesProperty, value);
+    }
+
+    public bool RemoveLoraSources
+    {
+        get => GetValue(RemoveLoraSourcesProperty);
+        set => SetValue(RemoveLoraSourcesProperty, value);
+    }
+
+    public bool RemoveBaseModelFolders
+    {
+        get => GetValue(RemoveBaseModelFoldersProperty);
+        set => SetValue(RemoveBaseModelFoldersProperty, value);
+    }
+
+    /// <summary>The user's choice; <see cref="RemoveInstallationResult.Cancelled"/> until Yes is clicked.</summary>
+    public RemoveInstallationResult Result { get; private set; } = RemoveInstallationResult.Cancelled();
+
+    /// <summary>Fills the dialog from the prompt. Checkboxes default to checked where folders exist.</summary>
+    public void Configure(RemoveInstallationPrompt prompt)
+    {
+        Message = $"Remove \"{prompt.InstallationName}\" from the Installer Manager?\n\nThis will NOT delete any files on disk.";
+
+        GalleryLabel = ComposeLabel("Gallery", prompt.GalleryFolders);
+        LoraSourceLabel = ComposeLabel("LoRA Source", prompt.LoraSourceFolders);
+        BaseModelFolderLabel = ComposeLabel("Base Model Folder", prompt.BaseModelFolders);
+
+        HasGalleries = prompt.GalleryFolders.Count > 0;
+        HasLoraSources = prompt.LoraSourceFolders.Count > 0;
+        HasBaseModelFolders = prompt.BaseModelFolders.Count > 0;
+
+        RemoveGalleries = HasGalleries;
+        RemoveLoraSources = HasLoraSources;
+        RemoveBaseModelFolders = HasBaseModelFolders;
+    }
+
+    private static string ComposeLabel(string what, System.Collections.Generic.IReadOnlyList<string> folders) =>
+        folders.Count == 0
+            ? $"{what} — none linked"
+            : $"{what}\n{string.Join("\n", folders)}";
+
+    private void OnYesClick(object? sender, RoutedEventArgs e)
+    {
+        Result = new RemoveInstallationResult(
+            Confirmed: true,
+            RemoveGalleries: HasGalleries && RemoveGalleries,
+            RemoveLoraSources: HasLoraSources && RemoveLoraSources,
+            RemoveBaseModelFolders: HasBaseModelFolders && RemoveBaseModelFolders);
+        Close(true);
+    }
+
+    private void OnCancelClick(object? sender, RoutedEventArgs e)
+    {
+        Result = RemoveInstallationResult.Cancelled();
+        Close(false);
+    }
+}

--- a/DiffusionNexus.UI/Views/SettingsView.axaml
+++ b/DiffusionNexus.UI/Views/SettingsView.axaml
@@ -234,7 +234,7 @@
                               CornerRadius="4"
                               Padding="12"
                               Margin="0,4">
-                        <Grid ColumnDefinitions="Auto,Auto,*,Auto,Auto">
+                        <Grid ColumnDefinitions="Auto,Auto,*,Auto,Auto,Auto">
                           <CheckBox Grid.Column="0"
                                     IsChecked="{Binding IsEnabled, Mode=TwoWay}"
                                     VerticalAlignment="Center"
@@ -260,12 +260,21 @@
                                    Text="{Binding FolderPath, Mode=TwoWay}"
                                    Watermark="Enter folder path..."
                                    Margin="8,0"/>
-                          <Button Grid.Column="3"
+                          <!-- ⚠ shown when the configured folder does not exist on disk. -->
+                          <TextBlock Grid.Column="3"
+                                     Text="&#x26A0;"
+                                     FontSize="14"
+                                     Foreground="#FF6B6B"
+                                     VerticalAlignment="Center"
+                                     Margin="0,0,8,0"
+                                     IsVisible="{Binding IsMissing}"
+                                     ToolTip.Tip="Folder not found on disk"/>
+                          <Button Grid.Column="4"
                                   Content="Browse..."
                                   Command="{Binding $parent[ItemsControl].((vm:SettingsViewModel)DataContext).BrowseLoraSourceCommand}"
                                   CommandParameter="{Binding}"
                                   Margin="0,0,8,0"/>
-                          <Button Grid.Column="4"
+                          <Button Grid.Column="5"
                                   Content="X"
                                   FontWeight="Bold"
                                   Foreground="#FF6B6B"
@@ -358,29 +367,39 @@
                               CornerRadius="4"
                               Padding="12"
                               Margin="0,4">
-                        <Grid ColumnDefinitions="Auto,*,Auto,Auto">
-                          
+                        <Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto">
+
                           <!-- Enabled Checkbox -->
                           <CheckBox Grid.Column="0"
                                     IsChecked="{Binding IsEnabled, Mode=TwoWay}"
                                     VerticalAlignment="Center"
                                     ToolTip.Tip="Enable/disable this gallery"/>
-                          
+
                           <!-- Path -->
                           <TextBox Grid.Column="1"
                                    Text="{Binding FolderPath, Mode=TwoWay}"
                                    Watermark="Enter folder path..."
                                    Margin="8,0"/>
-                          
+
+                          <!-- ⚠ shown when the configured folder does not exist on disk. -->
+                          <TextBlock Grid.Column="2"
+                                     Text="&#x26A0;"
+                                     FontSize="14"
+                                     Foreground="#FF6B6B"
+                                     VerticalAlignment="Center"
+                                     Margin="0,0,8,0"
+                                     IsVisible="{Binding IsMissing}"
+                                     ToolTip.Tip="Folder not found on disk"/>
+
                           <!-- Browse Button -->
-                          <Button Grid.Column="2"
+                          <Button Grid.Column="3"
                                   Content="Browse..."
                                   Command="{Binding $parent[ItemsControl].((vm:SettingsViewModel)DataContext).BrowseImageGallerySourceCommand}"
                                   CommandParameter="{Binding}"
                                   Margin="0,0,8,0"/>
-                          
+
                           <!-- Remove Button -->
-                          <Button Grid.Column="3"
+                          <Button Grid.Column="4"
                                   Content="X"
                                   FontWeight="Bold"
                                   Foreground="#FF6B6B"
@@ -422,7 +441,7 @@
                               CornerRadius="4"
                               Padding="12"
                               Margin="0,4">
-                        <Grid ColumnDefinitions="Auto,Auto,*,Auto,Auto">
+                        <Grid ColumnDefinitions="Auto,Auto,*,Auto,Auto,Auto">
 
                           <!-- Enabled Checkbox -->
                           <CheckBox Grid.Column="0"
@@ -452,15 +471,25 @@
                                    Watermark="Enter folder path..."
                                    Margin="8,0"/>
 
+                          <!-- ⚠ shown when the configured folder does not exist on disk. -->
+                          <TextBlock Grid.Column="3"
+                                     Text="&#x26A0;"
+                                     FontSize="14"
+                                     Foreground="#FF6B6B"
+                                     VerticalAlignment="Center"
+                                     Margin="0,0,8,0"
+                                     IsVisible="{Binding IsMissing}"
+                                     ToolTip.Tip="Folder not found on disk"/>
+
                           <!-- Browse Button -->
-                          <Button Grid.Column="3"
+                          <Button Grid.Column="4"
                                   Content="Browse..."
                                   Command="{Binding $parent[ItemsControl].((vm:SettingsViewModel)DataContext).BrowseBaseModelFolderCommand}"
                                   CommandParameter="{Binding}"
                                   Margin="0,0,8,0"/>
 
                           <!-- Remove Button -->
-                          <Button Grid.Column="4"
+                          <Button Grid.Column="5"
                                   Content="X"
                                   FontWeight="Bold"
                                   Foreground="#FF6B6B"

--- a/DiffusionNexus.UI/Views/SettingsView.axaml
+++ b/DiffusionNexus.UI/Views/SettingsView.axaml
@@ -399,6 +399,86 @@
           </Border>
         </Expander>
 
+        <!-- Base Model Folders -->
+        <Expander Header="Base Model Folders" IsExpanded="False" HorizontalAlignment="Stretch">
+          <Border Padding="16">
+            <StackPanel Spacing="16">
+
+              <StackPanel Spacing="8">
+                <TextBlock Text="Model Storage Folders" FontWeight="SemiBold" FontSize="14"/>
+                <TextBlock FontSize="12" Opacity="0.7" TextWrapping="Wrap"
+                           Text="Folders where Diffusion Nexus Core stores and looks up models (diffusion models, text encoders, VAEs, LoRAs). The ⭐ folder is the default download target for Core workloads; the Workloads window lets you pick any folder per install. Folders of installations you add (including ComfyUI extra_model_paths.yaml entries) appear here automatically. When the list is empty, models are stored under %LocalAppData%\DiffusionNexus\Models."/>
+
+                <!-- Add Button -->
+                <Button Content="+ Add Base Model Folder"
+                        Command="{Binding AddBaseModelFolderCommand}"
+                        HorizontalAlignment="Left"/>
+
+                <!-- Folder List -->
+                <ItemsControl ItemsSource="{Binding BaseModelFolders}">
+                  <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="vm:BaseModelFolderViewModel">
+                      <Border Background="#20FFFFFF"
+                              CornerRadius="4"
+                              Padding="12"
+                              Margin="0,4">
+                        <Grid ColumnDefinitions="Auto,Auto,*,Auto,Auto">
+
+                          <!-- Enabled Checkbox -->
+                          <CheckBox Grid.Column="0"
+                                    IsChecked="{Binding IsEnabled, Mode=TwoWay}"
+                                    VerticalAlignment="Center"
+                                    ToolTip.Tip="Enable/disable this folder for scanning and downloads"/>
+
+                          <!-- Default (star) toggle — only one folder can be the default. -->
+                          <ToggleButton Grid.Column="1"
+                                        IsChecked="{Binding IsDefault, Mode=TwoWay}"
+                                        VerticalAlignment="Center"
+                                        Margin="6,0"
+                                        Padding="6,4"
+                                        ToolTip.Tip="Set as default download target for Core workloads">
+                            <Panel>
+                              <!-- Yellow filled star when checked, faded outline when not. -->
+                              <TextBlock Text="&#x2605;" FontSize="14" Foreground="#FBBF24"
+                                         IsVisible="{Binding IsDefault}"/>
+                              <TextBlock Text="&#x2606;" FontSize="14" Foreground="#888888"
+                                         IsVisible="{Binding !IsDefault}"/>
+                            </Panel>
+                          </ToggleButton>
+
+                          <!-- Path -->
+                          <TextBox Grid.Column="2"
+                                   Text="{Binding FolderPath, Mode=TwoWay}"
+                                   Watermark="Enter folder path..."
+                                   Margin="8,0"/>
+
+                          <!-- Browse Button -->
+                          <Button Grid.Column="3"
+                                  Content="Browse..."
+                                  Command="{Binding $parent[ItemsControl].((vm:SettingsViewModel)DataContext).BrowseBaseModelFolderCommand}"
+                                  CommandParameter="{Binding}"
+                                  Margin="0,0,8,0"/>
+
+                          <!-- Remove Button -->
+                          <Button Grid.Column="4"
+                                  Content="X"
+                                  FontWeight="Bold"
+                                  Foreground="#FF6B6B"
+                                  Command="{Binding $parent[ItemsControl].((vm:SettingsViewModel)DataContext).RemoveBaseModelFolderCommand}"
+                                  CommandParameter="{Binding}"
+                                  ToolTip.Tip="Remove this folder (files on disk are not touched)"/>
+
+                        </Grid>
+                      </Border>
+                    </DataTemplate>
+                  </ItemsControl.ItemTemplate>
+                </ItemsControl>
+              </StackPanel>
+
+            </StackPanel>
+          </Border>
+        </Expander>
+
         <!-- LoRA Dataset Helper (NEW) -->
         <Expander Header="LoRA Dataset Helper" IsExpanded="True" HorizontalAlignment="Stretch">
           <Border Padding="16">

--- a/DiffusionNexus.UI/Views/SettingsView.axaml.cs
+++ b/DiffusionNexus.UI/Views/SettingsView.axaml.cs
@@ -29,5 +29,13 @@ public partial class SettingsView : UserControl
         {
             aware.DialogService = new DialogService(window);
         }
+
+        // Re-check the ⚠ folder-not-found badges every time the page is shown,
+        // so folders deleted (or restored) on disk mid-session are reflected.
+        // Fire-and-forget: the probes run off-thread and must not delay attach.
+        if (DataContext is SettingsViewModel settingsViewModel)
+        {
+            _ = settingsViewModel.RefreshFolderPresenceAsync();
+        }
     }
 }

--- a/docs/superpowers/plans/2026-07-26-base-model-folders.md
+++ b/docs/superpowers/plans/2026-07-26-base-model-folders.md
@@ -1,0 +1,272 @@
+# Base Model Folders Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A general Base Model Folders registry (settings list + ⭐ default + auto-registration per installation) that feeds a download-target dropdown in the Core Workloads window and the model search roots everywhere, with `%LOCALAPPDATA%\DiffusionNexus\Models` as built-in fallback.
+
+**Architecture:** New `BaseModelFolder` child table on the AppSettings singleton (mirrors `ImageGallery`); a `ModelFolderCatalog` service resolves download targets + search roots; `LocalDiffusionBackendProvider` prepends catalog roots so all consumers see them; `PipelineAssetInstaller.InstallMissingAsync` takes an explicit `downloadRoot`; auto-registration runs on package add and as idempotent startup backfill (ComfyUI roots via `ComfyUiPathDiscovery`, which expands `extra_model_paths.yaml`).
+
+**Tech Stack:** .NET 10, Avalonia, EF Core (SQLite, `DiffusionNexusCoreDbContext`), CommunityToolkit.Mvvm, xunit + Moq + FluentAssertions.
+
+**Spec:** `docs/superpowers/specs/2026-07-26-base-model-folders-design.md`
+
+## Global Constraints
+
+- Branch `feature/base-model-folders` off `develop`; single PR to `develop` only.
+- Run `publish.ps1` BEFORE modifying entities/EF configs/migrations (repo rule, `.github/copilot-instructions.md`).
+- Migration command: `dotnet ef migrations add AddBaseModelFolders --project DiffusionNexus.DataAccess --startup-project DiffusionNexus.UI --context DiffusionNexusCoreDbContext --output-dir Migrations/Core`
+- Fallback root constant: `Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "DiffusionNexus", "Models")`
+- At most one `BaseModelFolder.IsDefault == true` (service enforces, last-set wins).
+- No Avalonia global test initialization in unit tests (repo gotcha).
+- ComfyUI workload install flow (`WorkloadInstallService`) is untouched.
+- TDD every task: failing test → verify fail → implement → verify pass → commit.
+
+---
+
+### Task 1: `BaseModelFolder` entity, EF config, migration
+
+**Files:**
+- Create: `DiffusionNexus.Domain/Entities/BaseModelFolder.cs`
+- Modify: `DiffusionNexus.Domain/Entities/AppSettings.cs` (~line 41, after `ImageGalleries`)
+- Modify: `DiffusionNexus.DataAccess/Configurations/AppSettingsConfiguration.cs` (after `ImageGalleries` HasMany)
+- Modify: `DiffusionNexus.DataAccess/Data/DiffusionNexusCoreDbContext.cs` (~line 61, DbSets)
+- Create (generated): `DiffusionNexus.DataAccess/Migrations/Core/*_AddBaseModelFolders.cs` + snapshot
+- Test: `DiffusionNexus.Tests/DataAccess/Repositories/AppSettingsRepositoryTests.cs` (extend)
+
+**Interfaces produced:**
+```csharp
+public class BaseModelFolder : BaseEntity
+{
+    public int AppSettingsId { get; set; }
+    public string FolderPath { get; set; } = string.Empty;
+    public bool IsEnabled { get; set; } = true;
+    public int Order { get; set; }
+    public bool IsDefault { get; set; }
+    public int? InstallerPackageId { get; set; }
+    public AppSettings? AppSettings { get; set; }
+    public InstallerPackage? InstallerPackage { get; set; }
+}
+// AppSettings: public ICollection<BaseModelFolder> BaseModelFolders { get; set; } = new List<BaseModelFolder>();
+// DbContext:   public DbSet<BaseModelFolder> BaseModelFolders => Set<BaseModelFolder>();
+```
+
+- [ ] **Step 1:** Run `.\publish.ps1` (repo rule before entity/migration changes).
+- [ ] **Step 2:** Failing test in `AppSettingsRepositoryTests` (follow the file's existing SQLite fixture pattern): add a `BaseModelFolder` to settings, save, reload with includes, assert row + `IsDefault` round-trip. Expect compile failure (`BaseModelFolder` missing).
+- [ ] **Step 3:** Create entity (code above); add collection to `AppSettings`; EF config:
+```csharp
+entity.HasMany(e => e.BaseModelFolders)
+    .WithOne(f => f.AppSettings)
+    .HasForeignKey(f => f.AppSettingsId)
+    .OnDelete(DeleteBehavior.Cascade);
+```
+plus a separate `builder.Entity<BaseModelFolder>()` block if the file configures children that way for `FolderPath` max length 1000, index on `FolderPath`, and `HasOne(f => f.InstallerPackage).WithMany().HasForeignKey(f => f.InstallerPackageId).OnDelete(DeleteBehavior.SetNull)`. Add DbSet. Include `BaseModelFolders` in `AppSettingsRepository.GetSettingsWithIncludesAsync`.
+- [ ] **Step 4:** Generate migration (command in Global Constraints); inspect it (TEXT 1000, FKs cascade/SetNull, indexes).
+- [ ] **Step 5:** Test passes; full `DiffusionNexus.Tests` still green. Commit `feat(data): BaseModelFolder entity + migration`.
+
+### Task 2: Repository + AppSettingsService (sync, invariant, targeted APIs)
+
+**Files:**
+- Modify: `DiffusionNexus.DataAccess/Repositories/Interfaces/IAppSettingsRepository.cs` (after `RemoveImageGallery`)
+- Modify: `DiffusionNexus.DataAccess/Repositories/AppSettingsRepository.cs`
+- Modify: `DiffusionNexus.Domain/Services/IAppSettingsService.cs`
+- Modify: `DiffusionNexus.Service/Services/AppSettingsService.cs` (snapshot ~line 134, sync block ~line 222)
+- Test: create `DiffusionNexus.Tests/Service/Services/AppSettingsServiceBaseModelFolderTests.cs`
+
+**Interfaces produced:**
+```csharp
+// IAppSettingsRepository
+Task AddBaseModelFolderAsync(BaseModelFolder folder, CancellationToken cancellationToken = default);
+void RemoveBaseModelFolder(BaseModelFolder folder);
+// IAppSettingsService
+Task<IReadOnlyList<BaseModelFolder>> GetEnabledBaseModelFoldersAsync(CancellationToken cancellationToken = default);
+Task AddBaseModelFolderAsync(string folderPath, int? installerPackageId = null, CancellationToken cancellationToken = default);
+```
+
+- [ ] **Step 1:** Failing tests (SQLite in-memory UoW, copy fixture from `AppSettingsServiceCivitaiKeyTests`):
+  1. `SaveSettingsAsync` round-trips added/updated/removed `BaseModelFolders` rows (mirror an existing ImageGallery sync test).
+  2. Saving two rows with `IsDefault = true` persists only the **last** one as default.
+  3. `AddBaseModelFolderAsync("C:\\x", packageId)` twice → one row; second call re-links `InstallerPackageId`; path match is OrdinalIgnoreCase.
+  4. `GetEnabledBaseModelFoldersAsync` returns only `IsEnabled`, ordered by `Order`.
+- [ ] **Step 2:** Verify failure (missing members).
+- [ ] **Step 3:** Implement: repo methods (copy gallery impls); snapshot incoming list in `SaveSettingsAsync` (like `incomingGalleryData`); `SyncChildCollection` call copying `FolderPath/IsEnabled/Order/IsDefault/InstallerPackageId`; after sync enforce invariant:
+```csharp
+var defaults = existingSettings.BaseModelFolders.Where(f => f.IsDefault).ToList();
+foreach (var f in defaults.Take(defaults.Count - 1)) f.IsDefault = false; // keep last
+```
+(keep the row matching the *last* incoming default; simplest: iterate incoming order). Targeted service methods follow `GetFavoriteLoraSourceAsync`/`AddLoraSourceAsync` patterns (no full save; `_unitOfWork.SaveChangesAsync`).
+- [ ] **Step 4:** Tests pass; suite green. Commit `feat(service): BaseModelFolders persistence + single-default invariant`.
+
+### Task 3: Settings export/import round-trip
+
+**Files:**
+- Modify: `DiffusionNexus.Domain/Models/SettingsExportData.cs` (`BaseModelFolderExport` record + list, next to `ImageGalleryExport` ~line 106)
+- Modify: `DiffusionNexus.Service/Services/SettingsExportService.cs` (export ~line 90 block, import ~line 181 block)
+- Test: extend the existing SettingsExportService test file (or create `DiffusionNexus.Tests/Service/Services/SettingsExportServiceBaseModelFolderTests.cs`)
+
+**Interfaces produced:**
+```csharp
+public sealed record BaseModelFolderExport
+{
+    public string FolderPath { get; init; } = string.Empty;
+    public bool IsEnabled { get; init; } = true;
+    public int Order { get; init; }
+    public bool IsDefault { get; init; }
+}
+// SettingsExportData: public List<BaseModelFolderExport> BaseModelFolders { get; init; } = [];
+```
+
+- [ ] **Step 1:** Failing test: settings with 2 folders (one default) → export → import into fresh settings → rows + IsDefault preserved. (`InstallerPackageId` intentionally NOT exported — machine-specific.)
+- [ ] **Step 2:** Verify fail → implement export/import loops (copy the `ImageGalleries` blocks verbatim, plus `IsDefault`) → pass → commit `feat(service): export/import BaseModelFolders`.
+
+### Task 4: `IModelFolderCatalog`
+
+**Files:**
+- Create: `DiffusionNexus.UI/Services/Diffusion/IModelFolderCatalog.cs`
+- Create: `DiffusionNexus.UI/Services/Diffusion/ModelFolderCatalog.cs`
+- Modify: DI registration site of `PipelineAssetInstaller` (grep `PipelineAssetInstaller` in `DiffusionNexus.UI/App.axaml.cs`; register `IModelFolderCatalog` → `ModelFolderCatalog` with the same lifetime)
+- Test: create `DiffusionNexus.Tests/Services/ModelFolderCatalogTests.cs` (Moq `IAppSettingsService`)
+
+**Interfaces produced:**
+```csharp
+public sealed record ModelFolderOption(string Path, bool IsDefault, bool Exists);
+
+public interface IModelFolderCatalog
+{
+    /// <summary>Dropdown items: enabled folders, default first; fallback-only when none configured.</summary>
+    Task<IReadOnlyList<ModelFolderOption>> GetDownloadTargetsAsync(CancellationToken cancellationToken = default);
+    /// <summary>First download target; directory created on demand; falls back to <see cref="FallbackRoot"/> on create failure (logged warning).</summary>
+    Task<string> GetDefaultDownloadRootAsync(CancellationToken cancellationToken = default);
+    /// <summary>Enabled folders + fallback root, deduped OrdinalIgnoreCase, existing dirs only.</summary>
+    Task<IReadOnlyList<string>> GetSearchRootsAsync(CancellationToken cancellationToken = default);
+}
+// ModelFolderCatalog ctor: (IAppSettingsService settings)
+// public static string FallbackRoot { get; } = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "DiffusionNexus", "Models");
+```
+
+- [ ] **Step 1:** Failing tests:
+  1. Empty registry → `GetDownloadTargetsAsync` = exactly `[ (FallbackRoot, IsDefault: true, …) ]`.
+  2. Folders A (Order 1), B (Order 0, IsDefault) → targets = [B, A]; `GetDefaultDownloadRootAsync` = B and creates the directory (temp paths).
+  3. No default flagged → first enabled by Order is the default target.
+  4. `GetSearchRootsAsync` skips nonexistent dirs, dedupes case-insensitively, includes FallbackRoot when it exists.
+  5. Default folder uncreatable (invalid char path) → `GetDefaultDownloadRootAsync` returns `FallbackRoot`.
+- [ ] **Step 2:** Verify fail → implement → pass → register in DI → commit `feat(ui): ModelFolderCatalog (download targets + search roots)`.
+
+### Task 5: Auto-registration (package add + startup backfill)
+
+**Files:**
+- Create: `DiffusionNexus.UI/Services/Diffusion/BaseModelFolderRegistrar.cs`
+- Modify: `DiffusionNexus.UI/ViewModels/InstallerManagerViewModel.cs` (in `AddExistingInstallation` success path, next to `LinkOutputFolderAsync` ~line 168)
+- Modify: App startup where `OutputsFolderRegistrar.EnsureRegisteredAsync` is called (grep in `App.axaml.cs` / startup data loader) — call backfill alongside it; register registrar in DI
+- Test: create `DiffusionNexus.Tests/Services/BaseModelFolderRegistrarTests.cs`
+
+**Interfaces produced:**
+```csharp
+public sealed class BaseModelFolderRegistrar
+{
+    public BaseModelFolderRegistrar(IAppSettingsService settingsService);
+    /// <summary>Registers all model roots of one package (idempotent by path, links InstallerPackageId).</summary>
+    public Task RegisterPackageFoldersAsync(InstallerPackage package, CancellationToken cancellationToken = default);
+    /// <summary>Startup backfill over all packages; never throws (logs warnings).</summary>
+    public Task EnsureRegisteredAsync(IEnumerable<InstallerPackage> packages, CancellationToken cancellationToken = default);
+    internal static IReadOnlyList<string> ResolveModelRoots(InstallerPackage package); // testable core
+}
+```
+Root resolution: `package.Type == InstallerType.ComfyUI` → `ComfyUiPathDiscovery.EnumerateModelSearchPaths(package.InstallationPath)` (own models/ + **extra_model_paths.yaml roots** + portable sibling); other types → `Path.Combine(InstallationPath, "models")` when the directory exists; invalid/missing `InstallationPath` → empty.
+
+- [ ] **Step 1:** Failing tests (temp dirs):
+  1. ComfyUI layout (`main.py` + `models/`) + `extra_model_paths.yaml` declaring an existing extra base path → `ResolveModelRoots` returns both.
+  2. Forge-style package (`models/` only, Type != ComfyUI) → `[{install}\models]`.
+  3. `RegisterPackageFoldersAsync` twice → rows unchanged (idempotent); rows carry `InstallerPackageId`; never sets `IsDefault`.
+- [ ] **Step 2:** Verify fail → implement (persist via `IAppSettingsService.AddBaseModelFolderAsync(path, package.Id, ct)`) → pass.
+- [ ] **Step 3:** Wire: `await _baseModelFolderRegistrar.RegisterPackageFoldersAsync(package);` in `InstallerManagerViewModel` add-flow (after `LinkOutputFolderAsync`, inside the try); startup backfill next to `OutputsFolderRegistrar` call using packages from `IUnitOfWork.InstallerPackages.GetAllAsync`. Commit `feat(ui): auto-register installation model folders (incl. extra_model_paths.yaml)`.
+
+### Task 6: Root plumbing — provider prepend + installer downloadRoot
+
+**Files:**
+- Modify: `DiffusionNexus.UI/Services/Diffusion/LocalDiffusionBackendProvider.cs` (`ResolveModelsRootsAsync` ~line 93)
+- Modify: `DiffusionNexus.UI/Services/Pipelines/IPipelineAssetInstaller.cs` (`InstallMissingAsync` ~line 44)
+- Modify: `DiffusionNexus.UI/Services/Pipelines/PipelineAssetInstaller.cs` (`InstallMissingAsync`; ctor gains `IModelFolderCatalog`)
+- Modify: `DiffusionNexus.UI/ViewModels/PipelinesViewModel.cs` (~lines 94-117, 191-199: "No ComfyUI install" gates can no longer trigger — update copy to reflect roots always exist)
+- Test: extend `DiffusionNexus.Tests/InstallerManager/PipelineAssetInstallerTests.cs`
+
+**Interfaces:**
+- Consumes: `IModelFolderCatalog.GetSearchRootsAsync` (Task 4).
+- Produces: `Task<PipelineReadiness> InstallMissingAsync(PipelineManifest manifest, int vramGb, string downloadRoot, CancellationToken cancellationToken = default);`
+
+- [ ] **Step 1:** Failing tests:
+  1. `InstallMissingAsync(manifest, 0, tempRootB, ct)` downloads into `tempRootB\loras` even while `tempRootA` is first in catalog roots (coordinator mock records target via civitai mock + file assertions — reuse existing mock harness; assert enqueue happened and, after simulating success by pre-creating the file, sidecar lands in tempRootB).
+  2. Readiness (via `CheckAsync` with provider… keep unit-level: `BuildReadiness(manifest, [catalogRoot, comfyRoot])` already covered — add case where asset exists only in catalog root).
+  3. `InstallMissingAsync` with empty registry + zero ComfyUI installs does NOT throw (backend provider mocked/bypassed: pass `downloadRoot` explicitly; remove of throw verified by absence).
+- [ ] **Step 2:** Verify fail → implement:
+  - `LocalDiffusionBackendProvider.ResolveModelsRootsAsync`: resolve `IModelFolderCatalog` from the scope, `var catalogRoots = await catalog.GetSearchRootsAsync(ct)`, prepend before ComfyUI-derived roots with OrdinalIgnoreCase dedupe; drop the "returns empty when no ComfyUI" doc wording.
+  - Installer: remove `roots[0]`/throw block; use the `downloadRoot` parameter; update `CoreWorkloadsViewModel` call site minimally (`await _catalog.GetDefaultDownloadRootAsync(ct)` until Task 7 adds the dropdown).
+  - `PipelinesViewModel`: keep null-guards but change message to point at the Workloads dialog (root can no longer be null).
+- [ ] **Step 3:** Pass; full suite green; commit `feat(ui): catalog-aware search roots + explicit pipeline download root`.
+
+### Task 7: Core Workloads window dropdown
+
+**Files:**
+- Modify: `DiffusionNexus.UI/ViewModels/CoreWorkloadsViewModel.cs` (ctor + `LoadAsync` + `CreatePipelineInstallCallback` ~line 222)
+- Modify: `DiffusionNexus.UI/Views/Dialogs/CoreWorkloadsDialog.axaml` (Grid row 0 area, above `TabControl`)
+- Test: create `DiffusionNexus.Tests/InstallerManager/CoreWorkloadsViewModelTests.cs`
+
+**Interfaces:**
+- Consumes: `IModelFolderCatalog.GetDownloadTargetsAsync` / `GetDefaultDownloadRootAsync` (Task 4), `InstallMissingAsync(manifest, vramGb, downloadRoot, ct)` (Task 6).
+- Produces (VM):
+```csharp
+public ObservableCollection<ModelFolderOption> DownloadTargets { get; }
+[ObservableProperty] private ModelFolderOption? _selectedDownloadTarget;
+// ctor gains IModelFolderCatalog? modelFolderCatalog (nullable like the other optional deps)
+```
+
+- [ ] **Step 1:** Failing VM tests: after `LoadAsync` — (a) targets from catalog listed, default preselected; (b) empty registry → single fallback entry selected; (c) install callback passes `SelectedDownloadTarget.Path` to `InstallMissingAsync` (Moq `IPipelineAssetInstaller`… it's an interface — verify arg).
+- [ ] **Step 2:** Verify fail → implement VM + XAML:
+```xml
+<StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="8" Margin="0,0,0,8">
+    <TextBlock Text="Diffusion Nexus Core" FontSize="18" FontWeight="Bold" Foreground="White" VerticalAlignment="Center"/>
+    <TextBlock Text="Download to:" Foreground="#AAAAAA" VerticalAlignment="Center" Margin="16,0,0,0"/>
+    <ComboBox MinWidth="320" ItemsSource="{Binding DownloadTargets}" SelectedItem="{Binding SelectedDownloadTarget}">
+        <ComboBox.ItemTemplate>
+            <DataTemplate x:DataType="services:ModelFolderOption">
+                <TextBlock Text="{Binding Display}"/>
+            </DataTemplate>
+        </ComboBox.ItemTemplate>
+    </ComboBox>
+</StackPanel>
+```
+(`Display` = computed property on `ModelFolderOption`: `Path` + `" (default)"` when `IsDefault` — add to the record in Task 4 if not present.) Selection is per-window; nothing written back to settings.
+- [ ] **Step 3:** Pass; commit `feat(ui): download-target dropdown in Core Workloads window`.
+
+### Task 8: Settings UI — "Base Model Folders" section
+
+**Files:**
+- Modify: `DiffusionNexus.UI/ViewModels/SettingsViewModel.cs` (collection + row VM + commands + Load ~line 373 / Save ~line 569 mapping)
+- Modify: `DiffusionNexus.UI/Views/SettingsView.axaml` (new Expander after Generation Galleries ~line 400)
+- Test: create `DiffusionNexus.Tests/ViewModels/SettingsViewModelBaseModelFolderTests.cs` (no Avalonia init; construct VM with mocked services like existing settings VM tests)
+
+**Interfaces produced (row VM, mirrors `LoraSourceViewModel` + `ImageGalleryViewModel`):**
+```csharp
+public partial class BaseModelFolderViewModel : ObservableObject
+{
+    public int Id { get; set; }
+    public int? InstallerPackageId { get; set; }
+    [ObservableProperty] private string _folderPath = string.Empty;
+    [ObservableProperty] private bool _isEnabled = true;
+    [ObservableProperty] private bool _isDefault;
+    public int Order { get; set; }
+    public event EventHandler? SourceChanged;      // any property change → HasChanges
+    public event EventHandler? DefaultSelected;    // parent clears other rows' IsDefault
+}
+```
+
+- [ ] **Step 1:** Failing VM tests: (a) Load populates rows from settings; (b) setting `IsDefault` on row B clears it on row A and sets `HasChanges`; (c) Save snapshot contains the rows incl. `InstallerPackageId` pass-through; (d) Add/Remove commands mutate the collection + `HasChanges`.
+- [ ] **Step 2:** Verify fail → implement VM parts (copy the ImageGallery collection wiring: `ObservableCollection<BaseModelFolderViewModel> BaseModelFolders`, `AddBaseModelFolderCommand`, `RemoveBaseModelFolderCommand(row)`, `BrowseBaseModelFolderAsync(row)` via `DialogService.ShowOpenFolderDialogAsync("Select Base Model Folder")`, load/save mapping, `DefaultSelected` handler enforcing exclusivity).
+- [ ] **Step 3:** XAML Expander (copy the Generation Galleries block structure; row template: CheckBox `IsEnabled` → ToggleButton "⭐" bound `IsDefault` (LoRA favorite-star pattern, `SettingsView.axaml:245-258`) → TextBox `FolderPath` → Browse → Remove; description text: "Folders where Diffusion Nexus Core stores and looks up models. The ⭐ folder is the default download target. Folders of added installations appear here automatically.").
+- [ ] **Step 4:** Tests pass; commit `feat(ui): Base Model Folders settings section`.
+
+### Task 9: Verification + PR
+
+- [ ] **Step 1:** `dotnet build DiffusionNexus.sln` — 0 errors/warnings.
+- [ ] **Step 2:** `dotnet test DiffusionNexus.sln` — full suite green.
+- [ ] **Step 3:** Manual sanity greps: no remaining caller of old `InstallMissingAsync(manifest, vramGb, ct)` overload; `GetComfyUiModelsRootsAsync` doc updated.
+- [ ] **Step 4:** Push branch; PR → `develop` referencing the spec; note follow-up candidates (auto-register LoRA sources on package add).

--- a/docs/superpowers/specs/2026-07-26-base-model-folders-design.md
+++ b/docs/superpowers/specs/2026-07-26-base-model-folders-design.md
@@ -1,0 +1,148 @@
+# Base Model Folders — Design
+
+**Date:** 2026-07-26
+**Branch:** `feature/base-model-folders` (off `develop` — develop-only, no main backport)
+**Status:** Approved by user (dialogue 2026-07-25/26)
+
+## Problem
+
+Diffusion Nexus Core workloads (pipelines like Anime-To-Real, and anything else installed
+from Installer Manager → Diffusion Nexus Core → Workloads) download their models into the
+*default ComfyUI installation's* models tree. A user with no ComfyUI installation registered
+cannot install Core workloads at all (`InstallMissingAsync` throws "No ComfyUI installation
+is registered"), and the download target silently shifts depending on which packages exist
+and which is flagged default.
+
+## Goal
+
+A general **Base Model Folders** registry — the same system the app already uses for
+Generation Galleries (auto-registered per installation) and the LoRA Viewer source list
+(user-managed rows, one favorite) — applied to model storage:
+
+1. Users manage a list of model storage folders in Settings, with one row marked **Default** (⭐).
+2. Adding an installation in Installer Manager **auto-registers** its model folders
+   (for ComfyUI: including every root declared in `extra_model_paths.yaml`).
+3. The Diffusion Nexus Core Workloads window shows a **dropdown of all enabled folders**
+   (Default preselected); the chosen folder is the download target for that install.
+4. `%LOCALAPPDATA%\DiffusionNexus\Models` is the built-in fallback when no folders exist —
+   a fresh user with zero installations can install Core workloads out of the box.
+5. Fully compatible with the current approach: all existing detection keeps working;
+   nothing already on disk is re-downloaded.
+
+Out of scope: moving files when folders change; auto-registering LoRA Viewer sources on
+package add (possible follow-up); captioning model storage (already app-managed);
+the ComfyUI *workload* install flow (Workloads dialog → `WorkloadInstallService`), which
+keeps targeting the selected ComfyUI installation per user decision.
+
+## Data model (`Diffusion_Nexus-core.db`)
+
+New entity `BaseModelFolder : BaseEntity`, collection on `AppSettings` (singleton Id=1):
+
+| Column | Type | Notes |
+|---|---|---|
+| `AppSettingsId` | FK → AppSettings, cascade | same as `ImageGallery` |
+| `FolderPath` | string, required, max 1000 | a models root (contains/receives `diffusion_models/`, `loras/`, `text_encoders/`, `vae/`, …) |
+| `IsEnabled` | bool, default true | disabled rows are excluded from scanning and the dropdown |
+| `Order` | int | display + scan order |
+| `IsDefault` | bool, default false | at most one row true (service enforces on save) |
+| `InstallerPackageId` | nullable FK → InstallerPackage, **SetNull** on delete | set for auto-registered rows; row survives package removal |
+
+EF config mirrors `ImageGallery` (`HasMany` cascade, indexes on `AppSettingsId` + `FolderPath`).
+One migration (`AddBaseModelFolders`). Per repo rule, run `publish.ps1` before entity/migration
+changes. `AppSettingsService.SaveSettingsAsync` syncs the collection via the existing
+`SyncChildCollection` helper and enforces the single-default invariant (last-set wins).
+`SettingsExportData`/`SettingsExportService` round-trip the rows.
+
+## Services
+
+### `IAppSettingsService` additions (follow the LoraSources precedent)
+
+- `GetEnabledBaseModelFoldersAsync()` → ordered enabled rows
+- `AddBaseModelFolderAsync(folder)` — idempotent by path (case-insensitive); re-links
+  `InstallerPackageId` when the path already exists (gallery `LinkOutputFolderAsync` behavior)
+- `RemoveBaseModelFolderAsync(id)` / `UpdateBaseModelFolderAsync(folder)`
+
+### `IModelFolderCatalog` (new, DiffusionNexus.UI/Services/Diffusion)
+
+The single resolution authority consumed by installer + backend:
+
+- `GetDownloadTargetsAsync()` → dropdown items, in order: enabled Base Model Folders
+  (Default first); if none exist → exactly one item, the LocalAppData fallback
+  (`%LOCALAPPDATA%\DiffusionNexus\Models`), labelled as default. Item = path + IsDefault flag.
+- `GetDefaultDownloadRootAsync()` → first item of the above; directory created on demand.
+- `GetSearchRootsAsync()` → deduped (OrdinalIgnoreCase), existing-dirs-only:
+  enabled Base Model Folders → LocalAppData fallback → *nothing else* (ComfyUI roots are
+  appended by the backend provider, below).
+
+### Auto-registration
+
+- **On package add** (`InstallerManagerViewModel.AddExistingInstallation` flow, next to
+  `LinkOutputFolderAsync`): register model roots for the package —
+  - ComfyUI: `ComfyUiPathDiscovery.EnumerateModelSearchPaths(installPath)` (own `models/`
+    **+ every `extra_model_paths.yaml` root** + portable sibling `models/`), one row each;
+  - other types (Forge/A1111/…): `{InstallationPath}\models` when the directory exists.
+  All rows linked to the package, idempotent by path.
+- **On startup**: idempotent backfill registrar (pattern: `OutputsFolderRegistrar`) runs the
+  same logic for every already-registered package, so existing users see their folders appear
+  without re-adding installations. No row is ever auto-marked Default.
+- **On package removal**: FK SetNull — the folder row stays, now user-owned.
+
+### Root resolution for detection/inference
+
+`LocalDiffusionBackendProvider.ResolveModelsRootsAsync` prepends
+`IModelFolderCatalog.GetSearchRootsAsync()` to the existing ComfyUI-derived roots (deduped).
+Single choke point: pipeline readiness, `FindLoraPathBy*`, and local inference all see
+Base Model Folders + LocalAppData fallback + all ComfyUI roots (incl. yaml extras).
+The "returns empty when no ComfyUI" contract disappears — at minimum the fallback is returned.
+
+## Download flow changes
+
+- `PipelineAssetInstaller.InstallMissingAsync` gains a `downloadRoot` parameter
+  (`InstallMissingAsync(manifest, vramGb, downloadRoot, ct)`); the old "first ComfyUI root"
+  selection and the "No ComfyUI installation is registered" throw are removed. Callers pass
+  the dropdown selection (Workloads window) or `GetDefaultDownloadRootAsync()` (run screens /
+  tiles, which have no dropdown).
+- Subfolders (`loras/`, `vae/`, …) are created inside the chosen root on demand, as today.
+
+## UI
+
+### Settings — new "Base Model Folders" expander
+
+Built from the Generation Galleries template: description text, Add button, rows of
+[enable checkbox] [path textbox] [⭐ default toggle] [Browse] [Remove]. The ⭐ behaves like
+the LoRA source favorite star (selecting one clears the others, `HasChanges` set). Wired
+into `LoadAsync`/`SaveAsync` like the other collections.
+
+### Core Workloads window (`CoreWorkloadsDialog` / `CoreWorkloadsViewModel`)
+
+ComboBox "Download to:" above the tabs, items from `GetDownloadTargetsAsync()`
+(display: folder path, default item marked "(default)"), Default preselected.
+Selection is **per-window only** — it does not write back to settings. The selected path
+flows into the pipeline install callback → `InstallMissingAsync(..., downloadRoot, ...)`.
+
+## Error handling
+
+- Selected/download root uncreatable → the per-asset error isolation added in the sidecar
+  fix surfaces it; no silent fallback to a different folder once one was explicitly chosen.
+  The *automatic* default resolution (no dropdown involved) falls back to LocalAppData with
+  a logged warning when a configured default cannot be created.
+- Nonexistent registry folders are skipped by `GetSearchRootsAsync` (scan) but still listed
+  in Settings (user may plug the drive back in). Dropdown lists them too; choosing one
+  attempts creation.
+- `extra_model_paths.yaml` parse failures already degrade gracefully (existing parser).
+
+## Testing (TDD)
+
+- Catalog: fallback-only when registry empty; Default-first ordering; dedupe; skip missing dirs.
+- Auto-registration: ComfyUI package registers models/ + yaml roots + portable sibling;
+  non-ComfyUI registers `models/`; idempotent re-run; re-link existing path to package.
+- Settings service: collection sync round-trip; single-default invariant.
+- Installer: `InstallMissingAsync` downloads into the passed root; readiness detects assets
+  across catalog + ComfyUI roots (extend `PipelineAssetInstallerTests`).
+- ViewModel: dropdown preselects default; empty registry shows fallback item.
+- Export/import round-trip.
+- Full existing suite stays green.
+
+## Rollout
+
+Single branch `feature/base-model-folders` → one PR to `develop`. No main backport.


### PR DESCRIPTION
Implements the spec in `docs/superpowers/specs/2026-07-26-base-model-folders-design.md` (plan alongside in `docs/superpowers/plans/`). Develop-only by design — no main backport.

## What this adds

**A general Base Model Folders registry** — the Generation-Galleries/LoRA-sources pattern applied to model storage:

- **Settings → Base Model Folders**: manage model storage roots (add/browse/enable/remove) with an exclusive ⭐ **default** toggle (same star mechanism as the LoRA favorite source).
- **Auto-registration**: adding an installation in Installer Manager registers its model folders automatically — for ComfyUI via `ComfyUiPathDiscovery`, i.e. its own `models/`, **every `extra_model_paths.yaml` root**, and the portable sibling `models/`; other types register `{install}\models`. An idempotent startup backfill (`BaseModelFolderRegistrar`, `OutputsFolderRegistrar` pattern) does the same for already-registered installations, so existing users see their folders appear without re-adding anything. Removing a package keeps the folder row (FK SetNull).
- **Core Workloads window**: new **"Download to:"** dropdown listing all enabled folders, ⭐ default preselected, `%LOCALAPPDATA%\DiffusionNexus\Models` as the only entry when nothing is configured. Selection is per-window.
- **Fresh users need zero ComfyUI installs**: `InstallMissingAsync` now takes the caller-chosen download root; the *"No ComfyUI installation is registered"* failure mode is gone.
- **Detection stays a superset**: `LocalDiffusionBackendProvider` prepends the catalog's search roots to the existing ComfyUI discovery, so readiness checks, run-screen LoRA lookups, and local inference all see Base Model Folders + LocalAppData fallback + every ComfyUI root (incl. yaml extras). Nothing previously detected becomes undetected; nothing re-downloads.
- ComfyUI *workloads* (Workloads dialog → `WorkloadInstallService`) intentionally unchanged — they still install into the selected ComfyUI installation.

## Data / persistence

- New `BaseModelFolders` table (AppSettings child; `FolderPath`, `IsEnabled`, `Order`, `IsDefault`, nullable `InstallerPackageId` SetNull-FK) + migration `AddBaseModelFolders`.
- `AppSettingsService`: collection sync + single-default invariant (last flagged wins) + idempotent `AddBaseModelFolderAsync(path, packageId)` used by auto-registration.
- Settings export/import round-trips the rows (package links deliberately excluded).

## Breaking change (internal)

`IPipelineAssetInstaller.InstallMissingAsync(manifest, vramGb, ct)` → `InstallMissingAsync(manifest, vramGb, downloadRoot, ct)`.

## Tests

~20 new tests (TDD, red first): repository round-trip, service sync/invariant/idempotency, export/import, catalog ordering + fallback + uncreatable-default, registrar roots (incl. yaml) + idempotency + failure isolation, installer explicit-root + cross-root readiness, Core Workloads dropdown preselection, settings VM section (load/save/star exclusivity/add-remove). Full suite: **3282 passed, 0 failed**; solution builds clean.

## Manual smoke suggested before merge

1. Open Settings → Base Model Folders: existing installations' folders appear after startup backfill; add a folder, star it, save, reopen.
2. Installer Manager → Diffusion Nexus Core → Workloads: dropdown shows folders with the ⭐ default preselected; install a workload into a non-default folder and verify files land there.
3. Fresh-user path: with no ComfyUI packages, install a pipeline workload → assets land in `%LOCALAPPDATA%\DiffusionNexus\Models`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)