### PR TITLE
feat(gallery): manual SFW/NSFW rating override that survives index rebuilds

### DIFF
--- a/DiffusionNexus.DataAccess/Configurations/ImageRatingOverrideConfiguration.cs
+++ b/DiffusionNexus.DataAccess/Configurations/ImageRatingOverrideConfiguration.cs
@@ -1,0 +1,22 @@
+using DiffusionNexus.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DiffusionNexus.DataAccess.Configurations;
+
+internal sealed class ImageRatingOverrideConfiguration : IEntityTypeConfiguration<ImageRatingOverride>
+{
+    public void Configure(EntityTypeBuilder<ImageRatingOverride> entity)
+    {
+        entity.ToTable("ImageRatingOverrides");
+        entity.HasKey(e => e.Id);
+
+        entity.HasIndex(e => e.FilePath).IsUnique();
+
+        // NOCASE for the same reason as ImageMediaTagIndexes.FilePath: Windows
+        // paths are case-insensitive, and the override must match the index
+        // row it overrides regardless of the casing either was stored with.
+        // (Same Linux TODO applies as on ImageMediaTagIndexConfiguration.)
+        entity.Property(e => e.FilePath).IsRequired().HasMaxLength(1000).UseCollation("NOCASE");
+    }
+}

--- a/DiffusionNexus.DataAccess/Data/DiffusionNexusCoreDbContext.cs
+++ b/DiffusionNexus.DataAccess/Data/DiffusionNexusCoreDbContext.cs
@@ -73,6 +73,9 @@ public class DiffusionNexusCoreDbContext : DbContext
     /// <summary>Image ↔ tag assignments with per-assignment confidence.</summary>
     public DbSet<ImageMediaTagAssignment> ImageMediaTagAssignments => Set<ImageMediaTagAssignment>();
 
+    /// <summary>User-owned manual SFW/NSFW overrides — survive index rebuilds.</summary>
+    public DbSet<ImageRatingOverride> ImageRatingOverrides => Set<ImageRatingOverride>();
+
     #endregion
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/DiffusionNexus.DataAccess/Migrations/Core/20260811121330_AddImageRatingOverrides.Designer.cs
+++ b/DiffusionNexus.DataAccess/Migrations/Core/20260811121330_AddImageRatingOverrides.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DiffusionNexus.DataAccess.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DiffusionNexus.DataAccess.Migrations.Core
 {
     [DbContext(typeof(DiffusionNexusCoreDbContext))]
-    partial class DiffusionNexusCoreDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260811121330_AddImageRatingOverrides")]
+    partial class AddImageRatingOverrides
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.10");

--- a/DiffusionNexus.DataAccess/Migrations/Core/20260811121330_AddImageRatingOverrides.cs
+++ b/DiffusionNexus.DataAccess/Migrations/Core/20260811121330_AddImageRatingOverrides.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DiffusionNexus.DataAccess.Migrations.Core
+{
+    /// <inheritdoc />
+    public partial class AddImageRatingOverrides : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ImageRatingOverrides",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    FilePath = table.Column<string>(type: "TEXT", maxLength: 1000, nullable: false, collation: "NOCASE"),
+                    IsNsfw = table.Column<bool>(type: "INTEGER", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ImageRatingOverrides", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ImageRatingOverrides_FilePath",
+                table: "ImageRatingOverrides",
+                column: "FilePath",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ImageRatingOverrides");
+        }
+    }
+}

--- a/DiffusionNexus.Domain/Entities/ImageRatingOverride.cs
+++ b/DiffusionNexus.Domain/Entities/ImageRatingOverride.cs
@@ -1,0 +1,19 @@
+namespace DiffusionNexus.Domain.Entities;
+
+/// <summary>
+/// A user's manual SFW/NSFW decision for one gallery file, taking precedence
+/// over the tagger's automatic rating. Deliberately a separate table from
+/// <see cref="ImageMediaTagIndex"/>: index rows are machine-owned — builds
+/// rewrite them and Rebuild wipes them wholesale — while these rows are
+/// user-owned and must survive all of that. An override whose file has no
+/// index row (or no file) is a harmless orphan that re-applies if the file
+/// is ever indexed again.
+/// </summary>
+public class ImageRatingOverride : BaseEntity
+{
+    /// <summary>Full, normalized (<see cref="Path.GetFullPath"/>) file path. Unique.</summary>
+    public string FilePath { get; set; } = string.Empty;
+
+    /// <summary>The user's verdict — replaces the policy-derived rating entirely.</summary>
+    public bool IsNsfw { get; set; }
+}

--- a/DiffusionNexus.Domain/Services/ITagIndexService.cs
+++ b/DiffusionNexus.Domain/Services/ITagIndexService.cs
@@ -27,7 +27,13 @@ public sealed record TagIndexBuildProgress(
 
 public sealed record TagIndexBuildResult(int Indexed, int Skipped, int Failed, int NsfwCount);
 
-public sealed record ImageTagLookup(bool IsNsfw, IReadOnlyList<string> Tags);
+/// <summary>
+/// Per-file lookup result. <paramref name="IsNsfw"/> is the EFFECTIVE rating:
+/// the user's manual override when one exists, the policy-derived automatic
+/// rating otherwise. <paramref name="IsRatingOverridden"/> tells the UI which
+/// of the two it is looking at.
+/// </summary>
+public sealed record ImageTagLookup(bool IsNsfw, IReadOnlyList<string> Tags, bool IsRatingOverridden = false);
 
 /// <summary>
 /// Builds and queries the searchable local tag index for the Generation
@@ -121,4 +127,21 @@ public interface ITagIndexService
     Task<int> RemoveIndexEntriesAsync(
         IReadOnlyList<string> filePaths,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Records the user's manual SFW/NSFW verdict for one file, replacing the
+    /// tagger's automatic rating in every query (search filters, tile badges,
+    /// viewer panel). Upserts: a second call for the same file replaces the
+    /// previous verdict. Overrides live in their own user-owned table and
+    /// survive incremental builds, Rebuild, and
+    /// <see cref="RemoveIndexEntriesAsync"/>.
+    /// </summary>
+    Task SetRatingOverrideAsync(string filePath, bool isNsfw, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes the manual verdict for one file, returning it to the automatic
+    /// policy-derived rating. A file with no override is a no-op.
+    /// </summary>
+    /// <returns>True when an override existed and was removed.</returns>
+    Task<bool> ClearRatingOverrideAsync(string filePath, CancellationToken cancellationToken = default);
 }

--- a/DiffusionNexus.IntegrationTests/DatasetManagementIntegrationTests.cs
+++ b/DiffusionNexus.IntegrationTests/DatasetManagementIntegrationTests.cs
@@ -130,7 +130,8 @@ public class DatasetManagementIntegrationTests : IClassFixture<TestAppHost>
             Func<string, Task<bool>>? onToggleFavorite = null,
             Func<string, bool>? isFavoriteCheck = null,
             IVideoThumbnailService? videoThumbnailService = null,
-            ITagIndexService? tagIndexService = null) =>
+            ITagIndexService? tagIndexService = null,
+            Action<string, bool>? onNsfwRatingChanged = null) =>
             Task.CompletedTask;
 
         public Task<SaveAsResult> ShowSaveAsDialogAsync(string originalFilePath, IEnumerable<DatasetCardViewModel> availableDatasets) =>

--- a/DiffusionNexus.Service/Services/TagIndexService.cs
+++ b/DiffusionNexus.Service/Services/TagIndexService.cs
@@ -403,11 +403,19 @@ public sealed class TagIndexService : ITagIndexService
         // translates to an IN (...) that uses IX_ImageMediaTagIndexes_RatingLabel,
         // and any row whose label matches none of the safe buckets (different
         // casing, corrupt value) classifies as NSFW — filtering fails closed.
+        // A user-set ImageRatingOverride row beats the policy entirely: the
+        // two Any(...) branches translate to EXISTS subqueries over the
+        // override table's unique NOCASE FilePath index.
         var sfwLabels = ContentRatingPolicy.SfwRatingLabels;
+        var overrides = context.ImageRatingOverrides;
         query = nsfwFilter switch
         {
-            NsfwFilterMode.HideNsfw => query.Where(e => sfwLabels.Contains(e.RatingLabel)),
-            NsfwFilterMode.NsfwOnly => query.Where(e => !sfwLabels.Contains(e.RatingLabel)),
+            NsfwFilterMode.HideNsfw => query.Where(e =>
+                overrides.Any(o => o.FilePath == e.FilePath && !o.IsNsfw)
+                || (!overrides.Any(o => o.FilePath == e.FilePath) && sfwLabels.Contains(e.RatingLabel))),
+            NsfwFilterMode.NsfwOnly => query.Where(e =>
+                overrides.Any(o => o.FilePath == e.FilePath && o.IsNsfw)
+                || (!overrides.Any(o => o.FilePath == e.FilePath) && !sfwLabels.Contains(e.RatingLabel))),
             _ => query,
         };
 
@@ -476,10 +484,23 @@ public sealed class TagIndexService : ITagIndexService
             })
             .ToListAsync(cancellationToken);
 
+        // Manual overrides beat the policy-derived rating (see SearchAsync).
+        // Second small query instead of a join: the override table is tiny
+        // (one row per hand-corrected image), and keeping the main projection
+        // untouched keeps its no-tracking/no-graph guarantees obvious.
+        var userOverrides = await context.ImageRatingOverrides
+            .AsNoTracking()
+            .Where(o => normalizedPaths.Contains(o.FilePath))
+            .ToListAsync(cancellationToken);
+        var overrideByPath = userOverrides.ToDictionary(
+            o => o.FilePath, o => o.IsNsfw, StringComparer.OrdinalIgnoreCase);
+
         // NSFW derived at read time from the stored rating (see SearchAsync).
         return rows.ToDictionary(
             e => e.FilePath,
-            e => new ImageTagLookup(ContentRatingPolicy.IsNsfw(e.RatingLabel), e.Tags),
+            e => overrideByPath.TryGetValue(e.FilePath, out var userIsNsfw)
+                ? new ImageTagLookup(userIsNsfw, e.Tags, IsRatingOverridden: true)
+                : new ImageTagLookup(ContentRatingPolicy.IsNsfw(e.RatingLabel), e.Tags),
             StringComparer.OrdinalIgnoreCase);
     }
 
@@ -507,9 +528,54 @@ public sealed class TagIndexService : ITagIndexService
         // enforces because Microsoft.Data.Sqlite turns foreign keys on for
         // every connection. Covered by
         // RemoveIndexEntriesAsync_AlsoRemovesTheTagAssignments.
+        // Deliberately does NOT touch ImageRatingOverrides: this method serves
+        // both "file left the gallery" pruning and the Rebuild wipe, and a
+        // manual rating must survive a rebuild. An override for a truly gone
+        // file is a harmless orphan that re-applies if the file returns.
         return await context.ImageMediaTagIndexes
             .Where(e => normalizedPaths.Contains(e.FilePath))
             .ExecuteDeleteAsync(cancellationToken);
     }
 
+    public async Task SetRatingOverrideAsync(
+        string filePath,
+        bool isNsfw,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        var normalized = Path.GetFullPath(filePath);
+
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var existing = await context.ImageRatingOverrides
+            .FirstOrDefaultAsync(o => o.FilePath == normalized, cancellationToken);
+        if (existing is null)
+        {
+            context.ImageRatingOverrides.Add(new ImageRatingOverride
+            {
+                FilePath = normalized,
+                IsNsfw = isNsfw,
+            });
+        }
+        else
+        {
+            existing.IsNsfw = isNsfw;
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<bool> ClearRatingOverrideAsync(
+        string filePath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        var normalized = Path.GetFullPath(filePath);
+
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+        var removed = await context.ImageRatingOverrides
+            .Where(o => o.FilePath == normalized)
+            .ExecuteDeleteAsync(cancellationToken);
+        return removed > 0;
+    }
 }

--- a/DiffusionNexus.Tests/Service/Services/TagIndexServiceTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/TagIndexServiceTests.cs
@@ -939,4 +939,79 @@ public sealed class TagIndexServiceTests : IAsyncDisposable
         public SynchronousProgress(Action<T> handler) => _handler = handler;
         public void Report(T value) => _handler(value);
     }
+
+    [Fact]
+    public async Task RatingOverride_BeatsTheAutomaticRating_InEveryQuery()
+    {
+        // The user marks a "questionable"-rated image as SFW (the Ellie case:
+        // the tagger was simply wrong). Search filters and tile lookups must
+        // all side with the user from that point on.
+        var path = CreateFakeImage("misrated.png");
+        var tagging = TaggerByWidth(_ =>
+            ImageTagResult.Succeeded(Array.Empty<ImageTagScore>(), "questionable", 0.9f, isNsfw: true));
+        var service = new TagIndexService(new SingleDbContextFactory(_options), tagging.Object);
+        await service.BuildIndexAsync(new[] { path });
+
+        await service.SetRatingOverrideAsync(path, isNsfw: false);
+
+        var hidden = await service.SearchAsync(Array.Empty<string>(), NsfwFilterMode.HideNsfw);
+        hidden.Should().ContainSingle("the user said SFW, so Hide NSFW keeps it")
+            .Which.Should().Be(Path.GetFullPath(path));
+        var nsfwOnly = await service.SearchAsync(Array.Empty<string>(), NsfwFilterMode.NsfwOnly);
+        nsfwOnly.Should().BeEmpty();
+
+        var lookup = await service.GetTagsForFilesAsync(new[] { path });
+        lookup[Path.GetFullPath(path)].IsNsfw.Should().BeFalse();
+        lookup[Path.GetFullPath(path)].IsRatingOverridden.Should().BeTrue("the UI shows a 'manual' marker for it");
+
+        // And the opposite direction: flip an automatic-SFW image to NSFW.
+        await service.SetRatingOverrideAsync(path, isNsfw: true);
+        (await service.SearchAsync(Array.Empty<string>(), NsfwFilterMode.NsfwOnly))
+            .Should().ContainSingle("the upsert replaced the earlier verdict");
+    }
+
+    [Fact]
+    public async Task RatingOverride_SurvivesARebuild_AndClearingRestoresTheAutomaticRating()
+    {
+        // The whole reason overrides live in their own table: Rebuild wipes
+        // every index row (RemoveIndexEntriesAsync) and re-tags from scratch,
+        // and a hand-set rating must come out the other side intact.
+        var path = CreateFakeImage("corrected.png");
+        var tagging = TaggerByWidth(_ =>
+            ImageTagResult.Succeeded(Array.Empty<ImageTagScore>(), "questionable", 0.9f, isNsfw: true));
+        var service = new TagIndexService(new SingleDbContextFactory(_options), tagging.Object);
+        await service.BuildIndexAsync(new[] { path });
+        await service.SetRatingOverrideAsync(path, isNsfw: false);
+
+        await service.RemoveIndexEntriesAsync(new[] { path });
+        await service.BuildIndexAsync(new[] { path });
+
+        var lookup = await service.GetTagsForFilesAsync(new[] { path });
+        lookup[Path.GetFullPath(path)].IsNsfw.Should().BeFalse("the manual SFW verdict survived the rebuild");
+        lookup[Path.GetFullPath(path)].IsRatingOverridden.Should().BeTrue();
+
+        var cleared = await service.ClearRatingOverrideAsync(path);
+        cleared.Should().BeTrue();
+        lookup = await service.GetTagsForFilesAsync(new[] { path });
+        lookup[Path.GetFullPath(path)].IsNsfw.Should().BeTrue("back to the automatic 'questionable' rating");
+        lookup[Path.GetFullPath(path)].IsRatingOverridden.Should().BeFalse();
+
+        (await service.ClearRatingOverrideAsync(path)).Should().BeFalse("clearing twice is a no-op, not an error");
+    }
+
+    [Fact]
+    public async Task RatingOverride_MatchesCaseInsensitively_LikeEveryOtherPathIdentity()
+    {
+        var path = CreateFakeImage("cased.png");
+        var tagging = TaggerByWidth(_ =>
+            ImageTagResult.Succeeded(Array.Empty<ImageTagScore>(), "general", 0.9f, isNsfw: false));
+        var service = new TagIndexService(new SingleDbContextFactory(_options), tagging.Object);
+        await service.BuildIndexAsync(new[] { path });
+
+        await service.SetRatingOverrideAsync(path.ToUpperInvariant(), isNsfw: true);
+
+        var lookup = await service.GetTagsForFilesAsync(new[] { path });
+        lookup[Path.GetFullPath(path)].IsNsfw.Should().BeTrue(
+            "Windows paths are case-insensitive, so the override must match regardless of casing");
+    }
 }

--- a/DiffusionNexus.Tests/ViewModels/ImageMetadataPanelViewModelTests.cs
+++ b/DiffusionNexus.Tests/ViewModels/ImageMetadataPanelViewModelTests.cs
@@ -91,6 +91,86 @@ public class ImageMetadataPanelViewModelTests
     }
 
     [Fact]
+    public async Task ToggleRating_StoresTheOppositeVerdict_AndNotifiesTheGallery()
+    {
+        var path = ImagePath("misrated");
+        var mockIndex = new Mock<ITagIndexService>();
+        mockIndex.Setup(t => t.GetTagsForFilesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, ImageTagLookup>(StringComparer.OrdinalIgnoreCase)
+            {
+                [path] = new ImageTagLookup(IsNsfw: true, Tags: ["1girl"]),
+            });
+
+        var notified = new List<(string Path, bool IsNsfw)>();
+        var panel = new ImageMetadataPanelViewModel(mockIndex.Object, (p, n) => notified.Add((p, n)));
+        panel.LoadMetadata(path);
+        await panel.TagLookup;
+
+        await panel.ToggleRatingCommand.ExecuteAsync(null);
+
+        mockIndex.Verify(t => t.SetRatingOverrideAsync(path, false, It.IsAny<CancellationToken>()), Times.Once);
+        panel.IsNsfw.Should().BeFalse("the badge flips to the user's verdict");
+        panel.IsRatingOverridden.Should().BeTrue("the 'manual' marker appears");
+        notified.Should().ContainSingle().Which.Should().Be((path, false));
+    }
+
+    [Fact]
+    public async Task ToggleRating_WhenTheWriteFails_KeepsShowingTheStoredRating()
+    {
+        var path = ImagePath("locked-db");
+        var mockIndex = new Mock<ITagIndexService>();
+        mockIndex.Setup(t => t.GetTagsForFilesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, ImageTagLookup>(StringComparer.OrdinalIgnoreCase)
+            {
+                [path] = new ImageTagLookup(IsNsfw: true, Tags: ["1girl"]),
+            });
+        mockIndex.Setup(t => t.SetRatingOverrideAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("database is locked"));
+
+        var notified = 0;
+        var panel = new ImageMetadataPanelViewModel(mockIndex.Object, (_, _) => notified++);
+        panel.LoadMetadata(path);
+        await panel.TagLookup;
+
+        await panel.ToggleRatingCommand.ExecuteAsync(null);
+
+        panel.IsNsfw.Should().BeTrue("the badge must not lie about what is actually stored");
+        panel.IsRatingOverridden.Should().BeFalse();
+        notified.Should().Be(0, "the gallery must not be told about a change that never landed");
+    }
+
+    [Fact]
+    public async Task ResetRating_ClearsTheOverride_AndReloadsTheAutomaticRating()
+    {
+        var path = ImagePath("reset-me");
+        var mockIndex = new Mock<ITagIndexService>();
+        // First load: overridden to NSFW. After the clear: automatic SFW.
+        var cleared = false;
+        mockIndex.Setup(t => t.GetTagsForFilesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new Dictionary<string, ImageTagLookup>(StringComparer.OrdinalIgnoreCase)
+            {
+                [path] = cleared
+                    ? new ImageTagLookup(IsNsfw: false, Tags: ["1girl"])
+                    : new ImageTagLookup(IsNsfw: true, Tags: ["1girl"], IsRatingOverridden: true),
+            });
+        mockIndex.Setup(t => t.ClearRatingOverrideAsync(path, It.IsAny<CancellationToken>()))
+            .Callback(() => cleared = true)
+            .ReturnsAsync(true);
+
+        var notified = new List<(string Path, bool IsNsfw)>();
+        var panel = new ImageMetadataPanelViewModel(mockIndex.Object, (p, n) => notified.Add((p, n)));
+        panel.LoadMetadata(path);
+        await panel.TagLookup;
+        panel.IsRatingOverridden.Should().BeTrue("precondition: the stored rating is a manual verdict");
+
+        await panel.ResetRatingCommand.ExecuteAsync(null);
+
+        panel.IsRatingOverridden.Should().BeFalse();
+        panel.IsNsfw.Should().BeFalse("back to the automatic rating, re-read from the index");
+        notified.Should().ContainSingle().Which.Should().Be((path, false));
+    }
+
+    [Fact]
     public async Task ATagIndexError_LeavesThePanelUsable_WithoutTags()
     {
         var mockIndex = new Mock<ITagIndexService>();

--- a/DiffusionNexus.UI/Services/DialogService.cs
+++ b/DiffusionNexus.UI/Services/DialogService.cs
@@ -260,10 +260,11 @@ public class DialogService : IDialogService
         Func<string, Task<bool>>? onToggleFavorite = null,
         Func<string, bool>? isFavoriteCheck = null,
         IVideoThumbnailService? videoThumbnailService = null,
-        ITagIndexService? tagIndexService = null)
+        ITagIndexService? tagIndexService = null,
+        Action<string, bool>? onNsfwRatingChanged = null)
     {
         var dialog = new ImageViewerDialog()
-            .WithImages(images, startIndex, eventAggregator, onSendToImageEditor, onSendToCaptioning, onDeleteRequested, showRatingControls, onToggleFavorite, isFavoriteCheck, videoThumbnailService, tagIndexService);
+            .WithImages(images, startIndex, eventAggregator, onSendToImageEditor, onSendToCaptioning, onDeleteRequested, showRatingControls, onToggleFavorite, isFavoriteCheck, videoThumbnailService, tagIndexService, onNsfwRatingChanged);
 
         await dialog.ShowDialog(_window);
     }

--- a/DiffusionNexus.UI/Services/IDialogService.cs
+++ b/DiffusionNexus.UI/Services/IDialogService.cs
@@ -186,7 +186,8 @@ public interface IDialogService
         Func<string, Task<bool>>? onToggleFavorite = null,
         Func<string, bool>? isFavoriteCheck = null,
         IVideoThumbnailService? videoThumbnailService = null,
-        ITagIndexService? tagIndexService = null);
+        ITagIndexService? tagIndexService = null,
+        Action<string, bool>? onNsfwRatingChanged = null);
 
     /// <summary>
     /// Shows the Save As dialog for saving an image with a new name and optional rating.

--- a/DiffusionNexus.UI/ViewModels/GenerationGalleryViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/GenerationGalleryViewModel.cs
@@ -1103,6 +1103,21 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
                     ?.IsFavorite ?? false;
         }
 
+        // A manual SFW/NSFW override in the viewer must show on the tile
+        // badge and count for the NSFW filter. The tile updates immediately;
+        // filter/cache refresh waits until the modal closes — the gallery is
+        // invisible behind it anyway, and re-filtering under a dialog per
+        // click would be wasted work.
+        var nsfwRatingsChanged = false;
+        void OnNsfwRatingChanged(string filePath, bool isNsfw)
+        {
+            nsfwRatingsChanged = true;
+            var galleryItem = _allMediaItems.FirstOrDefault(
+                item => string.Equals(Path.GetFullPath(item.FilePath), Path.GetFullPath(filePath), StringComparison.OrdinalIgnoreCase));
+            if (galleryItem is not null)
+                galleryItem.IsNsfw = isNsfw;
+        }
+
         await DialogService.ShowImageViewerDialogAsync(
             viewerImages,
             index,
@@ -1110,7 +1125,14 @@ public partial class GenerationGalleryViewModel : BusyViewModelBase, IThumbnailA
             onToggleFavorite: toggleFavorite,
             isFavoriteCheck: isFavoriteCheck,
             videoThumbnailService: _videoThumbnailService,
-            tagIndexService: _tagIndexService);
+            tagIndexService: _tagIndexService,
+            onNsfwRatingChanged: OnNsfwRatingChanged);
+
+        if (nsfwRatingsChanged)
+        {
+            InvalidateTagSearchCache();
+            ApplySortingAndGrouping();
+        }
     }
 
     private static List<string> GetEnabledGalleryPaths(AppSettings settings)

--- a/DiffusionNexus.UI/ViewModels/ImageMetadataPanelViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/ImageMetadataPanelViewModel.cs
@@ -15,7 +15,9 @@ public partial class ImageMetadataPanelViewModel : ObservableObject
 {
     private readonly Services.ImageMetadataParser _parser = new();
     private readonly ITagIndexService? _tagIndexService;
+    private readonly Action<string, bool>? _onNsfwRatingChanged;
     private Func<string, Task>? _copyToClipboard;
+    private string? _currentImagePath;
 
     /// <summary>
     /// Guards against out-of-order tag lookups: arrow-key navigation fires
@@ -32,9 +34,18 @@ public partial class ImageMetadataPanelViewModel : ObservableObject
     /// </summary>
     internal Task TagLookup { get; private set; } = Task.CompletedTask;
 
-    public ImageMetadataPanelViewModel(ITagIndexService? tagIndexService = null)
+    /// <param name="tagIndexService">Enables the Content Tags section when present.</param>
+    /// <param name="onNsfwRatingChanged">
+    /// Invoked with (path, effectiveIsNsfw) after the user overrides or resets
+    /// a rating, so the gallery behind the viewer can update its tile badge
+    /// and re-apply its NSFW filter without re-querying everything.
+    /// </param>
+    public ImageMetadataPanelViewModel(
+        ITagIndexService? tagIndexService = null,
+        Action<string, bool>? onNsfwRatingChanged = null)
     {
         _tagIndexService = tagIndexService;
+        _onNsfwRatingChanged = onNsfwRatingChanged;
     }
 
     [ObservableProperty]
@@ -69,6 +80,14 @@ public partial class ImageMetadataPanelViewModel : ObservableObject
 
     [ObservableProperty]
     private bool _isNsfw;
+
+    /// <summary>
+    /// True when <see cref="IsNsfw"/> is the user's manual verdict rather
+    /// than the tagger's automatic rating — shows the "manual" marker and
+    /// the reset-to-auto affordance.
+    /// </summary>
+    [ObservableProperty]
+    private bool _isRatingOverridden;
 
     /// <summary>Whether any LoRAs were found in the metadata.</summary>
     public bool HasLoras => Metadata?.Loras.Count > 0;
@@ -140,9 +159,11 @@ public partial class ImageMetadataPanelViewModel : ObservableObject
     private async Task LoadTagIndexDataAsync(string? imagePath)
     {
         var generation = ++_tagLookupGeneration;
+        _currentImagePath = imagePath;
         Tags = [];
         HasTagData = false;
         IsNsfw = false;
+        IsRatingOverridden = false;
 
         if (_tagIndexService is null || string.IsNullOrWhiteSpace(imagePath)) return;
 
@@ -157,6 +178,7 @@ public partial class ImageMetadataPanelViewModel : ObservableObject
             {
                 Tags = info.Tags;
                 IsNsfw = info.IsNsfw;
+                IsRatingOverridden = info.IsRatingOverridden;
                 HasTagData = true;
             }
         }
@@ -164,6 +186,58 @@ public partial class ImageMetadataPanelViewModel : ObservableObject
         {
             Log.Warning(ex, "[ImageViewer] Tag index lookup failed for {Path}", imagePath);
         }
+    }
+
+    /// <summary>
+    /// Flips the current rating and records it as the user's manual verdict.
+    /// The override wins over the tagger everywhere (badge, gallery tiles,
+    /// Hide NSFW / NSFW only) and survives index rebuilds.
+    /// </summary>
+    [RelayCommand]
+    private async Task ToggleRatingAsync()
+    {
+        var path = _currentImagePath;
+        if (_tagIndexService is null || path is null || !HasTagData) return;
+
+        var newIsNsfw = !IsNsfw;
+        try
+        {
+            await Task.Run(() => _tagIndexService.SetRatingOverrideAsync(path, newIsNsfw));
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "[ImageViewer] Failed to save the rating override for {Path}", path);
+            return;
+        }
+
+        // Only reflect the change after the write actually landed — a DB
+        // failure must not leave the badge lying about what is stored.
+        IsNsfw = newIsNsfw;
+        IsRatingOverridden = true;
+        _onNsfwRatingChanged?.Invoke(path, newIsNsfw);
+    }
+
+    /// <summary>Discards the manual verdict and re-reads the automatic rating.</summary>
+    [RelayCommand]
+    private async Task ResetRatingAsync()
+    {
+        var path = _currentImagePath;
+        if (_tagIndexService is null || path is null || !IsRatingOverridden) return;
+
+        try
+        {
+            await Task.Run(() => _tagIndexService.ClearRatingOverrideAsync(path));
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "[ImageViewer] Failed to clear the rating override for {Path}", path);
+            return;
+        }
+
+        // Re-query rather than guessing what the automatic rating was.
+        await (TagLookup = LoadTagIndexDataAsync(path));
+        if (HasTagData)
+            _onNsfwRatingChanged?.Invoke(path, IsNsfw);
     }
 
     [RelayCommand]

--- a/DiffusionNexus.UI/ViewModels/ImageViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/ImageViewerViewModel.cs
@@ -162,9 +162,10 @@ public partial class ImageViewerViewModel : ObservableObject, IDisposable
         Func<string, Task<bool>>? onToggleFavorite = null,
         Func<string, bool>? isFavoriteCheck = null,
         IVideoThumbnailService? videoThumbnailService = null,
-        ITagIndexService? tagIndexService = null)
+        ITagIndexService? tagIndexService = null,
+        Action<string, bool>? onNsfwRatingChanged = null)
     {
-        MetadataPanel = new ImageMetadataPanelViewModel(tagIndexService);
+        MetadataPanel = new ImageMetadataPanelViewModel(tagIndexService, onNsfwRatingChanged);
         _allImages = images ?? throw new ArgumentNullException(nameof(images));
         _eventAggregator = eventAggregator;
         _onSendToImageEditor = onSendToImageEditor;

--- a/DiffusionNexus.UI/Views/Controls/ImageMetadataPanelView.axaml
+++ b/DiffusionNexus.UI/Views/Controls/ImageMetadataPanelView.axaml
@@ -288,16 +288,38 @@
                         <DockPanel>
                             <TextBlock Text="Content Tags" Classes="fieldLabel"
                                        DockPanel.Dock="Left" VerticalAlignment="Center"/>
-                            <Border DockPanel.Dock="Right" HorizontalAlignment="Right"
-                                    Background="#2d5a3d" CornerRadius="100" Padding="10,3"
-                                    IsVisible="{Binding !IsNsfw}">
-                                <TextBlock Text="SFW" FontSize="11" FontWeight="SemiBold" Foreground="#b9e6c8"/>
-                            </Border>
-                            <Border DockPanel.Dock="Right" HorizontalAlignment="Right"
-                                    Background="#7a2d2d" CornerRadius="100" Padding="10,3"
-                                    IsVisible="{Binding IsNsfw}">
-                                <TextBlock Text="NSFW" FontSize="11" FontWeight="SemiBold" Foreground="#f0bcbc"/>
-                            </Border>
+                            <StackPanel DockPanel.Dock="Right" HorizontalAlignment="Right"
+                                        Orientation="Horizontal" Spacing="8">
+                                <!-- Shown only for a manual verdict: marks the
+                                     rating as user-set and offers the way back
+                                     to the tagger's automatic rating. -->
+                                <Button Content="manual · reset"
+                                        Command="{Binding ResetRatingCommand}"
+                                        IsVisible="{Binding IsRatingOverridden}"
+                                        Background="Transparent" BorderThickness="0"
+                                        Padding="2,0" FontSize="10" Foreground="#888"
+                                        VerticalAlignment="Center" Cursor="Hand"
+                                        ToolTip.Tip="This rating was set by hand — click to return to the automatic rating"/>
+                                <!-- The badge itself is the override control:
+                                     one click flips SFW <-> NSFW and stores it
+                                     as a manual verdict that survives index
+                                     rebuilds. -->
+                                <Button Command="{Binding ToggleRatingCommand}"
+                                        Background="Transparent" BorderThickness="0" Padding="0"
+                                        Cursor="Hand"
+                                        ToolTip.Tip="Click to change the rating — your choice overrides the automatic one and survives index rebuilds">
+                                    <Panel>
+                                        <Border Background="#2d5a3d" CornerRadius="100" Padding="10,3"
+                                                IsVisible="{Binding !IsNsfw}">
+                                            <TextBlock Text="SFW" FontSize="11" FontWeight="SemiBold" Foreground="#b9e6c8"/>
+                                        </Border>
+                                        <Border Background="#7a2d2d" CornerRadius="100" Padding="10,3"
+                                                IsVisible="{Binding IsNsfw}">
+                                            <TextBlock Text="NSFW" FontSize="11" FontWeight="SemiBold" Foreground="#f0bcbc"/>
+                                        </Border>
+                                    </Panel>
+                                </Button>
+                            </StackPanel>
                         </DockPanel>
                         <ItemsControl ItemsSource="{Binding Tags}">
                             <ItemsControl.ItemsPanel>

--- a/DiffusionNexus.UI/Views/Dialogs/ImageViewerDialog.axaml.cs
+++ b/DiffusionNexus.UI/Views/Dialogs/ImageViewerDialog.axaml.cs
@@ -62,9 +62,10 @@ public partial class ImageViewerDialog : Window
         Func<string, Task<bool>>? onToggleFavorite = null,
         Func<string, bool>? isFavoriteCheck = null,
         IVideoThumbnailService? videoThumbnailService = null,
-        ITagIndexService? tagIndexService = null)
+        ITagIndexService? tagIndexService = null,
+        Action<string, bool>? onNsfwRatingChanged = null)
     {
-        _viewModel = new ImageViewerViewModel(images, startIndex, eventAggregator, onSendToImageEditor, onSendToCaptioning, onDeleteRequested, showRatingControls, onToggleFavorite, isFavoriteCheck, videoThumbnailService, tagIndexService);
+        _viewModel = new ImageViewerViewModel(images, startIndex, eventAggregator, onSendToImageEditor, onSendToCaptioning, onDeleteRequested, showRatingControls, onToggleFavorite, isFavoriteCheck, videoThumbnailService, tagIndexService, onNsfwRatingChanged);
         _viewModel.CloseRequested += (_, _) => Close();
         DataContext = _viewModel;
         return this;


### PR DESCRIPTION
Clicking the rating badge in the image viewer''s Content Tags section flips SFW <-> NSFW and stores the verdict in a new user-owned ImageRatingOverrides table (EF migration, applied automatically at startup). A "manual - reset" affordance returns to the automatic rating.

The override beats the tagger''s rating everywhere: Hide NSFW / NSFW only search filters, tile badges, viewer panel. Because overrides live in their own table, incremental builds, Rebuild, and index pruning cannot touch them - the "user edits silently wiped" failure mode is impossible by construction.

The gallery tile badge updates immediately; filters re-apply when the viewer closes. A failed DB write leaves the badge showing the stored rating and does not notify the gallery.

Tests: 3431/3431 green (3 new real-SQLite service tests incl. rebuild-survival + case-insensitive path matching, 3 new panel VM tests incl. write-failure honesty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)