### PR TITLE
Tagging: 'sensitive' is SFW (query-time), add Rebuild Index button

### DIFF
--- a/DiffusionNexus.Domain/Services/ContentRatingPolicy.cs
+++ b/DiffusionNexus.Domain/Services/ContentRatingPolicy.cs
@@ -5,25 +5,28 @@ namespace DiffusionNexus.Domain.Services;
 /// NSFW. Both the write side (<c>ImageTaggingService</c> stamping
 /// <c>ImageTagResult.IsNsfw</c>) and the read side (<c>TagIndexService</c>
 /// queries deriving NSFW from the stored <c>RatingLabel</c>) go through this,
-/// so a future policy change (e.g. treating "sensitive" as SFW, or a
-/// user-configurable threshold) is one edit here and takes effect on the next
-/// query — no re-index of the whole gallery required.
+/// so a policy change is one edit here and takes effect on the next query —
+/// no re-index of the whole gallery required.
 /// </summary>
 public static class ContentRatingPolicy
 {
     /// <summary>
-    /// The one hardcoded rating-name assumption: WD14/Danbooru's rating
-    /// taxonomy has used "general" as the safest bucket since the schema's
-    /// introduction ("sensitive", "questionable" and "explicit" are the
-    /// others). Every other tag/rating name is read from the model's CSV.
+    /// The WD14/Danbooru rating labels that count as safe. "general" is the
+    /// taxonomy's fully-safe bucket; "sensitive" is included deliberately:
+    /// the tagger assigns it to a large share of completely ordinary
+    /// character art (an early policy that treated anything non-"general" as
+    /// NSFW badged obviously-safe images and hid most of a typical gallery
+    /// behind Hide NSFW). NSFW is therefore "questionable" and "explicit" —
+    /// and, failing closed, anything unknown.
     /// </summary>
-    public const string SfwRatingLabel = "general";
+    public static readonly string[] SfwRatingLabels = ["general", "sensitive"];
 
     /// <summary>
-    /// True when <paramref name="ratingLabel"/> is not the safest rating.
-    /// Null/empty (an unrated or corrupt row) counts as NSFW — content
-    /// filtering fails closed.
+    /// True when <paramref name="ratingLabel"/> is not one of the safe
+    /// ratings. Null/empty (an unrated or corrupt row) counts as NSFW —
+    /// content filtering fails closed.
     /// </summary>
     public static bool IsNsfw(string? ratingLabel)
-        => !string.Equals(ratingLabel, SfwRatingLabel, StringComparison.OrdinalIgnoreCase);
+        => ratingLabel is null
+           || !SfwRatingLabels.Contains(ratingLabel, StringComparer.OrdinalIgnoreCase);
 }

--- a/DiffusionNexus.Service/Services/TagIndexService.cs
+++ b/DiffusionNexus.Service/Services/TagIndexService.cs
@@ -399,15 +399,15 @@ public sealed class TagIndexService : ITagIndexService
         // NSFW is derived from the stored RatingLabel at query time via
         // ContentRatingPolicy — never from the frozen IsNsfw column — so a
         // rating-policy change takes effect without re-running the tagger over
-        // the whole gallery. The comparison is a plain equality against the
-        // policy's SFW label: it translates to indexed SQL
-        // (IX_ImageMediaTagIndexes_RatingLabel), and any row whose label
-        // doesn't exactly match the safest bucket (different casing, corrupt
-        // value) classifies as NSFW — filtering fails closed.
+        // the whole gallery. Contains over the policy's SFW label set
+        // translates to an IN (...) that uses IX_ImageMediaTagIndexes_RatingLabel,
+        // and any row whose label matches none of the safe buckets (different
+        // casing, corrupt value) classifies as NSFW — filtering fails closed.
+        var sfwLabels = ContentRatingPolicy.SfwRatingLabels;
         query = nsfwFilter switch
         {
-            NsfwFilterMode.HideNsfw => query.Where(e => e.RatingLabel == ContentRatingPolicy.SfwRatingLabel),
-            NsfwFilterMode.NsfwOnly => query.Where(e => e.RatingLabel != ContentRatingPolicy.SfwRatingLabel),
+            NsfwFilterMode.HideNsfw => query.Where(e => sfwLabels.Contains(e.RatingLabel)),
+            NsfwFilterMode.NsfwOnly => query.Where(e => !sfwLabels.Contains(e.RatingLabel)),
             _ => query,
         };
 

--- a/DiffusionNexus.Tests/Domain/ContentRatingPolicyTests.cs
+++ b/DiffusionNexus.Tests/Domain/ContentRatingPolicyTests.cs
@@ -1,0 +1,25 @@
+using DiffusionNexus.Domain.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace DiffusionNexus.Tests.Domain;
+
+public sealed class ContentRatingPolicyTests
+{
+    [Theory]
+    [InlineData("general")]
+    [InlineData("sensitive")] // WD14 assigns this to much completely ordinary art — it must not badge/hide SFW images
+    [InlineData("General")]   // labels come from a CSV; casing must not matter
+    [InlineData("SENSITIVE")]
+    public void SafeRatings_AreNotNsfw(string label)
+        => ContentRatingPolicy.IsNsfw(label).Should().BeFalse();
+
+    [Theory]
+    [InlineData("questionable")]
+    [InlineData("explicit")]
+    [InlineData(null)]        // unrated/corrupt rows fail closed
+    [InlineData("")]
+    [InlineData("garbage")]
+    public void EverythingElse_IsNsfw(string? label)
+        => ContentRatingPolicy.IsNsfw(label).Should().BeTrue();
+}

--- a/DiffusionNexus.Tests/Service/Services/TagIndexServiceTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/TagIndexServiceTests.cs
@@ -222,24 +222,27 @@ public sealed class TagIndexServiceTests : IAsyncDisposable
         // read — a rating-policy change has to take effect at query time
         // without re-running the tagger over the whole gallery. This tagger
         // stamps a contradictory frozen flag (isNsfw: false on a
-        // non-"general" rating); every query has to side with the rating.
-        var sfwPath = CreateFakeImage("rating-sfw.png");
-        var sensitivePath = CreateFakeImage("rating-sensitive.png", width: 8);
+        // "questionable" rating); every query has to side with the rating.
+        // "sensitive" deliberately lands on the SFW side: WD14 assigns it to
+        // a large share of completely ordinary character art.
+        var sensitivePath = CreateFakeImage("rating-sensitive.png");
+        var questionablePath = CreateFakeImage("rating-questionable.png", width: 8);
         var tagging = TaggerByWidth(w => w == 8
-            ? ImageTagResult.Succeeded(Array.Empty<ImageTagScore>(), "sensitive", 0.9f, isNsfw: false)
-            : ImageTagResult.Succeeded(Array.Empty<ImageTagScore>(), "general", 0.9f, isNsfw: false));
+            ? ImageTagResult.Succeeded(Array.Empty<ImageTagScore>(), "questionable", 0.9f, isNsfw: false)
+            : ImageTagResult.Succeeded(Array.Empty<ImageTagScore>(), "sensitive", 0.9f, isNsfw: false));
         var service = new TagIndexService(new SingleDbContextFactory(_options), tagging.Object);
-        await service.BuildIndexAsync(new[] { sfwPath, sensitivePath });
+        await service.BuildIndexAsync(new[] { sensitivePath, questionablePath });
 
         var hidden = await service.SearchAsync(Array.Empty<string>(), NsfwFilterMode.HideNsfw);
-        hidden.Should().ContainSingle().Which.Should().Be(Path.GetFullPath(sfwPath));
+        hidden.Should().ContainSingle("a 'sensitive'-rated image is SFW under the policy")
+            .Which.Should().Be(Path.GetFullPath(sensitivePath));
 
         var nsfwOnly = await service.SearchAsync(Array.Empty<string>(), NsfwFilterMode.NsfwOnly);
-        nsfwOnly.Should().ContainSingle().Which.Should().Be(Path.GetFullPath(sensitivePath));
+        nsfwOnly.Should().ContainSingle().Which.Should().Be(Path.GetFullPath(questionablePath));
 
-        var lookup = await service.GetTagsForFilesAsync(new[] { sfwPath, sensitivePath });
-        lookup[Path.GetFullPath(sensitivePath)].IsNsfw.Should().BeTrue("tile badges derive from the rating too");
-        lookup[Path.GetFullPath(sfwPath)].IsNsfw.Should().BeFalse();
+        var lookup = await service.GetTagsForFilesAsync(new[] { sensitivePath, questionablePath });
+        lookup[Path.GetFullPath(questionablePath)].IsNsfw.Should().BeTrue("tile badges derive from the rating too");
+        lookup[Path.GetFullPath(sensitivePath)].IsNsfw.Should().BeFalse("no NSFW badge on ordinary 'sensitive'-rated art");
     }
 
     [Fact]

--- a/DiffusionNexus.Tests/Viewer/GenerationGalleryViewModelTests.cs
+++ b/DiffusionNexus.Tests/Viewer/GenerationGalleryViewModelTests.cs
@@ -1024,6 +1024,56 @@ public class GenerationGalleryViewModelTests : IDisposable
     }
 
     [Fact]
+    public async Task RebuildTagIndexCommand_ClearsTheIndex_ThenRunsAFullBuild()
+    {
+        // The incremental build skips unchanged files forever, so a row
+        // written by an older build (different tagger/threshold, or simply
+        // bad) is sticky — Rebuild is the escape hatch: wipe, then re-tag.
+        var galleryPath = CreateTempDirectory();
+        var image = Path.Combine(galleryPath, "a.png");
+        File.WriteAllText(image, "test");
+
+        var calls = new List<string>();
+        var mockTagIndex = BuildableTagIndex(new TagIndexBuildResult(1, 0, 0, 0));
+        mockTagIndex.Setup(t => t.RemoveIndexEntriesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .Callback(() => calls.Add("remove"))
+            .ReturnsAsync(1);
+        mockTagIndex.Setup(t => t.BuildIndexAsync(
+                It.IsAny<IReadOnlyList<string>>(), It.IsAny<IProgress<TagIndexBuildProgress>>(), It.IsAny<CancellationToken>()))
+            .Callback(() => calls.Add("build"))
+            .ReturnsAsync(new TagIndexBuildResult(1, 0, 0, 0));
+
+        var viewModel = CreateGalleryViewModel(galleryPath, mockTagIndex.Object);
+        await viewModel.LoadMediaCommand.ExecuteAsync(null);
+
+        await viewModel.RebuildTagIndexCommand.ExecuteAsync(null);
+
+        calls.Should().Equal("remove", "build");
+        mockTagIndex.Verify(t => t.RemoveIndexEntriesAsync(
+            It.Is<IReadOnlyList<string>>(p => p.Contains(image)), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RebuildTagIndexCommand_WhenTheWipeFails_DoesNotBuildOnTopOfStaleRows()
+    {
+        var galleryPath = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(galleryPath, "a.png"), "test");
+
+        var mockTagIndex = BuildableTagIndex(new TagIndexBuildResult(1, 0, 0, 0));
+        mockTagIndex.Setup(t => t.RemoveIndexEntriesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("SQLite Error 5: 'database is locked'."));
+
+        var viewModel = CreateGalleryViewModel(galleryPath, mockTagIndex.Object);
+        await viewModel.LoadMediaCommand.ExecuteAsync(null);
+
+        await viewModel.RebuildTagIndexCommand.ExecuteAsync(null);
+
+        mockTagIndex.Verify(t => t.BuildIndexAsync(
+            It.IsAny<IReadOnlyList<string>>(), It.IsAny<IProgress<TagIndexBuildProgress>>(), It.IsAny<CancellationToken>()), Times.Never);
+        viewModel.StatusMessage.Should().NotBeNullOrEmpty("the user must learn the rebuild did not happen");
+    }
+
+    [Fact]
     public async Task BuildTagIndexCommand_CompletesItsTrackedTask_InTheUnifiedConsole()
     {
         // Issue #488: the ~30-second model download was already visible in

--- a/DiffusionNexus.UI/ViewModels/GenerationGalleryViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/GenerationGalleryViewModel.cs
@@ -792,6 +792,47 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
     private void CancelTagIndex() => _tagIndexCts?.Cancel();
 
     /// <summary>
+    /// Deletes this gallery's index rows, then re-tags everything from
+    /// scratch. This is the escape hatch the incremental build cannot
+    /// provide: it skips any file whose size/mtime is unchanged, so a row
+    /// written by an older build (different tagger, different threshold, or
+    /// simply suspected bad) is sticky forever. NSFW policy changes do NOT
+    /// need this — they apply at query time (see ContentRatingPolicy).
+    /// </summary>
+    [RelayCommand]
+    private async Task RebuildTagIndexAsync()
+    {
+        if (_tagIndexService is null || IsIndexingTagIndex) return;
+
+        if (DialogService is not null)
+        {
+            var confirm = await DialogService.ShowConfirmAsync(
+                "Rebuild Tag Index",
+                $"Delete the tag index for this gallery and re-tag all {TotalGalleryImageCount:N0} images from scratch? " +
+                "The tagger runs over every image again, which can take a while.");
+            if (!confirm) return;
+        }
+
+        var imagePaths = _allMediaItems.Where(i => i.IsImage).Select(i => i.FilePath).ToList();
+        try
+        {
+            await Task.Run(() => _tagIndexService.RemoveIndexEntriesAsync(imagePaths));
+        }
+        catch (Exception ex)
+        {
+            // Bail rather than build: building on top of rows that failed to
+            // clear would silently keep the stale data this command exists to
+            // destroy.
+            Logger.Error(ex, "Failed to clear the tag index before a rebuild");
+            StatusMessage = $"Rebuild failed while clearing the old index: {ex.Message}";
+            return;
+        }
+
+        InvalidateTagSearchCache();
+        await BuildTagIndexAsync();
+    }
+
+    /// <summary>
     /// Pulls the indexed count, the tag cloud and the per-tile tag data back
     /// into sync after a build. Guarded for the same reason the gallery-load
     /// path is: these are DB calls on a table set that may not exist, and

--- a/DiffusionNexus.UI/Views/GenerationGalleryView.axaml
+++ b/DiffusionNexus.UI/Views/GenerationGalleryView.axaml
@@ -421,6 +421,13 @@
                           IsVisible="{Binding IsIndexingTagIndex}"
                           Padding="10,6"
                           ToolTip.Tip="Stop the running tag index build — images already indexed are kept"/>
+                  <!-- Swaps with Cancel (hidden while a build runs) so the row
+                       never overflows the panel. -->
+                  <Button Content="♻ Rebuild"
+                          Command="{Binding RebuildTagIndexCommand}"
+                          IsVisible="{Binding !IsIndexingTagIndex}"
+                          Padding="10,6"
+                          ToolTip.Tip="Delete the tag index for this gallery and re-tag every image from scratch"/>
                   <Border Background="#1c1c1c" BorderBrush="#3a3a3a" BorderThickness="1" CornerRadius="100"
                           Padding="8,2" VerticalAlignment="Center">
                     <TextBlock Text="{Binding IndexStatusText}" FontSize="11" Foreground="#9a9a9a"/>


### PR DESCRIPTION
Follow-up to the manual-testing feedback (SFW image badged NSFW):

- **"sensitive" is now SFW.** WD14 rates a huge share of ordinary character art "sensitive"; the old anything-but-"general" rule badged clearly-safe images and gutted Hide NSFW. NSFW = questionable/explicit only (unknown labels still fail closed). Applies at query time — badges/search/counts update immediately, **no re-index needed**.
- **New "Rebuild" button** in the drawer's INDEXING section: wipes this gallery's index rows and re-tags from scratch (confirmed via dialog). Escape hatch for rows written by an older tagger/threshold — the incremental build would otherwise skip them forever.

3414/3414 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)