### PR TITLE
Gallery: scope tag-cloud counts to current view + hidden-matches indicator

### DIFF
--- a/DiffusionNexus.Tests/Viewer/GenerationGalleryViewModelTests.cs
+++ b/DiffusionNexus.Tests/Viewer/GenerationGalleryViewModelTests.cs
@@ -1056,9 +1056,59 @@ public class GenerationGalleryViewModelTests : IDisposable
             .And.Contain("Last 3 Months")
             .And.Contain("All Time", "the message must hand the user the fix, not just the diagnosis");
 
-        viewModel.SelectedDateFilter = "All Time";
+        // The drawer's own indicator carries the same diagnosis…
+        viewModel.HasHiddenTagMatches.Should().BeTrue();
+        viewModel.HiddenTagMatchesText.Should().Contain("1").And.Contain("Last 3 Months");
+
+        // …and its one-click fix widens the toolbar filters.
+        viewModel.RevealHiddenMatchesCommand.Execute(null);
         await viewModel.WaitForSortingAsync();
         viewModel.MediaItems.Should().ContainSingle("widening the window reveals the match, proving the diagnosis");
+        viewModel.HasHiddenTagMatches.Should().BeFalse();
+        viewModel.ActiveTagFilters.Should().ContainSingle("the drawer's own filters must survive the reveal");
+    }
+
+    [Fact]
+    public async Task TagCloudChips_ShowScopedCounts_WhenTheDateFilterHidesCarriers()
+    {
+        // "1girl (55)" clicking into an empty grid was a lie: the chip count
+        // was gallery-global while the default date window hid every carrier.
+        // Chips now show "in scope / total" whenever the two differ.
+        var galleryPath = CreateTempDirectory();
+        var oldImage = Path.Combine(galleryPath, "old.png");
+        var newImage = Path.Combine(galleryPath, "new.png");
+        File.WriteAllText(oldImage, "test");
+        File.WriteAllText(newImage, "test");
+        File.SetCreationTimeUtc(oldImage, DateTime.UtcNow.AddYears(-1));
+
+        var mockTagIndex = BuildableTagIndex(new TagIndexBuildResult(2, 0, 0, 0));
+        mockTagIndex.Setup(t => t.GetTagCloudAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new TagFrequency("dog", 2) });
+        mockTagIndex.Setup(t => t.GetTagsForFilesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, ImageTagLookup>(StringComparer.OrdinalIgnoreCase)
+            {
+                [Path.GetFullPath(oldImage)] = new ImageTagLookup(IsNsfw: false, Tags: ["dog"]),
+                [Path.GetFullPath(newImage)] = new ImageTagLookup(IsNsfw: false, Tags: ["dog"]),
+            });
+        mockTagIndex.Setup(t => t.SearchAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<NsfwFilterMode>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { oldImage, newImage });
+
+        var viewModel = CreateGalleryViewModel(galleryPath, mockTagIndex.Object);
+        await viewModel.LoadMediaCommand.ExecuteAsync(null);
+        await viewModel.BuildTagIndexCommand.ExecuteAsync(null);
+        await viewModel.WaitForSortingAsync();
+
+        viewModel.SelectedDateFilter.Should().Be("Last 3 Months", "precondition: the default window hides the old file");
+        var chip = viewModel.TagCloud.Single(t => t.Name == "dog");
+        chip.Count.Should().Be(2);
+        chip.ScopedCount.Should().Be(1, "only the recent file falls inside the date window");
+        chip.DisplayText.Should().Be("dog (1/2)");
+
+        viewModel.SelectedDateFilter = "All Time";
+        await viewModel.WaitForSortingAsync();
+
+        chip.ScopedCount.Should().Be(2);
+        chip.DisplayText.Should().Be("dog (2)", "the split disappears when it carries no information");
     }
 
     [Fact]

--- a/DiffusionNexus.UI/ViewModels/GenerationGalleryViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/GenerationGalleryViewModel.cs
@@ -490,6 +490,11 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
                     if (IndexedImageCount > 0)
                     {
                         await HydrateTagDataAsync(mediaItems);
+
+                        // The filter pass inside ApplyMediaItemsAsync ran
+                        // before hydration, over tagless items — re-run it so
+                        // the scoped chip counts see the tag data.
+                        ApplySortingAndGrouping();
                     }
                 }
                 catch (Exception ex)
@@ -940,6 +945,11 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
             _allTagCloudEntries.Clear();
             _allTagCloudEntries.AddRange(
                 cloud.Select(t => new TagCloudEntryViewModel(t.Name, t.Count) { IsActive = activeNames.Contains(t.Name) }));
+            // Fresh entries default ScopedCount to the global count; bring
+            // them in line with the last completed filter pass so a chip
+            // never shows a global number the current view scope can't serve.
+            if (_lastScopedTagCounts is not null)
+                ApplyScopedTagCounts(_lastScopedTagCounts);
             ApplyTagCloudSearch();
             OnPropertyChanged(nameof(TagCloudHeader));
         }
@@ -1499,7 +1509,7 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
         }
 
         // Run sorting, filtering, and group creation on a background thread
-        var (sortedList, groups, hiddenTagMatches) = await Task.Run(() =>
+        var (sortedList, groups, hiddenTagMatches, scopedCounts) = await Task.Run(() =>
         {
             IEnumerable<GenerationGalleryMediaItemViewModel> filtered = allItems;
 
@@ -1520,13 +1530,21 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
                 filtered = filtered.Where(item => item.IsFavorite);
             }
 
-            if (tagFilterFailed)
+            // Materialized checkpoint: everything the TOOLBAR filters
+            // (date/search/favorites) leave visible, before the drawer's
+            // tag/NSFW filters apply. This is the scope the tag-cloud chip
+            // counts are computed against below.
+            var toolbarScoped = filtered.ToList();
+            filtered = toolbarScoped;
+
+            // The drawer's own filters (tag chips + NSFW mode) as a reusable
+            // predicate: applied to the pipeline below AND evaluated against
+            // the unfiltered item list to detect matches that the TOOLBAR
+            // filters (date/search/favorites) are hiding.
+            Func<GenerationGalleryMediaItemViewModel, bool>? drawerFilter = null;
+            if (!tagFilterFailed && (tagMatchPaths is not null || knownNsfwPaths is not null))
             {
-                filtered = [];
-            }
-            else if (tagMatchPaths is not null || knownNsfwPaths is not null)
-            {
-                filtered = filtered.Where(item =>
+                drawerFilter = item =>
                 {
                     var fullPath = Path.GetFullPath(item.FilePath);
 
@@ -1543,7 +1561,16 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
                     }
 
                     return true;
-                });
+                };
+            }
+
+            if (tagFilterFailed)
+            {
+                filtered = [];
+            }
+            else if (drawerFilter is not null)
+            {
+                filtered = filtered.Where(drawerFilter);
             }
 
             IEnumerable<GenerationGalleryMediaItemViewModel> sorted = filtered;
@@ -1560,17 +1587,40 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
 
             var resultList = sorted.ToList();
 
-            // Debuggability for a real support case: the tag filter matched
-            // files, but the grid still came up empty because the OTHER
-            // filters (date/search/favorites) excluded every match — e.g. the
-            // default "Last 3 Months" date window hiding an index that so far
-            // only covers old files. Count the tag matches alone so the empty
-            // state can name the real culprit instead of a generic shrug.
+            // Field-diagnosed support case: the tag filter matched files, but
+            // the grid came up short (or empty) because the toolbar filters
+            // excluded matches — e.g. the default "Last 3 Months" date window
+            // hiding an index that so far only covers old files. Count the
+            // drawer-filter matches across the WHOLE gallery so the UI can
+            // say how many exist beyond the current view scope.
             var tagMatchesHiddenByOtherFilters = 0;
-            if (resultList.Count == 0 && !tagFilterFailed && tagMatchPaths is { Count: > 0 })
+            if (drawerFilter is not null)
             {
-                tagMatchesHiddenByOtherFilters =
-                    allItems.Count(item => tagMatchPaths.Contains(Path.GetFullPath(item.FilePath)));
+                var drawerOnlyMatches = allItems.Count(drawerFilter);
+                tagMatchesHiddenByOtherFilters = Math.Max(0, drawerOnlyMatches - resultList.Count);
+            }
+
+            // Scoped chip counts: how many toolbar-scoped items — further
+            // restricted by the NSFW mode, but NOT by the tag chips — carry
+            // each tag. This is exactly what clicking a single chip can
+            // surface, so the cloud shows "in scope / total" instead of a
+            // global count that clicks into an empty grid. Built from the
+            // per-tile tag data hydrated at load/build time; unindexed items
+            // carry no tags and naturally contribute nothing.
+            var scopedTagCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            foreach (var item in toolbarScoped)
+            {
+                if (knownNsfwPaths is not null)
+                {
+                    var isKnownNsfw = knownNsfwPaths.Contains(Path.GetFullPath(item.FilePath));
+                    if (nsfwFilter == NsfwFilterMode.HideNsfw && isKnownNsfw)
+                        continue;
+                    if (nsfwFilter == NsfwFilterMode.NsfwOnly && !isKnownNsfw)
+                        continue;
+                }
+
+                foreach (var tag in item.Tags)
+                    scopedTagCounts[tag] = scopedTagCounts.GetValueOrDefault(tag) + 1;
             }
 
             // Build groups on background thread too
@@ -1588,7 +1638,7 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
                 }).ToList();
             }
 
-            return (resultList, resultGroups, tagMatchesHiddenByOtherFilters);
+            return (resultList, resultGroups, tagMatchesHiddenByOtherFilters, scopedTagCounts);
         });
 
         // A newer pass started while this one was querying/sorting — its
@@ -1598,18 +1648,57 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
 
         FilteredMatchCount = sortedList.Count;
         _tagMatchesHiddenByOtherFilters = hiddenTagMatches;
+        OnPropertyChanged(nameof(HasHiddenTagMatches));
+        OnPropertyChanged(nameof(HiddenTagMatchesText));
+
+        _lastScopedTagCounts = scopedCounts;
+        ApplyScopedTagCounts(scopedCounts);
 
         // Back on the original context (UI thread) — apply results directly
         ApplySortedResults(sortedList, groups);
     }
 
     /// <summary>
-    /// How many images matched the active tag filter but were excluded by the
-    /// date/search/favorites filters in the last pass that came up empty.
-    /// Only non-zero when the grid is empty for exactly that reason; feeds
-    /// the empty-state message.
+    /// How many images matched the drawer's tag/NSFW filters but were
+    /// excluded by the toolbar's date/search/favorites filters in the last
+    /// pass. Feeds the drawer's "N more hidden" indicator and the empty-state
+    /// message.
     /// </summary>
     private int _tagMatchesHiddenByOtherFilters;
+
+    /// <summary>
+    /// The scoped chip counts from the last completed filter pass, kept so a
+    /// tag-cloud refresh (which rebuilds the chip entries) can re-apply them
+    /// without waiting for the next pass.
+    /// </summary>
+    private Dictionary<string, int>? _lastScopedTagCounts;
+
+    /// <summary>True when the toolbar filters hide drawer-filter matches.</summary>
+    public bool HasHiddenTagMatches => _tagMatchesHiddenByOtherFilters > 0;
+
+    public string HiddenTagMatchesText =>
+        $"⚠ {_tagMatchesHiddenByOtherFilters:N0} more match but are outside the current view — " +
+        $"date filter ('{SelectedDateFilter}'), search box or favorites toggle.";
+
+    /// <summary>
+    /// One-click escape from the hidden-matches situation: widen the toolbar
+    /// filters that can hide drawer-filter matches. Deliberately leaves the
+    /// drawer's own filters (chips, NSFW mode) untouched — those are what the
+    /// user is actively composing.
+    /// </summary>
+    [RelayCommand]
+    private void RevealHiddenMatches()
+    {
+        SelectedDateFilter = "All Time";
+        SearchText = string.Empty;
+        ShowFavoritesOnly = false;
+    }
+
+    private void ApplyScopedTagCounts(Dictionary<string, int> scopedCounts)
+    {
+        foreach (var entry in _allTagCloudEntries)
+            entry.ScopedCount = scopedCounts.GetValueOrDefault(entry.Name);
+    }
 
     private void ApplySortedResults(
         List<GenerationGalleryMediaItemViewModel> sortedList,

--- a/DiffusionNexus.UI/ViewModels/TagCloudEntryViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/TagCloudEntryViewModel.cs
@@ -6,8 +6,29 @@ namespace DiffusionNexus.UI.ViewModels;
 public partial class TagCloudEntryViewModel : ObservableObject
 {
     public string Name { get; }
+
+    /// <summary>How many indexed images carry this tag, gallery-wide.</summary>
     public int Count { get; }
-    public string DisplayText => $"{Name} ({Count})";
+
+    /// <summary>
+    /// How many of those fall inside the CURRENT view scope — the toolbar's
+    /// date/search/favorites filters plus the drawer's NSFW mode. Clicking a
+    /// chip can only ever surface this many images, so showing the global
+    /// count alone was a lie: "1girl (55)" clicked into an empty grid when
+    /// every match sat outside the default 3-month date window.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DisplayText))]
+    private int _scopedCount;
+
+    /// <summary>
+    /// "name (in-scope/total)" when the view scope hides some carriers,
+    /// "name (total)" when it hides none — the split only appears when it
+    /// carries information.
+    /// </summary>
+    public string DisplayText => ScopedCount == Count
+        ? $"{Name} ({Count})"
+        : $"{Name} ({ScopedCount}/{Count})";
 
     [ObservableProperty]
     private bool _isActive;
@@ -16,5 +37,6 @@ public partial class TagCloudEntryViewModel : ObservableObject
     {
         Name = name;
         Count = count;
+        _scopedCount = count;
     }
 }

--- a/DiffusionNexus.UI/Views/GenerationGalleryView.axaml
+++ b/DiffusionNexus.UI/Views/GenerationGalleryView.axaml
@@ -479,7 +479,20 @@
           </ScrollViewer>
 
           <Border Grid.Row="2" Padding="16" BorderBrush="#333" BorderThickness="0,1,0,0">
-            <TextBlock Text="{Binding FilteredMatchCountText}" FontSize="12" Foreground="#9a9a9a" HorizontalAlignment="Center"/>
+            <StackPanel Spacing="6">
+              <TextBlock Text="{Binding FilteredMatchCountText}" FontSize="12" Foreground="#9a9a9a" HorizontalAlignment="Center"/>
+              <!-- The toolbar's date/search/favorites filters can hide files
+                   the drawer's filters matched (field case: the default
+                   "Last 3 Months" window hid every indexed match). Say so
+                   here, where the user is looking, with a one-click fix. -->
+              <StackPanel IsVisible="{Binding HasHiddenTagMatches}" Spacing="4">
+                <TextBlock Text="{Binding HiddenTagMatchesText}"
+                           FontSize="11" Foreground="#d9a334" TextWrapping="Wrap"/>
+                <Button Content="Show them — widen date/search filters"
+                        Command="{Binding RevealHiddenMatchesCommand}"
+                        Padding="8,4" FontSize="11" HorizontalAlignment="Left"/>
+              </StackPanel>
+            </StackPanel>
           </Border>
         </Grid>
       </Border>


### PR DESCRIPTION
Follow-up to the date-filter diagnosis — the drawer now tells the truth about scope:

- **Scoped chip counts**: chips read `1girl (0/55)` when the toolbar filters (date/search/favorites) or NSFW mode hide carriers, `1girl (55)` when nothing is hidden. Computed per filter pass from the hydrated per-tile tags; exactly what clicking that chip can surface.
- **Hidden-matches indicator** in the drawer footer whenever toolbar filters hide drawer-filter matches: "N more match but are outside the current view — date filter ('Last 3 Months'), search box or favorites toggle", plus a one-click **Show them** button that widens date/search/favorites (drawer filters untouched).

3417/3417 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)