### PR TITLE
Gallery: hidden-images warning fires for any hiding filter

### DIFF
--- a/DiffusionNexus.Tests/Viewer/GenerationGalleryViewModelTests.cs
+++ b/DiffusionNexus.Tests/Viewer/GenerationGalleryViewModelTests.cs
@@ -1069,6 +1069,69 @@ public class GenerationGalleryViewModelTests : IDisposable
     }
 
     [Fact]
+    public async Task HiddenIndicator_AppearsWheneverAnyFilterHidesImages()
+    {
+        // User requirement, verbatim: "I want a warning whenever something is
+        // hidden." Not just toolbar-vs-tag interactions — Hide NSFW on its
+        // own, with All Time and no chips, must announce what it swallowed.
+        var galleryPath = CreateTempDirectory();
+        var sfwImage = Path.Combine(galleryPath, "sfw.png");
+        var nsfwImage = Path.Combine(galleryPath, "nsfw.png");
+        File.WriteAllText(sfwImage, "test");
+        File.WriteAllText(nsfwImage, "test");
+
+        var mockTagIndex = new Mock<ITagIndexService>();
+        mockTagIndex.Setup(t => t.GetIndexedCountAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(2);
+        mockTagIndex.Setup(t => t.GetTagsForFilesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, ImageTagLookup>());
+        mockTagIndex.Setup(t => t.SearchAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<NsfwFilterMode>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { nsfwImage });
+
+        var viewModel = CreateGalleryViewModel(galleryPath, mockTagIndex.Object);
+        await viewModel.LoadMediaCommand.ExecuteAsync(null);
+
+        viewModel.SelectedDateFilter = "All Time";
+        await viewModel.WaitForSortingAsync();
+        viewModel.HasHiddenTagMatches.Should().BeFalse("nothing narrows the gallery yet");
+
+        viewModel.SetNsfwFilterCommand.Execute(nameof(NsfwFilterMode.HideNsfw));
+        await viewModel.WaitForSortingAsync();
+
+        viewModel.MediaItems.Should().ContainSingle();
+        viewModel.HasHiddenTagMatches.Should().BeTrue("Hide NSFW swallowed an image and must say so");
+        viewModel.HiddenTagMatchesText.Should().Contain("1").And.Contain("NSFW");
+    }
+
+    [Fact]
+    public async Task HiddenIndicator_AppearsForTheDateWindowAlone_WithoutAnyDrawerFilter()
+    {
+        // The other half of "whenever something is hidden": a time constraint
+        // with Show all and no chips still hides files — say so.
+        var galleryPath = CreateTempDirectory();
+        var oldImage = Path.Combine(galleryPath, "old.png");
+        var newImage = Path.Combine(galleryPath, "new.png");
+        File.WriteAllText(oldImage, "test");
+        File.WriteAllText(newImage, "test");
+        File.SetCreationTimeUtc(oldImage, DateTime.UtcNow.AddYears(-1));
+
+        var mockTagIndex = new Mock<ITagIndexService>();
+        mockTagIndex.Setup(t => t.GetIndexedCountAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(0);
+
+        var viewModel = CreateGalleryViewModel(galleryPath, mockTagIndex.Object);
+        await viewModel.LoadMediaCommand.ExecuteAsync(null);
+        await viewModel.WaitForSortingAsync();
+
+        viewModel.SelectedDateFilter.Should().Be("Last 3 Months");
+        viewModel.MediaItems.Should().ContainSingle("the year-old file is outside the window");
+        viewModel.HasHiddenTagMatches.Should().BeTrue();
+        viewModel.HiddenTagMatchesText.Should().Contain("1").And.Contain("Last 3 Months");
+
+        viewModel.SelectedDateFilter = "All Time";
+        await viewModel.WaitForSortingAsync();
+        viewModel.HasHiddenTagMatches.Should().BeFalse("nothing is hidden any more");
+    }
+
+    [Fact]
     public async Task TagCloudChips_ShowScopedCounts_WhenTheDateFilterHidesCarriers()
     {
         // "1girl (55)" clicking into an empty grid was a lie: the chip count

--- a/DiffusionNexus.UI/ViewModels/GenerationGalleryViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/GenerationGalleryViewModel.cs
@@ -1390,9 +1390,13 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
             // tends to cover the oldest files first, which is exactly what a
             // recent-only date window hides. Name the culprit and the fix.
             NoMediaMessage = _tagMatchesHiddenByOtherFilters > 0
-                ? $"{_tagMatchesHiddenByOtherFilters:N0} image(s) match your tag filter, but the date filter " +
-                  $"('{SelectedDateFilter}'), the search box or the favorites toggle is hiding all of them. " +
-                  "Set the date filter to 'All Time' to see them."
+                ? ActiveTagFilters.Count > 0
+                    ? $"{_tagMatchesHiddenByOtherFilters:N0} image(s) match your tag filter, but the date filter " +
+                      $"('{SelectedDateFilter}'), the search box, the favorites toggle or the NSFW mode is hiding " +
+                      "all of them. Set the date filter to 'All Time' to see them."
+                    : $"All {_tagMatchesHiddenByOtherFilters:N0} image(s) are hidden by your current filters — " +
+                      $"the date filter ('{SelectedDateFilter}'), the search box, the favorites toggle or the NSFW mode. " +
+                      "Adjust them to see the gallery."
                 : "No images match your current filters. Try clearing the filters, or build the tag index if you haven't done that yet.";
         }
         else
@@ -1587,17 +1591,20 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
 
             var resultList = sorted.ToList();
 
-            // Field-diagnosed support case: the tag filter matched files, but
-            // the grid came up short (or empty) because the toolbar filters
-            // excluded matches — e.g. the default "Last 3 Months" date window
-            // hiding an index that so far only covers old files. Count the
-            // drawer-filter matches across the WHOLE gallery so the UI can
-            // say how many exist beyond the current view scope.
+            // "Warn whenever something is hidden" (user requirement, verbatim):
+            // the baseline is what the tag CHIPS alone would match gallery-wide
+            // — the whole gallery when no chip is active. Everything that the
+            // remaining filters (date window, search box, favorites toggle,
+            // NSFW mode) removed from that baseline counts as hidden. The
+            // chips themselves are exempt: narrowing to a tag is the search
+            // the user asked for, not something being withheld from it.
             var tagMatchesHiddenByOtherFilters = 0;
-            if (drawerFilter is not null)
+            if (!tagFilterFailed)
             {
-                var drawerOnlyMatches = allItems.Count(drawerFilter);
-                tagMatchesHiddenByOtherFilters = Math.Max(0, drawerOnlyMatches - resultList.Count);
+                var baseline = tagMatchPaths is null
+                    ? allItems.Count
+                    : allItems.Count(item => tagMatchPaths.Contains(Path.GetFullPath(item.FilePath)));
+                tagMatchesHiddenByOtherFilters = Math.Max(0, baseline - resultList.Count);
             }
 
             // Scoped chip counts: how many toolbar-scoped items — further
@@ -1673,12 +1680,13 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
     /// </summary>
     private Dictionary<string, int>? _lastScopedTagCounts;
 
-    /// <summary>True when the toolbar filters hide drawer-filter matches.</summary>
+    /// <summary>True when any filter besides the tag chips hides images.</summary>
     public bool HasHiddenTagMatches => _tagMatchesHiddenByOtherFilters > 0;
 
-    public string HiddenTagMatchesText =>
-        $"⚠ {_tagMatchesHiddenByOtherFilters:N0} more match but are outside the current view — " +
-        $"date filter ('{SelectedDateFilter}'), search box or favorites toggle.";
+    public string HiddenTagMatchesText => (ActiveTagFilters.Count > 0
+            ? $"⚠ {_tagMatchesHiddenByOtherFilters:N0} more match your tags but are hidden by "
+            : $"⚠ {_tagMatchesHiddenByOtherFilters:N0} image(s) are hidden by ")
+        + $"the date filter ('{SelectedDateFilter}'), the search box, the favorites toggle or the NSFW mode.";
 
     /// <summary>
     /// One-click escape from the hidden-matches situation: widen the toolbar


### PR DESCRIPTION
Widens the drawer's hidden-images warning per feedback: it now fires **whenever anything is hidden**, by any filter except the tag chips themselves.

- Baseline = what the tag chips alone would match (whole gallery when no chip is active).
- Anything the **date window, search box, favorites toggle or NSFW mode** removes from that baseline is counted and announced — so "Last 3 Months + Show all" warns, and "All Time + Hide NSFW" warns too.
- Chips stay exempt: narrowing to a tag is the search the user asked for.
- Empty-state message gains a chip-less variant.

3419/3419 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)