### PR TITLE
feat(viewer): content tags + SFW/NSFW rating in the Generation Data panel

### DIFF
--- a/DiffusionNexus.IntegrationTests/DatasetManagementIntegrationTests.cs
+++ b/DiffusionNexus.IntegrationTests/DatasetManagementIntegrationTests.cs
@@ -129,7 +129,8 @@ public class DatasetManagementIntegrationTests : IClassFixture<TestAppHost>
             bool showRatingControls = true,
             Func<string, Task<bool>>? onToggleFavorite = null,
             Func<string, bool>? isFavoriteCheck = null,
-            IVideoThumbnailService? videoThumbnailService = null) =>
+            IVideoThumbnailService? videoThumbnailService = null,
+            ITagIndexService? tagIndexService = null) =>
             Task.CompletedTask;
 
         public Task<SaveAsResult> ShowSaveAsDialogAsync(string originalFilePath, IEnumerable<DatasetCardViewModel> availableDatasets) =>

--- a/DiffusionNexus.Tests/ViewModels/ImageMetadataPanelViewModelTests.cs
+++ b/DiffusionNexus.Tests/ViewModels/ImageMetadataPanelViewModelTests.cs
@@ -1,0 +1,106 @@
+using DiffusionNexus.Domain.Services;
+using DiffusionNexus.UI.ViewModels;
+using FluentAssertions;
+using Moq;
+
+namespace DiffusionNexus.Tests.ViewModels;
+
+/// <summary>
+/// Tests for the tag-index integration of <see cref="ImageMetadataPanelViewModel"/>:
+/// the Content Tags section of the image viewer's Generation Data panel.
+/// Paths use a non-<c>.png</c> extension so the PNG metadata parse takes its
+/// early-out branch and never touches the file system.
+/// </summary>
+public class ImageMetadataPanelViewModelTests
+{
+    private static string ImagePath(string name) => Path.GetFullPath(Path.Combine("gallery", $"{name}.jpg"));
+
+    [Fact]
+    public async Task LoadMetadata_PopulatesTagsAndRating_ForAnIndexedImage()
+    {
+        var path = ImagePath("indexed");
+        var mockIndex = new Mock<ITagIndexService>();
+        mockIndex.Setup(t => t.GetTagsForFilesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, ImageTagLookup>(StringComparer.OrdinalIgnoreCase)
+            {
+                [path] = new ImageTagLookup(IsNsfw: true, Tags: ["1girl", "solo"]),
+            });
+
+        var panel = new ImageMetadataPanelViewModel(mockIndex.Object);
+        panel.LoadMetadata(path);
+        await panel.TagLookup;
+
+        panel.HasTagData.Should().BeTrue();
+        panel.IsNsfw.Should().BeTrue();
+        panel.Tags.Should().Equal("1girl", "solo");
+    }
+
+    [Fact]
+    public async Task LoadMetadata_HidesTheTagSection_ForAnUnindexedImage()
+    {
+        var mockIndex = new Mock<ITagIndexService>();
+        mockIndex.Setup(t => t.GetTagsForFilesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, ImageTagLookup>());
+
+        var panel = new ImageMetadataPanelViewModel(mockIndex.Object);
+        panel.LoadMetadata(ImagePath("unindexed"));
+        await panel.TagLookup;
+
+        panel.HasTagData.Should().BeFalse("an unindexed image must not show a misleading empty tag list");
+        panel.Tags.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task LoadMetadata_WithoutATagIndexService_ShowsNoTagSection()
+    {
+        var panel = new ImageMetadataPanelViewModel();
+        panel.LoadMetadata(ImagePath("any"));
+        await panel.TagLookup;
+
+        panel.HasTagData.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task NavigatingToAnotherImage_ReplacesTheTags_AndClearsThemWhenUnindexed()
+    {
+        var first = ImagePath("first");
+        var second = ImagePath("second");
+        var mockIndex = new Mock<ITagIndexService>();
+        mockIndex.Setup(t => t.GetTagsForFilesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<string> paths, CancellationToken _) =>
+                paths.Contains(first)
+                    ? new Dictionary<string, ImageTagLookup>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        [first] = new ImageTagLookup(IsNsfw: false, Tags: ["dog"]),
+                    }
+                    : new Dictionary<string, ImageTagLookup>());
+
+        var panel = new ImageMetadataPanelViewModel(mockIndex.Object);
+
+        panel.LoadMetadata(first);
+        await panel.TagLookup;
+        panel.HasTagData.Should().BeTrue();
+        panel.IsNsfw.Should().BeFalse();
+
+        // Arrow-key navigation to an unindexed image: the previous image's
+        // tags must not linger on screen.
+        panel.LoadMetadata(second);
+        await panel.TagLookup;
+        panel.HasTagData.Should().BeFalse();
+        panel.Tags.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ATagIndexError_LeavesThePanelUsable_WithoutTags()
+    {
+        var mockIndex = new Mock<ITagIndexService>();
+        mockIndex.Setup(t => t.GetTagsForFilesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("db is broken"));
+
+        var panel = new ImageMetadataPanelViewModel(mockIndex.Object);
+        panel.LoadMetadata(ImagePath("any"));
+        await panel.TagLookup;
+
+        panel.HasTagData.Should().BeFalse("a broken index must degrade to 'no tags shown', not crash the viewer");
+    }
+}

--- a/DiffusionNexus.UI/Services/DialogService.cs
+++ b/DiffusionNexus.UI/Services/DialogService.cs
@@ -259,10 +259,11 @@ public class DialogService : IDialogService
         bool showRatingControls = true,
         Func<string, Task<bool>>? onToggleFavorite = null,
         Func<string, bool>? isFavoriteCheck = null,
-        IVideoThumbnailService? videoThumbnailService = null)
+        IVideoThumbnailService? videoThumbnailService = null,
+        ITagIndexService? tagIndexService = null)
     {
         var dialog = new ImageViewerDialog()
-            .WithImages(images, startIndex, eventAggregator, onSendToImageEditor, onSendToCaptioning, onDeleteRequested, showRatingControls, onToggleFavorite, isFavoriteCheck, videoThumbnailService);
+            .WithImages(images, startIndex, eventAggregator, onSendToImageEditor, onSendToCaptioning, onDeleteRequested, showRatingControls, onToggleFavorite, isFavoriteCheck, videoThumbnailService, tagIndexService);
 
         await dialog.ShowDialog(_window);
     }

--- a/DiffusionNexus.UI/Services/IDialogService.cs
+++ b/DiffusionNexus.UI/Services/IDialogService.cs
@@ -174,6 +174,7 @@ public interface IDialogService
     /// <param name="onToggleFavorite">Optional callback to toggle favorite state. Returns the new state. When null, favorite controls are hidden.</param>
     /// <param name="isFavoriteCheck">Optional callback to check if a file is currently favorited.</param>
     /// <param name="videoThumbnailService">Optional video thumbnail service for on-demand thumbnail generation.</param>
+    /// <param name="tagIndexService">Optional tag index service — enables the content-tags/rating section in the metadata panel.</param>
     Task ShowImageViewerDialogAsync(
         ObservableCollection<DatasetImageViewModel> images,
         int startIndex,
@@ -184,7 +185,8 @@ public interface IDialogService
         bool showRatingControls = true,
         Func<string, Task<bool>>? onToggleFavorite = null,
         Func<string, bool>? isFavoriteCheck = null,
-        IVideoThumbnailService? videoThumbnailService = null);
+        IVideoThumbnailService? videoThumbnailService = null,
+        ITagIndexService? tagIndexService = null);
 
     /// <summary>
     /// Shows the Save As dialog for saving an image with a new name and optional rating.

--- a/DiffusionNexus.UI/ViewModels/GenerationGalleryViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/GenerationGalleryViewModel.cs
@@ -1109,7 +1109,8 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
             showRatingControls: false,
             onToggleFavorite: toggleFavorite,
             isFavoriteCheck: isFavoriteCheck,
-            videoThumbnailService: _videoThumbnailService);
+            videoThumbnailService: _videoThumbnailService,
+            tagIndexService: _tagIndexService);
     }
 
     private static List<string> GetEnabledGalleryPaths(AppSettings settings)

--- a/DiffusionNexus.UI/ViewModels/ImageMetadataPanelViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/ImageMetadataPanelViewModel.cs
@@ -1,17 +1,41 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using DiffusionNexus.Domain.Services;
 using DiffusionNexus.UI.Models;
+using Serilog;
 
 namespace DiffusionNexus.UI.ViewModels;
 
 /// <summary>
 /// ViewModel for the image generation metadata side panel in the image viewer.
-/// Displays ComfyUI workflow data parsed from PNG text chunks.
+/// Displays ComfyUI workflow data parsed from PNG text chunks, plus the
+/// content tags and SFW/NSFW rating from the local tag index when available.
 /// </summary>
 public partial class ImageMetadataPanelViewModel : ObservableObject
 {
     private readonly Services.ImageMetadataParser _parser = new();
+    private readonly ITagIndexService? _tagIndexService;
     private Func<string, Task>? _copyToClipboard;
+
+    /// <summary>
+    /// Guards against out-of-order tag lookups: arrow-key navigation fires
+    /// one async index query per image, and a slow query for image N must
+    /// not overwrite the tags already shown for image N+1. Only ever touched
+    /// on the UI thread, so a plain int is enough.
+    /// </summary>
+    private int _tagLookupGeneration;
+
+    /// <summary>
+    /// The in-flight (or last completed) tag-index lookup. The panel never
+    /// awaits it — tags pop in when ready — but tests must, or they assert
+    /// against a race.
+    /// </summary>
+    internal Task TagLookup { get; private set; } = Task.CompletedTask;
+
+    public ImageMetadataPanelViewModel(ITagIndexService? tagIndexService = null)
+    {
+        _tagIndexService = tagIndexService;
+    }
 
     [ObservableProperty]
     private bool _isPanelExpanded = true;
@@ -30,6 +54,21 @@ public partial class ImageMetadataPanelViewModel : ObservableObject
 
     [ObservableProperty]
     private bool _negativeCopied;
+
+    /// <summary>Content tags for the current image from the local tag index.</summary>
+    [ObservableProperty]
+    private IReadOnlyList<string> _tags = [];
+
+    /// <summary>
+    /// True when the current image has a row in the tag index — gates the
+    /// whole tags section, so unindexed images (and videos) show nothing
+    /// rather than a misleading empty list.
+    /// </summary>
+    [ObservableProperty]
+    private bool _hasTagData;
+
+    [ObservableProperty]
+    private bool _isNsfw;
 
     /// <summary>Whether any LoRAs were found in the metadata.</summary>
     public bool HasLoras => Metadata?.Loras.Count > 0;
@@ -51,6 +90,10 @@ public partial class ImageMetadataPanelViewModel : ObservableObject
     /// </summary>
     public void LoadMetadata(string? imagePath)
     {
+        // Tag-index lookup is independent of the PNG metadata parse below —
+        // a JPG has no generation chunks but can still be indexed and tagged.
+        TagLookup = LoadTagIndexDataAsync(imagePath);
+
         if (string.IsNullOrWhiteSpace(imagePath))
         {
             Metadata = null;
@@ -87,6 +130,40 @@ public partial class ImageMetadataPanelViewModel : ObservableObject
         }
 
         OnDerivedPropertiesChanged();
+    }
+
+    /// <summary>
+    /// Queries the tag index for the current image's tags and rating.
+    /// Fire-and-forget from <see cref="LoadMetadata"/>: the panel renders the
+    /// (fast) PNG parse immediately and the tags pop in when the DB answers.
+    /// </summary>
+    private async Task LoadTagIndexDataAsync(string? imagePath)
+    {
+        var generation = ++_tagLookupGeneration;
+        Tags = [];
+        HasTagData = false;
+        IsNsfw = false;
+
+        if (_tagIndexService is null || string.IsNullOrWhiteSpace(imagePath)) return;
+
+        try
+        {
+            // SQLite's async is synchronous under the hood — keep it off the
+            // UI thread. The index stores normalized full paths.
+            var lookup = await Task.Run(() => _tagIndexService.GetTagsForFilesAsync([imagePath]));
+            if (generation != _tagLookupGeneration) return;
+
+            if (lookup.TryGetValue(Path.GetFullPath(imagePath), out var info))
+            {
+                Tags = info.Tags;
+                IsNsfw = info.IsNsfw;
+                HasTagData = true;
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "[ImageViewer] Tag index lookup failed for {Path}", imagePath);
+        }
     }
 
     [RelayCommand]

--- a/DiffusionNexus.UI/ViewModels/ImageViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/ImageViewerViewModel.cs
@@ -42,7 +42,7 @@ public partial class ImageViewerViewModel : ObservableObject, IDisposable
     public VideoPlayerViewModel VideoPlayer { get; } = new();
 
     /// <summary>ViewModel for the generation metadata side panel.</summary>
-    public ImageMetadataPanelViewModel MetadataPanel { get; } = new();
+    public ImageMetadataPanelViewModel MetadataPanel { get; }
 
     /// <summary>Event raised when the dialog should close.</summary>
     public event EventHandler? CloseRequested;
@@ -161,8 +161,10 @@ public partial class ImageViewerViewModel : ObservableObject, IDisposable
         bool showRatingControls = true,
         Func<string, Task<bool>>? onToggleFavorite = null,
         Func<string, bool>? isFavoriteCheck = null,
-        IVideoThumbnailService? videoThumbnailService = null)
+        IVideoThumbnailService? videoThumbnailService = null,
+        ITagIndexService? tagIndexService = null)
     {
+        MetadataPanel = new ImageMetadataPanelViewModel(tagIndexService);
         _allImages = images ?? throw new ArgumentNullException(nameof(images));
         _eventAggregator = eventAggregator;
         _onSendToImageEditor = onSendToImageEditor;

--- a/DiffusionNexus.UI/Views/Controls/ImageMetadataPanelView.axaml
+++ b/DiffusionNexus.UI/Views/Controls/ImageMetadataPanelView.axaml
@@ -278,6 +278,41 @@
                                    Margin="0,4,0,0"/>
 
                     </StackPanel>
+
+                    <!-- Content tags + rating from the local tag index.
+                         Outside the HasData block on purpose: a JPG has no
+                         generation chunks but can still be indexed/tagged.
+                         Hidden entirely for unindexed images. -->
+                    <StackPanel Spacing="8" IsVisible="{Binding HasTagData}">
+                        <Separator Background="#333" Height="1"/>
+                        <DockPanel>
+                            <TextBlock Text="Content Tags" Classes="fieldLabel"
+                                       DockPanel.Dock="Left" VerticalAlignment="Center"/>
+                            <Border DockPanel.Dock="Right" HorizontalAlignment="Right"
+                                    Background="#2d5a3d" CornerRadius="100" Padding="10,3"
+                                    IsVisible="{Binding !IsNsfw}">
+                                <TextBlock Text="SFW" FontSize="11" FontWeight="SemiBold" Foreground="#b9e6c8"/>
+                            </Border>
+                            <Border DockPanel.Dock="Right" HorizontalAlignment="Right"
+                                    Background="#7a2d2d" CornerRadius="100" Padding="10,3"
+                                    IsVisible="{Binding IsNsfw}">
+                                <TextBlock Text="NSFW" FontSize="11" FontWeight="SemiBold" Foreground="#f0bcbc"/>
+                            </Border>
+                        </DockPanel>
+                        <ItemsControl ItemsSource="{Binding Tags}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate><WrapPanel Orientation="Horizontal"/></ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="x:String">
+                                    <Border Background="#80222222" BorderBrush="#444" BorderThickness="1"
+                                            CornerRadius="100" Padding="8,3" Margin="0,0,6,6">
+                                        <TextBlock Text="{Binding}" FontSize="11" Foreground="#CCC"/>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
                 </StackPanel>
             </ScrollViewer>
         </Border>

--- a/DiffusionNexus.UI/Views/Dialogs/ImageViewerDialog.axaml.cs
+++ b/DiffusionNexus.UI/Views/Dialogs/ImageViewerDialog.axaml.cs
@@ -49,6 +49,7 @@ public partial class ImageViewerDialog : Window
     /// <param name="onToggleFavorite">Optional callback to toggle favorite state.</param>
     /// <param name="isFavoriteCheck">Optional callback to check if a file is favorited.</param>
     /// <param name="videoThumbnailService">Optional video thumbnail service for on-demand thumbnail generation.</param>
+    /// <param name="tagIndexService">Optional tag index service — enables the content-tags/rating section in the metadata panel.</param>
     /// <returns>The dialog instance for fluent chaining.</returns>
     public ImageViewerDialog WithImages(
         ObservableCollection<DatasetImageViewModel> images,
@@ -60,9 +61,10 @@ public partial class ImageViewerDialog : Window
         bool showRatingControls = true,
         Func<string, Task<bool>>? onToggleFavorite = null,
         Func<string, bool>? isFavoriteCheck = null,
-        IVideoThumbnailService? videoThumbnailService = null)
+        IVideoThumbnailService? videoThumbnailService = null,
+        ITagIndexService? tagIndexService = null)
     {
-        _viewModel = new ImageViewerViewModel(images, startIndex, eventAggregator, onSendToImageEditor, onSendToCaptioning, onDeleteRequested, showRatingControls, onToggleFavorite, isFavoriteCheck, videoThumbnailService);
+        _viewModel = new ImageViewerViewModel(images, startIndex, eventAggregator, onSendToImageEditor, onSendToCaptioning, onDeleteRequested, showRatingControls, onToggleFavorite, isFavoriteCheck, videoThumbnailService, tagIndexService);
         _viewModel.CloseRequested += (_, _) => Close();
         DataContext = _viewModel;
         return this;


### PR DESCRIPTION
New Content Tags section under the sampler settings in the image viewer: tag chips + a green SFW / red NSFW badge, read from the local tag index. Hidden entirely for unindexed images and videos. Lookup runs independently of the PNG metadata parse (JPGs can be tagged too) with a generation guard against stale results during fast arrow-key navigation.

ITagIndexService threads through DialogService -> ImageViewerDialog -> ImageViewerViewModel -> ImageMetadataPanelViewModel as an optional dependency; only the Generation Gallery passes it.

Display-only for now - tag editing / rating override is a separate decision.

Tests: 3425/3425 green (5 new ImageMetadataPanelViewModel tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)