### PR TITLE
fix(gallery): counter-less hidden-images warning + drop zero-scoped tag chips

### DIFF
--- a/DiffusionNexus.Tests/Viewer/GenerationGalleryViewModelTests.cs
+++ b/DiffusionNexus.Tests/Viewer/GenerationGalleryViewModelTests.cs
@@ -1058,7 +1058,7 @@ public class GenerationGalleryViewModelTests : IDisposable
 
         // The drawer's own indicator carries the same diagnosis…
         viewModel.HasHiddenTagMatches.Should().BeTrue();
-        viewModel.HiddenTagMatchesText.Should().Contain("1").And.Contain("Last 3 Months");
+        viewModel.HiddenTagMatchesText.Should().Contain("Last 3 Months").And.Contain("hidden");
 
         // …and its one-click fix widens the toolbar filters.
         viewModel.RevealHiddenMatchesCommand.Execute(null);
@@ -1099,7 +1099,14 @@ public class GenerationGalleryViewModelTests : IDisposable
 
         viewModel.MediaItems.Should().ContainSingle();
         viewModel.HasHiddenTagMatches.Should().BeTrue("Hide NSFW swallowed an image and must say so");
-        viewModel.HiddenTagMatchesText.Should().Contain("1").And.Contain("NSFW");
+        // Counter-less by design (user feedback: baseline-minus-shown counts
+        // read as nonsense — NSFW only showed a HIGHER number than Show all).
+        // The warning names only the filters actually narrowing the view.
+        viewModel.HiddenTagMatchesText.Should().Contain("NSFW mode")
+            .And.NotContain("date filter", "All Time is not narrowing anything")
+            .And.NotContainAny("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+        viewModel.CanRevealHiddenMatches.Should().BeFalse(
+            "the widen-filters button never touches the NSFW mode, so it would be a no-op here");
     }
 
     [Fact]
@@ -1124,7 +1131,8 @@ public class GenerationGalleryViewModelTests : IDisposable
         viewModel.SelectedDateFilter.Should().Be("Last 3 Months");
         viewModel.MediaItems.Should().ContainSingle("the year-old file is outside the window");
         viewModel.HasHiddenTagMatches.Should().BeTrue();
-        viewModel.HiddenTagMatchesText.Should().Contain("1").And.Contain("Last 3 Months");
+        viewModel.HiddenTagMatchesText.Should().Contain("Last 3 Months");
+        viewModel.CanRevealHiddenMatches.Should().BeTrue("the date window is a toolbar filter the button can widen");
 
         viewModel.SelectedDateFilter = "All Time";
         await viewModel.WaitForSortingAsync();
@@ -1172,6 +1180,58 @@ public class GenerationGalleryViewModelTests : IDisposable
 
         chip.ScopedCount.Should().Be(2);
         chip.DisplayText.Should().Be("dog (2)", "the split disappears when it carries no information");
+    }
+
+    [Fact]
+    public async Task TagCloud_DropsChipsTheCurrentViewCannotServe_UnlessTheyAreActive()
+    {
+        // User request: a "tag (0/400)" chip only ever clicks into an empty
+        // grid — drop it from the cloud instead of displaying it. Active
+        // chips survive regardless, or a narrowed view would strand them
+        // with no way to deselect.
+        var galleryPath = CreateTempDirectory();
+        var oldImage = Path.Combine(galleryPath, "old.png");
+        var newImage = Path.Combine(galleryPath, "new.png");
+        File.WriteAllText(oldImage, "test");
+        File.WriteAllText(newImage, "test");
+        File.SetCreationTimeUtc(oldImage, DateTime.UtcNow.AddYears(-1));
+
+        var mockTagIndex = BuildableTagIndex(new TagIndexBuildResult(2, 0, 0, 0));
+        mockTagIndex.Setup(t => t.GetTagCloudAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new TagFrequency("dog", 1), new TagFrequency("cat", 1) });
+        mockTagIndex.Setup(t => t.GetTagsForFilesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, ImageTagLookup>(StringComparer.OrdinalIgnoreCase)
+            {
+                [Path.GetFullPath(oldImage)] = new ImageTagLookup(IsNsfw: false, Tags: ["dog"]),
+                [Path.GetFullPath(newImage)] = new ImageTagLookup(IsNsfw: false, Tags: ["cat"]),
+            });
+        mockTagIndex.Setup(t => t.SearchAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<NsfwFilterMode>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { oldImage });
+
+        var viewModel = CreateGalleryViewModel(galleryPath, mockTagIndex.Object);
+        await viewModel.LoadMediaCommand.ExecuteAsync(null);
+        await viewModel.BuildTagIndexCommand.ExecuteAsync(null);
+        await viewModel.WaitForSortingAsync();
+
+        viewModel.SelectedDateFilter.Should().Be("Last 3 Months", "precondition: the default window hides the old file");
+        viewModel.TagCloud.Select(t => t.Name).Should().BeEquivalentTo(new[] { "cat" },
+            "'dog' lives only on the year-old file — zero in scope, so its chip is dropped");
+
+        // A chip can be active while zero-scoped (activated before the view
+        // narrowed) — it must stay visible so it can be deselected.
+        viewModel.ToggleTagFilterCommand.Execute("dog");
+        await viewModel.WaitForSortingAsync();
+        viewModel.TagCloud.Single(t => t.Name == "dog").DisplayText.Should().Be("dog (0/1)");
+
+        viewModel.ToggleTagFilterCommand.Execute("dog");
+        await viewModel.WaitForSortingAsync();
+        viewModel.TagCloud.Select(t => t.Name).Should().BeEquivalentTo(new[] { "cat" },
+            "deactivating the zero-scoped chip drops it again");
+
+        viewModel.SelectedDateFilter = "All Time";
+        await viewModel.WaitForSortingAsync();
+        viewModel.TagCloud.Select(t => t.Name).Should().BeEquivalentTo(new[] { "cat", "dog" },
+            "widening the window brings every chip back");
     }
 
     [Fact]
@@ -1315,7 +1375,11 @@ public class GenerationGalleryViewModelTests : IDisposable
 
         viewModel.TagCloud.Should().HaveCount(3, "no filter shows the whole cloud");
 
+        // Toggling a chip kicks off an async filter pass whose publish step
+        // re-emits the cloud — await it, or the assertions below enumerate
+        // TagCloud while the pass is replacing it.
         viewModel.ToggleTagFilterCommand.Execute("dog");
+        await viewModel.WaitForSortingAsync();
         viewModel.TagCloudSearchText = "do";
 
         viewModel.TagCloud.Select(t => t.Name).Should().BeEquivalentTo(new[] { "dog", "door" });
@@ -1331,6 +1395,7 @@ public class GenerationGalleryViewModelTests : IDisposable
         // filter: the chip must come back with its CURRENT state, not the
         // state it had when it was hidden.
         viewModel.ToggleTagFilterCommand.Execute("dog");
+        await viewModel.WaitForSortingAsync();
         viewModel.TagCloudSearchText = null;
 
         viewModel.TagCloud.Should().HaveCount(3);

--- a/DiffusionNexus.UI/ViewModels/GenerationGalleryViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/GenerationGalleryViewModel.cs
@@ -989,11 +989,13 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
     private void ApplyTagCloudSearch()
     {
         var search = TagCloudSearchText?.Trim();
-        TagCloud.ReplaceAll(string.IsNullOrEmpty(search)
-            ? _allTagCloudEntries.ToList()
-            : _allTagCloudEntries
-                .Where(e => e.Name.Contains(search, StringComparison.OrdinalIgnoreCase))
-                .ToList());
+        // Zero-scoped chips are dropped entirely (user request): a "tag
+        // (0/400)" chip can only click into an empty grid. Active chips stay
+        // regardless — hiding one would strand it with no way to deselect.
+        TagCloud.ReplaceAll(_allTagCloudEntries
+            .Where(e => e.ScopedCount > 0 || e.IsActive)
+            .Where(e => string.IsNullOrEmpty(search) || e.Name.Contains(search, StringComparison.OrdinalIgnoreCase))
+            .ToList());
     }
 
     private void InvalidateTagSearchCache()
@@ -1630,6 +1632,15 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
                     scopedTagCounts[tag] = scopedTagCounts.GetValueOrDefault(tag) + 1;
             }
 
+            // Zero-scoped chips are HIDDEN from the cloud, so all-zero counts
+            // must mean "nothing in scope carries this tag" — not "tag data
+            // simply isn't hydrated yet" (pre-hydration pass, or a cloud built
+            // from index rows for files outside this gallery). When no item
+            // gallery-wide carries any tag data, scope is unknown: report null
+            // and let the chips keep their global counts instead of emptying
+            // the whole cloud.
+            var hasHydratedTagData = allItems.Any(i => i.Tags.Count > 0);
+
             // Build groups on background thread too
             List<GenerationGalleryGroupViewModel>? resultGroups = null;
             if (isGroupingEnabled)
@@ -1645,7 +1656,8 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
                 }).ToList();
             }
 
-            return (resultList, resultGroups, tagMatchesHiddenByOtherFilters, scopedTagCounts);
+            return (resultList, resultGroups, tagMatchesHiddenByOtherFilters,
+                hasHydratedTagData ? scopedTagCounts : null);
         });
 
         // A newer pass started while this one was querying/sorting — its
@@ -1657,9 +1669,13 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
         _tagMatchesHiddenByOtherFilters = hiddenTagMatches;
         OnPropertyChanged(nameof(HasHiddenTagMatches));
         OnPropertyChanged(nameof(HiddenTagMatchesText));
+        OnPropertyChanged(nameof(CanRevealHiddenMatches));
 
         _lastScopedTagCounts = scopedCounts;
         ApplyScopedTagCounts(scopedCounts);
+        // Scoped counts decide chip VISIBILITY now (zero-scoped chips are
+        // hidden), so the published cloud must be refreshed with them.
+        ApplyTagCloudSearch();
 
         // Back on the original context (UI thread) — apply results directly
         ApplySortedResults(sortedList, groups);
@@ -1683,10 +1699,46 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
     /// <summary>True when any filter besides the tag chips hides images.</summary>
     public bool HasHiddenTagMatches => _tagMatchesHiddenByOtherFilters > 0;
 
-    public string HiddenTagMatchesText => (ActiveTagFilters.Count > 0
-            ? $"⚠ {_tagMatchesHiddenByOtherFilters:N0} more match your tags but are hidden by "
-            : $"⚠ {_tagMatchesHiddenByOtherFilters:N0} image(s) are hidden by ")
-        + $"the date filter ('{SelectedDateFilter}'), the search box, the favorites toggle or the NSFW mode.";
+    /// <summary>
+    /// The widen-filters button only helps when a TOOLBAR filter is
+    /// narrowing the view — it deliberately never touches the drawer's NSFW
+    /// mode, so when that is the sole culprit the button would be a no-op.
+    /// </summary>
+    public bool CanRevealHiddenMatches =>
+        !string.Equals(SelectedDateFilter, "All Time", StringComparison.OrdinalIgnoreCase)
+        || !string.IsNullOrWhiteSpace(SearchText)
+        || ShowFavoritesOnly;
+
+    /// <summary>
+    /// Deliberately counter-less (user feedback): the old "N hidden" number
+    /// was baseline-minus-shown, so switching Show all → NSFW only made the
+    /// count JUMP (fewer shown, same baseline) — arithmetically right,
+    /// humanly wrong. Now it just names the filters actually narrowing the
+    /// view.
+    /// </summary>
+    public string HiddenTagMatchesText
+    {
+        get
+        {
+            var culprits = new List<string>();
+            if (!string.Equals(SelectedDateFilter, "All Time", StringComparison.OrdinalIgnoreCase))
+                culprits.Add($"the date filter ('{SelectedDateFilter}')");
+            if (!string.IsNullOrWhiteSpace(SearchText))
+                culprits.Add("the search box");
+            if (ShowFavoritesOnly)
+                culprits.Add("the favorites toggle");
+            if (NsfwFilter != NsfwFilterMode.ShowAll)
+                culprits.Add("the NSFW mode");
+
+            var subject = culprits.Count switch
+            {
+                0 => "the current filters",
+                1 => culprits[0],
+                _ => string.Join(", ", culprits.Take(culprits.Count - 1)) + " and " + culprits[^1],
+            };
+            return $"⚠ Due to {subject}, images and tags may be hidden.";
+        }
+    }
 
     /// <summary>
     /// One-click escape from the hidden-matches situation: widen the toolbar
@@ -1702,10 +1754,13 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
         ShowFavoritesOnly = false;
     }
 
-    private void ApplyScopedTagCounts(Dictionary<string, int> scopedCounts)
+    private void ApplyScopedTagCounts(Dictionary<string, int>? scopedCounts)
     {
+        // Null = scope unknown (no hydrated tag data anywhere) — fall back to
+        // the global count so DisplayText collapses to "name (N)" and the
+        // zero-scoped-chips-are-hidden rule can't empty the cloud.
         foreach (var entry in _allTagCloudEntries)
-            entry.ScopedCount = scopedCounts.GetValueOrDefault(entry.Name);
+            entry.ScopedCount = scopedCounts?.GetValueOrDefault(entry.Name) ?? entry.Count;
     }
 
     private void ApplySortedResults(

--- a/DiffusionNexus.UI/Views/GenerationGalleryView.axaml
+++ b/DiffusionNexus.UI/Views/GenerationGalleryView.axaml
@@ -490,6 +490,7 @@
                            FontSize="11" Foreground="#d9a334" TextWrapping="Wrap"/>
                 <Button Content="Show them — widen date/search filters"
                         Command="{Binding RevealHiddenMatchesCommand}"
+                        IsVisible="{Binding CanRevealHiddenMatches}"
                         Padding="8,4" FontSize="11" HorizontalAlignment="Left"/>
               </StackPanel>
             </StackPanel>


### PR DESCRIPTION
User-reported: the hidden-images warning counter was baseline-minus-shown, so "NSFW only" showed a HIGHER number than "Show all" (fewer shown, same baseline) - arithmetically right, humanly nonsense.

- Warning is now counter-less and names only the filters actually narrowing the view: "Due to the date filter (''Last 3 Months'') and the NSFW mode, images and tags may be hidden."
- The "widen date/search filters" button hides when the NSFW mode is the sole culprit (it never touches drawer filters, so it would be a no-op).
- Zero-scoped chips ("tag (0/400)") are dropped from the tag cloud (user request) - they can only click into an empty grid. Active chips always stay visible so they can be deselected; when no tag data is hydrated anywhere, scope is treated as unknown and chips keep global counts instead of the cloud emptying.

Tests: 3420/3420 green (new: TagCloud_DropsChipsTheCurrentViewCannotServe_UnlessTheyAreActive; updated the three hidden-indicator pins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)