### PR TITLE
Gallery: dock Advanced Search, drop NSFW auto-seed, fix stranded lazy loading

### DIFF
--- a/DiffusionNexus.Tests/Viewer/GenerationGalleryViewModelTests.cs
+++ b/DiffusionNexus.Tests/Viewer/GenerationGalleryViewModelTests.cs
@@ -750,11 +750,7 @@ public class GenerationGalleryViewModelTests : IDisposable
 
         var settings = new AppSettings
         {
-            ImageGalleries = [new() { FolderPath = galleryPath, IsEnabled = true, Order = 0 }],
-            // Keep the AppSettings NSFW seed out of this test: SearchAsync
-            // below answers every query with the indexed set, so a seeded
-            // Hide NSFW would treat every indexed file as known-NSFW.
-            ShowNsfw = true,
+            ImageGalleries = [new() { FolderPath = galleryPath, IsEnabled = true, Order = 0 }]
         };
         var mockSettings = new Mock<IAppSettingsService>();
         mockSettings.Setup(service => service.GetSettingsAsync(It.IsAny<CancellationToken>()))
@@ -945,10 +941,6 @@ public class GenerationGalleryViewModelTests : IDisposable
         mockSettings.Setup(service => service.GetSettingsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(settings);
 
-        // The tile carries IsNsfw: true, so the AppSettings NSFW seed would
-        // hide it before the assertion could look at it.
-        settings.ShowNsfw = true;
-
         var mockTagIndex = new Mock<ITagIndexService>();
         mockTagIndex.Setup(t => t.GetIndexedCountAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(1);
         mockTagIndex.Setup(t => t.GetTagsForFilesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
@@ -995,58 +987,15 @@ public class GenerationGalleryViewModelTests : IDisposable
     }
 
     [Fact]
-    public async Task LoadMediaAsync_SeedsHideNsfwFromTheAppWideSetting_AndHidesKnownNsfwImages()
+    public async Task LoadMediaAsync_NeverSeedsAnNsfwModeFromSettings()
     {
-        // Issue #492: AppSettings.ShowNsfw (off by default) and the drawer's
-        // NSFW mode used to be two disconnected switches for one user intent —
-        // hiding NSFW app-wide did nothing here. The setting seeds the
-        // drawer's mode, so the filtering is visible (radio + filter strip)
-        // rather than an invisible standing gate.
-        var galleryPath = CreateTempDirectory();
-        var sfwImage = Path.Combine(galleryPath, "sfw.png");
-        var nsfwImage = Path.Combine(galleryPath, "nsfw.png");
-        File.WriteAllText(sfwImage, "test");
-        File.WriteAllText(nsfwImage, "test");
-
-        var settings = new AppSettings
-        {
-            ImageGalleries = [new() { FolderPath = galleryPath, IsEnabled = true, Order = 0 }],
-            ShowNsfw = false,
-        };
-        var mockSettings = new Mock<IAppSettingsService>();
-        mockSettings.Setup(service => service.GetSettingsAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(settings);
-
-        var mockTagIndex = new Mock<ITagIndexService>();
-        mockTagIndex.Setup(t => t.GetIndexedCountAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(2);
-        mockTagIndex.Setup(t => t.GetTagsForFilesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Dictionary<string, ImageTagLookup>());
-        mockTagIndex.Setup(t => t.SearchAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<NsfwFilterMode>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { nsfwImage });
-
-        var viewModel = new GenerationGalleryViewModel(
-            mockSettings.Object,
-            new Mock<IDatasetEventAggregator>().Object,
-            new Mock<IDatasetState>().Object,
-            null,
-            tagIndexService: mockTagIndex.Object);
-
-        await viewModel.LoadMediaCommand.ExecuteAsync(null);
-        await viewModel.WaitForSortingAsync();
-
-        viewModel.NsfwFilter.Should().Be(NsfwFilterMode.HideNsfw,
-            "the app-wide setting seeds the drawer so the two switches agree");
-        viewModel.HasActiveTagFilters.Should().BeTrue(
-            "the seeded filter must be visible in the filter strip, not an invisible gate");
-        viewModel.MediaItems.Should().ContainSingle()
-            .Which.FilePath.Should().Be(sfwImage);
-    }
-
-    [Fact]
-    public async Task LoadMediaAsync_DoesNotReSeed_AfterTheUserExplicitlyChoseAMode()
-    {
-        // A reload (settings saved, folders changed) must never stomp a
-        // deliberate per-session choice with the seed.
+        // Regression guard for a removed behavior: an earlier iteration
+        // seeded the drawer's NSFW mode from AppSettings.ShowNsfw (off by
+        // default). In real use that silently opened every gallery in Hide
+        // NSFW mode, and because the tagger rates much ordinary content
+        // "sensitive", a tag filter matching thousands of images showed a
+        // fraction of them with nothing on screen explaining why. The NSFW
+        // mode is opt-in, per session, full stop.
         var galleryPath = CreateTempDirectory();
         File.WriteAllText(Path.Combine(galleryPath, "a.png"), "test");
 
@@ -1059,27 +1008,19 @@ public class GenerationGalleryViewModelTests : IDisposable
         mockSettings.Setup(service => service.GetSettingsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(settings);
 
-        var mockTagIndex = new Mock<ITagIndexService>();
-        mockTagIndex.Setup(t => t.GetIndexedCountAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(0);
-        mockTagIndex.Setup(t => t.SearchAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<NsfwFilterMode>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<string>());
-
         var viewModel = new GenerationGalleryViewModel(
             mockSettings.Object,
             new Mock<IDatasetEventAggregator>().Object,
             new Mock<IDatasetState>().Object,
             null,
-            tagIndexService: mockTagIndex.Object);
+            tagIndexService: new Mock<ITagIndexService>().Object);
 
         await viewModel.LoadMediaCommand.ExecuteAsync(null);
-        viewModel.NsfwFilter.Should().Be(NsfwFilterMode.HideNsfw, "the first load seeds from the setting");
-
-        viewModel.SetNsfwFilterCommand.Execute(nameof(NsfwFilterMode.ShowAll));
         await viewModel.WaitForSortingAsync();
 
-        await viewModel.LoadMediaCommand.ExecuteAsync(null);
-        viewModel.NsfwFilter.Should().Be(NsfwFilterMode.ShowAll,
-            "the user's explicit choice survives the reload");
+        viewModel.NsfwFilter.Should().Be(NsfwFilterMode.ShowAll);
+        viewModel.HasActiveTagFilters.Should().BeFalse();
+        viewModel.MediaItems.Should().ContainSingle("no invisible filter may hide gallery content");
     }
 
     [Fact]
@@ -1624,12 +1565,7 @@ public class GenerationGalleryViewModelTests : IDisposable
     {
         var settings = new AppSettings
         {
-            ImageGalleries = [new() { FolderPath = galleryPath, IsEnabled = true, Order = 0 }],
-            // ShowNsfw=false (the AppSettings default) seeds the drawer's
-            // Hide NSFW mode on load, which makes every filter pass query the
-            // known-NSFW set — noise these tests don't set up. Tests covering
-            // the seeding itself build their own settings with ShowNsfw=false.
-            ShowNsfw = true,
+            ImageGalleries = [new() { FolderPath = galleryPath, IsEnabled = true, Order = 0 }]
         };
         var mockSettings = new Mock<IAppSettingsService>();
         mockSettings.Setup(service => service.GetSettingsAsync(It.IsAny<CancellationToken>()))

--- a/DiffusionNexus.UI/ViewModels/GenerationGalleryViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/GenerationGalleryViewModel.cs
@@ -33,14 +33,6 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
     private readonly ITaskTracker? _taskTracker;
     private readonly List<GenerationGalleryMediaItemViewModel> _allMediaItems = [];
 
-    /// <summary>
-    /// True once the user has explicitly chosen an NSFW mode (radio button or
-    /// "Clear filters") this session. Gates the seeding in
-    /// <see cref="LoadMediaAsync"/>: the app-wide <c>AppSettings.ShowNsfw</c>
-    /// setting seeds the drawer's filter so the two switches agree, but a
-    /// deliberate per-session choice is never stomped by a later reload.
-    /// </summary>
-    private bool _nsfwFilterTouched;
     private GenerationGalleryMediaItemViewModel? _lastClickedItem;
     private int _selectionCount;
     private bool _isUpdatingGroupingOptions;
@@ -452,23 +444,14 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
             var enabledPaths = GetEnabledGalleryPaths(settings);
             var includeSubFolders = IncludeSubFolders;
 
-            // The app-wide setting (Settings → "Show NSFW", off by default)
-            // seeds the Advanced Search drawer's NSFW mode so the two switches
-            // agree — the persisted setting used to be silently ignored here,
-            // leaving NSFW tiles visible until the user found the second,
-            // per-session filter. Seeding (rather than an invisible standing
-            // gate) keeps the filtering visible in the UI: the radio shows
-            // "Hide NSFW", the filter strip appears, and "Clear filters"
-            // remains an escape hatch if the tag index is broken. An explicit
-            // per-session choice is never overridden, and flipping the setting
-            // takes effect through the OnSettingsSaved reload.
-            if (!_nsfwFilterTouched)
-            {
-                if (!settings.ShowNsfw && NsfwFilter == NsfwFilterMode.ShowAll)
-                    NsfwFilter = NsfwFilterMode.HideNsfw;
-                else if (settings.ShowNsfw && NsfwFilter == NsfwFilterMode.HideNsfw)
-                    NsfwFilter = NsfwFilterMode.ShowAll;
-            }
+            // NOTE: an earlier iteration seeded the drawer's NSFW mode from
+            // AppSettings.ShowNsfw here. Removed after real-world use: with
+            // the setting off (the default) the gallery silently opened in
+            // Hide NSFW mode, and because the tagger rates a large share of
+            // ordinary images "sensitive" (= NSFW under ContentRatingPolicy),
+            // a tag filter that should have matched thousands of images
+            // showed a fraction of them, with nothing obviously wrong. The
+            // NSFW mode is a per-session, opt-in filter only.
 
             // Offload the recursive folder scan (per-file IO syscalls + item creation)
             // to the thread pool so the UI thread stays responsive; with large auto-
@@ -884,11 +867,6 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
         // its own, so leaving it set would hide the active-filter strip while
         // the gallery stayed filtered. Assigning it also refreshes the
         // Is*-flavored booleans behind the radio buttons (NotifyPropertyChangedFor).
-        // Clearing counts as an explicit choice: the AppSettings.ShowNsfw seed
-        // must not re-apply Hide NSFW on the next reload right after the user
-        // deliberately cleared it (it's also the escape hatch when the tag
-        // index itself is broken and the filter fails closed).
-        _nsfwFilterTouched = true;
         NsfwFilter = NsfwFilterMode.ShowAll;
 
         OnPropertyChanged(nameof(HasActiveTagFilters));
@@ -901,7 +879,6 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
         // The Is*-flavored booleans are notified via [NotifyPropertyChangedFor]
         // on the NsfwFilter backing field, so they stay in sync however
         // NsfwFilter is set (not just through this command).
-        _nsfwFilterTouched = true;
         NsfwFilter = Enum.Parse<NsfwFilterMode>(mode);
         ApplySortingAndGrouping();
     }

--- a/DiffusionNexus.UI/Views/GenerationGalleryView.axaml
+++ b/DiffusionNexus.UI/Views/GenerationGalleryView.axaml
@@ -319,15 +319,19 @@
       </WrapPanel>
     </Border>
 
-    <Grid Grid.Row="3">
-      <Border IsVisible="{Binding IsBusy}" Background="#80000000" ZIndex="100">
+    <!-- Two columns: gallery content | docked Advanced Search panel. The
+         panel is docked, not a modal overlay — filtering and browsing are
+         one activity, so the gallery must stay scrollable and clickable
+         while the panel is open (the old dim backdrop blocked it). -->
+    <Grid Grid.Row="3" ColumnDefinitions="*,Auto">
+      <Border Grid.Column="0" IsVisible="{Binding IsBusy}" Background="#80000000" ZIndex="100">
         <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="8">
           <ProgressBar IsIndeterminate="True" Width="200"/>
           <TextBlock Text="{Binding BusyMessage}" Foreground="White" HorizontalAlignment="Center"/>
         </StackPanel>
       </Border>
 
-      <Border IsVisible="{Binding HasNoMedia}"
+      <Border Grid.Column="0" IsVisible="{Binding HasNoMedia}"
               Background="#1A1A1A" CornerRadius="8" Margin="16" Padding="32"
               HorizontalAlignment="Center" VerticalAlignment="Center">
         <StackPanel Spacing="16" HorizontalAlignment="Center">
@@ -343,7 +347,7 @@
         </StackPanel>
       </Border>
 
-      <ScrollViewer x:Name="GalleryScrollViewer" IsVisible="{Binding HasMedia}" Padding="16">
+      <ScrollViewer Grid.Column="0" x:Name="GalleryScrollViewer" IsVisible="{Binding HasMedia}" Padding="16">
         <Grid>
           <ItemsControl ItemsSource="{Binding GroupedMediaItems}" IsVisible="{Binding IsGroupingEnabled}">
             <ItemsControl.ItemsPanel>
@@ -384,17 +388,12 @@
         </Grid>
       </ScrollViewer>
 
-      <Border IsVisible="{Binding IsAdvancedSearchOpen}"
-              Background="#66000000" ZIndex="90"
-              Tapped="OnAdvancedSearchBackdropTapped"/>
-
-      <!-- ZIndex above the busy overlay (100): the drawer now hosts the
-           build's Cancel button, which must stay clickable while the busy
-           dim is up — that is the only time it exists. -->
-      <Border IsVisible="{Binding IsAdvancedSearchOpen}"
-              Width="420" HorizontalAlignment="Right"
-              Background="#1a1a1c" BorderBrush="#6a4fb3" BorderThickness="1,0,0,0"
-              ZIndex="110">
+      <!-- Docked in its own column: the busy overlay dims only the content
+           column, so the build's Cancel button in here stays clickable while
+           the busy dim is up — the only time it exists. -->
+      <Border Grid.Column="1" IsVisible="{Binding IsAdvancedSearchOpen}"
+              Width="420"
+              Background="#1a1a1c" BorderBrush="#6a4fb3" BorderThickness="1,0,0,0">
         <Grid RowDefinitions="Auto,*,Auto">
           <Border Grid.Row="0" Padding="16,14" BorderBrush="#333" BorderThickness="0,0,0,1">
             <Grid ColumnDefinitions="*,Auto">

--- a/DiffusionNexus.UI/Views/GenerationGalleryView.axaml.cs
+++ b/DiffusionNexus.UI/Views/GenerationGalleryView.axaml.cs
@@ -98,11 +98,22 @@ public partial class GenerationGalleryView : UserControl
             if (_galleryScrollViewer is not null)
             {
                 _galleryScrollViewer.ScrollChanged += OnGalleryScrollChanged;
+                // ScrollChanged alone is not enough: when the current page
+                // fits inside the viewport there is no scrollbar, no scroll
+                // event ever fires, and the gallery would sit on the first 50
+                // items forever (easily reached on a wide monitor with small
+                // tiles, or after a filter). LayoutUpdated keeps topping the
+                // page up until the content actually overflows the viewport.
+                _galleryScrollViewer.LayoutUpdated += OnGalleryLayoutUpdated;
             }
         }
     }
 
-    private void OnGalleryScrollChanged(object? sender, ScrollChangedEventArgs e)
+    private void OnGalleryScrollChanged(object? sender, ScrollChangedEventArgs e) => LoadMoreIfNearBottom();
+
+    private void OnGalleryLayoutUpdated(object? sender, EventArgs e) => LoadMoreIfNearBottom();
+
+    private void LoadMoreIfNearBottom()
     {
         if (_galleryScrollViewer is null || DataContext is not GenerationGalleryViewModel vm)
             return;
@@ -110,7 +121,11 @@ public partial class GenerationGalleryView : UserControl
         if (!vm.HasMoreItems)
             return;
 
-        // Load more when within 200px of the bottom
+        // Load more when within 200px of the bottom. When content does not
+        // overflow the viewport at all, this distance is <= 0 — i.e. the
+        // no-scrollbar case loads more too, and the LayoutUpdated that
+        // follows each batch re-checks until the viewport is overfilled or
+        // the items run out.
         var distanceToBottom = _galleryScrollViewer.Extent.Height
                              - _galleryScrollViewer.Viewport.Height
                              - _galleryScrollViewer.Offset.Y;
@@ -227,14 +242,6 @@ public partial class GenerationGalleryView : UserControl
         }
 
         _deferredSelectItem = null;
-    }
-
-    private void OnAdvancedSearchBackdropTapped(object? sender, TappedEventArgs e)
-    {
-        if (DataContext is GenerationGalleryViewModel vm)
-        {
-            vm.ToggleAdvancedSearchCommand.Execute(null);
-        }
     }
 
     private void OnMediaDoubleTapped(object? sender, TappedEventArgs e)


### PR DESCRIPTION
Fixes the two problems found in manual testing of the Advanced Search drawer:

1. **No more grey veil** — the panel is docked in its own column; the gallery stays scrollable/clickable while filtering.
2. **"2000+ 1girl but only ~50 shown"** — two causes addressed:
   - The `AppSettings.ShowNsfw` → Hide NSFW auto-seed is removed. With the setting off (default) it silently pre-selected Hide NSFW, and WD14 rates much ordinary content "sensitive" (= NSFW), so most matches were hidden with no obvious cause. NSFW filtering is opt-in per session again.
   - Lazy loading could strand the gallery on the first 50 tiles when the page fit the viewport (no scrollbar → no scroll events → no next page). LayoutUpdated now tops up until content overflows.

3403/3403 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)