### PR TITLE
ux(gallery): one home per number in the Advanced Search drawer

### DIFF
--- a/DiffusionNexus.UI/ViewModels/GenerationGalleryViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/GenerationGalleryViewModel.cs
@@ -407,8 +407,10 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
 
     // Counts the full entry list, not the filtered TagCloud view — the header
     // describes the index, and must not shrink while the user types in the
-    // tag filter box.
-    public string TagCloudHeader => $"TAG INDEX — {TotalGalleryImageCount:N0} images · {_allTagCloudEntries.Count:N0} tags";
+    // tag filter box. Deliberately tags-only: the image counts live in the
+    // INDEXING row and the drawer footer, and repeating them here was the
+    // third copy of the same number (user feedback).
+    public string TagCloudHeader => $"TAG INDEX — {_allTagCloudEntries.Count:N0} tags";
 
     #region IThumbnailAware
 
@@ -1345,7 +1347,6 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
         // TotalGalleryImageCount is computed from _allMediaItems.
         OnPropertyChanged(nameof(TotalGalleryImageCount));
         OnPropertyChanged(nameof(IndexStatusText));
-        OnPropertyChanged(nameof(TagCloudHeader));
 
         // Recorded before the pipeline starts: ApplySortedResults recomputes
         // the empty-state message on every run and needs this to distinguish
@@ -1906,7 +1907,6 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
         // changed — raise it and its dependents.
         OnPropertyChanged(nameof(TotalGalleryImageCount));
         OnPropertyChanged(nameof(IndexStatusText));
-        OnPropertyChanged(nameof(TagCloudHeader));
 
         if (_tagIndexService is null) return;
 

--- a/DiffusionNexus.UI/Views/GenerationGalleryView.axaml
+++ b/DiffusionNexus.UI/Views/GenerationGalleryView.axaml
@@ -428,10 +428,6 @@
                           IsVisible="{Binding !IsIndexingTagIndex}"
                           Padding="10,6"
                           ToolTip.Tip="Delete the tag index for this gallery and re-tag every image from scratch"/>
-                  <Border Background="#1c1c1c" BorderBrush="#3a3a3a" BorderThickness="1" CornerRadius="100"
-                          Padding="8,2" VerticalAlignment="Center">
-                    <TextBlock Text="{Binding IndexStatusText}" FontSize="11" Foreground="#9a9a9a"/>
-                  </Border>
                 </StackPanel>
                 <TextBlock Text="{Binding StatusMessage}"
                            IsVisible="{Binding StatusMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
@@ -480,7 +476,14 @@
 
           <Border Grid.Row="2" Padding="16" BorderBrush="#333" BorderThickness="0,1,0,0">
             <StackPanel Spacing="6">
-              <TextBlock Text="{Binding FilteredMatchCountText}" FontSize="12" Foreground="#9a9a9a" HorizontalAlignment="Center"/>
+              <!-- One home per number (user feedback — it used to appear three
+                   times): match count + indexed progress live here, the tag
+                   count lives in the TAG INDEX header. -->
+              <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
+                <TextBlock Text="{Binding FilteredMatchCountText}" FontSize="12" Foreground="#9a9a9a"/>
+                <TextBlock Text="·" FontSize="12" Foreground="#4a4a4a"/>
+                <TextBlock Text="{Binding IndexStatusText}" FontSize="12" Foreground="#6f6f6f"/>
+              </StackPanel>
               <!-- The toolbar's date/search/favorites filters can hide files
                    the drawer's filters matched (field case: the default
                    "Last 3 Months" window hid every indexed match). Say so


### PR DESCRIPTION
User feedback: the indexed/image counts appeared three times in the drawer. Now the INDEXING row keeps only the buttons, the TAG INDEX header shows just the tag count ("TAG INDEX - 200 tags"), and the footer carries "N images match - N / M indexed" on one line.

Tests: 3420/3420 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)