### PR TITLE
Gallery tagging: review follow-ups (#487-#492) + Advanced Search drawer rework

### DIFF
--- a/DiffusionNexus.Domain/Entities/ImageMediaTagIndex.cs
+++ b/DiffusionNexus.Domain/Entities/ImageMediaTagIndex.cs
@@ -23,7 +23,13 @@ public class ImageMediaTagIndex : BaseEntity
 
     public float RatingScore { get; set; }
 
-    /// <summary>True when <see cref="RatingLabel"/> is not the model's safest ("general") label.</summary>
+    /// <summary>
+    /// True when <see cref="RatingLabel"/> was not the model's safest
+    /// ("general") label at index time. Written for diagnostics only — queries
+    /// must NOT read it: they derive NSFW from <see cref="RatingLabel"/> at
+    /// query time through <c>ContentRatingPolicy</c>, so a rating-policy
+    /// change never requires a full re-index to take effect.
+    /// </summary>
     public bool IsNsfw { get; set; }
 
     public DateTimeOffset IndexedAtUtc { get; set; }

--- a/DiffusionNexus.Domain/Services/ContentRatingPolicy.cs
+++ b/DiffusionNexus.Domain/Services/ContentRatingPolicy.cs
@@ -1,0 +1,29 @@
+namespace DiffusionNexus.Domain.Services;
+
+/// <summary>
+/// The single place that decides whether a tagger content rating counts as
+/// NSFW. Both the write side (<c>ImageTaggingService</c> stamping
+/// <c>ImageTagResult.IsNsfw</c>) and the read side (<c>TagIndexService</c>
+/// queries deriving NSFW from the stored <c>RatingLabel</c>) go through this,
+/// so a future policy change (e.g. treating "sensitive" as SFW, or a
+/// user-configurable threshold) is one edit here and takes effect on the next
+/// query — no re-index of the whole gallery required.
+/// </summary>
+public static class ContentRatingPolicy
+{
+    /// <summary>
+    /// The one hardcoded rating-name assumption: WD14/Danbooru's rating
+    /// taxonomy has used "general" as the safest bucket since the schema's
+    /// introduction ("sensitive", "questionable" and "explicit" are the
+    /// others). Every other tag/rating name is read from the model's CSV.
+    /// </summary>
+    public const string SfwRatingLabel = "general";
+
+    /// <summary>
+    /// True when <paramref name="ratingLabel"/> is not the safest rating.
+    /// Null/empty (an unrated or corrupt row) counts as NSFW — content
+    /// filtering fails closed.
+    /// </summary>
+    public static bool IsNsfw(string? ratingLabel)
+        => !string.Equals(ratingLabel, SfwRatingLabel, StringComparison.OrdinalIgnoreCase);
+}

--- a/DiffusionNexus.Service/Services/BackgroundRemovalService.cs
+++ b/DiffusionNexus.Service/Services/BackgroundRemovalService.cs
@@ -10,21 +10,18 @@ namespace DiffusionNexus.Service.Services;
 
 /// <summary>
 /// Service for removing backgrounds from images using the RMBG-1.4 ONNX model.
-/// Performs inference locally using GPU acceleration when available, with CPU fallback.
+/// Session lifecycle (DirectML/CPU selection, GPU demotion, disposal) lives in
+/// <see cref="OnnxSessionHost"/>; this class owns only the RMBG-specific
+/// pre/post-processing.
 /// </summary>
 public sealed class BackgroundRemovalService : IBackgroundRemovalService
 {
     private const int ModelInputSize = 1024;
 
     private readonly OnnxModelManager _modelManager;
-    private readonly SemaphoreSlim _sessionLock = new(1, 1);
-    private InferenceSession? _session;
+    private readonly OnnxSessionHost _host = new("RMBG-1.4");
     private string? _inputName;
     private string? _outputName;
-    private bool _isGpuAvailable;
-    private bool _isProcessing;
-    private bool _disposed;
-    private bool _disableGpu;
 
     /// <summary>
     /// Creates a new BackgroundRemovalService.
@@ -41,10 +38,10 @@ public sealed class BackgroundRemovalService : IBackgroundRemovalService
     }
 
     /// <inheritdoc />
-    public bool IsGpuAvailable => _isGpuAvailable;
+    public bool IsGpuAvailable => _host.IsGpuAvailable;
 
     /// <inheritdoc />
-    public bool IsProcessing => _isProcessing;
+    public bool IsProcessing => _host.IsProcessing;
 
     /// <inheritdoc />
     public ModelStatus GetModelStatus() => _modelManager.GetRmbg14Status();
@@ -63,7 +60,7 @@ public sealed class BackgroundRemovalService : IBackgroundRemovalService
     /// <inheritdoc />
     public async Task<bool> InitializeAsync(CancellationToken cancellationToken = default)
     {
-        if (_session is not null)
+        if (_host.IsInitialized)
             return true;
 
         var status = GetModelStatus();
@@ -73,91 +70,7 @@ public sealed class BackgroundRemovalService : IBackgroundRemovalService
             return false;
         }
 
-        await _sessionLock.WaitAsync(cancellationToken);
-        try
-        {
-            if (_session is not null)
-                return true;
-
-            _session = await Task.Run(() => CreateSession(), cancellationToken);
-            return _session is not null;
-        }
-        finally
-        {
-            _sessionLock.Release();
-        }
-    }
-
-    private InferenceSession? CreateSession()
-    {
-        var modelPath = _modelManager.Rmbg14ModelPath;
-        if (!File.Exists(modelPath))
-        {
-            Log.Error("RMBG-1.4 model file not found: {Path}", modelPath);
-            return null;
-        }
-
-        // Try DirectML first (only if not disabled)
-        if (!_disableGpu)
-        {
-            try
-            {
-                var dmlOptions = new SessionOptions();
-                
-                // Compatibility parameters for DirectML on RMBG-1.4
-                // These settings prioritize stability over performance to fix the "Resize node" invalid parameter error.
-                dmlOptions.GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_BASIC;
-                dmlOptions.ExecutionMode = ExecutionMode.ORT_SEQUENTIAL;
-                
-                dmlOptions.EnableMemoryPattern = false;
-                dmlOptions.EnableCpuMemArena = false;
-                
-                dmlOptions.AddSessionConfigEntry("session.disable_prepacking", "1");
-                dmlOptions.AddSessionConfigEntry("ep.dml.enable_graph_capture", "0");
-                
-                // Add DirectML as primary execution provider
-                dmlOptions.AppendExecutionProvider_DML(0);
-                
-                // Add CPU as fallback for operations DirectML doesn't support
-                dmlOptions.AppendExecutionProvider_CPU(0);
-
-                var session = new InferenceSession(modelPath, dmlOptions);
-                _isGpuAvailable = true;
-                
-                // Discover input/output names from model metadata
-                DiscoverTensorNames(session);
-                
-                Log.Information("RMBG-1.4 ONNX session created with GPU (DirectML) acceleration");
-                return session;
-            }
-            catch (Exception ex)
-            {
-                Log.Warning(ex, "DirectML not available or failed to initialize, falling back to CPU");
-            }
-        }
-
-        // Fall back to CPU
-        try
-        {
-            var cpuOptions = new SessionOptions();
-            cpuOptions.GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL;
-            cpuOptions.EnableMemoryPattern = true;
-            cpuOptions.EnableCpuMemArena = true;
-
-            var session = new InferenceSession(modelPath, cpuOptions);
-            _isGpuAvailable = false;
-            
-            // Discover input/output names from model metadata
-            DiscoverTensorNames(session);
-            
-            Log.Information("RMBG-1.4 ONNX session created with CPU execution");
-            return session;
-        }
-        catch (Exception ex)
-        {
-            Log.Error(ex, "Failed to create ONNX session");
-            return null;
-        }
+        return await _host.InitializeAsync(_modelManager.Rmbg14ModelPath, DiscoverTensorNames, cancellationToken);
     }
 
     /// <summary>
@@ -165,18 +78,17 @@ public sealed class BackgroundRemovalService : IBackgroundRemovalService
     /// </summary>
     private void DiscoverTensorNames(InferenceSession session)
     {
-        // Get input name from model metadata
         _inputName = session.InputMetadata.Keys.FirstOrDefault();
         _outputName = session.OutputMetadata.Keys.FirstOrDefault();
-        
-        Log.Debug("RMBG-1.4 model input name: {InputName}, output name: {OutputName}", 
+
+        Log.Debug("RMBG-1.4 model input name: {InputName}, output name: {OutputName}",
             _inputName, _outputName);
-        
+
         if (string.IsNullOrEmpty(_inputName))
         {
             throw new InvalidOperationException("Could not determine input tensor name from model metadata");
         }
-        
+
         if (string.IsNullOrEmpty(_outputName))
         {
             throw new InvalidOperationException("Could not determine output tensor name from model metadata");
@@ -194,61 +106,53 @@ public sealed class BackgroundRemovalService : IBackgroundRemovalService
         if (width <= 0 || height <= 0)
             return BackgroundRemovalResult.Failed("Invalid image dimensions");
 
-        if (_isProcessing)
+        if (_host.IsDisposed)
+            return BackgroundRemovalResult.Failed("Service is disposed");
+
+        if (!_host.TryBeginProcessing())
             return BackgroundRemovalResult.Failed("Service is already processing an image");
 
-        // Ensure session is initialized
-        if (!await InitializeAsync(cancellationToken))
-            return BackgroundRemovalResult.Failed("Failed to initialize ONNX session. Please ensure the model is downloaded.");
-
-        _isProcessing = true;
         try
         {
-            return await Task.Run(() => ProcessImage(imageData, width, height, cancellationToken), cancellationToken);
-        }
-        catch (OnnxRuntimeException ex) when (_isGpuAvailable && !_disableGpu)
-        {
-            Log.Warning("GPU inference failed (likely driver/model incompatibility). Disabling GPU and retrying on CPU. Error: {Error}", ex.Message);
+            if (!await InitializeAsync(cancellationToken))
+                return BackgroundRemovalResult.Failed("Failed to initialize ONNX session. Please ensure the model is downloaded.");
 
-            // Reset session
-            await _sessionLock.WaitAsync(cancellationToken);
             try
             {
-                _session?.Dispose();
-                _session = null;
-                _disableGpu = true;
-                _isGpuAvailable = false;
+                return await Task.Run(() => ProcessImage(imageData, width, height, cancellationToken), cancellationToken);
             }
-            finally
+            catch (OnnxRuntimeException ex) when (_host.CanRetryOnCpu)
             {
-                _sessionLock.Release();
-            }
+                Log.Warning("GPU inference failed (likely driver/model incompatibility). Disabling GPU and retrying on CPU. Error: {Error}", ex.Message);
 
-            // Retry initialization (will force CPU)
-            if (await InitializeAsync(cancellationToken))
+                await _host.DemoteToCpuAsync(cancellationToken);
+
+                // Retry initialization (will force CPU)
+                if (await InitializeAsync(cancellationToken))
+                {
+                    try
+                    {
+                        Log.Information("Retrying background removal on CPU...");
+                        return await Task.Run(() => ProcessImage(imageData, width, height, cancellationToken), cancellationToken);
+                    }
+                    catch (Exception retryEx)
+                    {
+                        Log.Error(retryEx, "Retry on CPU failed");
+                        return BackgroundRemovalResult.Failed($"Background removal failed (CPU retry): {retryEx.Message}");
+                    }
+                }
+
+                return BackgroundRemovalResult.Failed($"Background removal failed (GPU Error: {ex.Message})");
+            }
+            catch (Exception ex)
             {
-                try
-                {
-                    Log.Information("Retrying background removal on CPU...");
-                    return await Task.Run(() => ProcessImage(imageData, width, height, cancellationToken), cancellationToken);
-                }
-                catch (Exception retryEx)
-                {
-                    Log.Error(retryEx, "Retry on CPU failed");
-                    return BackgroundRemovalResult.Failed($"Background removal failed (CPU retry): {retryEx.Message}");
-                }
+                Log.Error(ex, "Background removal failed");
+                return BackgroundRemovalResult.Failed($"Background removal failed: {ex.Message}");
             }
-
-            return BackgroundRemovalResult.Failed($"Background removal failed (GPU Error: {ex.Message})");
-        }
-        catch (Exception ex)
-        {
-            Log.Error(ex, "Background removal failed");
-            return BackgroundRemovalResult.Failed($"Background removal failed: {ex.Message}");
         }
         finally
         {
-            _isProcessing = false;
+            _host.EndProcessing();
         }
     }
 
@@ -275,12 +179,14 @@ public sealed class BackgroundRemovalService : IBackgroundRemovalService
             NamedOnnxValue.CreateFromTensor(_inputName!, inputTensor)
         };
 
-        using var results = _session!.Run(inputs);
-        var outputTensor = results.First().AsTensor<float>();
-
-        // Step 5: Postprocess - convert output to mask and resize
-        cancellationToken.ThrowIfCancellationRequested();
-        var maskData = PostprocessOutput(outputTensor, width, height);
+        // Step 5: Postprocess - convert output to mask and resize. Runs inside
+        // the host's Run scope because the output tensor is native memory owned
+        // by the result set.
+        var maskData = _host.Run(inputs, results =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return PostprocessOutput(results.First().AsTensor<float>(), width, height);
+        });
 
         return BackgroundRemovalResult.Succeeded(maskData, width, height);
     }
@@ -375,22 +281,5 @@ public sealed class BackgroundRemovalService : IBackgroundRemovalService
     }
 
     /// <inheritdoc />
-    public void Dispose()
-    {
-        if (_disposed) return;
-
-        _sessionLock.Wait();
-        try
-        {
-            _session?.Dispose();
-            _session = null;
-        }
-        finally
-        {
-            _sessionLock.Release();
-        }
-
-        _sessionLock.Dispose();
-        _disposed = true;
-    }
+    public void Dispose() => _host.Dispose();
 }

--- a/DiffusionNexus.Service/Services/ImageTaggingService.cs
+++ b/DiffusionNexus.Service/Services/ImageTaggingService.cs
@@ -22,22 +22,12 @@ public sealed class ImageTaggingService : IImageTaggingService
     private const string GeneralCategory = "0";
     private const string CharacterCategory = "4";
 
-    // The one hardcoded rating-name assumption in this class: WD14/Danbooru's
-    // rating taxonomy has used "general" as the safest bucket since the
-    // schema's introduction. Every other tag/rating name is read from the CSV.
-    private const string SfwRatingLabel = "general";
-
     private readonly OnnxModelManager _modelManager;
-    private readonly SemaphoreSlim _sessionLock = new(1, 1);
-    private InferenceSession? _session;
+    private readonly OnnxSessionHost _host = new("WD14 tagger");
     private string? _inputName;
     private string? _outputName;
     private int _inputSize;
     private List<(string Name, string Category)>? _tagList;
-    private bool _isGpuAvailable;
-    private bool _isProcessing;
-    private bool _disposed;
-    private bool _disableGpu;
 
     public ImageTaggingService() : this(new OnnxModelManager()) { }
 
@@ -46,8 +36,8 @@ public sealed class ImageTaggingService : IImageTaggingService
         _modelManager = modelManager ?? throw new ArgumentNullException(nameof(modelManager));
     }
 
-    public bool IsGpuAvailable => _isGpuAvailable;
-    public bool IsProcessing => _isProcessing;
+    public bool IsGpuAvailable => _host.IsGpuAvailable;
+    public bool IsProcessing => _host.IsProcessing;
 
     public ModelStatus GetModelStatus() => _modelManager.GetWd14TaggerStatus();
 
@@ -58,7 +48,7 @@ public sealed class ImageTaggingService : IImageTaggingService
 
     public async Task<bool> InitializeAsync(CancellationToken cancellationToken = default)
     {
-        if (_session is not null)
+        if (_host.IsInitialized && _tagList is not null)
             return true;
 
         var status = GetModelStatus();
@@ -68,14 +58,12 @@ public sealed class ImageTaggingService : IImageTaggingService
             return false;
         }
 
-        await _sessionLock.WaitAsync(cancellationToken);
-        try
+        if (_tagList is null)
         {
-            if (_session is not null)
-                return true;
-
             try
             {
+                // Concurrent callers may both load the CSV; the assignment is an
+                // atomic reference swap of identical content, so last-wins is fine.
                 _tagList = await Task.Run(() =>
                 {
                     using var reader = new StreamReader(_modelManager.Wd14TaggerTagsPath);
@@ -84,22 +72,18 @@ public sealed class ImageTaggingService : IImageTaggingService
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                // Mirrors CreateSession()'s own defensive catch: a failure here (file
-                // deleted mid-race, permissions, or a CSV that parses to zero rows
-                // despite passing the coarse size check in GetWd14TaggerStatus) must
-                // surface as InitializeAsync returning false — not as an exception
-                // escaping past TagImageAsync's Task<ImageTagResult> contract.
+                // Mirrors the session host's own defensive catch: a failure here
+                // (file deleted mid-race, permissions, or a CSV that parses to zero
+                // rows despite passing the coarse size check in GetWd14TaggerStatus)
+                // must surface as InitializeAsync returning false — not as an
+                // exception escaping past TagImageAsync's Task<ImageTagResult>
+                // contract.
                 Log.Error(ex, "Failed to load WD14 tagger tag list: {Path}", _modelManager.Wd14TaggerTagsPath);
                 return false;
             }
+        }
 
-            _session = await Task.Run(CreateSession, cancellationToken);
-            return _session is not null;
-        }
-        finally
-        {
-            _sessionLock.Release();
-        }
+        return await _host.InitializeAsync(_modelManager.Wd14TaggerModelPath, DiscoverModelShape, cancellationToken);
     }
 
     /// <summary>Parses a WD14 <c>selected_tags.csv</c> stream into (name, category) pairs.</summary>
@@ -168,68 +152,6 @@ public sealed class ImageTaggingService : IImageTaggingService
         return (tags.OrderByDescending(t => t.Confidence).ToList(), bestRatingName, bestRatingScore);
     }
 
-    private InferenceSession? CreateSession()
-    {
-        var modelPath = _modelManager.Wd14TaggerModelPath;
-        if (!File.Exists(modelPath))
-        {
-            Log.Error("WD14 tagger model file not found: {Path}", modelPath);
-            return null;
-        }
-
-        if (!_disableGpu)
-        {
-            InferenceSession? session = null;
-            try
-            {
-                using var dmlOptions = new SessionOptions();
-                dmlOptions.GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_BASIC;
-                dmlOptions.ExecutionMode = ExecutionMode.ORT_SEQUENTIAL;
-                dmlOptions.EnableMemoryPattern = false;
-                dmlOptions.EnableCpuMemArena = false;
-                // TODO: Linux Implementation — DirectML is Windows-only; a Linux
-                // port needs CUDA/ROCm providers here (the CPU fallback below
-                // already keeps this path non-fatal on other platforms).
-                dmlOptions.AppendExecutionProvider_DML(0);
-                dmlOptions.AppendExecutionProvider_CPU(0);
-
-                session = new InferenceSession(modelPath, dmlOptions);
-                DiscoverModelShape(session);
-                _isGpuAvailable = true;
-                Log.Information("WD14 tagger ONNX session created with GPU (DirectML) acceleration");
-                return session;
-            }
-            catch (Exception ex)
-            {
-                // Dispose on the shape-discovery throw path too — a session that
-                // constructed fine but reported an unusable input shape would
-                // otherwise leak its native model memory on every retry.
-                session?.Dispose();
-                Log.Warning(ex, "DirectML not available or failed to initialize, falling back to CPU");
-            }
-        }
-
-        {
-            InferenceSession? session = null;
-            try
-            {
-                using var cpuOptions = new SessionOptions();
-                cpuOptions.GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL;
-                session = new InferenceSession(modelPath, cpuOptions);
-                DiscoverModelShape(session);
-                _isGpuAvailable = false;
-                Log.Information("WD14 tagger ONNX session created with CPU execution");
-                return session;
-            }
-            catch (Exception ex)
-            {
-                session?.Dispose();
-                Log.Error(ex, "Failed to create WD14 tagger ONNX session");
-                return null;
-            }
-        }
-    }
-
     /// <summary>
     /// Reads input/output tensor names and the model's square input size from
     /// its own metadata rather than hardcoding them — WD14 tagger variants
@@ -258,72 +180,63 @@ public sealed class ImageTaggingService : IImageTaggingService
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(imagePath);
 
-        if (_disposed)
+        if (_host.IsDisposed)
             return ImageTagResult.Failed("Service is disposed");
 
-        if (_isProcessing)
+        if (!_host.TryBeginProcessing())
             return ImageTagResult.Failed("Service is already processing an image");
 
-        if (!await InitializeAsync(cancellationToken))
-            return ImageTagResult.Failed("Failed to initialize ONNX session. Please ensure the model is downloaded.");
-
-        _isProcessing = true;
         try
         {
-            return await Task.Run(() => ProcessImage(imagePath, tagConfidenceThreshold, cancellationToken), cancellationToken);
-        }
-        catch (OnnxRuntimeException ex) when (_isGpuAvailable && !_disableGpu)
-        {
-            Log.Warning("GPU inference failed for WD14 tagger, disabling GPU and retrying on CPU. Error: {Error}", ex.Message);
+            if (!await InitializeAsync(cancellationToken))
+                return ImageTagResult.Failed("Failed to initialize ONNX session. Please ensure the model is downloaded.");
 
-            await _sessionLock.WaitAsync(cancellationToken);
             try
             {
-                _session?.Dispose();
-                _session = null;
-                _disableGpu = true;
-                _isGpuAvailable = false;
+                return await Task.Run(() => ProcessImage(imagePath, tagConfidenceThreshold, cancellationToken), cancellationToken);
             }
-            finally
+            catch (OnnxRuntimeException ex) when (_host.CanRetryOnCpu)
             {
-                _sessionLock.Release();
-            }
+                Log.Warning("GPU inference failed for WD14 tagger, disabling GPU and retrying on CPU. Error: {Error}", ex.Message);
 
-            if (await InitializeAsync(cancellationToken))
+                await _host.DemoteToCpuAsync(cancellationToken);
+
+                if (await InitializeAsync(cancellationToken))
+                {
+                    try
+                    {
+                        return await Task.Run(() => ProcessImage(imagePath, tagConfidenceThreshold, cancellationToken), cancellationToken);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        throw;
+                    }
+                    catch (Exception retryEx)
+                    {
+                        return ImageTagResult.Failed($"Tagging failed (CPU retry): {retryEx.Message}");
+                    }
+                }
+
+                return ImageTagResult.Failed($"Tagging failed (GPU error): {ex.Message}");
+            }
+            // One cancellation policy for the whole class: InitializeAsync lets
+            // OperationCanceledException propagate raw, so TagImageAsync must too.
+            // Without this the general catch below would quietly turn a cancelled
+            // batch into a stream of "Failed" results, which callers cannot tell
+            // apart from real tagging errors.
+            catch (OperationCanceledException)
             {
-                try
-                {
-                    return await Task.Run(() => ProcessImage(imagePath, tagConfidenceThreshold, cancellationToken), cancellationToken);
-                }
-                catch (OperationCanceledException)
-                {
-                    throw;
-                }
-                catch (Exception retryEx)
-                {
-                    return ImageTagResult.Failed($"Tagging failed (CPU retry): {retryEx.Message}");
-                }
+                throw;
             }
-
-            return ImageTagResult.Failed($"Tagging failed (GPU error): {ex.Message}");
-        }
-        // One cancellation policy for the whole class: InitializeAsync lets
-        // OperationCanceledException propagate raw, so TagImageAsync must too.
-        // Without this the general catch below would quietly turn a cancelled
-        // batch into a stream of "Failed" results, which callers cannot tell
-        // apart from real tagging errors.
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            Log.Error(ex, "Image tagging failed");
-            return ImageTagResult.Failed($"Tagging failed: {ex.Message}");
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Image tagging failed");
+                return ImageTagResult.Failed($"Tagging failed: {ex.Message}");
+            }
         }
         finally
         {
-            _isProcessing = false;
+            _host.EndProcessing();
         }
     }
 
@@ -344,15 +257,14 @@ public sealed class ImageTaggingService : IImageTaggingService
 
         cancellationToken.ThrowIfCancellationRequested();
         var inputs = new List<NamedOnnxValue> { NamedOnnxValue.CreateFromTensor(_inputName!, inputTensor) };
-        using var results = _session!.Run(inputs);
-        var scores = results.First().AsTensor<float>().ToArray();
+        var scores = _host.Run(inputs, results => results.First().AsTensor<float>().ToArray());
 
         var (tags, ratingLabel, ratingScore) = SelectTagsAndRating(_tagList!, scores, tagConfidenceThreshold);
 
         if (ratingLabel is null)
             return ImageTagResult.Failed("Tag list contains no rating (category 9) entries");
 
-        var isNsfw = !string.Equals(ratingLabel, SfwRatingLabel, StringComparison.OrdinalIgnoreCase);
+        var isNsfw = ContentRatingPolicy.IsNsfw(ratingLabel);
         return ImageTagResult.Succeeded(tags, ratingLabel, ratingScore, isNsfw);
     }
 
@@ -426,20 +338,5 @@ public sealed class ImageTaggingService : IImageTaggingService
         return tensor;
     }
 
-    public void Dispose()
-    {
-        if (_disposed) return;
-        _sessionLock.Wait();
-        try
-        {
-            _session?.Dispose();
-            _session = null;
-        }
-        finally
-        {
-            _sessionLock.Release();
-        }
-        _sessionLock.Dispose();
-        _disposed = true;
-    }
+    public void Dispose() => _host.Dispose();
 }

--- a/DiffusionNexus.Service/Services/ImageUpscalingService.cs
+++ b/DiffusionNexus.Service/Services/ImageUpscalingService.cs
@@ -5,14 +5,15 @@ using Serilog;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
-using SixLabors.ImageSharp.Processing.Processors.Transforms;
 
 namespace DiffusionNexus.Service.Services;
 
 /// <summary>
 /// Service for upscaling images using the 4x-UltraSharp ONNX model.
-/// Performs inference locally using GPU acceleration when available, with CPU fallback.
 /// Uses tile-based processing to handle large images within memory constraints.
+/// Session lifecycle (DirectML/CPU selection, GPU demotion, disposal) lives in
+/// <see cref="OnnxSessionHost"/>; this class owns only the tiling and
+/// pre/post-processing.
 /// </summary>
 public sealed class ImageUpscalingService : IImageUpscalingService
 {
@@ -23,14 +24,9 @@ public sealed class ImageUpscalingService : IImageUpscalingService
     private const int TileParseSize = TileSize - 2 * TilePadding; // The actual valid content size per tile
 
     private readonly OnnxModelManager _modelManager;
-    private readonly SemaphoreSlim _sessionLock = new(1, 1);
-    private InferenceSession? _session;
+    private readonly OnnxSessionHost _host = new("4x-UltraSharp");
     private string? _inputName;
     private string? _outputName;
-    private bool _isGpuAvailable;
-    private bool _isProcessing;
-    private bool _disposed;
-    private bool _disableGpu;
 
     /// <summary>
     /// Creates a new ImageUpscalingService.
@@ -47,10 +43,10 @@ public sealed class ImageUpscalingService : IImageUpscalingService
     }
 
     /// <inheritdoc />
-    public bool IsGpuAvailable => _isGpuAvailable;
+    public bool IsGpuAvailable => _host.IsGpuAvailable;
 
     /// <inheritdoc />
-    public bool IsProcessing => _isProcessing;
+    public bool IsProcessing => _host.IsProcessing;
 
     /// <inheritdoc />
     public ModelStatus GetModelStatus() => _modelManager.GetUltraSharp4xStatus();
@@ -69,7 +65,7 @@ public sealed class ImageUpscalingService : IImageUpscalingService
     /// <inheritdoc />
     public async Task<bool> InitializeAsync(CancellationToken cancellationToken = default)
     {
-        if (_session is not null)
+        if (_host.IsInitialized)
             return true;
 
         var status = GetModelStatus();
@@ -79,93 +75,7 @@ public sealed class ImageUpscalingService : IImageUpscalingService
             return false;
         }
 
-        await _sessionLock.WaitAsync(cancellationToken);
-        try
-        {
-            if (_session is not null)
-                return true;
-
-            _session = await Task.Run(() => CreateSession(), cancellationToken);
-            return _session is not null;
-        }
-        finally
-        {
-            _sessionLock.Release();
-        }
-    }
-
-    private InferenceSession? CreateSession()
-    {
-        var modelPath = _modelManager.UltraSharp4xModelPath;
-        if (!File.Exists(modelPath))
-        {
-            Log.Error("4x-UltraSharp model file not found: {Path}", modelPath);
-            return null;
-        }
-
-        // Try DirectML first (only if not disabled)
-        if (!_disableGpu)
-        {
-            try
-            {
-                var dmlOptions = new SessionOptions();
-                
-                // Compatibility parameters for DirectML on 4x-UltraSharp
-                // These settings prioritize stability over performance to prevent known DirectML issues.
-                dmlOptions.GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_BASIC;
-                dmlOptions.ExecutionMode = ExecutionMode.ORT_SEQUENTIAL;
-                
-                dmlOptions.EnableMemoryPattern = false;
-                dmlOptions.EnableCpuMemArena = false;
-                
-                dmlOptions.AddSessionConfigEntry("session.disable_prepacking", "1");
-                dmlOptions.AddSessionConfigEntry("ep.dml.enable_graph_capture", "0");
-                
-                // Add DirectML as primary execution provider
-                dmlOptions.AppendExecutionProvider_DML(0);
-                
-                // Add CPU as fallback for operations DirectML doesn't support
-                dmlOptions.AppendExecutionProvider_CPU(0);
-
-                var session = new InferenceSession(modelPath, dmlOptions);
-                _isGpuAvailable = true;
-
-                // Discover input/output names from model metadata
-                DiscoverTensorNames(session);
-
-                Log.Information("4x-UltraSharp ONNX session created with GPU (DirectML) acceleration");
-                return session;
-            }
-            catch (Exception ex)
-            {
-                Log.Warning(ex, "DirectML not available or failed to initialize, falling back to CPU");
-            }
-        }
-
-        // Fall back to CPU
-        try
-        {
-            var cpuOptions = new SessionOptions();
-            cpuOptions.GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL;
-            cpuOptions.EnableMemoryPattern = true;
-            cpuOptions.EnableCpuMemArena = true;
-            cpuOptions.IntraOpNumThreads = Environment.ProcessorCount;
-
-            var session = new InferenceSession(modelPath, cpuOptions);
-            _isGpuAvailable = false;
-
-            // Discover input/output names from model metadata
-            DiscoverTensorNames(session);
-
-            Log.Information("4x-UltraSharp ONNX session created with CPU execution ({Threads} threads)",
-                Environment.ProcessorCount);
-            return session;
-        }
-        catch (Exception ex)
-        {
-            Log.Error(ex, "Failed to create ONNX session for upscaling");
-            return null;
-        }
+        return await _host.InitializeAsync(_modelManager.UltraSharp4xModelPath, DiscoverTensorNames, cancellationToken);
     }
 
     /// <summary>
@@ -173,7 +83,6 @@ public sealed class ImageUpscalingService : IImageUpscalingService
     /// </summary>
     private void DiscoverTensorNames(InferenceSession session)
     {
-        // Get input name from model metadata
         _inputName = session.InputMetadata.Keys.FirstOrDefault();
         _outputName = session.OutputMetadata.Keys.FirstOrDefault();
 
@@ -207,65 +116,57 @@ public sealed class ImageUpscalingService : IImageUpscalingService
         if (targetScale < 1.1f || targetScale > 4.0f)
             return ImageUpscalingResult.Failed("Target scale must be between 1.1 and 4.0");
 
-        if (_isProcessing)
+        if (_host.IsDisposed)
+            return ImageUpscalingResult.Failed("Service is disposed");
+
+        if (!_host.TryBeginProcessing())
             return ImageUpscalingResult.Failed("Service is already processing an image");
 
-        // Ensure session is initialized
-        if (!await InitializeAsync(cancellationToken))
-            return ImageUpscalingResult.Failed("Failed to initialize ONNX session. Please ensure the model is downloaded.");
-
-        _isProcessing = true;
         try
         {
-            return await Task.Run(() =>
-                ProcessImage(imageData, width, height, targetScale, progress, cancellationToken),
-                cancellationToken);
-        }
-        catch (OnnxRuntimeException ex) when (_isGpuAvailable && !_disableGpu)
-        {
-            Log.Warning(ex, "GPU inference failed. Disabling GPU and retrying on CPU.");
+            if (!await InitializeAsync(cancellationToken))
+                return ImageUpscalingResult.Failed("Failed to initialize ONNX session. Please ensure the model is downloaded.");
 
-            // Reset session
-            await _sessionLock.WaitAsync(cancellationToken);
             try
             {
-                _session?.Dispose();
-                _session = null;
-                _disableGpu = true;
-                _isGpuAvailable = false;
+                return await Task.Run(() =>
+                    ProcessImage(imageData, width, height, targetScale, progress, cancellationToken),
+                    cancellationToken);
             }
-            finally
+            catch (OnnxRuntimeException ex) when (_host.CanRetryOnCpu)
             {
-                _sessionLock.Release();
-            }
+                Log.Warning(ex, "GPU inference failed. Disabling GPU and retrying on CPU.");
 
-            // Retry initialization (will force CPU)
-            if (await InitializeAsync(cancellationToken))
+                await _host.DemoteToCpuAsync(cancellationToken);
+
+                // Retry initialization (will force CPU)
+                if (await InitializeAsync(cancellationToken))
+                {
+                    try
+                    {
+                        Log.Information("Retrying upscaling on CPU...");
+                        return await Task.Run(() =>
+                            ProcessImage(imageData, width, height, targetScale, progress, cancellationToken),
+                            cancellationToken);
+                    }
+                    catch (Exception retryEx)
+                    {
+                        Log.Error(retryEx, "Retry on CPU failed");
+                        return ImageUpscalingResult.Failed($"Upscaling failed (CPU retry): {retryEx.Message}");
+                    }
+                }
+
+                return ImageUpscalingResult.Failed($"Upscaling failed (GPU Error: {ex.Message})");
+            }
+            catch (Exception ex)
             {
-                try
-                {
-                    Log.Information("Retrying upscaling on CPU...");
-                    return await Task.Run(() =>
-                        ProcessImage(imageData, width, height, targetScale, progress, cancellationToken),
-                        cancellationToken);
-                }
-                catch (Exception retryEx)
-                {
-                    Log.Error(retryEx, "Retry on CPU failed");
-                    return ImageUpscalingResult.Failed($"Upscaling failed (CPU retry): {retryEx.Message}");
-                }
+                Log.Error(ex, "Image upscaling failed");
+                return ImageUpscalingResult.Failed($"Upscaling failed: {ex.Message}");
             }
-
-            return ImageUpscalingResult.Failed($"Upscaling failed (GPU Error: {ex.Message})");
-        }
-        catch (Exception ex)
-        {
-            Log.Error(ex, "Image upscaling failed");
-            return ImageUpscalingResult.Failed($"Upscaling failed: {ex.Message}");
         }
         finally
         {
-            _isProcessing = false;
+            _host.EndProcessing();
         }
     }
 
@@ -383,10 +284,10 @@ public sealed class ImageUpscalingService : IImageUpscalingService
                 // We discard 'TilePadding' from all sides of the upscaled result to remove edge artifacts
                 var destX = inputStartX * ScaleFactor;
                 var destY = inputStartY * ScaleFactor;
-                
+
                 var srcCropX = TilePadding * ScaleFactor;
                 var srcCropY = TilePadding * ScaleFactor;
-                
+
                 var validWidth = TileParseSize * ScaleFactor;
                 var validHeight = TileParseSize * ScaleFactor;
 
@@ -433,7 +334,9 @@ public sealed class ImageUpscalingService : IImageUpscalingService
     }
 
     /// <summary>
-    /// Processes a single tile through the ONNX model.
+    /// Processes a single tile through the ONNX model. Each tile is one
+    /// inference inside the host's Run scope, so disposal can interleave
+    /// between tiles (yielding a managed failure) but never under one.
     /// </summary>
     private Image<Rgba32> ProcessSingleTile(Image<Rgba32> tile)
     {
@@ -461,29 +364,37 @@ public sealed class ImageUpscalingService : IImageUpscalingService
             NamedOnnxValue.CreateFromTensor(_inputName!, tensor)
         };
 
-        using var results = _session!.Run(inputs);
-        var outputTensor = results.First().AsTensor<float>();
-
-        // Convert output tensor to image
-        var outputSize = TileSize * ScaleFactor;
-        var output = new Image<Rgba32>(outputSize, outputSize);
-
-        output.ProcessPixelRows(accessor =>
+        return _host.Run(inputs, results =>
         {
-            for (var y = 0; y < outputSize; y++)
+            var outputTensor = results.First().AsTensor<float>();
+
+            // Convert output tensor to image
+            var outputSize = TileSize * ScaleFactor;
+            var output = new Image<Rgba32>(outputSize, outputSize);
+            try
             {
-                var row = accessor.GetRowSpan(y);
-                for (var x = 0; x < outputSize; x++)
+                output.ProcessPixelRows(accessor =>
                 {
-                    var r = (byte)Math.Clamp(outputTensor[0, 0, y, x] * 255.0f, 0, 255);
-                    var g = (byte)Math.Clamp(outputTensor[0, 1, y, x] * 255.0f, 0, 255);
-                    var b = (byte)Math.Clamp(outputTensor[0, 2, y, x] * 255.0f, 0, 255);
-                    row[x] = new Rgba32(r, g, b, 255);
-                }
+                    for (var y = 0; y < outputSize; y++)
+                    {
+                        var row = accessor.GetRowSpan(y);
+                        for (var x = 0; x < outputSize; x++)
+                        {
+                            var r = (byte)Math.Clamp(outputTensor[0, 0, y, x] * 255.0f, 0, 255);
+                            var g = (byte)Math.Clamp(outputTensor[0, 1, y, x] * 255.0f, 0, 255);
+                            var b = (byte)Math.Clamp(outputTensor[0, 2, y, x] * 255.0f, 0, 255);
+                            row[x] = new Rgba32(r, g, b, 255);
+                        }
+                    }
+                });
+                return output;
+            }
+            catch
+            {
+                output.Dispose();
+                throw;
             }
         });
-
-        return output;
     }
 
     /// <summary>
@@ -519,22 +430,5 @@ public sealed class ImageUpscalingService : IImageUpscalingService
     }
 
     /// <inheritdoc />
-    public void Dispose()
-    {
-        if (_disposed) return;
-
-        _sessionLock.Wait();
-        try
-        {
-            _session?.Dispose();
-            _session = null;
-        }
-        finally
-        {
-            _sessionLock.Release();
-        }
-
-        _sessionLock.Dispose();
-        _disposed = true;
-    }
+    public void Dispose() => _host.Dispose();
 }

--- a/DiffusionNexus.Service/Services/OnnxSessionHost.cs
+++ b/DiffusionNexus.Service/Services/OnnxSessionHost.cs
@@ -1,0 +1,262 @@
+using Microsoft.ML.OnnxRuntime;
+using Serilog;
+
+namespace DiffusionNexus.Service.Services;
+
+/// <summary>
+/// Owns the full lifecycle of one ONNX <see cref="InferenceSession"/>:
+/// provider selection (DirectML with CPU fallback), lazy double-checked
+/// initialization, permanent GPU demotion after a failed GPU inference,
+/// single-flight processing admission, and disposal that waits out any
+/// in-flight inference. <see cref="BackgroundRemovalService"/>,
+/// <see cref="ImageUpscalingService"/> and <see cref="ImageTaggingService"/>
+/// each used to carry a hand-rolled copy of all of this; the copies had
+/// already drifted (missing DirectML compatibility flags, missing CPU tuning,
+/// leaked sessions on metadata-discovery failures) and every provider fix had
+/// to be found and applied three times.
+/// </summary>
+/// <remarks>
+/// Threading model:
+/// <list type="bullet">
+/// <item><see cref="_sessionLock"/> guards every touch of <see cref="_session"/> —
+/// creation, inference, demotion and disposal. Holding it across
+/// <see cref="Run{T}"/> (including result read-out, whose tensors are native
+/// memory owned by the result set) is what makes <see cref="Dispose"/> safe to
+/// call while an inference is in flight: it blocks until the run finishes
+/// instead of freeing the native session under it, which would be an
+/// uncatchable <c>AccessViolationException</c> at best.</item>
+/// <item><see cref="_processing"/> is a separate, non-blocking admission gate:
+/// callers that lose <see cref="TryBeginProcessing"/> get an immediate
+/// "already processing" answer instead of queueing on the session lock. It is
+/// an <see cref="Interlocked"/> exchange, not a bool — the services' old plain
+/// <c>_isProcessing</c> check-then-set let two concurrent callers both pass
+/// and then fail unpredictably inside the session.</item>
+/// </list>
+/// </remarks>
+public sealed class OnnxSessionHost : IDisposable
+{
+    private readonly string _modelDescription;
+    private readonly SemaphoreSlim _sessionLock = new(1, 1);
+    private InferenceSession? _session;
+    private bool _isGpuAvailable;
+    private bool _disableGpu;
+    private volatile bool _disposed;
+    private int _processing;
+
+    /// <param name="modelDescription">
+    /// Short human-readable model name used in log messages, e.g. "RMBG-1.4".
+    /// </param>
+    public OnnxSessionHost(string modelDescription)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(modelDescription);
+        _modelDescription = modelDescription;
+    }
+
+    public bool IsGpuAvailable => _isGpuAvailable;
+    public bool IsProcessing => Volatile.Read(ref _processing) == 1;
+    public bool IsDisposed => _disposed;
+    public bool IsInitialized => _session is not null;
+
+    /// <summary>
+    /// True when a failed GPU inference can still be retried by demoting to
+    /// CPU — i.e. the current session actually runs on the GPU and no earlier
+    /// failure has already forced CPU-only mode. Mirrors the services'
+    /// <c>when (_isGpuAvailable &amp;&amp; !_disableGpu)</c> catch filters.
+    /// </summary>
+    public bool CanRetryOnCpu => _isGpuAvailable && !_disableGpu;
+
+    /// <summary>
+    /// Atomically claims the single-flight processing slot. A <c>false</c>
+    /// return means another inference is already running and the caller should
+    /// answer "busy" immediately. Pair every successful claim with
+    /// <see cref="EndProcessing"/> in a <c>finally</c>.
+    /// </summary>
+    public bool TryBeginProcessing() => Interlocked.CompareExchange(ref _processing, 1, 0) == 0;
+
+    public void EndProcessing() => Volatile.Write(ref _processing, 0);
+
+    /// <summary>
+    /// Creates the session if it does not exist yet. Returns false when
+    /// creation failed (missing model file, unloadable model, metadata
+    /// rejected by <paramref name="inspectModel"/>) — never throws for those.
+    /// </summary>
+    /// <param name="inspectModel">
+    /// Runs against the freshly created session, still under the session lock,
+    /// so the owner can read tensor names/shapes. Throwing rejects the
+    /// session: it is disposed, never published, and on the DirectML attempt
+    /// the CPU fallback is tried next.
+    /// </param>
+    public async Task<bool> InitializeAsync(
+        string modelPath,
+        Action<InferenceSession>? inspectModel = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (_disposed)
+            return false;
+        if (_session is not null)
+            return true;
+
+        await _sessionLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (_disposed)
+                return false;
+            if (_session is not null)
+                return true;
+
+            _session = await Task.Run(() => CreateSession(modelPath, inspectModel), cancellationToken);
+            return _session is not null;
+        }
+        finally
+        {
+            _sessionLock.Release();
+        }
+    }
+
+    private InferenceSession? CreateSession(string modelPath, Action<InferenceSession>? inspectModel)
+    {
+        if (!File.Exists(modelPath))
+        {
+            Log.Error("{Model} model file not found: {Path}", _modelDescription, modelPath);
+            return null;
+        }
+
+        if (!_disableGpu)
+        {
+            InferenceSession? session = null;
+            try
+            {
+                using var dmlOptions = new SessionOptions();
+                // Compatibility parameters for DirectML. These prioritize
+                // stability over performance: ORT_ENABLE_BASIC + sequential
+                // execution + disabled prepacking/graph-capture fix known
+                // DirectML issues (e.g. the RMBG-1.4 "Resize node" invalid
+                // parameter error) and are applied uniformly — the tagger's
+                // former private copy had silently dropped them.
+                dmlOptions.GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_BASIC;
+                dmlOptions.ExecutionMode = ExecutionMode.ORT_SEQUENTIAL;
+                dmlOptions.EnableMemoryPattern = false;
+                dmlOptions.EnableCpuMemArena = false;
+                dmlOptions.AddSessionConfigEntry("session.disable_prepacking", "1");
+                dmlOptions.AddSessionConfigEntry("ep.dml.enable_graph_capture", "0");
+                // TODO: Linux Implementation — DirectML is Windows-only; a
+                // Linux port needs CUDA/ROCm providers here (the CPU fallback
+                // below already keeps this path non-fatal on other platforms).
+                dmlOptions.AppendExecutionProvider_DML(0);
+                // CPU as fallback for operations DirectML doesn't support.
+                dmlOptions.AppendExecutionProvider_CPU(0);
+
+                session = new InferenceSession(modelPath, dmlOptions);
+                inspectModel?.Invoke(session);
+                _isGpuAvailable = true;
+                Log.Information("{Model} ONNX session created with GPU (DirectML) acceleration", _modelDescription);
+                return session;
+            }
+            catch (Exception ex)
+            {
+                // Dispose on the inspection-throw path too — a session that
+                // constructed fine but reported unusable metadata would
+                // otherwise leak its native model memory on every retry.
+                session?.Dispose();
+                Log.Warning(ex, "DirectML not available or failed to initialize for {Model}, falling back to CPU", _modelDescription);
+            }
+        }
+
+        {
+            InferenceSession? session = null;
+            try
+            {
+                using var cpuOptions = new SessionOptions();
+                cpuOptions.GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL;
+                cpuOptions.EnableMemoryPattern = true;
+                cpuOptions.EnableCpuMemArena = true;
+                cpuOptions.IntraOpNumThreads = Environment.ProcessorCount;
+
+                session = new InferenceSession(modelPath, cpuOptions);
+                inspectModel?.Invoke(session);
+                _isGpuAvailable = false;
+                Log.Information("{Model} ONNX session created with CPU execution ({Threads} threads)",
+                    _modelDescription, Environment.ProcessorCount);
+                return session;
+            }
+            catch (Exception ex)
+            {
+                session?.Dispose();
+                Log.Error(ex, "Failed to create ONNX session for {Model}", _modelDescription);
+                return null;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Runs one inference and reads the results out, all under the session
+    /// lock. <paramref name="readResults"/> must copy what it needs (e.g.
+    /// <c>AsTensor&lt;float&gt;().ToArray()</c> or writing into an image) —
+    /// the result collection and its tensors are disposed when it returns.
+    /// </summary>
+    public T Run<T>(
+        IReadOnlyCollection<NamedOnnxValue> inputs,
+        Func<IDisposableReadOnlyCollection<DisposableNamedOnnxValue>, T> readResults)
+    {
+        _sessionLock.Wait();
+        try
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            var session = _session
+                ?? throw new InvalidOperationException($"{_modelDescription}: ONNX session is not initialized");
+
+            using var results = session.Run(inputs);
+            return readResults(results);
+        }
+        finally
+        {
+            _sessionLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Permanently disables the GPU after a failed GPU inference and tears the
+    /// session down so the next <see cref="InitializeAsync"/> rebuilds it
+    /// CPU-only. There is deliberately no way back: a GPU that failed once
+    /// (driver/model incompatibility) would just fail again.
+    /// </summary>
+    public async Task DemoteToCpuAsync(CancellationToken cancellationToken = default)
+    {
+        await _sessionLock.WaitAsync(cancellationToken);
+        try
+        {
+            _session?.Dispose();
+            _session = null;
+            _disableGpu = true;
+            _isGpuAvailable = false;
+        }
+        finally
+        {
+            _sessionLock.Release();
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+
+        // Taking the session lock first means an in-flight Run finishes
+        // before the native session is freed. Late callers then observe
+        // _disposed (their entry guard) or get a managed
+        // ObjectDisposedException from the disposed semaphore — never a
+        // native crash.
+        _sessionLock.Wait();
+        try
+        {
+            _disposed = true;
+            _session?.Dispose();
+            _session = null;
+        }
+        finally
+        {
+            _sessionLock.Release();
+        }
+
+        _sessionLock.Dispose();
+    }
+}

--- a/DiffusionNexus.Service/Services/TagIndexService.cs
+++ b/DiffusionNexus.Service/Services/TagIndexService.cs
@@ -24,6 +24,20 @@ public sealed class TagIndexService : ITagIndexService
     private readonly IImageTaggingService _taggingService;
     private readonly IDownloadCoordinator? _downloadCoordinator;
 
+    /// <summary>
+    /// One index build at a time, app-wide (this service is a DI singleton).
+    /// Two overlapping builds — reachable because every gallery-page scope
+    /// gets its own Build command over these shared services — used to
+    /// interact badly twice over: both raced the tagger's single-flight gate
+    /// (per-file "already processing" failures on a healthy install), and each
+    /// build's "already indexed?" snapshot couldn't see the other's unflushed
+    /// inserts, so both staged the same FilePath and the loser's whole
+    /// 25-file chunk died on the UNIQUE constraint. Serializing here removes
+    /// both: the second build waits, then sees the first's rows and skips them
+    /// as unchanged.
+    /// </summary>
+    private readonly SemaphoreSlim _buildGate = new(1, 1);
+
     public TagIndexService(
         IDbContextFactory<DiffusionNexusCoreDbContext> contextFactory,
         IImageTaggingService taggingService,
@@ -64,17 +78,33 @@ public sealed class TagIndexService : ITagIndexService
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
 
+        // Nothing taggable was supplied. Return before the download gate:
+        // otherwise an empty selection — or a folder that only holds videos —
+        // would trigger a ~379 MB model download to index zero files.
+        if (work.Count == 0)
+            return new TagIndexBuildResult(Indexed: 0, Skipped: 0, Failed: 0, NsfwCount: 0);
+
+        await _buildGate.WaitAsync(cancellationToken);
+        try
+        {
+            return await BuildIndexCoreAsync(work, progress, cancellationToken);
+        }
+        finally
+        {
+            _buildGate.Release();
+        }
+    }
+
+    private async Task<TagIndexBuildResult> BuildIndexCoreAsync(
+        List<string> work,
+        IProgress<TagIndexBuildProgress>? progress,
+        CancellationToken cancellationToken)
+    {
         var indexed = 0;
         var skipped = 0;
         var failed = 0;
         var nsfwCount = 0;
         var total = work.Count;
-
-        // Nothing taggable was supplied. Return before the download gate:
-        // otherwise an empty selection — or a folder that only holds videos —
-        // would trigger a ~379 MB model download to index zero files.
-        if (total == 0)
-            return new TagIndexBuildResult(Indexed: 0, Skipped: 0, Failed: 0, NsfwCount: 0);
 
         // The model downloads on first use, not eagerly — this is that
         // trigger point. Routed through IDownloadCoordinator when available
@@ -135,7 +165,7 @@ public sealed class TagIndexService : ITagIndexService
         // clearing flushes.
         var existingMeta = await context.ImageMediaTagIndexes
             .AsNoTracking()
-            .Select(e => new { e.Id, e.FilePath, e.FileSizeBytes, e.FileLastWriteTimeUtc, e.IsNsfw })
+            .Select(e => new { e.Id, e.FilePath, e.FileSizeBytes, e.FileLastWriteTimeUtc, e.RatingLabel })
             .ToListAsync(cancellationToken);
         var metaByPath = existingMeta.ToDictionary(e => e.FilePath, e => e, StringComparer.OrdinalIgnoreCase);
 
@@ -210,7 +240,7 @@ public sealed class TagIndexService : ITagIndexService
                     && meta.FileLastWriteTimeUtc == fileInfo.LastWriteTimeUtc)
                 {
                     skipped++;
-                    if (meta.IsNsfw) nsfwCount++;
+                    if (ContentRatingPolicy.IsNsfw(meta.RatingLabel)) nsfwCount++;
                     continue;
                 }
 
@@ -366,10 +396,18 @@ public sealed class TagIndexService : ITagIndexService
 
         var query = context.ImageMediaTagIndexes.AsQueryable();
 
+        // NSFW is derived from the stored RatingLabel at query time via
+        // ContentRatingPolicy — never from the frozen IsNsfw column — so a
+        // rating-policy change takes effect without re-running the tagger over
+        // the whole gallery. The comparison is a plain equality against the
+        // policy's SFW label: it translates to indexed SQL
+        // (IX_ImageMediaTagIndexes_RatingLabel), and any row whose label
+        // doesn't exactly match the safest bucket (different casing, corrupt
+        // value) classifies as NSFW — filtering fails closed.
         query = nsfwFilter switch
         {
-            NsfwFilterMode.HideNsfw => query.Where(e => !e.IsNsfw),
-            NsfwFilterMode.NsfwOnly => query.Where(e => e.IsNsfw),
+            NsfwFilterMode.HideNsfw => query.Where(e => e.RatingLabel == ContentRatingPolicy.SfwRatingLabel),
+            NsfwFilterMode.NsfwOnly => query.Where(e => e.RatingLabel != ContentRatingPolicy.SfwRatingLabel),
             _ => query,
         };
 
@@ -433,14 +471,15 @@ public sealed class TagIndexService : ITagIndexService
             .Select(e => new
             {
                 e.FilePath,
-                e.IsNsfw,
+                e.RatingLabel,
                 Tags = e.TagAssignments.Select(a => a.ImageTag!.Name).ToList(),
             })
             .ToListAsync(cancellationToken);
 
+        // NSFW derived at read time from the stored rating (see SearchAsync).
         return rows.ToDictionary(
             e => e.FilePath,
-            e => new ImageTagLookup(e.IsNsfw, e.Tags),
+            e => new ImageTagLookup(ContentRatingPolicy.IsNsfw(e.RatingLabel), e.Tags),
             StringComparer.OrdinalIgnoreCase);
     }
 

--- a/DiffusionNexus.Tests/Service/Services/OnnxSessionHostTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/OnnxSessionHostTests.cs
@@ -1,0 +1,131 @@
+using DiffusionNexus.Service.Services;
+using FluentAssertions;
+using Microsoft.ML.OnnxRuntime;
+using Xunit;
+
+namespace DiffusionNexus.Tests.Service.Services;
+
+/// <summary>
+/// Lifecycle tests for the shared ONNX session host (issue #487). Real
+/// inference needs a model file, so these cover exactly the paths that do not:
+/// initialization failure, the single-flight admission gate (the old plain
+/// bool let two concurrent callers both pass, issue #491), and the
+/// guard/ordering behavior around disposal (issue #490).
+/// </summary>
+public sealed class OnnxSessionHostTests
+{
+    [Fact]
+    public async Task InitializeAsync_WithMissingModelFile_ReturnsFalseInsteadOfThrowing()
+    {
+        using var host = new OnnxSessionHost("test-model");
+
+        var result = await host.InitializeAsync(Path.Combine(Path.GetTempPath(), "does-not-exist-" + Guid.NewGuid().ToString("N") + ".onnx"));
+
+        result.Should().BeFalse();
+        host.IsInitialized.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithAnUnloadableModelFile_ReturnsFalse_AndTriesCpuAfterGpu()
+    {
+        // A file that exists but is not a valid ONNX model exercises both
+        // provider branches (DirectML attempt, then the CPU fallback) and
+        // must come back as a clean false, never an exception.
+        var bogusModel = Path.Combine(Path.GetTempPath(), "bogus-" + Guid.NewGuid().ToString("N") + ".onnx");
+        await File.WriteAllTextAsync(bogusModel, "not an onnx model");
+        try
+        {
+            using var host = new OnnxSessionHost("test-model");
+
+            var result = await host.InitializeAsync(bogusModel);
+
+            result.Should().BeFalse();
+            host.IsInitialized.Should().BeFalse();
+        }
+        finally
+        {
+            File.Delete(bogusModel);
+        }
+    }
+
+    [Fact]
+    public async Task InitializeAsync_AfterDispose_ReturnsFalse()
+    {
+        var host = new OnnxSessionHost("test-model");
+        host.Dispose();
+
+        var result = await host.InitializeAsync("irrelevant.onnx");
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Run_BeforeInitialize_ThrowsInvalidOperation()
+    {
+        using var host = new OnnxSessionHost("test-model");
+
+        var act = () => host.Run(new List<NamedOnnxValue>(), _ => 0);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*not initialized*");
+    }
+
+    [Fact]
+    public void Run_AfterDispose_ThrowsAManagedException()
+    {
+        // The whole point of issue #490: a Run racing Dispose must surface as
+        // a managed exception the caller's catch can turn into a Failed
+        // result — never as native teardown under an in-flight inference.
+        var host = new OnnxSessionHost("test-model");
+        host.Dispose();
+
+        var act = () => host.Run(new List<NamedOnnxValue>(), _ => 0);
+
+        act.Should().Throw<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        var host = new OnnxSessionHost("test-model");
+
+        host.Dispose();
+        var act = () => host.Dispose();
+
+        act.Should().NotThrow();
+        host.IsDisposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryBeginProcessing_IsSingleFlight_UntilEndProcessing()
+    {
+        using var host = new OnnxSessionHost("test-model");
+
+        host.IsProcessing.Should().BeFalse();
+        host.TryBeginProcessing().Should().BeTrue();
+        host.IsProcessing.Should().BeTrue();
+        host.TryBeginProcessing().Should().BeFalse("the slot is taken");
+
+        host.EndProcessing();
+
+        host.IsProcessing.Should().BeFalse();
+        host.TryBeginProcessing().Should().BeTrue("the slot reopened");
+    }
+
+    [Fact]
+    public void TryBeginProcessing_UnderContention_AdmitsExactlyOneCaller()
+    {
+        // The services' old `if (_isProcessing) ... _isProcessing = true`
+        // check-then-set let several concurrent callers pass together and
+        // fail unpredictably inside the shared session (issue #491).
+        using var host = new OnnxSessionHost("test-model");
+        var admitted = 0;
+
+        Parallel.For(0, 64, _ =>
+        {
+            if (host.TryBeginProcessing())
+                Interlocked.Increment(ref admitted);
+        });
+
+        admitted.Should().Be(1);
+    }
+}

--- a/DiffusionNexus.Tests/Service/Services/TagIndexServiceTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/TagIndexServiceTests.cs
@@ -177,6 +177,72 @@ public sealed class TagIndexServiceTests : IAsyncDisposable
     }
 
     [Fact]
+    public async Task BuildIndexAsync_SerializesConcurrentBuilds_SoTheyCannotCorruptEachOther()
+    {
+        // Issue #491: two gallery scopes can start builds over the same shared
+        // singletons. Unserialized, both raced the tagger's single-flight gate
+        // (per-file "already processing" failures on a healthy install) and
+        // staged duplicate rows for the same FilePath (a UNIQUE violation that
+        // discarded whole flush chunks). The build gate makes the second build
+        // wait, then skip the first's rows as unchanged.
+        var paths = Enumerable.Range(0, 6).Select(i => CreateFakeImage($"conc{i}.png")).ToList();
+
+        var inFlight = 0;
+        var maxInFlight = 0;
+        var tagging = new Mock<IImageTaggingService>();
+        tagging.Setup(t => t.GetModelStatus()).Returns(ModelStatus.Ready);
+        tagging.Setup(t => t.TagImageAsync(It.IsAny<string>(), It.IsAny<float>(), It.IsAny<CancellationToken>()))
+            .Returns(async (string _, float _, CancellationToken ct) =>
+            {
+                var now = Interlocked.Increment(ref inFlight);
+                int seen;
+                while (now > (seen = Volatile.Read(ref maxInFlight)))
+                    Interlocked.CompareExchange(ref maxInFlight, now, seen);
+                await Task.Delay(10, ct);
+                Interlocked.Decrement(ref inFlight);
+                return ImageTagResult.Succeeded(Array.Empty<ImageTagScore>(), "general", 0.9f, isNsfw: false);
+            });
+        var service = new TagIndexService(new SingleDbContextFactory(_options), tagging.Object);
+
+        var results = await Task.WhenAll(
+            Task.Run(() => service.BuildIndexAsync(paths)),
+            Task.Run(() => service.BuildIndexAsync(paths)));
+
+        maxInFlight.Should().Be(1, "the build gate must keep the shared tagger single-flight");
+        results.Sum(r => r.Failed).Should().Be(0, "a second build on a healthy install must not manufacture failures");
+        results.Sum(r => r.Indexed).Should().Be(6, "each file is tagged exactly once across both builds");
+        results.Sum(r => r.Skipped).Should().Be(6, "the waiting build sees the first one's rows and skips them");
+        (await service.GetIndexedCountAsync()).Should().Be(6, "no duplicate rows, no dropped chunks");
+    }
+
+    [Fact]
+    public async Task NsfwQueries_DeriveFromTheStoredRatingLabel_NotTheFrozenFlag()
+    {
+        // Issue #492: IsNsfw is written for diagnostics but must never be
+        // read — a rating-policy change has to take effect at query time
+        // without re-running the tagger over the whole gallery. This tagger
+        // stamps a contradictory frozen flag (isNsfw: false on a
+        // non-"general" rating); every query has to side with the rating.
+        var sfwPath = CreateFakeImage("rating-sfw.png");
+        var sensitivePath = CreateFakeImage("rating-sensitive.png", width: 8);
+        var tagging = TaggerByWidth(w => w == 8
+            ? ImageTagResult.Succeeded(Array.Empty<ImageTagScore>(), "sensitive", 0.9f, isNsfw: false)
+            : ImageTagResult.Succeeded(Array.Empty<ImageTagScore>(), "general", 0.9f, isNsfw: false));
+        var service = new TagIndexService(new SingleDbContextFactory(_options), tagging.Object);
+        await service.BuildIndexAsync(new[] { sfwPath, sensitivePath });
+
+        var hidden = await service.SearchAsync(Array.Empty<string>(), NsfwFilterMode.HideNsfw);
+        hidden.Should().ContainSingle().Which.Should().Be(Path.GetFullPath(sfwPath));
+
+        var nsfwOnly = await service.SearchAsync(Array.Empty<string>(), NsfwFilterMode.NsfwOnly);
+        nsfwOnly.Should().ContainSingle().Which.Should().Be(Path.GetFullPath(sensitivePath));
+
+        var lookup = await service.GetTagsForFilesAsync(new[] { sfwPath, sensitivePath });
+        lookup[Path.GetFullPath(sensitivePath)].IsNsfw.Should().BeTrue("tile badges derive from the rating too");
+        lookup[Path.GetFullPath(sfwPath)].IsNsfw.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task SearchAsync_ReturnsOnlyImagesWithAllRequiredTags()
     {
         var pathA = CreateFakeImage("dog-outdoor.png");

--- a/DiffusionNexus.Tests/Viewer/GenerationGalleryViewModelTests.cs
+++ b/DiffusionNexus.Tests/Viewer/GenerationGalleryViewModelTests.cs
@@ -1152,6 +1152,50 @@ public class GenerationGalleryViewModelTests : IDisposable
         tracked.IsTerminal.Should().BeTrue();
     }
 
+    [Fact]
+    public async Task TagCloudSearchText_FiltersTheVisibleChips_WithoutTouchingActiveFilters()
+    {
+        // A fully indexed gallery fills the cloud's 200-chip budget with booru
+        // tags — the filter box narrows what is SHOWN, case-insensitively,
+        // and must never alter which filters are ACTIVE.
+        var galleryPath = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(galleryPath, "a.png"), "test");
+
+        var mockTagIndex = BuildableTagIndex(new TagIndexBuildResult(1, 0, 0, 0));
+        mockTagIndex.Setup(t => t.GetTagCloudAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new TagFrequency("dog", 3), new TagFrequency("door", 2), new TagFrequency("cat", 1) });
+        mockTagIndex.Setup(t => t.SearchAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<NsfwFilterMode>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<string>());
+
+        var viewModel = CreateGalleryViewModel(galleryPath, mockTagIndex.Object);
+        await viewModel.LoadMediaCommand.ExecuteAsync(null);
+        await viewModel.BuildTagIndexCommand.ExecuteAsync(null);
+
+        viewModel.TagCloud.Should().HaveCount(3, "no filter shows the whole cloud");
+
+        viewModel.ToggleTagFilterCommand.Execute("dog");
+        viewModel.TagCloudSearchText = "do";
+
+        viewModel.TagCloud.Select(t => t.Name).Should().BeEquivalentTo(new[] { "dog", "door" });
+        viewModel.ActiveTagFilters.Should().ContainSingle().Which.Should().Be("dog",
+            "the box filters the display, not the active filter set");
+        viewModel.TagCloudHeader.Should().Contain("3 tags",
+            "the header describes the index and must not shrink while typing");
+
+        viewModel.TagCloudSearchText = "DOOR";
+        viewModel.TagCloud.Select(t => t.Name).Should().BeEquivalentTo(new[] { "door" }, "matching is case-insensitive");
+
+        // Deactivate "dog" while the filter hides its chip, then clear the
+        // filter: the chip must come back with its CURRENT state, not the
+        // state it had when it was hidden.
+        viewModel.ToggleTagFilterCommand.Execute("dog");
+        viewModel.TagCloudSearchText = null;
+
+        viewModel.TagCloud.Should().HaveCount(3);
+        viewModel.TagCloud.Single(t => t.Name == "dog").IsActive.Should().BeFalse(
+            "chips hidden by the display filter stay in sync with the active filter set");
+    }
+
     // ---- Final-review fixes: threading, resilience, feedback, cancellation ----
 
     [Fact]

--- a/DiffusionNexus.Tests/Viewer/GenerationGalleryViewModelTests.cs
+++ b/DiffusionNexus.Tests/Viewer/GenerationGalleryViewModelTests.cs
@@ -2,6 +2,8 @@ using System.Globalization;
 using DiffusionNexus.DataAccess.Data;
 using DiffusionNexus.Domain.Entities;
 using DiffusionNexus.Domain.Services;
+using DiffusionNexus.Domain.Services.UnifiedLogging;
+using DiffusionNexus.Infrastructure.Services;
 using DiffusionNexus.Service.Services;
 using DiffusionNexus.UI.Services;
 using DiffusionNexus.UI.ViewModels;
@@ -748,7 +750,11 @@ public class GenerationGalleryViewModelTests : IDisposable
 
         var settings = new AppSettings
         {
-            ImageGalleries = [new() { FolderPath = galleryPath, IsEnabled = true, Order = 0 }]
+            ImageGalleries = [new() { FolderPath = galleryPath, IsEnabled = true, Order = 0 }],
+            // Keep the AppSettings NSFW seed out of this test: SearchAsync
+            // below answers every query with the indexed set, so a seeded
+            // Hide NSFW would treat every indexed file as known-NSFW.
+            ShowNsfw = true,
         };
         var mockSettings = new Mock<IAppSettingsService>();
         mockSettings.Setup(service => service.GetSettingsAsync(It.IsAny<CancellationToken>()))
@@ -939,6 +945,10 @@ public class GenerationGalleryViewModelTests : IDisposable
         mockSettings.Setup(service => service.GetSettingsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(settings);
 
+        // The tile carries IsNsfw: true, so the AppSettings NSFW seed would
+        // hide it before the assertion could look at it.
+        settings.ShowNsfw = true;
+
         var mockTagIndex = new Mock<ITagIndexService>();
         mockTagIndex.Setup(t => t.GetIndexedCountAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(1);
         mockTagIndex.Setup(t => t.GetTagsForFilesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
@@ -960,6 +970,186 @@ public class GenerationGalleryViewModelTests : IDisposable
         var item = viewModel.MediaItems.Single();
         item.IsNsfw.Should().BeTrue();
         item.Tags.Should().BeEquivalentTo(new[] { "dog", "outdoor" });
+    }
+
+    [Fact]
+    public void IsTaggingAvailable_ReflectsWhetherATagIndexServiceExists()
+    {
+        // Issue #489: the view binds every tagging affordance's visibility to
+        // this single gate, so a configuration without the service shows no
+        // tagging UI instead of clickable buttons that silently do nothing.
+        var without = new GenerationGalleryViewModel(
+            new Mock<IAppSettingsService>().Object,
+            new Mock<IDatasetEventAggregator>().Object,
+            new Mock<IDatasetState>().Object,
+            null);
+        without.IsTaggingAvailable.Should().BeFalse();
+
+        var with = new GenerationGalleryViewModel(
+            new Mock<IAppSettingsService>().Object,
+            new Mock<IDatasetEventAggregator>().Object,
+            new Mock<IDatasetState>().Object,
+            null,
+            tagIndexService: new Mock<ITagIndexService>().Object);
+        with.IsTaggingAvailable.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task LoadMediaAsync_SeedsHideNsfwFromTheAppWideSetting_AndHidesKnownNsfwImages()
+    {
+        // Issue #492: AppSettings.ShowNsfw (off by default) and the drawer's
+        // NSFW mode used to be two disconnected switches for one user intent —
+        // hiding NSFW app-wide did nothing here. The setting seeds the
+        // drawer's mode, so the filtering is visible (radio + filter strip)
+        // rather than an invisible standing gate.
+        var galleryPath = CreateTempDirectory();
+        var sfwImage = Path.Combine(galleryPath, "sfw.png");
+        var nsfwImage = Path.Combine(galleryPath, "nsfw.png");
+        File.WriteAllText(sfwImage, "test");
+        File.WriteAllText(nsfwImage, "test");
+
+        var settings = new AppSettings
+        {
+            ImageGalleries = [new() { FolderPath = galleryPath, IsEnabled = true, Order = 0 }],
+            ShowNsfw = false,
+        };
+        var mockSettings = new Mock<IAppSettingsService>();
+        mockSettings.Setup(service => service.GetSettingsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(settings);
+
+        var mockTagIndex = new Mock<ITagIndexService>();
+        mockTagIndex.Setup(t => t.GetIndexedCountAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(2);
+        mockTagIndex.Setup(t => t.GetTagsForFilesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, ImageTagLookup>());
+        mockTagIndex.Setup(t => t.SearchAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<NsfwFilterMode>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { nsfwImage });
+
+        var viewModel = new GenerationGalleryViewModel(
+            mockSettings.Object,
+            new Mock<IDatasetEventAggregator>().Object,
+            new Mock<IDatasetState>().Object,
+            null,
+            tagIndexService: mockTagIndex.Object);
+
+        await viewModel.LoadMediaCommand.ExecuteAsync(null);
+        await viewModel.WaitForSortingAsync();
+
+        viewModel.NsfwFilter.Should().Be(NsfwFilterMode.HideNsfw,
+            "the app-wide setting seeds the drawer so the two switches agree");
+        viewModel.HasActiveTagFilters.Should().BeTrue(
+            "the seeded filter must be visible in the filter strip, not an invisible gate");
+        viewModel.MediaItems.Should().ContainSingle()
+            .Which.FilePath.Should().Be(sfwImage);
+    }
+
+    [Fact]
+    public async Task LoadMediaAsync_DoesNotReSeed_AfterTheUserExplicitlyChoseAMode()
+    {
+        // A reload (settings saved, folders changed) must never stomp a
+        // deliberate per-session choice with the seed.
+        var galleryPath = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(galleryPath, "a.png"), "test");
+
+        var settings = new AppSettings
+        {
+            ImageGalleries = [new() { FolderPath = galleryPath, IsEnabled = true, Order = 0 }],
+            ShowNsfw = false,
+        };
+        var mockSettings = new Mock<IAppSettingsService>();
+        mockSettings.Setup(service => service.GetSettingsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(settings);
+
+        var mockTagIndex = new Mock<ITagIndexService>();
+        mockTagIndex.Setup(t => t.GetIndexedCountAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(0);
+        mockTagIndex.Setup(t => t.SearchAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<NsfwFilterMode>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<string>());
+
+        var viewModel = new GenerationGalleryViewModel(
+            mockSettings.Object,
+            new Mock<IDatasetEventAggregator>().Object,
+            new Mock<IDatasetState>().Object,
+            null,
+            tagIndexService: mockTagIndex.Object);
+
+        await viewModel.LoadMediaCommand.ExecuteAsync(null);
+        viewModel.NsfwFilter.Should().Be(NsfwFilterMode.HideNsfw, "the first load seeds from the setting");
+
+        viewModel.SetNsfwFilterCommand.Execute(nameof(NsfwFilterMode.ShowAll));
+        await viewModel.WaitForSortingAsync();
+
+        await viewModel.LoadMediaCommand.ExecuteAsync(null);
+        viewModel.NsfwFilter.Should().Be(NsfwFilterMode.ShowAll,
+            "the user's explicit choice survives the reload");
+    }
+
+    [Fact]
+    public async Task BuildTagIndexCommand_CompletesItsTrackedTask_InTheUnifiedConsole()
+    {
+        // Issue #488: the ~30-second model download was already visible in
+        // the Unified Console but the potentially far longer index build was
+        // not. The build registers a tracked task and finishes it with the
+        // same summary the gallery shows.
+        var galleryPath = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(galleryPath, "a.png"), "test");
+
+        var tracker = new TaskTracker(new Mock<IUnifiedLogger>().Object);
+        var mockTagIndex = BuildableTagIndex(new TagIndexBuildResult(Indexed: 1, Skipped: 0, Failed: 0, NsfwCount: 0));
+
+        var viewModel = CreateGalleryViewModel(galleryPath, mockTagIndex.Object, tracker);
+
+        await viewModel.LoadMediaCommand.ExecuteAsync(null);
+        await viewModel.BuildTagIndexCommand.ExecuteAsync(null);
+
+        var tracked = tracker.AllTasks.Should().ContainSingle(t => t.Name == "Building tag index").Subject;
+        tracked.Status.Should().Be(TrackedTaskStatus.Completed);
+        tracked.StatusText.Should().Be(viewModel.StatusMessage,
+            "the console shows the same summary as the gallery");
+    }
+
+    [Fact]
+    public async Task BuildTagIndexCommand_CanBeCancelledFromTheUnifiedConsole()
+    {
+        // The tracker is handed the same CancellationTokenSource as the
+        // toolbar Cancel button, so the console's per-task Cancel stops a
+        // build started from the gallery.
+        var galleryPath = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(galleryPath, "a.png"), "test");
+
+        var tracker = new TaskTracker(new Mock<IUnifiedLogger>().Object);
+
+        var buildStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var mockTagIndex = new Mock<ITagIndexService>();
+        mockTagIndex.Setup(t => t.GetIndexedCountAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(0);
+        mockTagIndex.Setup(t => t.GetTagCloudAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<TagFrequency>());
+        mockTagIndex.Setup(t => t.GetTagsForFilesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, ImageTagLookup>());
+        mockTagIndex.Setup(t => t.BuildIndexAsync(
+                It.IsAny<IReadOnlyList<string>>(), It.IsAny<IProgress<TagIndexBuildProgress>>(), It.IsAny<CancellationToken>()))
+            .Returns(async (IReadOnlyList<string> _, IProgress<TagIndexBuildProgress> _, CancellationToken ct) =>
+            {
+                buildStarted.TrySetResult();
+                // Ends only through cancellation — exactly the long build the
+                // console needs to be able to stop.
+                await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+                return new TagIndexBuildResult(0, 0, 0, 0);
+            });
+
+        var viewModel = CreateGalleryViewModel(galleryPath, mockTagIndex.Object, tracker);
+
+        await viewModel.LoadMediaCommand.ExecuteAsync(null);
+        var buildTask = viewModel.BuildTagIndexCommand.ExecuteAsync(null);
+        await buildStarted.Task;
+
+        var tracked = tracker.AllTasks.Should().ContainSingle(t => t.Name == "Building tag index").Subject;
+        tracked.Status.Should().Be(TrackedTaskStatus.Running);
+
+        tracker.CancelTask(tracked.TaskId);
+        await buildTask;
+
+        viewModel.StatusMessage.Should().Contain("cancelled");
+        viewModel.IsIndexingTagIndex.Should().BeFalse();
+        tracked.IsTerminal.Should().BeTrue();
     }
 
     // ---- Final-review fixes: threading, resilience, feedback, cancellation ----
@@ -1385,11 +1575,17 @@ public class GenerationGalleryViewModelTests : IDisposable
     /// A gallery ViewModel over a single enabled folder, with the supplied tag
     /// index service.
     /// </summary>
-    private static GenerationGalleryViewModel CreateGalleryViewModel(string galleryPath, ITagIndexService tagIndexService)
+    private static GenerationGalleryViewModel CreateGalleryViewModel(
+        string galleryPath, ITagIndexService tagIndexService, ITaskTracker? taskTracker = null)
     {
         var settings = new AppSettings
         {
-            ImageGalleries = [new() { FolderPath = galleryPath, IsEnabled = true, Order = 0 }]
+            ImageGalleries = [new() { FolderPath = galleryPath, IsEnabled = true, Order = 0 }],
+            // ShowNsfw=false (the AppSettings default) seeds the drawer's
+            // Hide NSFW mode on load, which makes every filter pass query the
+            // known-NSFW set — noise these tests don't set up. Tests covering
+            // the seeding itself build their own settings with ShowNsfw=false.
+            ShowNsfw = true,
         };
         var mockSettings = new Mock<IAppSettingsService>();
         mockSettings.Setup(service => service.GetSettingsAsync(It.IsAny<CancellationToken>()))
@@ -1400,7 +1596,8 @@ public class GenerationGalleryViewModelTests : IDisposable
             new Mock<IDatasetEventAggregator>().Object,
             new Mock<IDatasetState>().Object,
             null,
-            tagIndexService: tagIndexService);
+            tagIndexService: tagIndexService,
+            taskTracker: taskTracker);
     }
 
     /// <summary>

--- a/DiffusionNexus.UI/App.axaml.cs
+++ b/DiffusionNexus.UI/App.axaml.cs
@@ -926,7 +926,8 @@ public partial class App : Application
             sp.GetService<IVideoThumbnailService>(),
             sp.GetService<IThumbnailOrchestrator>(),
             sp.GetService<IImageFavoritesService>(),
-            sp.GetService<ITagIndexService>()));
+            sp.GetService<ITagIndexService>(),
+            sp.GetService<Domain.Services.UnifiedLogging.ITaskTracker>()));
         
         // LoraDatasetHelperViewModel - use factory to inject all required services
         services.AddScoped<LoraDatasetHelperViewModel>(sp => new LoraDatasetHelperViewModel(

--- a/DiffusionNexus.UI/ViewModels/GenerationGalleryViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/GenerationGalleryViewModel.cs
@@ -365,6 +365,26 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
 
     public BatchObservableCollection<TagCloudEntryViewModel> TagCloud { get; } = [];
 
+    /// <summary>
+    /// Every tag-cloud entry from the last refresh. <see cref="TagCloud"/> is
+    /// the filtered VIEW of this list (see <see cref="TagCloudSearchText"/>).
+    /// Chip active-state updates iterate this list, not the view, so chips
+    /// currently hidden by the filter stay in sync — both collections hold
+    /// the same entry instances.
+    /// </summary>
+    private readonly List<TagCloudEntryViewModel> _allTagCloudEntries = [];
+
+    /// <summary>
+    /// Live substring filter over the tag-cloud chips. A fully indexed
+    /// gallery easily fills the cloud's 200-chip budget with booru tags,
+    /// which makes eyeballing for one tag hopeless. Display-only: it narrows
+    /// which chips are shown, never which filters are active.
+    /// </summary>
+    [ObservableProperty]
+    private string? _tagCloudSearchText;
+
+    partial void OnTagCloudSearchTextChanged(string? value) => ApplyTagCloudSearch();
+
     public ObservableCollection<string> ActiveTagFilters { get; } = [];
 
     /// <summary>
@@ -393,7 +413,10 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
 
     public string FilteredMatchCountText => $"{FilteredMatchCount:N0} images match";
 
-    public string TagCloudHeader => $"TAG INDEX — {TotalGalleryImageCount:N0} images · {TagCloud.Count:N0} tags";
+    // Counts the full entry list, not the filtered TagCloud view — the header
+    // describes the index, and must not shrink while the user types in the
+    // tag filter box.
+    public string TagCloudHeader => $"TAG INDEX — {TotalGalleryImageCount:N0} images · {_allTagCloudEntries.Count:N0} tags";
 
     #region IThumbnailAware
 
@@ -841,7 +864,9 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
         if (!ActiveTagFilters.Remove(tagName))
             ActiveTagFilters.Add(tagName);
 
-        foreach (var entry in TagCloud)
+        // The full list, not the filtered TagCloud view — a chip toggled and
+        // then hidden by the tag filter box must not come back stale.
+        foreach (var entry in _allTagCloudEntries)
             entry.IsActive = ActiveTagFilters.Contains(entry.Name);
 
         OnPropertyChanged(nameof(HasActiveTagFilters));
@@ -852,7 +877,7 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
     private void ClearTagFilters()
     {
         ActiveTagFilters.Clear();
-        foreach (var entry in TagCloud)
+        foreach (var entry in _allTagCloudEntries)
             entry.IsActive = false;
 
         // "Clear filters" has to clear all of them. The NSFW mode filters on
@@ -894,7 +919,10 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
         {
             var cloud = await Task.Run(() => _tagIndexService.GetTagCloudAsync());
             var activeNames = ActiveTagFilters.ToHashSet(StringComparer.OrdinalIgnoreCase);
-            TagCloud.ReplaceAll(cloud.Select(t => new TagCloudEntryViewModel(t.Name, t.Count) { IsActive = activeNames.Contains(t.Name) }).ToList());
+            _allTagCloudEntries.Clear();
+            _allTagCloudEntries.AddRange(
+                cloud.Select(t => new TagCloudEntryViewModel(t.Name, t.Count) { IsActive = activeNames.Contains(t.Name) }));
+            ApplyTagCloudSearch();
             OnPropertyChanged(nameof(TagCloudHeader));
         }
         catch (Exception ex)
@@ -923,6 +951,21 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
                 item.Tags = info.Tags;
             }
         }
+    }
+
+    /// <summary>
+    /// Publishes the (possibly filtered) tag-cloud view. Runs on every
+    /// keystroke in the filter box and after every cloud refresh — pure
+    /// in-memory list work over ≤200 entries, no DB involved.
+    /// </summary>
+    private void ApplyTagCloudSearch()
+    {
+        var search = TagCloudSearchText?.Trim();
+        TagCloud.ReplaceAll(string.IsNullOrEmpty(search)
+            ? _allTagCloudEntries.ToList()
+            : _allTagCloudEntries
+                .Where(e => e.Name.Contains(search, StringComparison.OrdinalIgnoreCase))
+                .ToList());
     }
 
     private void InvalidateTagSearchCache()

--- a/DiffusionNexus.UI/ViewModels/GenerationGalleryViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/GenerationGalleryViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.ObjectModel;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
 using Avalonia.Threading;
@@ -8,6 +8,7 @@ using DiffusionNexus.Domain.Entities;
 using DiffusionNexus.Domain.Enums;
 using DiffusionNexus.Domain.Models;
 using DiffusionNexus.Domain.Services;
+using DiffusionNexus.Domain.Services.UnifiedLogging;
 using DiffusionNexus.UI.Services;
 using DiffusionNexus.UI.Utilities;
 using DiffusionNexus.UI.ViewModels.Controls;
@@ -29,7 +30,17 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
     private readonly IThumbnailOrchestrator? _thumbnailOrchestrator;
     private readonly IImageFavoritesService? _favoritesService;
     private readonly ITagIndexService? _tagIndexService;
+    private readonly ITaskTracker? _taskTracker;
     private readonly List<GenerationGalleryMediaItemViewModel> _allMediaItems = [];
+
+    /// <summary>
+    /// True once the user has explicitly chosen an NSFW mode (radio button or
+    /// "Clear filters") this session. Gates the seeding in
+    /// <see cref="LoadMediaAsync"/>: the app-wide <c>AppSettings.ShowNsfw</c>
+    /// setting seeds the drawer's filter so the two switches agree, but a
+    /// deliberate per-session choice is never stomped by a later reload.
+    /// </summary>
+    private bool _nsfwFilterTouched;
     private GenerationGalleryMediaItemViewModel? _lastClickedItem;
     private int _selectionCount;
     private bool _isUpdatingGroupingOptions;
@@ -111,7 +122,8 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
         IVideoThumbnailService? videoThumbnailService,
         IThumbnailOrchestrator? thumbnailOrchestrator = null,
         IImageFavoritesService? favoritesService = null,
-        ITagIndexService? tagIndexService = null)
+        ITagIndexService? tagIndexService = null,
+        ITaskTracker? taskTracker = null)
     {
         _settingsService = settingsService ?? throw new ArgumentNullException(nameof(settingsService));
         _eventAggregator = eventAggregator ?? throw new ArgumentNullException(nameof(eventAggregator));
@@ -120,6 +132,7 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
         _thumbnailOrchestrator = thumbnailOrchestrator;
         _favoritesService = favoritesService;
         _tagIndexService = tagIndexService;
+        _taskTracker = taskTracker;
 
         // Both toolbars are the SAME reusable component the workflow result strips use, so "Add
         // Selected To…" and "Send Selected To…" behave identically everywhere. They're split into two
@@ -367,6 +380,17 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
     public bool IsNsfwFilterHideNsfw => NsfwFilter == NsfwFilterMode.HideNsfw;
     public bool IsNsfwFilterNsfwOnly => NsfwFilter == NsfwFilterMode.NsfwOnly;
 
+    /// <summary>
+    /// The single availability gate for every tagging affordance (Build Tag
+    /// Index, the indexed-count pill, Advanced Search). The view binds this
+    /// for visibility so that a configuration without an
+    /// <see cref="ITagIndexService"/> (design time, tests, a future feature
+    /// flag) shows no tagging UI at all — instead of fully clickable buttons
+    /// that silently do nothing because each handler bailed on its own null
+    /// check. Fixed at construction, so no change notification is needed.
+    /// </summary>
+    public bool IsTaggingAvailable => _tagIndexService is not null;
+
     public string FilteredMatchCountText => $"{FilteredMatchCount:N0} images match";
 
     public string TagCloudHeader => $"TAG INDEX — {TotalGalleryImageCount:N0} images · {TagCloud.Count:N0} tags";
@@ -404,6 +428,24 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
             var settings = await _settingsService.GetSettingsAsync();
             var enabledPaths = GetEnabledGalleryPaths(settings);
             var includeSubFolders = IncludeSubFolders;
+
+            // The app-wide setting (Settings → "Show NSFW", off by default)
+            // seeds the Advanced Search drawer's NSFW mode so the two switches
+            // agree — the persisted setting used to be silently ignored here,
+            // leaving NSFW tiles visible until the user found the second,
+            // per-session filter. Seeding (rather than an invisible standing
+            // gate) keeps the filtering visible in the UI: the radio shows
+            // "Hide NSFW", the filter strip appears, and "Clear filters"
+            // remains an escape hatch if the tag index is broken. An explicit
+            // per-session choice is never overridden, and flipping the setting
+            // takes effect through the OnSettingsSaved reload.
+            if (!_nsfwFilterTouched)
+            {
+                if (!settings.ShowNsfw && NsfwFilter == NsfwFilterMode.ShowAll)
+                    NsfwFilter = NsfwFilterMode.HideNsfw;
+                else if (settings.ShowNsfw && NsfwFilter == NsfwFilterMode.HideNsfw)
+                    NsfwFilter = NsfwFilterMode.ShowAll;
+            }
 
             // Offload the recursive folder scan (per-file IO syscalls + item creation)
             // to the thread pool so the UI thread stays responsive; with large auto-
@@ -625,6 +667,16 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
         IsIndexingTagIndex = true;
         StatusMessage = null;
 
+        // Registered with the task tracker so the build is visible — and
+        // cancellable — in the Unified Console from anywhere in the app, not
+        // just this page: a first build is a 379 MB download plus a
+        // potentially very long walk of the whole gallery, and navigating away
+        // used to leave it running with no visible task anywhere. The tracker
+        // is handed the SAME CancellationTokenSource the toolbar Cancel button
+        // uses, so both cancel affordances converge on one token.
+        using var taskHandle = _taskTracker?.BeginTask("Building tag index", LogCategory.General, cts);
+        taskHandle?.ReportIndeterminate("Preparing…");
+
         try
         {
             await RunBusyAsync(async () =>
@@ -650,6 +702,14 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
                         ?? (p.CurrentFile is not null
                             ? $"Indexing images… {p.Completed:N0}/{p.Total:N0}"
                             : "Finalizing index…");
+
+                    // Mirror into the Unified Console task: phase text (the
+                    // download) has no per-file fraction yet, so it stays
+                    // indeterminate; the indexing phase reports a real 0..1.
+                    if (p.StatusMessage is not null)
+                        taskHandle?.ReportIndeterminate(p.StatusMessage);
+                    else if (p.Total > 0)
+                        taskHandle?.ReportProgress((double)p.Completed / p.Total, BusyMessage);
                 });
 
                 TagIndexBuildResult? result = null;
@@ -689,6 +749,17 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
                     : buildError is not null
                         ? $"Tag indexing failed: {buildError.Message}"
                         : DescribeBuildResult(result);
+
+                // Terminal state for the console task. A console-side cancel
+                // already marked it Cancelled (terminal), so these no-op then;
+                // Fail-on-cancel for the toolbar path matches the download
+                // tasks' idiom elsewhere in the app.
+                if (cancelled)
+                    taskHandle?.Fail(new OperationCanceledException(), StatusMessage);
+                else if (buildError is not null)
+                    taskHandle?.Fail(buildError, StatusMessage);
+                else
+                    taskHandle?.Complete(StatusMessage);
 
                 // Re-run the filter pipeline. Building the index is the usual way
                 // out of "I picked a filter before anything was indexed, so the
@@ -788,6 +859,11 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
         // its own, so leaving it set would hide the active-filter strip while
         // the gallery stayed filtered. Assigning it also refreshes the
         // Is*-flavored booleans behind the radio buttons (NotifyPropertyChangedFor).
+        // Clearing counts as an explicit choice: the AppSettings.ShowNsfw seed
+        // must not re-apply Hide NSFW on the next reload right after the user
+        // deliberately cleared it (it's also the escape hatch when the tag
+        // index itself is broken and the filter fails closed).
+        _nsfwFilterTouched = true;
         NsfwFilter = NsfwFilterMode.ShowAll;
 
         OnPropertyChanged(nameof(HasActiveTagFilters));
@@ -800,6 +876,7 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
         // The Is*-flavored booleans are notified via [NotifyPropertyChangedFor]
         // on the NsfwFilter backing field, so they stay in sync however
         // NsfwFilter is set (not just through this command).
+        _nsfwFilterTouched = true;
         NsfwFilter = Enum.Parse<NsfwFilterMode>(mode);
         ApplySortingAndGrouping();
     }

--- a/DiffusionNexus.UI/Views/GenerationGalleryView.axaml
+++ b/DiffusionNexus.UI/Views/GenerationGalleryView.axaml
@@ -235,33 +235,11 @@
           <TextBlock Text="{Binding TileHeight, StringFormat='{}{0:0}px'}" VerticalAlignment="Center"/>
         </StackPanel>
 
-        <!-- Every tagging affordance is gated on IsTaggingAvailable: without a
-             tag-index service (design time, tests, a future feature flag) the
-             UI shows nothing rather than fully clickable buttons that
-             silently do nothing. -->
-        <Button Content="🏷️ Build Tag Index"
-                Command="{Binding BuildTagIndexCommand}"
-                IsVisible="{Binding IsTaggingAvailable}"
-                Padding="10,6" Margin="0,4,4,4"
-                ToolTip.Tip="Scan enabled gallery folders and tag new/changed images"/>
-        <!-- Only shown while a build is running. A first build starts with a
-             379 MB model download and then walks the whole gallery, so there
-             has to be a way out that is not "kill the app". -->
-        <Button Content="✕ Cancel"
-                Command="{Binding CancelTagIndexCommand}"
-                IsVisible="{Binding IsIndexingTagIndex}"
-                Padding="10,6" Margin="0,4,4,4"
-                ToolTip.Tip="Stop the running tag index build — images already indexed are kept"/>
-        <Border Background="#1c1c1c" BorderBrush="#3a3a3a" BorderThickness="1" CornerRadius="100"
-                IsVisible="{Binding IsTaggingAvailable}"
-                Padding="8,2" Margin="0,4,12,4" VerticalAlignment="Center">
-          <TextBlock Text="{Binding IndexStatusText}" FontSize="11" Foreground="#9a9a9a"/>
-        </Border>
-        <TextBlock Text="{Binding StatusMessage}"
-                   IsVisible="{Binding StatusMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
-                   FontSize="11" Foreground="#9a9a9a" TextWrapping="Wrap" MaxWidth="380"
-                   VerticalAlignment="Center" Margin="0,4,12,4"/>
-
+        <!-- All index management (Build/Cancel/status) lives inside the
+             Advanced Search drawer — the toolbar carries only the way in.
+             Gated on IsTaggingAvailable: without a tag-index service (design
+             time, tests, a future feature flag) the UI shows nothing rather
+             than a clickable button that silently does nothing. -->
         <Button Content="🔎 Advanced Search"
                 Command="{Binding ToggleAdvancedSearchCommand}"
                 IsVisible="{Binding IsTaggingAvailable}"
@@ -410,10 +388,13 @@
               Background="#66000000" ZIndex="90"
               Tapped="OnAdvancedSearchBackdropTapped"/>
 
+      <!-- ZIndex above the busy overlay (100): the drawer now hosts the
+           build's Cancel button, which must stay clickable while the busy
+           dim is up — that is the only time it exists. -->
       <Border IsVisible="{Binding IsAdvancedSearchOpen}"
-              Width="340" HorizontalAlignment="Right"
+              Width="420" HorizontalAlignment="Right"
               Background="#1a1a1c" BorderBrush="#6a4fb3" BorderThickness="1,0,0,0"
-              ZIndex="95">
+              ZIndex="110">
         <Grid RowDefinitions="Auto,*,Auto">
           <Border Grid.Row="0" Padding="16,14" BorderBrush="#333" BorderThickness="0,0,0,1">
             <Grid ColumnDefinitions="*,Auto">
@@ -425,6 +406,32 @@
 
           <ScrollViewer Grid.Row="1" Padding="16">
             <StackPanel Spacing="18">
+              <StackPanel Spacing="8">
+                <TextBlock Text="INDEXING" FontSize="11" Foreground="#6f6f6f" FontWeight="SemiBold"/>
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                  <Button Content="🏷️ Build Tag Index"
+                          Command="{Binding BuildTagIndexCommand}"
+                          Padding="10,6"
+                          ToolTip.Tip="Scan enabled gallery folders and tag new/changed images"/>
+                  <!-- Only shown while a build is running. A first build starts
+                       with a 379 MB model download and then walks the whole
+                       gallery, so there has to be a way out that is not "kill
+                       the app". -->
+                  <Button Content="✕ Cancel"
+                          Command="{Binding CancelTagIndexCommand}"
+                          IsVisible="{Binding IsIndexingTagIndex}"
+                          Padding="10,6"
+                          ToolTip.Tip="Stop the running tag index build — images already indexed are kept"/>
+                  <Border Background="#1c1c1c" BorderBrush="#3a3a3a" BorderThickness="1" CornerRadius="100"
+                          Padding="8,2" VerticalAlignment="Center">
+                    <TextBlock Text="{Binding IndexStatusText}" FontSize="11" Foreground="#9a9a9a"/>
+                  </Border>
+                </StackPanel>
+                <TextBlock Text="{Binding StatusMessage}"
+                           IsVisible="{Binding StatusMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                           FontSize="11" Foreground="#9a9a9a" TextWrapping="Wrap"/>
+              </StackPanel>
+
               <StackPanel Spacing="8">
                 <TextBlock Text="CONTENT RATING" FontSize="11" Foreground="#6f6f6f" FontWeight="SemiBold"/>
                 <StackPanel Orientation="Horizontal" Spacing="4">
@@ -442,6 +449,12 @@
 
               <StackPanel Spacing="8">
                 <TextBlock Text="{Binding TagCloudHeader}" FontSize="11" Foreground="#6f6f6f" FontWeight="SemiBold"/>
+                <!-- Display-only substring filter over the chips below — a
+                     fully indexed gallery fills the 200-chip budget with
+                     booru tags, far too many to scan by eye. -->
+                <TextBox Watermark="Filter tags…"
+                         Text="{Binding TagCloudSearchText, Mode=TwoWay}"
+                         FontSize="12"/>
                 <ItemsControl ItemsSource="{Binding TagCloud}">
                   <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate><WrapPanel Orientation="Horizontal"/></ItemsPanelTemplate>

--- a/DiffusionNexus.UI/Views/GenerationGalleryView.axaml
+++ b/DiffusionNexus.UI/Views/GenerationGalleryView.axaml
@@ -235,8 +235,13 @@
           <TextBlock Text="{Binding TileHeight, StringFormat='{}{0:0}px'}" VerticalAlignment="Center"/>
         </StackPanel>
 
+        <!-- Every tagging affordance is gated on IsTaggingAvailable: without a
+             tag-index service (design time, tests, a future feature flag) the
+             UI shows nothing rather than fully clickable buttons that
+             silently do nothing. -->
         <Button Content="🏷️ Build Tag Index"
                 Command="{Binding BuildTagIndexCommand}"
+                IsVisible="{Binding IsTaggingAvailable}"
                 Padding="10,6" Margin="0,4,4,4"
                 ToolTip.Tip="Scan enabled gallery folders and tag new/changed images"/>
         <!-- Only shown while a build is running. A first build starts with a
@@ -248,6 +253,7 @@
                 Padding="10,6" Margin="0,4,4,4"
                 ToolTip.Tip="Stop the running tag index build — images already indexed are kept"/>
         <Border Background="#1c1c1c" BorderBrush="#3a3a3a" BorderThickness="1" CornerRadius="100"
+                IsVisible="{Binding IsTaggingAvailable}"
                 Padding="8,2" Margin="0,4,12,4" VerticalAlignment="Center">
           <TextBlock Text="{Binding IndexStatusText}" FontSize="11" Foreground="#9a9a9a"/>
         </Border>
@@ -258,6 +264,7 @@
 
         <Button Content="🔎 Advanced Search"
                 Command="{Binding ToggleAdvancedSearchCommand}"
+                IsVisible="{Binding IsTaggingAvailable}"
                 Padding="10,6" Margin="0,4,12,4"
                 ToolTip.Tip="Filter the gallery by tag and content rating"/>
 


### PR DESCRIPTION
PR #486 was merged at commit 91e43d7, before two follow-up commits landed on the branch. This picks up the remainder:

- `0b2f204` — review follow-ups #487-#492: shared `OnnxSessionHost` (unified DML/CPU session lifecycle, Dispose waits out in-flight Run, atomic single-flight gate), one-build-at-a-time gate in `TagIndexService`, build tracked + cancellable in the Unified Console, `IsTaggingAvailable` visibility gate, query-time NSFW via `ContentRatingPolicy` + `AppSettings.ShowNsfw` seeding the drawer filter.
- `530b23c` — index controls (Build/Cancel/pill/status) moved into the Advanced Search drawer, drawer widened to 420 and raised above the busy overlay, new "Filter tags..." box over the tag cloud.

3404/3404 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)