### PR TITLE
fix(tests): anchor Civitai early-access fixtures to today, not a fixed date

### DIFF
--- a/DiffusionNexus.Tests/Viewer/CivitaiWaitlistTests.cs
+++ b/DiffusionNexus.Tests/Viewer/CivitaiWaitlistTests.cs
@@ -11,7 +11,19 @@ namespace DiffusionNexus.Tests.Viewer;
 /// </summary>
 public sealed class CivitaiWaitlistTests : IDisposable
 {
-    private static readonly DateTimeOffset Now = new(2026, 8, 13, 10, 0, 0, TimeSpan.Zero);
+    /// <summary>
+    /// The fixtures' "now", anchored to today's date rather than a fixed calendar day.
+    ///
+    /// These tests describe deadlines relative to <c>Now</c> ("three days out", "one day ago"),
+    /// but the service recomputes availability against the real <see cref="DateTimeOffset.UtcNow"/>
+    /// when it restores persisted entries. A pinned date therefore rots: once the real clock passes
+    /// it, every "future deadline" in the fixtures silently becomes a past one and entries restore
+    /// as Available instead of Waiting. Anchoring to today keeps the relative intent true forever.
+    ///
+    /// Whole seconds, so a JSON persist/restore round-trip compares exactly.
+    /// </summary>
+    private static readonly DateTimeOffset Now =
+        new(DateTime.UtcNow.Date.AddHours(10), TimeSpan.Zero);
     private readonly string _tempDir = Directory.CreateTempSubdirectory("dn-waitlist-tests").FullName;
 
     public void Dispose()

--- a/DiffusionNexus.Tests/Viewer/DownloadPreflightChoiceTests.cs
+++ b/DiffusionNexus.Tests/Viewer/DownloadPreflightChoiceTests.cs
@@ -14,7 +14,14 @@ namespace DiffusionNexus.Tests.Viewer;
 /// </summary>
 public sealed class DownloadPreflightChoiceTests : IDisposable
 {
-    private static readonly DateTimeOffset Now = new(2026, 8, 13, 10, 0, 0, TimeSpan.Zero);
+    /// <summary>
+    /// The fixtures' "now", anchored to today's date rather than a fixed calendar day — see the
+    /// same field on <see cref="CivitaiWaitlistTests"/> for why. Here the rot shows up differently:
+    /// an expired deadline stops a version counting as early-access, so it is enqueued instead of
+    /// opened, and the assertion fails on an empty collection rather than a wrong value.
+    /// </summary>
+    private static readonly DateTimeOffset Now =
+        new(DateTime.UtcNow.Date.AddHours(10), TimeSpan.Zero);
     private readonly string _tempDir = Directory.CreateTempSubdirectory("dn-ea-choice").FullName;
 
     public void Dispose()


### PR DESCRIPTION
Stacked on #513 — targets `feature/diffusion-nexus-engine` so that branch's pipeline goes green.

## The bug

Two tests were failing before the engine work started, and they share one root cause: each pinned `Now` to the literal date **2026-08-13** and then described deadlines relative to it (`Now.AddDays(3)`, `Now.AddDays(2)`). That holds only until the real clock passes the pinned date — after which every "future deadline" in the fixtures is silently a **past** one.

They then failed in two different-looking ways, which is why they read as unrelated:

- **`CivitaiWaitlistTests.PersistRestore_RoundTripsEntries`** — `CivitaiWaitlist` recomputes availability against the real `DateTimeOffset.UtcNow` when it restores persisted entries, so the round-tripped entry came back `Available` instead of `Waiting`.
- **`DownloadPreflightChoiceTests.OpenWebsite_NsfwModel_OpensCivitaiRedHost`** — an expired deadline stops a version counting as early access, so the pair landed in `unflagged` and was *enqueued* rather than opened. The assertion failed on an empty collection, not a wrong URL.

Neither is a product defect: the shipping behaviour is correct in both cases. The fixtures had rotted.

## The fix

Anchor `Now` to today at 10:00 UTC in both files, so every relative offset keeps meaning what it says. Whole seconds, so the JSON persist/restore round-trip still compares exactly. Every existing usage is a relative offset (including the intentionally-past `AddDays(-1)`), so nothing else needed touching.

## Testing

Full suite **3685 passed / 0 failed** — the first fully green run on this stack.

## Not addressed here

`GenerationGalleryViewModelTests.TagCloudSearchText_...` was observed failing once during this work and passed in isolation and on a clean re-run — order-dependent flakiness, distinct from these two, and not reproducible on demand. Left alone rather than guessed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)