### PR TITLE
Gallery: empty state names the date filter when it hides all tag matches

### DIFF
--- a/DiffusionNexus.Tests/Viewer/GenerationGalleryViewModelTests.cs
+++ b/DiffusionNexus.Tests/Viewer/GenerationGalleryViewModelTests.cs
@@ -1024,6 +1024,44 @@ public class GenerationGalleryViewModelTests : IDisposable
     }
 
     [Fact]
+    public async Task WhenTagMatchesAreHiddenByTheDateFilter_TheEmptyStateNamesTheCulprit()
+    {
+        // Field-diagnosed: 331 images matched the tag, the grid showed zero,
+        // and nothing on screen said why — the default "Last 3 Months" date
+        // window was quietly excluding every match (a partially built index
+        // covers the oldest files first, exactly what a recent-only window
+        // hides). The empty state must name the culprit and the fix.
+        var galleryPath = CreateTempDirectory();
+        var oldImage = Path.Combine(galleryPath, "old.png");
+        File.WriteAllText(oldImage, "test");
+        File.SetCreationTimeUtc(oldImage, DateTime.UtcNow.AddYears(-1));
+
+        var mockTagIndex = new Mock<ITagIndexService>();
+        mockTagIndex.Setup(t => t.GetIndexedCountAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(1);
+        mockTagIndex.Setup(t => t.GetTagsForFilesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, ImageTagLookup>());
+        mockTagIndex.Setup(t => t.SearchAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<NsfwFilterMode>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { oldImage });
+
+        var viewModel = CreateGalleryViewModel(galleryPath, mockTagIndex.Object);
+        await viewModel.LoadMediaCommand.ExecuteAsync(null);
+
+        viewModel.SelectedDateFilter.Should().Be("Last 3 Months", "precondition: the default window hides year-old files");
+
+        viewModel.ToggleTagFilterCommand.Execute("dog");
+        await viewModel.WaitForSortingAsync();
+
+        viewModel.MediaItems.Should().BeEmpty();
+        viewModel.NoMediaMessage.Should().Contain("date filter")
+            .And.Contain("Last 3 Months")
+            .And.Contain("All Time", "the message must hand the user the fix, not just the diagnosis");
+
+        viewModel.SelectedDateFilter = "All Time";
+        await viewModel.WaitForSortingAsync();
+        viewModel.MediaItems.Should().ContainSingle("widening the window reveals the match, proving the diagnosis");
+    }
+
+    [Fact]
     public async Task RebuildTagIndexCommand_ClearsTheIndex_ThenRunsAFullBuild()
     {
         // The incremental build skips unchanged files forever, so a row

--- a/DiffusionNexus.UI/ViewModels/GenerationGalleryViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/GenerationGalleryViewModel.cs
@@ -1374,7 +1374,16 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
         }
         else if (HasActiveTagFilters && MediaItems.Count == 0)
         {
-            NoMediaMessage = "No images match your current filters. Try clearing the filters, or build the tag index if you haven't done that yet.";
+            // Field-diagnosed trap: the tag filter DID match files, but the
+            // date filter (default "Last 3 Months"), the search box or the
+            // favorites toggle excluded every match — a partially built index
+            // tends to cover the oldest files first, which is exactly what a
+            // recent-only date window hides. Name the culprit and the fix.
+            NoMediaMessage = _tagMatchesHiddenByOtherFilters > 0
+                ? $"{_tagMatchesHiddenByOtherFilters:N0} image(s) match your tag filter, but the date filter " +
+                  $"('{SelectedDateFilter}'), the search box or the favorites toggle is hiding all of them. " +
+                  "Set the date filter to 'All Time' to see them."
+                : "No images match your current filters. Try clearing the filters, or build the tag index if you haven't done that yet.";
         }
         else
         {
@@ -1490,7 +1499,7 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
         }
 
         // Run sorting, filtering, and group creation on a background thread
-        var (sortedList, groups) = await Task.Run(() =>
+        var (sortedList, groups, hiddenTagMatches) = await Task.Run(() =>
         {
             IEnumerable<GenerationGalleryMediaItemViewModel> filtered = allItems;
 
@@ -1551,6 +1560,19 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
 
             var resultList = sorted.ToList();
 
+            // Debuggability for a real support case: the tag filter matched
+            // files, but the grid still came up empty because the OTHER
+            // filters (date/search/favorites) excluded every match — e.g. the
+            // default "Last 3 Months" date window hiding an index that so far
+            // only covers old files. Count the tag matches alone so the empty
+            // state can name the real culprit instead of a generic shrug.
+            var tagMatchesHiddenByOtherFilters = 0;
+            if (resultList.Count == 0 && !tagFilterFailed && tagMatchPaths is { Count: > 0 })
+            {
+                tagMatchesHiddenByOtherFilters =
+                    allItems.Count(item => tagMatchPaths.Contains(Path.GetFullPath(item.FilePath)));
+            }
+
             // Build groups on background thread too
             List<GenerationGalleryGroupViewModel>? resultGroups = null;
             if (isGroupingEnabled)
@@ -1566,7 +1588,7 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
                 }).ToList();
             }
 
-            return (resultList, resultGroups);
+            return (resultList, resultGroups, tagMatchesHiddenByOtherFilters);
         });
 
         // A newer pass started while this one was querying/sorting — its
@@ -1575,10 +1597,19 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
             return;
 
         FilteredMatchCount = sortedList.Count;
+        _tagMatchesHiddenByOtherFilters = hiddenTagMatches;
 
         // Back on the original context (UI thread) — apply results directly
         ApplySortedResults(sortedList, groups);
     }
+
+    /// <summary>
+    /// How many images matched the active tag filter but were excluded by the
+    /// date/search/favorites filters in the last pass that came up empty.
+    /// Only non-zero when the grid is empty for exactly that reason; feeds
+    /// the empty-state message.
+    /// </summary>
+    private int _tagMatchesHiddenByOtherFilters;
 
     private void ApplySortedResults(
         List<GenerationGalleryMediaItemViewModel> sortedList,


### PR DESCRIPTION
Root cause of "search matches N images but the grid is empty", diagnosed against the live gallery DB:

- The **date filter defaults to "Last 3 Months"** and applies before the tag filter.
- A **partially built index covers the oldest files first** (ComfyUI `%`-prefixed root files sort ahead of the dated subfolders), so every tag match fell outside the window → silent zero, while the NSFW radio sat innocently on "Show all".
- Verified live: 0 shown on "Last 3 Months" → **331 shown on "All Time"**, same session, no other change.

Fix: the filter pass counts tag matches excluded by the other filters (date/search/favorites) whenever it comes up empty, and the empty state now says *"N image(s) match your tag filter, but the date filter ('Last 3 Months')... Set the date filter to 'All Time' to see them."* — naming the culprit and the fix. Pinned by a regression test.

3416/3416 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)