### PR TITLE
feat(sync): the identity chain — read the file before giving up (#521 WP4)

### DIFF
--- a/DiffusionNexus.DataAccess/Repositories/Interfaces/IModelRepository.cs
+++ b/DiffusionNexus.DataAccess/Repositories/Interfaces/IModelRepository.cs
@@ -49,6 +49,19 @@ public interface IModelRepository : IRepository<Model>
     Task<ModelImage?> GetImageByIdAsync(int imageId, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Loads a single <see cref="ModelVersion"/> by id, <b>tracked</b> — the identify step's
+    /// header/heuristic rungs write the base model straight onto the row they get back and save
+    /// through the same unit of work.
+    /// </summary>
+    /// <remarks>
+    /// Returns null when the row is gone, which is an ordinary outcome rather than an error: the
+    /// step selects its work in one scope and executes each item in another, and a version can be
+    /// deleted in between. No Includes — do NOT widen <see cref="GetByIdWithIncludesAsync"/> for
+    /// this instead, it carries image BLOBs.
+    /// </remarks>
+    Task<ModelVersion?> GetVersionByIdAsync(int versionId, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Loads a single model by ID with its full navigation graph.
     /// Much more memory-efficient than <see cref="GetAllWithIncludesAsync"/> when only one model is needed.
     /// </summary>

--- a/DiffusionNexus.DataAccess/Repositories/Interfaces/IModelRepository.cs
+++ b/DiffusionNexus.DataAccess/Repositories/Interfaces/IModelRepository.cs
@@ -56,8 +56,13 @@ public interface IModelRepository : IRepository<Model>
     /// <remarks>
     /// Returns null when the row is gone, which is an ordinary outcome rather than an error: the
     /// step selects its work in one scope and executes each item in another, and a version can be
-    /// deleted in between. No Includes — do NOT widen <see cref="GetByIdWithIncludesAsync"/> for
-    /// this instead, it carries image BLOBs.
+    /// deleted in between. Backed by <c>FindAsync</c>, which answers from the change tracker's
+    /// identity map before it ever queries — on the path where a sidecar was found and parsed, the
+    /// sidecar applier already pulled the whole model graph (<see cref="GetByIdWithIncludesAsync"/>)
+    /// onto this same unit of work moments earlier, so this call costs nothing further there. No
+    /// Includes here even so — do NOT widen <see cref="GetByIdWithIncludesAsync"/> for this instead:
+    /// on the no-sidecar path nothing has necessarily been loaded yet, and that method always runs a
+    /// query (five split queries) and drags in every version's image BLOBs, just to fetch one row by id.
     /// </remarks>
     Task<ModelVersion?> GetVersionByIdAsync(int versionId, CancellationToken cancellationToken = default);
 

--- a/DiffusionNexus.DataAccess/Repositories/ModelRepository.cs
+++ b/DiffusionNexus.DataAccess/Repositories/ModelRepository.cs
@@ -202,6 +202,10 @@ internal sealed class ModelRepository : RepositoryBase<Model>, IModelRepository
         => Context.ModelImages.FirstOrDefaultAsync(i => i.Id == imageId, cancellationToken);
 
     /// <inheritdoc />
+    public Task<ModelVersion?> GetVersionByIdAsync(int versionId, CancellationToken cancellationToken = default)
+        => Context.ModelVersions.FirstOrDefaultAsync(v => v.Id == versionId, cancellationToken);
+
+    /// <inheritdoc />
     public async Task<Model?> GetByIdWithIncludesAsync(int id, CancellationToken cancellationToken = default)
     {
         return await Context.Models

--- a/DiffusionNexus.DataAccess/Repositories/ModelRepository.cs
+++ b/DiffusionNexus.DataAccess/Repositories/ModelRepository.cs
@@ -202,8 +202,8 @@ internal sealed class ModelRepository : RepositoryBase<Model>, IModelRepository
         => Context.ModelImages.FirstOrDefaultAsync(i => i.Id == imageId, cancellationToken);
 
     /// <inheritdoc />
-    public Task<ModelVersion?> GetVersionByIdAsync(int versionId, CancellationToken cancellationToken = default)
-        => Context.ModelVersions.FirstOrDefaultAsync(v => v.Id == versionId, cancellationToken);
+    public async Task<ModelVersion?> GetVersionByIdAsync(int versionId, CancellationToken cancellationToken = default)
+        => await Context.ModelVersions.FindAsync([versionId], cancellationToken).ConfigureAwait(false);
 
     /// <inheritdoc />
     public async Task<Model?> GetByIdWithIncludesAsync(int id, CancellationToken cancellationToken = default)

--- a/DiffusionNexus.Service/Services/Sync/BaseModelWriter.cs
+++ b/DiffusionNexus.Service/Services/Sync/BaseModelWriter.cs
@@ -1,0 +1,46 @@
+using DiffusionNexus.Domain.Entities;
+using DiffusionNexus.Domain.Enums;
+
+namespace DiffusionNexus.Service.Services.Sync;
+
+/// <summary>
+/// The single rule for writing a version's base model, shared by every source that can propose
+/// one — sidecar (<see cref="SidecarMetadataApplier"/>), safetensors header and filename heuristic
+/// (<see cref="Steps.IdentifyModelStep"/>'s miss-branch) — so all of them agree on what counts as
+/// an answer and who is allowed to overwrite what.
+/// </summary>
+public static class BaseModelWriter
+{
+    /// <summary>
+    /// Writes both spellings of the base model — the raw Civitai string and the
+    /// <see cref="BaseModelType"/> the viewer's filter reads — using the same parser the detail
+    /// view's editor uses. Writing only the raw one left the enum reporting the previous base
+    /// model forever.
+    /// </summary>
+    /// <returns>Whether anything was written.</returns>
+    /// <remarks>
+    /// A blank <paramref name="baseModelRaw"/> is a missing answer, not an instruction to forget
+    /// the stored one — the call sites only reject an <i>absent</i> value, so a source carrying an
+    /// empty string must not blank the raw string and set the enum to <c>Unknown</c> on a version
+    /// nobody had edited.
+    /// </remarks>
+    public static bool Write(ModelVersion dbVersion, string? baseModelRaw)
+    {
+        if (string.IsNullOrWhiteSpace(baseModelRaw)) return false;
+
+        dbVersion.BaseModelRaw = baseModelRaw;
+        dbVersion.BaseModel = BaseModelTypeExtensions.ParseCivitai(baseModelRaw);
+        return true;
+    }
+
+    /// <summary>
+    /// The header/heuristic gate: only fill a placeholder, never a user's edit. Unlike the sidecar
+    /// formats (which have their own authored-text guard, <c>CanWriteVersionText</c>, because a
+    /// sidecar can also rename the version or replace its trigger words), the header/heuristic
+    /// rungs write nothing but the base model, so the narrower placeholder check is the correct
+    /// gate for them: a version whose base model already says something real is left alone even if
+    /// other fields on it are still blank.
+    /// </summary>
+    public static bool CanFill(ModelVersion dbVersion) =>
+        !dbVersion.IsUserEdited && dbVersion.BaseModelRaw is null or "???";
+}

--- a/DiffusionNexus.Service/Services/Sync/BaseModelWriter.cs
+++ b/DiffusionNexus.Service/Services/Sync/BaseModelWriter.cs
@@ -4,10 +4,20 @@ using DiffusionNexus.Domain.Enums;
 namespace DiffusionNexus.Service.Services.Sync;
 
 /// <summary>
-/// The single rule for writing a version's base model, shared by every source that can propose
-/// one — sidecar (<see cref="SidecarMetadataApplier"/>), safetensors header and filename heuristic
+/// The single rule for writing a version's base model from an automatic source, shared by every
+/// one that can propose an answer — sidecar (<see cref="SidecarMetadataApplier"/>), Civitai
+/// (<see cref="CivitaiMetadataApplier"/>), and the safetensors header / filename heuristic
 /// (<see cref="Steps.IdentifyModelStep"/>'s miss-branch) — so all of them agree on what counts as
 /// an answer and who is allowed to overwrite what.
+/// <para>
+/// The detail view's inline editor (<c>ModelDetailViewModel.Editing.SaveSelectedBaseModelAsync</c>)
+/// is a deliberate exception, not an oversight. It is the one place a user is allowed to blank a
+/// version's base model outright, which <see cref="Write"/> refuses by design — a blank is "no new
+/// answer", never "forget the old one" (see <see cref="Write"/>'s remarks). Routing a clearing UI
+/// through a method that cannot clear would mean either losing that ability or growing a second
+/// flag no automatic caller needs, so the editor keeps its own two-line write of the same two
+/// spellings instead of calling in here.
+/// </para>
 /// </summary>
 public static class BaseModelWriter
 {

--- a/DiffusionNexus.Service/Services/Sync/BaseModelWriter.cs
+++ b/DiffusionNexus.Service/Services/Sync/BaseModelWriter.cs
@@ -42,5 +42,6 @@ public static class BaseModelWriter
     /// other fields on it are still blank.
     /// </summary>
     public static bool CanFill(ModelVersion dbVersion) =>
-        !dbVersion.IsUserEdited && dbVersion.BaseModelRaw is null or "???";
+        !dbVersion.IsUserEdited &&
+        (string.IsNullOrWhiteSpace(dbVersion.BaseModelRaw) || dbVersion.BaseModelRaw == "???");
 }

--- a/DiffusionNexus.Service/Services/Sync/BaseModelWriter.cs
+++ b/DiffusionNexus.Service/Services/Sync/BaseModelWriter.cs
@@ -39,9 +39,9 @@ public static class BaseModelWriter
     /// sidecar can also rename the version or replace its trigger words), the header/heuristic
     /// rungs write nothing but the base model, so the narrower placeholder check is the correct
     /// gate for them: a version whose base model already says something real is left alone even if
-    /// other fields on it are still blank.
+    /// other fields on it are still blank. "Placeholder" is <see cref="SyncStateDeriver.IsPlaceholder"/> —
+    /// the one place that rule lives, so this and the retry-selection logic can never drift apart.
     /// </summary>
     public static bool CanFill(ModelVersion dbVersion) =>
-        !dbVersion.IsUserEdited &&
-        (string.IsNullOrWhiteSpace(dbVersion.BaseModelRaw) || dbVersion.BaseModelRaw == "???");
+        !dbVersion.IsUserEdited && SyncStateDeriver.IsPlaceholder(dbVersion.BaseModelRaw);
 }

--- a/DiffusionNexus.Service/Services/Sync/CivitaiMetadataApplier.cs
+++ b/DiffusionNexus.Service/Services/Sync/CivitaiMetadataApplier.cs
@@ -174,20 +174,11 @@ public sealed class CivitaiMetadataApplier
                 dbVersion.Name = bestCivitaiVersion.Name;
                 dbVersion.Description = bestCivitaiVersion.Description;
 
-                // Raw string and enum are two spellings of one answer and the editor writes both;
-                // writing only the raw one left the enum — which the viewer's base-model filter
-                // reads — reporting the previous base model forever.
-                //
                 // CivitaiModelVersion.BaseModel is a non-nullable string defaulting to "", so a
-                // response that omits it looks exactly like one that carries a blank. Writing that
-                // through would blank the raw string and set the enum to Unknown, undoing a base
-                // model an earlier sidecar established — on a version nobody edited, so no guard
-                // above catches it. A missing answer replaces nothing.
-                if (!string.IsNullOrWhiteSpace(bestCivitaiVersion.BaseModel))
-                {
-                    dbVersion.BaseModelRaw = bestCivitaiVersion.BaseModel;
-                    dbVersion.BaseModel = BaseModelTypeExtensions.ParseCivitai(bestCivitaiVersion.BaseModel);
-                }
+                // response that omits it looks exactly like one that carries a blank — BaseModelWriter
+                // treats that as a missing answer and writes nothing, which is what keeps a base
+                // model an earlier sidecar established from being undone on a version nobody edited.
+                BaseModelWriter.Write(dbVersion, bestCivitaiVersion.BaseModel);
             }
 
             dbVersion.DownloadUrl = bestCivitaiVersion.DownloadUrl;

--- a/DiffusionNexus.Service/Services/Sync/Identity/BaseModelHeaderMap.cs
+++ b/DiffusionNexus.Service/Services/Sync/Identity/BaseModelHeaderMap.cs
@@ -1,0 +1,97 @@
+namespace DiffusionNexus.Service.Services.Sync.Identity;
+
+/// <summary>
+/// Maps the fields of a parsed safetensors header (<see cref="SafetensorsHeaderInfo"/>) to a
+/// Civitai base-model display label.
+/// </summary>
+/// <remarks>
+/// Evaluation order is load-bearing, not incidental: Pony, Illustrious and NoobAI checkpoints are
+/// all trained on the SDXL architecture, so <c>modelspec.architecture</c> alone reads as plain
+/// SDXL for every one of them. The model-name hint (<c>ss_sd_model_name</c>) is checked FIRST so
+/// those refinements are identified correctly instead of collapsing into <c>"SDXL 1.0"</c>.
+/// </remarks>
+public static class BaseModelHeaderMap
+{
+    // Rung 1: ss_sd_model_name substring hints. Checked first — see class remarks.
+    private static readonly (string Needle, string Label)[] NameHints =
+    {
+        ("pony", "Pony"),
+        ("illustrious", "Illustrious"),
+        ("noob", "NoobAI"),
+    };
+
+    // Rung 2: modelspec.architecture, lowercased, with everything from the first '/' stripped
+    // (drops suffixes such as "/lora").
+    private static readonly Dictionary<string, string> ArchitectureMap = new(StringComparer.Ordinal)
+    {
+        ["stable-diffusion-xl-v1-base"] = "SDXL 1.0",
+        ["stable-diffusion-v1"] = "SD 1.5",
+        ["stable-diffusion-v2-768-v"] = "SD 2.1",
+        ["stable-diffusion-v2"] = "SD 2.0",
+        ["stable-diffusion-3-medium"] = "SD 3",
+        ["flux-1-dev"] = "Flux.1 D",
+        ["flux-1-schnell"] = "Flux.1 S",
+    };
+
+    // Rung 3: ss_base_model_version, lowercased prefix match. kohya writes the coarse "sd_v1" /
+    // "sd_v2" for every 1.x / 2.x checkpoint it trains against — there is no finer signal in that
+    // field — so this collapses to the dominant member of each family (1.5, 2.1) as an accepted
+    // approximation rather than a precise minor-version read.
+    private static readonly (string Prefix, string Label)[] VersionPrefixes =
+    {
+        ("sdxl_base_v1-0", "SDXL 1.0"),
+        ("sdxl_base_v0-9", "SDXL 0.9"),
+        ("sd_v1", "SD 1.5"),
+        ("sd_v2", "SD 2.1"),
+    };
+
+    /// <summary>
+    /// Every label this map can ever return. Test-only seam (DiffusionNexus.Tests,
+    /// InternalsVisibleTo) used to verify each label is a real Civitai display label.
+    /// </summary>
+    internal static IReadOnlyCollection<string> AllLabels { get; } = NameHints.Select(h => h.Label)
+        .Concat(ArchitectureMap.Values)
+        .Concat(VersionPrefixes.Select(p => p.Label))
+        .Distinct(StringComparer.Ordinal)
+        .ToArray();
+
+    /// <summary>Civitai display label for a parsed header, or null when the header says nothing usable.</summary>
+    public static string? Map(SafetensorsHeaderInfo info)
+    {
+        if (info is null)
+            return null;
+
+        if (!string.IsNullOrEmpty(info.ModelNameHint))
+        {
+            var hint = info.ModelNameHint.ToLowerInvariant();
+            foreach (var (needle, label) in NameHints)
+            {
+                if (hint.Contains(needle, StringComparison.Ordinal))
+                    return label;
+            }
+        }
+
+        if (!string.IsNullOrEmpty(info.Architecture))
+        {
+            var architecture = info.Architecture.ToLowerInvariant();
+            var slashIndex = architecture.IndexOf('/');
+            if (slashIndex >= 0)
+                architecture = architecture[..slashIndex];
+
+            if (ArchitectureMap.TryGetValue(architecture, out var architectureLabel))
+                return architectureLabel;
+        }
+
+        if (!string.IsNullOrEmpty(info.BaseModelVersion))
+        {
+            var version = info.BaseModelVersion.ToLowerInvariant();
+            foreach (var (prefix, label) in VersionPrefixes)
+            {
+                if (version.StartsWith(prefix, StringComparison.Ordinal))
+                    return label;
+            }
+        }
+
+        return null;
+    }
+}

--- a/DiffusionNexus.Service/Services/Sync/Identity/BaseModelHeaderMap.cs
+++ b/DiffusionNexus.Service/Services/Sync/Identity/BaseModelHeaderMap.cs
@@ -12,12 +12,23 @@ namespace DiffusionNexus.Service.Services.Sync.Identity;
 /// </remarks>
 public static class BaseModelHeaderMap
 {
-    // Rung 1: ss_sd_model_name substring hints. Checked first — see class remarks.
+    // Rung 1: ss_sd_model_name substring hints. Checked first — see class remarks. kohya writes a
+    // full file PATH into this field, not a bare file name, so only the file-name portion (see
+    // ExtractFileNameHint) is needle-matched: a directory segment (e.g.
+    // "...\noobs\base.safetensors") must never decide the label.
     private static readonly (string Needle, string Label)[] NameHints =
     {
         ("pony", "Pony"),
         ("illustrious", "Illustrious"),
         ("noob", "NoobAI"),
+    };
+
+    // Extensions ExtractFileNameHint will drop from the file-name portion of the hint. Mirrors
+    // FilenameBaseModelHeuristic.KnownModelExtensions (kept separate rather than shared — this
+    // class doesn't otherwise depend on that one, and the list is small).
+    private static readonly string[] KnownModelExtensions =
+    {
+        ".safetensors", ".pt", ".ckpt", ".bin", ".sft", ".gguf",
     };
 
     // Rung 2: modelspec.architecture, lowercased, with everything from the first '/' stripped
@@ -63,7 +74,7 @@ public static class BaseModelHeaderMap
 
         if (!string.IsNullOrEmpty(info.ModelNameHint))
         {
-            var hint = info.ModelNameHint.ToLowerInvariant();
+            var hint = ExtractFileNameHint(info.ModelNameHint).ToLowerInvariant();
             foreach (var (needle, label) in NameHints)
             {
                 if (hint.Contains(needle, StringComparison.Ordinal))
@@ -93,5 +104,26 @@ public static class BaseModelHeaderMap
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Strips a directory prefix and a known trailing extension from an <c>ss_sd_model_name</c>
+    /// hint, so rung 1 needle-matches only the actual file name — never a directory segment.
+    /// Checks '/' and '\' explicitly rather than calling <see cref="Path.GetFileName(string)"/>,
+    /// which strips only the platform's own separator and would leave a Windows-style prefix
+    /// intact on a non-Windows build/CI runner.
+    /// </summary>
+    private static string ExtractFileNameHint(string hint)
+    {
+        var separatorIndex = Math.Max(hint.LastIndexOf('/'), hint.LastIndexOf('\\'));
+        var fileName = separatorIndex >= 0 ? hint[(separatorIndex + 1)..] : hint;
+
+        foreach (var extension in KnownModelExtensions)
+        {
+            if (fileName.EndsWith(extension, StringComparison.OrdinalIgnoreCase))
+                return fileName[..^extension.Length];
+        }
+
+        return fileName;
     }
 }

--- a/DiffusionNexus.Service/Services/Sync/Identity/FilenameBaseModelHeuristic.cs
+++ b/DiffusionNexus.Service/Services/Sync/Identity/FilenameBaseModelHeuristic.cs
@@ -22,16 +22,42 @@ public static partial class FilenameBaseModelHeuristic
     [GeneratedRegex("[^a-z0-9]+")]
     private static partial Regex TokenSplitRegex();
 
-    // Rung 1: distinctive whole-name substrings — safe because they're long/specific enough not
-    // to false-positive inside an unrelated word.
+    // Rung 1: distinctive whole-name substrings for architectures whose full name is itself
+    // unambiguous — safe because they're long/specific enough not to false-positive inside an
+    // unrelated word.
     private static readonly (string Needle, string Label)[] WholeNameSubstrings =
     {
         ("illustrious", "Illustrious"),
         ("noobai", "NoobAI"),
-        ("sdxl", "SDXL 1.0"),
     };
 
-    // Rung 2: exact token, or exact adjacent-pair concatenation (handles a version number split
+    // Rung 2: refinement token signals. MUST be checked — and win — before the generic "sdxl"
+    // whole-name substring in rung 3, mirroring BaseModelHeaderMap's own class remarks: Pony,
+    // Illustrious and NoobAI checkpoints are all trained on the SDXL architecture, so a filename
+    // carrying both the refinement name and the literal word "sdxl" (extremely common for Pony
+    // LoRAs, e.g. "stylemix_pony_sdxl_v1") must label as the refinement, not the architecture it
+    // was built on. Token-level (StartsWith on a split token, or an exact token for "pdxl"), not a
+    // raw substring test against the whole name, because "pony"/"illust"/"noob" are short enough
+    // to false-positive inside an unrelated word if matched that way — the negative-case tests
+    // pin exactly this ("harmony_lora" -> null).
+    private static readonly (string Prefix, string Label)[] RefinementTokenPrefixes =
+    {
+        ("pony", "Pony"),
+        ("illust", "Illustrious"),
+        ("noob", "NoobAI"),
+    };
+
+    private static readonly Dictionary<string, string> RefinementExactTokens = new(StringComparer.Ordinal)
+    {
+        ["pdxl"] = "Pony",
+    };
+
+    // Rung 3: generic architecture whole-name substring — checked only after every refinement
+    // above has had its chance, so a refinement name never loses to the architecture it's built on.
+    private const string SdxlNeedle = "sdxl";
+    private const string SdxlLabel = "SDXL 1.0";
+
+    // Rung 4: exact token, or exact adjacent-pair concatenation (handles a version number split
     // across a separator, e.g. "sd_15" or "sd1.5" tokenizing to "sd1" + "5").
     private static readonly Dictionary<string, string> ExactTokenOrPairMap = new(StringComparer.Ordinal)
     {
@@ -39,21 +65,17 @@ public static partial class FilenameBaseModelHeuristic
         ["sd21"] = "SD 2.1",
         ["sd35"] = "SD 3.5",
         ["sd3"] = "SD 3",
-        ["pdxl"] = "Pony",
         ["il"] = "Illustrious",
         ["wan"] = "Wan Video",
         ["wan21"] = "Wan Video",
         ["wan22"] = "Wan Video",
     };
 
-    // Rung 3: token prefix match — last resort, so only distinctive prefixes that won't collide
+    // Rung 5: token prefix match — last resort, so only distinctive prefixes that won't collide
     // with common English words belong here.
     private static readonly (string Prefix, string Label)[] TokenPrefixes =
     {
-        ("pony", "Pony"),
         ("flux", "Flux.1 D"),
-        ("illust", "Illustrious"),
-        ("noob", "NoobAI"),
     };
 
     /// <summary>
@@ -62,6 +84,9 @@ public static partial class FilenameBaseModelHeuristic
     /// <see cref="BaseModelHeaderMap.AllLabels"/>.
     /// </summary>
     internal static IReadOnlyCollection<string> AllLabels { get; } = WholeNameSubstrings.Select(s => s.Label)
+        .Concat(RefinementTokenPrefixes.Select(p => p.Label))
+        .Concat(RefinementExactTokens.Values)
+        .Concat(new[] { SdxlLabel })
         .Concat(ExactTokenOrPairMap.Values)
         .Concat(TokenPrefixes.Select(p => p.Label))
         .Distinct(StringComparer.Ordinal)
@@ -86,6 +111,24 @@ public static partial class FilenameBaseModelHeuristic
         var tokens = TokenSplitRegex().Split(name).Where(t => t.Length > 0).ToArray();
         if (tokens.Length == 0)
             return null;
+
+        // Refinement rung — see the field's remarks. Must run before the "sdxl" substring check
+        // below, or a Pony/Illustrious/NoobAI filename that also carries the literal word "sdxl"
+        // would always collapse to the generic architecture label.
+        foreach (var token in tokens)
+        {
+            if (RefinementExactTokens.TryGetValue(token, out var refinementLabel))
+                return refinementLabel;
+
+            foreach (var (prefix, label) in RefinementTokenPrefixes)
+            {
+                if (token.StartsWith(prefix, StringComparison.Ordinal))
+                    return label;
+            }
+        }
+
+        if (name.Contains(SdxlNeedle, StringComparison.Ordinal))
+            return SdxlLabel;
 
         foreach (var token in tokens)
         {

--- a/DiffusionNexus.Service/Services/Sync/Identity/FilenameBaseModelHeuristic.cs
+++ b/DiffusionNexus.Service/Services/Sync/Identity/FilenameBaseModelHeuristic.cs
@@ -31,44 +31,72 @@ public static partial class FilenameBaseModelHeuristic
         ("noobai", "NoobAI"),
     };
 
-    // Rung 2: refinement token signals. MUST be checked — and win — before the generic "sdxl"
-    // whole-name substring in rung 3, mirroring BaseModelHeaderMap's own class remarks: Pony,
-    // Illustrious and NoobAI checkpoints are all trained on the SDXL architecture, so a filename
-    // carrying both the refinement name and the literal word "sdxl" (extremely common for Pony
-    // LoRAs, e.g. "stylemix_pony_sdxl_v1") must label as the refinement, not the architecture it
-    // was built on. Token-level (StartsWith on a split token, or an exact token for "pdxl"), not a
-    // raw substring test against the whole name, because "pony"/"illust"/"noob" are short enough
-    // to false-positive inside an unrelated word if matched that way — the negative-case tests
-    // pin exactly this ("harmony_lora" -> null).
-    private static readonly (string Prefix, string Label)[] RefinementTokenPrefixes =
+    // Rung 2: refinement signals for checkpoints that are architecturally plain SDXL under a
+    // different name. MUST be checked — and win — before the generic "sdxl" whole-name substring
+    // in rung 3, mirroring BaseModelHeaderMap's own class remarks: Pony, Illustrious and NoobAI
+    // checkpoints are all trained on the SDXL architecture, so a filename carrying both the
+    // refinement name and the literal word "sdxl" (extremely common for Pony LoRAs, e.g.
+    // "stylemix_pony_sdxl_v1") must label as the refinement, not the architecture it was built on.
+    //
+    // Deliberately NOT a StartsWith prefix test against every token: "pony", "illust" and "noob"
+    // are common enough as the start of an unrelated English word (ponytail, illustration,
+    // noobie) that prefix matching false-positives constantly — verified against the built
+    // assembly, "ponytail_v1", "illustration_style" and "noobie_lora" all used to match. Instead:
+    //   (a) RefinementExactTokens — a closed set of exact tokens: the bare refinement word and the
+    //       compound spelling that doesn't start with a decoration prefix at all ("pdxl"), plus
+    //       "il"/"illust", which are too short to ever safely prefix-match.
+    //   (b) RefinementDecorationPrefixes — a token that starts with one of these prefixes matches
+    //       ONLY when what remains is pure version/XL decoration (see
+    //       RefinementDecorationRemainderRegex), e.g. "ponyxl", "ponyv6", "ponyv6xl" — never an
+    //       arbitrary remainder like "tail", "ration" or "ie". "ponydiffusion" is a prefix here
+    //       (not only an exact token) because real filenames glue it straight to the version with
+    //       no separator to tokenize on, e.g. "ponyDiffusionV6XL" -> single token
+    //       "ponydiffusionv6xl".
+    private static readonly Dictionary<string, string> RefinementExactTokens = new(StringComparer.Ordinal)
     {
+        ["pdxl"] = "Pony",
+        ["pony"] = "Pony",
+        ["il"] = "Illustrious",
+        ["illust"] = "Illustrious",
+        ["noob"] = "NoobAI",
+    };
+
+    private static readonly (string Prefix, string Label)[] RefinementDecorationPrefixes =
+    {
+        ("ponydiffusion", "Pony"),
         ("pony", "Pony"),
         ("illust", "Illustrious"),
         ("noob", "NoobAI"),
     };
 
-    private static readonly Dictionary<string, string> RefinementExactTokens = new(StringComparer.Ordinal)
-    {
-        ["pdxl"] = "Pony",
-    };
+    // Matches an empty remainder or pure version/XL decoration left after stripping a refinement
+    // prefix: "", "xl", "v6", "v6xl", "xl2" ... but not "tail", "ration", "ie".
+    [GeneratedRegex(@"^(xl)?(v?\d+)?(xl)?$")]
+    private static partial Regex RefinementDecorationRemainderRegex();
 
     // Rung 3: generic architecture whole-name substring — checked only after every refinement
     // above has had its chance, so a refinement name never loses to the architecture it's built on.
     private const string SdxlNeedle = "sdxl";
     private const string SdxlLabel = "SDXL 1.0";
 
-    // Rung 4: exact token, or exact adjacent-pair concatenation (handles a version number split
-    // across a separator, e.g. "sd_15" or "sd1.5" tokenizing to "sd1" + "5").
+    // Rung 4: exact match against the token/pair/triple candidate set built in Guess() (handles a
+    // version number split across separators, e.g. "sd_3.5" tokenizing to "sd" + "3" + "5", where
+    // the full "35" only exists as a triple concatenation). Matched longest-key-first so a coarse
+    // key like "sd3" can never win over a finer one like "sd35" just because of where the
+    // separators happened to fall — see the longest-key-first loop in Guess().
+    //
+    // No "wan"/"wan21"/"wan22" here, deliberately: "Wan Video" is a real Civitai catalog label,
+    // but BaseModelTypeExtensions.ParseCivitai normalizes it (by stripping spaces) to "WanVideo",
+    // which is not a BaseModelType member — only WanVideo21/WanVideo22 exist — so it always ends
+    // up stored as Other. The bare "wan" token is also a false-positive magnet on its own:
+    // Star Wars character LoRAs ("obi_wan_kenobi") are extremely common. Do not re-add any of the
+    // three without also adding a representable BaseModelType member.
     private static readonly Dictionary<string, string> ExactTokenOrPairMap = new(StringComparer.Ordinal)
     {
         ["sd15"] = "SD 1.5",
         ["sd21"] = "SD 2.1",
         ["sd35"] = "SD 3.5",
         ["sd3"] = "SD 3",
-        ["il"] = "Illustrious",
-        ["wan"] = "Wan Video",
-        ["wan21"] = "Wan Video",
-        ["wan22"] = "Wan Video",
     };
 
     // Rung 5: token prefix match — last resort, so only distinctive prefixes that won't collide
@@ -84,8 +112,8 @@ public static partial class FilenameBaseModelHeuristic
     /// <see cref="BaseModelHeaderMap.AllLabels"/>.
     /// </summary>
     internal static IReadOnlyCollection<string> AllLabels { get; } = WholeNameSubstrings.Select(s => s.Label)
-        .Concat(RefinementTokenPrefixes.Select(p => p.Label))
         .Concat(RefinementExactTokens.Values)
+        .Concat(RefinementDecorationPrefixes.Select(p => p.Label))
         .Concat(new[] { SdxlLabel })
         .Concat(ExactTokenOrPairMap.Values)
         .Concat(TokenPrefixes.Select(p => p.Label))
@@ -112,7 +140,7 @@ public static partial class FilenameBaseModelHeuristic
         if (tokens.Length == 0)
             return null;
 
-        // Refinement rung — see the field's remarks. Must run before the "sdxl" substring check
+        // Refinement rung — see rung 2's remarks above. Must run before the "sdxl" substring check
         // below, or a Pony/Illustrious/NoobAI filename that also carries the literal word "sdxl"
         // would always collapse to the generic architecture label.
         foreach (var token in tokens)
@@ -120,9 +148,13 @@ public static partial class FilenameBaseModelHeuristic
             if (RefinementExactTokens.TryGetValue(token, out var refinementLabel))
                 return refinementLabel;
 
-            foreach (var (prefix, label) in RefinementTokenPrefixes)
+            foreach (var (prefix, label) in RefinementDecorationPrefixes)
             {
-                if (token.StartsWith(prefix, StringComparison.Ordinal))
+                if (token.Length <= prefix.Length || !token.StartsWith(prefix, StringComparison.Ordinal))
+                    continue;
+
+                var remainder = token[prefix.Length..];
+                if (RefinementDecorationRemainderRegex().IsMatch(remainder))
                     return label;
             }
         }
@@ -130,17 +162,21 @@ public static partial class FilenameBaseModelHeuristic
         if (name.Contains(SdxlNeedle, StringComparison.Ordinal))
             return SdxlLabel;
 
-        foreach (var token in tokens)
-        {
-            if (ExactTokenOrPairMap.TryGetValue(token, out var tokenLabel))
-                return tokenLabel;
-        }
-
+        // Candidate set = every token, adjacent-pair concatenation, and adjacent-triple
+        // concatenation, so a version number survives regardless of where separators land (e.g.
+        // "sd_3.5" -> tokens "sd","3","5" -> the pair "35" and the triple "sd35" both exist as
+        // candidates). Matched longest-key-first: without this, "sd3" (itself a key) would win
+        // over "sd35" purely because the exact-token check used to run before the pair check.
+        var candidates = new HashSet<string>(tokens, StringComparer.Ordinal);
         for (var i = 0; i < tokens.Length - 1; i++)
+            candidates.Add(tokens[i] + tokens[i + 1]);
+        for (var i = 0; i < tokens.Length - 2; i++)
+            candidates.Add(tokens[i] + tokens[i + 1] + tokens[i + 2]);
+
+        foreach (var key in ExactTokenOrPairMap.Keys.OrderByDescending(k => k.Length))
         {
-            var pair = tokens[i] + tokens[i + 1];
-            if (ExactTokenOrPairMap.TryGetValue(pair, out var pairLabel))
-                return pairLabel;
+            if (candidates.Contains(key))
+                return ExactTokenOrPairMap[key];
         }
 
         foreach (var token in tokens)

--- a/DiffusionNexus.Service/Services/Sync/Identity/FilenameBaseModelHeuristic.cs
+++ b/DiffusionNexus.Service/Services/Sync/Identity/FilenameBaseModelHeuristic.cs
@@ -1,0 +1,114 @@
+using System.Text.RegularExpressions;
+
+namespace DiffusionNexus.Service.Services.Sync.Identity;
+
+/// <summary>
+/// Guesses a Civitai base-model display label from a model FILE NAME when no header or sidecar
+/// metadata is available. Last-resort signal — used only after
+/// <see cref="BaseModelHeaderMap"/> and any sidecar read have already come up empty.
+/// </summary>
+public static partial class FilenameBaseModelHeuristic
+{
+    // Only strip a trailing extension when it is a KNOWN model-file extension. A blind
+    // Path.GetFileNameWithoutExtension call would eat the ".5" off "detailer_sd1.5" (turning it
+    // into "detailer_sd1" and losing the version digit the token match below depends on), and the
+    // Task 3 caller already pre-strips real extensions before calling in — so a second, unguarded
+    // strip here would be the live failure path, not a defensive no-op.
+    private static readonly string[] KnownModelExtensions =
+    {
+        ".safetensors", ".pt", ".ckpt", ".bin", ".sft", ".gguf",
+    };
+
+    [GeneratedRegex("[^a-z0-9]+")]
+    private static partial Regex TokenSplitRegex();
+
+    // Rung 1: distinctive whole-name substrings — safe because they're long/specific enough not
+    // to false-positive inside an unrelated word.
+    private static readonly (string Needle, string Label)[] WholeNameSubstrings =
+    {
+        ("illustrious", "Illustrious"),
+        ("noobai", "NoobAI"),
+        ("sdxl", "SDXL 1.0"),
+    };
+
+    // Rung 2: exact token, or exact adjacent-pair concatenation (handles a version number split
+    // across a separator, e.g. "sd_15" or "sd1.5" tokenizing to "sd1" + "5").
+    private static readonly Dictionary<string, string> ExactTokenOrPairMap = new(StringComparer.Ordinal)
+    {
+        ["sd15"] = "SD 1.5",
+        ["sd21"] = "SD 2.1",
+        ["sd35"] = "SD 3.5",
+        ["sd3"] = "SD 3",
+        ["pdxl"] = "Pony",
+        ["il"] = "Illustrious",
+        ["wan"] = "Wan Video",
+        ["wan21"] = "Wan Video",
+        ["wan22"] = "Wan Video",
+    };
+
+    // Rung 3: token prefix match — last resort, so only distinctive prefixes that won't collide
+    // with common English words belong here.
+    private static readonly (string Prefix, string Label)[] TokenPrefixes =
+    {
+        ("pony", "Pony"),
+        ("flux", "Flux.1 D"),
+        ("illust", "Illustrious"),
+        ("noob", "NoobAI"),
+    };
+
+    /// <summary>Civitai display label guessed from a model FILE NAME (no directory, extension ignored), or null.</summary>
+    public static string? Guess(string? fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+            return null;
+
+        var name = StripKnownExtension(fileName).ToLowerInvariant();
+        if (name.Length == 0)
+            return null;
+
+        foreach (var (needle, label) in WholeNameSubstrings)
+        {
+            if (name.Contains(needle, StringComparison.Ordinal))
+                return label;
+        }
+
+        var tokens = TokenSplitRegex().Split(name).Where(t => t.Length > 0).ToArray();
+        if (tokens.Length == 0)
+            return null;
+
+        foreach (var token in tokens)
+        {
+            if (ExactTokenOrPairMap.TryGetValue(token, out var tokenLabel))
+                return tokenLabel;
+        }
+
+        for (var i = 0; i < tokens.Length - 1; i++)
+        {
+            var pair = tokens[i] + tokens[i + 1];
+            if (ExactTokenOrPairMap.TryGetValue(pair, out var pairLabel))
+                return pairLabel;
+        }
+
+        foreach (var token in tokens)
+        {
+            foreach (var (prefix, label) in TokenPrefixes)
+            {
+                if (token.StartsWith(prefix, StringComparison.Ordinal))
+                    return label;
+            }
+        }
+
+        return null;
+    }
+
+    private static string StripKnownExtension(string fileName)
+    {
+        foreach (var extension in KnownModelExtensions)
+        {
+            if (fileName.EndsWith(extension, StringComparison.OrdinalIgnoreCase))
+                return fileName[..^extension.Length];
+        }
+
+        return fileName;
+    }
+}

--- a/DiffusionNexus.Service/Services/Sync/Identity/FilenameBaseModelHeuristic.cs
+++ b/DiffusionNexus.Service/Services/Sync/Identity/FilenameBaseModelHeuristic.cs
@@ -56,6 +56,17 @@ public static partial class FilenameBaseModelHeuristic
         ("noob", "NoobAI"),
     };
 
+    /// <summary>
+    /// Every label this heuristic can ever return. Test-only seam (DiffusionNexus.Tests,
+    /// InternalsVisibleTo) used to verify each label is a real Civitai display label — mirrors
+    /// <see cref="BaseModelHeaderMap.AllLabels"/>.
+    /// </summary>
+    internal static IReadOnlyCollection<string> AllLabels { get; } = WholeNameSubstrings.Select(s => s.Label)
+        .Concat(ExactTokenOrPairMap.Values)
+        .Concat(TokenPrefixes.Select(p => p.Label))
+        .Distinct(StringComparer.Ordinal)
+        .ToArray();
+
     /// <summary>Civitai display label guessed from a model FILE NAME (no directory, extension ignored), or null.</summary>
     public static string? Guess(string? fileName)
     {

--- a/DiffusionNexus.Service/Services/Sync/Identity/SafetensorsHeaderReader.cs
+++ b/DiffusionNexus.Service/Services/Sync/Identity/SafetensorsHeaderReader.cs
@@ -19,7 +19,10 @@ public static class SafetensorsHeaderReader
     // spec §4.5: cap 16 MB, never the tensors.
     public const long MaxHeaderBytes = 16 * 1024 * 1024;
 
-    private const string SafetensorsExtension = ".safetensors";
+    // ".sft" is the standard short alias for the same container (also listed in
+    // FilenameBaseModelHeuristic.KnownModelExtensions) — a readable header under either spelling
+    // must not fall through to the lower-confidence filename guess.
+    private static readonly string[] SafetensorsExtensions = { ".safetensors", ".sft" };
     private const int LengthPrefixBytes = 8;
 
     /// <summary>Best-effort read of the safetensors header; null on ANY failure, never throws.</summary>
@@ -27,7 +30,7 @@ public static class SafetensorsHeaderReader
     {
         try
         {
-            if (!string.Equals(Path.GetExtension(filePath), SafetensorsExtension, StringComparison.OrdinalIgnoreCase))
+            if (!IsSafetensorsExtension(filePath))
                 return null;
 
             // FileShare.ReadWrite (not the house FileShare.Read from FileHasher.cs:23) because a
@@ -70,6 +73,17 @@ public static class SafetensorsHeaderReader
             // No logging here — deliberately: the caller (the identity step) owns the log line.
             return null;
         }
+    }
+
+    private static bool IsSafetensorsExtension(string filePath)
+    {
+        var extension = Path.GetExtension(filePath);
+        foreach (var candidate in SafetensorsExtensions)
+        {
+            if (string.Equals(extension, candidate, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
     }
 
     private static string? ReadStringProperty(JsonElement obj, string propertyName) =>

--- a/DiffusionNexus.Service/Services/Sync/Identity/SafetensorsHeaderReader.cs
+++ b/DiffusionNexus.Service/Services/Sync/Identity/SafetensorsHeaderReader.cs
@@ -25,8 +25,18 @@ public static class SafetensorsHeaderReader
     private static readonly string[] SafetensorsExtensions = { ".safetensors", ".sft" };
     private const int LengthPrefixBytes = 8;
 
-    /// <summary>Best-effort read of the safetensors header; null on ANY failure, never throws.</summary>
-    public static SafetensorsHeaderInfo? TryRead(string filePath)
+    /// <summary>
+    /// Best-effort read of the safetensors header; null on ANY failure, never throws — except a
+    /// cancellation via <paramref name="ct"/>, which surfaces as <see cref="OperationCanceledException"/>
+    /// so the caller can tell "cancelled" apart from "unreadable".
+    /// </summary>
+    /// <remarks>
+    /// Async so a whole-library scan doesn't block a thread-pool thread per item on a read of up to
+    /// <see cref="MaxHeaderBytes"/> — real on a NAS or spinning disk, and items run back to back. The
+    /// stream opens with <see cref="FileOptions.Asynchronous"/> and every read is cancellable, so a
+    /// caller can actually interrupt a slow read instead of only checking before and after it.
+    /// </remarks>
+    public static async Task<SafetensorsHeaderInfo?> TryReadAsync(string filePath, CancellationToken ct = default)
     {
         try
         {
@@ -36,10 +46,11 @@ public static class SafetensorsHeaderReader
             // FileShare.ReadWrite (not the house FileShare.Read from FileHasher.cs:23) because a
             // trainer mid-checkpoint holds the file write-shared; a read-only share would fail to
             // open it and we'd never get a chance at the header.
-            using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 81920);
+            await using var stream = new FileStream(
+                filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 81920, FileOptions.Asynchronous);
 
-            Span<byte> lengthBuffer = stackalloc byte[LengthPrefixBytes];
-            stream.ReadExactly(lengthBuffer);
+            var lengthBuffer = new byte[LengthPrefixBytes];
+            await stream.ReadExactlyAsync(lengthBuffer, ct).ConfigureAwait(false);
             var headerLength = BinaryPrimitives.ReadUInt64LittleEndian(lengthBuffer);
 
             if (headerLength == 0 || headerLength > MaxHeaderBytes)
@@ -48,7 +59,7 @@ public static class SafetensorsHeaderReader
                 return null;
 
             var headerBytes = new byte[headerLength];
-            stream.ReadExactly(headerBytes);
+            await stream.ReadExactlyAsync(headerBytes, ct).ConfigureAwait(false);
 
             using var document = JsonDocument.Parse(headerBytes);
             if (document.RootElement.ValueKind != JsonValueKind.Object)
@@ -67,6 +78,12 @@ public static class SafetensorsHeaderReader
             }
 
             return new SafetensorsHeaderInfo(baseModelVersion, architecture, modelNameHint);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Let it through — a cancelled read is not "unreadable" and the caller (the identify
+            // step) needs to be able to tell the two apart.
+            throw;
         }
         catch
         {

--- a/DiffusionNexus.Service/Services/Sync/Identity/SafetensorsHeaderReader.cs
+++ b/DiffusionNexus.Service/Services/Sync/Identity/SafetensorsHeaderReader.cs
@@ -1,0 +1,79 @@
+using System.Buffers.Binary;
+using System.Text.Json;
+
+namespace DiffusionNexus.Service.Services.Sync.Identity;
+
+/// <summary>The identity-relevant fields of a safetensors JSON header's __metadata__ block.</summary>
+public sealed record SafetensorsHeaderInfo(
+    string? BaseModelVersion,   // __metadata__["ss_base_model_version"]
+    string? Architecture,       // __metadata__["modelspec.architecture"]
+    string? ModelNameHint);     // __metadata__["ss_sd_model_name"]
+
+/// <summary>
+/// Reads the JSON header a safetensors file carries in its first bytes, without ever touching
+/// the tensor payload that follows it. Later tasks use the extracted <c>__metadata__</c> fields
+/// to identify a model's base model straight from the file, independent of any sidecar.
+/// </summary>
+public static class SafetensorsHeaderReader
+{
+    // spec §4.5: cap 16 MB, never the tensors.
+    public const long MaxHeaderBytes = 16 * 1024 * 1024;
+
+    private const string SafetensorsExtension = ".safetensors";
+    private const int LengthPrefixBytes = 8;
+
+    /// <summary>Best-effort read of the safetensors header; null on ANY failure, never throws.</summary>
+    public static SafetensorsHeaderInfo? TryRead(string filePath)
+    {
+        try
+        {
+            if (!string.Equals(Path.GetExtension(filePath), SafetensorsExtension, StringComparison.OrdinalIgnoreCase))
+                return null;
+
+            // FileShare.ReadWrite (not the house FileShare.Read from FileHasher.cs:23) because a
+            // trainer mid-checkpoint holds the file write-shared; a read-only share would fail to
+            // open it and we'd never get a chance at the header.
+            using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 81920);
+
+            Span<byte> lengthBuffer = stackalloc byte[LengthPrefixBytes];
+            stream.ReadExactly(lengthBuffer);
+            var headerLength = BinaryPrimitives.ReadUInt64LittleEndian(lengthBuffer);
+
+            if (headerLength == 0 || headerLength > MaxHeaderBytes)
+                return null;
+            if (LengthPrefixBytes + (long)headerLength > stream.Length)
+                return null;
+
+            var headerBytes = new byte[headerLength];
+            stream.ReadExactly(headerBytes);
+
+            using var document = JsonDocument.Parse(headerBytes);
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+                return null;
+
+            string? baseModelVersion = null;
+            string? architecture = null;
+            string? modelNameHint = null;
+
+            if (document.RootElement.TryGetProperty("__metadata__", out var metadata) &&
+                metadata.ValueKind == JsonValueKind.Object)
+            {
+                baseModelVersion = ReadStringProperty(metadata, "ss_base_model_version");
+                architecture = ReadStringProperty(metadata, "modelspec.architecture");
+                modelNameHint = ReadStringProperty(metadata, "ss_sd_model_name");
+            }
+
+            return new SafetensorsHeaderInfo(baseModelVersion, architecture, modelNameHint);
+        }
+        catch
+        {
+            // No logging here — deliberately: the caller (the identity step) owns the log line.
+            return null;
+        }
+    }
+
+    private static string? ReadStringProperty(JsonElement obj, string propertyName) =>
+        obj.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+}

--- a/DiffusionNexus.Service/Services/Sync/SidecarMetadataApplier.cs
+++ b/DiffusionNexus.Service/Services/Sync/SidecarMetadataApplier.cs
@@ -464,9 +464,12 @@ public sealed class SidecarMetadataApplier
                 dirty |= WriteBaseModel(dbVersion, baseModelStr);
             }
 
-            // Fallback: "sd version" for very old sidecar format
+            // Fallback: "sd version" for very old sidecar format. Only when "baseModel" above left
+            // nothing real behind — SyncStateDeriver.IsPlaceholder is the one place that rule
+            // lives (it used to be a local `is null or "???"` copy that, unlike the real rule,
+            // didn't treat a blank string as a placeholder).
             if (CanWriteVersionText(dbVersion)
-                && dbVersion.BaseModelRaw is null or "???"
+                && SyncStateDeriver.IsPlaceholder(dbVersion.BaseModelRaw)
                 && root.TryGetProperty("sd version", out var sdVer) && sdVer.GetString() is { } sdVerStr)
             {
                 dirty |= WriteBaseModel(dbVersion, sdVerStr);

--- a/DiffusionNexus.Service/Services/Sync/SidecarMetadataApplier.cs
+++ b/DiffusionNexus.Service/Services/Sync/SidecarMetadataApplier.cs
@@ -508,16 +508,12 @@ public sealed class SidecarMetadataApplier
     /// A blank <c>baseModel</c> is a missing answer, not an instruction to forget the stored one
     /// (F6). The call sites only rejected an <i>absent</i> key, so a sidecar carrying
     /// <c>"baseModel": ""</c> blanked the raw string and set the enum to <c>Unknown</c> on a version
-    /// nobody had edited. The check lives here so all four of them inherit it.
+    /// nobody had edited. The check lives here so all four of them inherit it. Delegates to
+    /// <see cref="BaseModelWriter.Write"/>, the same rule the identify step's header/heuristic
+    /// rungs use so every source agrees on what counts as an answer.
     /// </remarks>
-    private static bool WriteBaseModel(ModelVersion dbVersion, string? baseModelRaw)
-    {
-        if (string.IsNullOrWhiteSpace(baseModelRaw)) return false;
-
-        dbVersion.BaseModelRaw = baseModelRaw;
-        dbVersion.BaseModel = BaseModelTypeExtensions.ParseCivitai(baseModelRaw);
-        return true;
-    }
+    private static bool WriteBaseModel(ModelVersion dbVersion, string? baseModelRaw) =>
+        BaseModelWriter.Write(dbVersion, baseModelRaw);
 
     /// <summary>
     /// Replaces a version's trigger words with the sidecar's <c>trainedWords</c>, returning whether

--- a/DiffusionNexus.Service/Services/Sync/Steps/IdentifyModelStep.cs
+++ b/DiffusionNexus.Service/Services/Sync/Steps/IdentifyModelStep.cs
@@ -223,7 +223,16 @@ public sealed class IdentifyModelStep : ISyncStep
                     // a version whose base model was just filled from its own file is no longer
                     // "unsynced", and several tile orderings (TileGroupingHelper) read LastSyncedAt to
                     // mean exactly that.
-                    dbModel.Source = DataSource.LocalFile;
+                    //
+                    // Source is deliberately NOT mirrored as unconditionally as the sidecar's. This
+                    // rung supplies one field, not a model's metadata set: a model whose name, tags,
+                    // images and CivitaiId all came from Civitai has not become locally sourced
+                    // because we read its header once after the upstream page 404'd. A sidecar
+                    // genuinely carries the whole set, which is why that branch may claim the model
+                    // outright and this one may only claim a model nothing else has claimed.
+                    if (dbModel.Source != DataSource.CivitaiApi)
+                        dbModel.Source = DataSource.LocalFile;
+
                     dbModel.LastSyncedAt = now;
                 }
                 else

--- a/DiffusionNexus.Service/Services/Sync/Steps/IdentifyModelStep.cs
+++ b/DiffusionNexus.Service/Services/Sync/Steps/IdentifyModelStep.cs
@@ -191,7 +191,7 @@ public sealed class IdentifyModelStep : ISyncStep
             }
 
             // No Civitai match, no sidecar — read the file's own header, then guess from its name.
-            var header = SafetensorsHeaderReader.TryRead(candidate.LocalPath);
+            var header = await SafetensorsHeaderReader.TryReadAsync(candidate.LocalPath, ct).ConfigureAwait(false);
             ct.ThrowIfCancellationRequested();
             var headerCheckedAt = header is not null ? now : (DateTimeOffset?)null;
             var label = header is not null ? BaseModelHeaderMap.Map(header) : null;

--- a/DiffusionNexus.Service/Services/Sync/Steps/IdentifyModelStep.cs
+++ b/DiffusionNexus.Service/Services/Sync/Steps/IdentifyModelStep.cs
@@ -187,7 +187,7 @@ public sealed class IdentifyModelStep : ISyncStep
 
             if (sidecar.Applied)
             {
-                await StampAsync(uow, candidate.ModelId, SyncOutcome.Sidecar, now, sidecar.Signature, error: null, ct).ConfigureAwait(false);
+                await StampAsync(uow, candidate.ModelId, SyncOutcome.Sidecar, now, sidecar.Signature, error: null, headerCheckedAt: null, ct).ConfigureAwait(false);
                 return SyncItemResult.Success;
             }
 
@@ -243,7 +243,7 @@ public sealed class IdentifyModelStep : ISyncStep
                 }
             }
 
-            await StampAsync(uow, candidate.ModelId, outcome, now, sidecar.Signature, error: null, ct, headerCheckedAt).ConfigureAwait(false);
+            await StampAsync(uow, candidate.ModelId, outcome, now, sidecar.Signature, error: null, headerCheckedAt, ct).ConfigureAwait(false);
 
             _logger?.Debug(LogCategory.General, LogSource,
                 $"'{candidate.Name}' not on Civitai → {outcome}" + (label is not null ? $" ({label})" : string.Empty), sidecar.SidecarPath);
@@ -272,7 +272,7 @@ public sealed class IdentifyModelStep : ISyncStep
 
             try
             {
-                await StampAsync(uow, candidate.ModelId, SyncOutcome.Error, now, signature: null, ex.Message, ct).ConfigureAwait(false);
+                await StampAsync(uow, candidate.ModelId, SyncOutcome.Error, now, signature: null, ex.Message, headerCheckedAt: null, ct).ConfigureAwait(false);
             }
             catch (Exception stampEx) when (stampEx is not OperationCanceledException && SyncFaults.IsItemFault(stampEx))
             {
@@ -321,13 +321,13 @@ public sealed class IdentifyModelStep : ISyncStep
         if (!applied || modelLevelDataMissing)
         {
             var reason = $"Civitai match applied nothing (model {candidate.ModelId}, version {version.Id})";
-            await StampAsync(uow, candidate.ModelId, SyncOutcome.Error, now, signature: null, reason, ct).ConfigureAwait(false);
+            await StampAsync(uow, candidate.ModelId, SyncOutcome.Error, now, signature: null, reason, headerCheckedAt: null, ct).ConfigureAwait(false);
 
             _logger?.Warn(LogCategory.Network, LogSource, $"Identify failed for '{candidate.Name}': {reason}");
             return SyncItemResult.Failure(reason);
         }
 
-        await StampAsync(uow, candidate.ModelId, SyncOutcome.Matched, now, signature: null, error: null, ct).ConfigureAwait(false);
+        await StampAsync(uow, candidate.ModelId, SyncOutcome.Matched, now, signature: null, error: null, headerCheckedAt: null, ct).ConfigureAwait(false);
 
         _logger?.Debug(LogCategory.Network, LogSource, $"Identified '{candidate.Name}' on Civitai", $"versionId={version.Id}");
         return SyncItemResult.Success;
@@ -362,7 +362,7 @@ public sealed class IdentifyModelStep : ISyncStep
 
     private static async Task StampAsync(
         IUnitOfWork uow, int modelId, SyncOutcome outcome, DateTimeOffset now,
-        string? signature, string? error, CancellationToken ct, DateTimeOffset? headerCheckedAt = null)
+        string? signature, string? error, DateTimeOffset? headerCheckedAt, CancellationToken ct)
     {
         var state = await uow.SyncStates.GetOrCreateAsync(modelId, ct).ConfigureAwait(false);
 

--- a/DiffusionNexus.Service/Services/Sync/Steps/IdentifyModelStep.cs
+++ b/DiffusionNexus.Service/Services/Sync/Steps/IdentifyModelStep.cs
@@ -6,6 +6,7 @@ using DiffusionNexus.Domain.Enums;
 using DiffusionNexus.Domain.Services;
 using DiffusionNexus.Domain.Services.Sync;
 using DiffusionNexus.Domain.Services.UnifiedLogging;
+using DiffusionNexus.Service.Services.Sync.Identity;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DiffusionNexus.Service.Services.Sync.Steps;
@@ -59,7 +60,7 @@ public sealed class IdentifyModelStep : ISyncStep
     public SyncStepKind Kind => SyncStepKind.IdentifyModel;
 
     /// <inheritdoc />
-    public string Description => "Identify models on Civitai";
+    public string Description => "Identify models (Civitai, sidecar, file header, filename)";
 
     /// <summary>Hash (large files) + two API calls (hash lookup, model page) with 1.5 s pacing between them.</summary>
     public TimeSpan EstimatedPerItem => TimeSpan.FromSeconds(3);
@@ -130,7 +131,7 @@ public sealed class IdentifyModelStep : ISyncStep
 
         // A sidecar that appeared or changed since the last look is new evidence, so it beats the
         // retry window: the user just dropped a .civitai.info next to the file and expects it read.
-        if (candidate.Outcome is not (SyncOutcome.Sidecar or SyncOutcome.NotIdentified)) return false;
+        if (candidate.Outcome is not (SyncOutcome.Sidecar or SyncOutcome.Header or SyncOutcome.Heuristic or SyncOutcome.NotIdentified)) return false;
         if (candidate.SidecarSignature is null) return false;
 
         var signature = SidecarMetadataApplier.Find(candidate.LocalPath).Signature;
@@ -180,11 +181,32 @@ public sealed class IdentifyModelStep : ISyncStep
             // cancelled out of would be stamped NotIdentified and then left alone for 30 days.
             ct.ThrowIfCancellationRequested();
 
-            var outcome = sidecar.Applied ? SyncOutcome.Sidecar : SyncOutcome.NotIdentified;
-            await StampAsync(uow, candidate.ModelId, outcome, now, sidecar.Signature, error: null, ct).ConfigureAwait(false);
+            if (sidecar.Applied)
+            {
+                await StampAsync(uow, candidate.ModelId, SyncOutcome.Sidecar, now, sidecar.Signature, error: null, ct).ConfigureAwait(false);
+                return SyncItemResult.Success;
+            }
+
+            // No Civitai match, no sidecar — read the file's own header, then guess from its name.
+            var header = SafetensorsHeaderReader.TryRead(candidate.LocalPath);
+            ct.ThrowIfCancellationRequested();
+            var headerCheckedAt = header is not null ? now : (DateTimeOffset?)null;
+            var label = header is not null ? BaseModelHeaderMap.Map(header) : null;
+            var outcome = label is not null ? SyncOutcome.Header : SyncOutcome.NotIdentified;
+            if (label is null)
+            {
+                label = FilenameBaseModelHeuristic.Guess(Path.GetFileNameWithoutExtension(candidate.LocalPath));
+                if (label is not null) outcome = SyncOutcome.Heuristic;
+            }
+            if (label is not null)
+            {
+                var dbVersion = await uow.Models.GetVersionByIdAsync(candidate.VersionId, ct).ConfigureAwait(false);
+                if (dbVersion is not null && BaseModelWriter.CanFill(dbVersion)) BaseModelWriter.Write(dbVersion, label);
+            }
+            await StampAsync(uow, candidate.ModelId, outcome, now, sidecar.Signature, error: null, ct, headerCheckedAt).ConfigureAwait(false);
 
             _logger?.Debug(LogCategory.Network, LogSource,
-                $"'{candidate.Name}' not on Civitai → {outcome}", sidecar.SidecarPath);
+                $"'{candidate.Name}' not on Civitai → {outcome}" + (label is not null ? $" ({label})" : string.Empty), sidecar.SidecarPath);
             return SyncItemResult.Success;
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -300,7 +322,7 @@ public sealed class IdentifyModelStep : ISyncStep
 
     private static async Task StampAsync(
         IUnitOfWork uow, int modelId, SyncOutcome outcome, DateTimeOffset now,
-        string? signature, string? error, CancellationToken ct)
+        string? signature, string? error, CancellationToken ct, DateTimeOffset? headerCheckedAt = null)
     {
         var state = await uow.SyncStates.GetOrCreateAsync(modelId, ct).ConfigureAwait(false);
 
@@ -322,6 +344,11 @@ public sealed class IdentifyModelStep : ISyncStep
         // Only the sidecar paths know the signature; Matched leaves the stored one alone so a later
         // fallback still notices whether that sidecar has changed.
         if (signature is not null) state.SidecarSignature = signature;
+
+        // Only the miss-branch ever reads the header, and only when the file itself could be
+        // opened as one — a non-safetensors file or a 404 that never reaches this stamp leaves the
+        // stored value alone rather than overwriting it with null.
+        if (headerCheckedAt is not null) state.HeaderCheckedAt = headerCheckedAt;
 
         await uow.SaveChangesAsync(ct).ConfigureAwait(false);
     }

--- a/DiffusionNexus.Service/Services/Sync/Steps/IdentifyModelStep.cs
+++ b/DiffusionNexus.Service/Services/Sync/Steps/IdentifyModelStep.cs
@@ -208,7 +208,7 @@ public sealed class IdentifyModelStep : ISyncStep
             }
             await StampAsync(uow, candidate.ModelId, outcome, now, sidecar.Signature, error: null, ct, headerCheckedAt).ConfigureAwait(false);
 
-            _logger?.Debug(LogCategory.Network, LogSource,
+            _logger?.Debug(LogCategory.General, LogSource,
                 $"'{candidate.Name}' not on Civitai → {outcome}" + (label is not null ? $" ({label})" : string.Empty), sidecar.SidecarPath);
             return SyncItemResult.Success;
         }

--- a/DiffusionNexus.Service/Services/Sync/Steps/IdentifyModelStep.cs
+++ b/DiffusionNexus.Service/Services/Sync/Steps/IdentifyModelStep.cs
@@ -195,17 +195,46 @@ public sealed class IdentifyModelStep : ISyncStep
             ct.ThrowIfCancellationRequested();
             var headerCheckedAt = header is not null ? now : (DateTimeOffset?)null;
             var label = header is not null ? BaseModelHeaderMap.Map(header) : null;
-            var outcome = label is not null ? SyncOutcome.Header : SyncOutcome.NotIdentified;
+            var rung = label is not null ? SyncOutcome.Header : (SyncOutcome?)null;
             if (label is null)
             {
                 label = FilenameBaseModelHeuristic.Guess(Path.GetFileNameWithoutExtension(candidate.LocalPath));
-                if (label is not null) outcome = SyncOutcome.Heuristic;
+                if (label is not null) rung = SyncOutcome.Heuristic;
             }
-            if (label is not null)
+
+            SyncOutcome outcome;
+            if (label is null)
+            {
+                // Nothing proposed a value at all.
+                outcome = SyncOutcome.NotIdentified;
+            }
+            else
             {
                 var dbVersion = await uow.Models.GetVersionByIdAsync(candidate.VersionId, ct).ConfigureAwait(false);
-                if (dbVersion is not null && BaseModelWriter.CanFill(dbVersion)) BaseModelWriter.Write(dbVersion, label);
+                var written = dbVersion is not null && BaseModelWriter.CanFill(dbVersion) && BaseModelWriter.Write(dbVersion, label);
+
+                if (written)
+                {
+                    // The rung that actually set the value is the one that gets credit for it.
+                    outcome = rung!.Value;
+                }
+                else
+                {
+                    // A label was produced, but CanFill said no — the value is already real, or the
+                    // version is user-edited — so the write never happened. Stamping the rung anyway
+                    // would be a lie: the detail panel's "Identity source: file header" row would be
+                    // describing the provenance of a Base Model the header had nothing to do with.
+                    // Preserve whatever settled identity the model already carried instead, so the
+                    // retry window and the sidecar-evidence bypass (IsDue, below) keep tracking the
+                    // real source rather than being reset by a rung that only reconfirmed it; fall
+                    // back to NotIdentified only when there was no settled identity to preserve.
+                    outcome = candidate.Outcome is SyncOutcome.Matched or SyncOutcome.Sidecar
+                        or SyncOutcome.Header or SyncOutcome.Heuristic
+                        ? candidate.Outcome
+                        : SyncOutcome.NotIdentified;
+                }
             }
+
             await StampAsync(uow, candidate.ModelId, outcome, now, sidecar.Signature, error: null, ct, headerCheckedAt).ConfigureAwait(false);
 
             _logger?.Debug(LogCategory.General, LogSource,

--- a/DiffusionNexus.Service/Services/Sync/Steps/IdentifyModelStep.cs
+++ b/DiffusionNexus.Service/Services/Sync/Steps/IdentifyModelStep.cs
@@ -157,7 +157,8 @@ public sealed class IdentifyModelStep : ISyncStep
         // rejected by SaveChanges. That rejection is survivable now (see the catch below), but a
         // failure row for a model the user deliberately deleted is noise, and hashing a
         // multi-gigabyte file for a model that no longer exists is wasted work on top of it.
-        if (await uow.Models.GetByIdAsync(candidate.ModelId, ct).ConfigureAwait(false) is null)
+        var dbModel = await uow.Models.GetByIdAsync(candidate.ModelId, ct).ConfigureAwait(false);
+        if (dbModel is null)
         {
             _logger?.Debug(LogCategory.General, LogSource,
                 $"Skipped '{candidate.Name}': model {candidate.ModelId} was deleted before the run reached it");
@@ -217,6 +218,13 @@ public sealed class IdentifyModelStep : ISyncStep
                 {
                     // The rung that actually set the value is the one that gets credit for it.
                     outcome = rung!.Value;
+
+                    // Mirrors SidecarMetadataApplier's own stamp the instant its write lands (~171-176):
+                    // a version whose base model was just filled from its own file is no longer
+                    // "unsynced", and several tile orderings (TileGroupingHelper) read LastSyncedAt to
+                    // mean exactly that.
+                    dbModel.Source = DataSource.LocalFile;
+                    dbModel.LastSyncedAt = now;
                 }
                 else
                 {

--- a/DiffusionNexus.Service/Services/Sync/Steps/IdentifyModelStep.cs
+++ b/DiffusionNexus.Service/Services/Sync/Steps/IdentifyModelStep.cs
@@ -13,15 +13,18 @@ namespace DiffusionNexus.Service.Services.Sync.Steps;
 
 /// <summary>
 /// Step 1 — establishes what a local file actually <i>is</i>: stored/computed SHA256 →
-/// Civitai hash lookup → local sidecar fallback. Replaces the ViewModel's Phase 1 / 1b and
-/// its per-tile metadata copy (#521 WP2).
+/// Civitai hash lookup → local sidecar fallback → the file's own safetensors header →
+/// a guess from the filename. Replaces the ViewModel's Phase 1 / 1b and its per-tile
+/// metadata copy (#521 WP2, WP4).
 /// </summary>
 /// <remarks>
 /// Every path stamps <c>ModelSyncState</c>, which is the whole point of the overhaul: a run that
 /// found nothing must be distinguishable from a run that never looked, or the next run repeats
 /// the same 2 500 fruitless requests. Successful outcomes (<see cref="SyncOutcome.Matched"/>,
-/// <see cref="SyncOutcome.Sidecar"/>, <see cref="SyncOutcome.NotIdentified"/>) reset the attempt
-/// counter; only <see cref="SyncOutcome.Error"/> increments it, which is what bounds retries.
+/// <see cref="SyncOutcome.Sidecar"/>, <see cref="SyncOutcome.Header"/>,
+/// <see cref="SyncOutcome.Heuristic"/>, <see cref="SyncOutcome.NotIdentified"/>) reset the
+/// attempt counter; only <see cref="SyncOutcome.Error"/> increments it, which is what bounds
+/// retries.
 /// </remarks>
 public sealed class IdentifyModelStep : ISyncStep
 {

--- a/DiffusionNexus.Tests/DataAccess/CoreDbMigrationTests.cs
+++ b/DiffusionNexus.Tests/DataAccess/CoreDbMigrationTests.cs
@@ -117,4 +117,55 @@ public class CoreDbMigrationTests
             tempDir.Delete(recursive: true);
         }
     }
+
+    /// <summary>
+    /// Mirrors the <see cref="SyncOutcome.NotIdentified"/> string round-trip above for
+    /// <see cref="SyncOutcome.Header"/> (Plan C) — the identify chain's safetensors-header rung —
+    /// so a future member rename cannot silently change what is stored on disk for it either.
+    /// </summary>
+    [Fact]
+    public void ModelSyncState_HeaderOutcome_RoundTripsAsStoredString()
+    {
+        var tempDir = Directory.CreateTempSubdirectory();
+        var dbPath = Path.Combine(tempDir.FullName, "syncstate-header-test.db");
+        try
+        {
+            var options = new DbContextOptionsBuilder<DiffusionNexusCoreDbContext>()
+                .UseSqlite($"Data Source={dbPath};Pooling=False")
+                .Options;
+
+            using (var ctx = new DiffusionNexusCoreDbContext(options))
+            {
+                ctx.Database.Migrate();
+                ctx.Models.Add(new Model
+                {
+                    Name = "header-outcome-model",
+                    SyncState = new ModelSyncState
+                    {
+                        MetadataOutcome = SyncOutcome.Header,
+                        HeaderCheckedAt = DateTimeOffset.UtcNow,
+                    }
+                });
+                ctx.SaveChanges();
+            }
+
+            using (var ctx = new DiffusionNexusCoreDbContext(options))
+            {
+                var model = ctx.Models.Include(m => m.SyncState).Single();
+                model.SyncState.Should().NotBeNull();
+                model.SyncState!.MetadataOutcome.Should().Be(SyncOutcome.Header);
+                model.SyncState.HeaderCheckedAt.Should().NotBeNull();
+
+                // Stored as text, not as the enum's ordinal.
+                var stored = ctx.Database.SqlQueryRaw<string>(
+                    "SELECT MetadataOutcome AS Value FROM ModelSyncStates").Single();
+                stored.Should().Be(nameof(SyncOutcome.Header));
+            }
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            tempDir.Delete(recursive: true);
+        }
+    }
 }

--- a/DiffusionNexus.Tests/Sync/Service/BaseModelWriterTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/BaseModelWriterTests.cs
@@ -1,0 +1,77 @@
+using DiffusionNexus.Domain.Entities;
+using DiffusionNexus.Domain.Enums;
+using DiffusionNexus.Service.Services.Sync;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.Sync.Service;
+
+/// <summary>
+/// Covers <see cref="BaseModelWriter"/> directly — until now it was only exercised indirectly
+/// through <c>IdentifyModelStepTests</c> and <c>SidecarMetadataApplierTests</c>.
+/// </summary>
+public class BaseModelWriterTests
+{
+    private static ModelVersion NewVersion(string? baseModelRaw, bool isUserEdited = false) =>
+        new() { BaseModelRaw = baseModelRaw, IsUserEdited = isUserEdited };
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("???")]
+    public void CanFill_TrueForAPlaceholderThatIsNotUserEdited(string? baseModelRaw)
+    {
+        BaseModelWriter.CanFill(NewVersion(baseModelRaw)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanFill_FalseWhenTheVersionIsUserEdited_EvenIfStillAPlaceholder()
+    {
+        BaseModelWriter.CanFill(NewVersion(null, isUserEdited: true)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void CanFill_FalseWhenARealBaseModelIsAlreadyStored()
+    {
+        BaseModelWriter.CanFill(NewVersion("SDXL 1.0")).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// B3. <c>CanFill</c> hand-wrote the same rule <see cref="SyncStateDeriver.IsPlaceholder"/>
+    /// already states — this pins that the two are literally the same rule, not two copies that
+    /// merely happen to agree today.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("???")]
+    [InlineData("SDXL 1.0")]
+    public void CanFill_AgreesWithIsPlaceholder_ForAVersionThatIsNotUserEdited(string? baseModelRaw)
+    {
+        BaseModelWriter.CanFill(NewVersion(baseModelRaw)).Should().Be(SyncStateDeriver.IsPlaceholder(baseModelRaw));
+    }
+
+    [Fact]
+    public void Write_BlankIsAMissingAnswer_NothingWritten()
+    {
+        var version = NewVersion("Pony");
+        version.BaseModel = BaseModelType.Pony;
+
+        BaseModelWriter.Write(version, "  ").Should().BeFalse();
+
+        version.BaseModelRaw.Should().Be("Pony");
+        version.BaseModel.Should().Be(BaseModelType.Pony);
+    }
+
+    [Fact]
+    public void Write_WritesBothSpellings()
+    {
+        var version = NewVersion(null);
+
+        BaseModelWriter.Write(version, "SDXL 1.0").Should().BeTrue();
+
+        version.BaseModelRaw.Should().Be("SDXL 1.0");
+        version.BaseModel.Should().Be(BaseModelType.SDXL10);
+    }
+}

--- a/DiffusionNexus.Tests/Sync/Service/Identity/BaseModelHeaderMapTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/Identity/BaseModelHeaderMapTests.cs
@@ -1,0 +1,110 @@
+using System.Reflection;
+using DiffusionNexus.Civitai;
+using DiffusionNexus.Service.Services.Sync.Identity;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.Sync.Service.Identity;
+
+/// <summary>
+/// Covers <see cref="BaseModelHeaderMap"/> — the safetensors-header-to-Civitai-label mapping.
+/// Evaluation order (name hint, then architecture, then version prefix) is load-bearing: Pony,
+/// Illustrious and NoobAI are all SDXL-architecture refinements, so a hint match must win over
+/// an architecture match or every Pony LoRA would report as plain "SDXL 1.0".
+/// </summary>
+public class BaseModelHeaderMapTests
+{
+    private static SafetensorsHeaderInfo NameHint(string hint) => new(null, null, hint);
+    private static SafetensorsHeaderInfo Architecture(string architecture) => new(null, architecture, null);
+    private static SafetensorsHeaderInfo Version(string version) => new(version, null, null);
+
+    // --- Rung 1: ss_sd_model_name hint ---
+    [Theory]
+    [InlineData("ponyDiffusionV6XL", "Pony")]
+    [InlineData("SomeIllustriousMix", "Illustrious")]
+    [InlineData("NoobAI-XL-v1", "NoobAI")]
+    public void Map_NameHintRungMapsKnownHints(string hint, string expected)
+    {
+        BaseModelHeaderMap.Map(NameHint(hint)).Should().Be(expected);
+    }
+
+    // --- Rung 2: modelspec.architecture, everything from the first '/' stripped ---
+    [Theory]
+    [InlineData("stable-diffusion-xl-v1-base", "SDXL 1.0")]
+    [InlineData("stable-diffusion-xl-v1-base/lora", "SDXL 1.0")]
+    [InlineData("stable-diffusion-v1", "SD 1.5")]
+    [InlineData("stable-diffusion-v2-768-v", "SD 2.1")]
+    [InlineData("stable-diffusion-v2", "SD 2.0")]
+    [InlineData("stable-diffusion-3-medium", "SD 3")]
+    [InlineData("flux-1-dev", "Flux.1 D")]
+    [InlineData("flux-1-schnell", "Flux.1 S")]
+    public void Map_ArchitectureRungMapsKnownArchitectures(string architecture, string expected)
+    {
+        BaseModelHeaderMap.Map(Architecture(architecture)).Should().Be(expected);
+    }
+
+    // --- Rung 3: ss_base_model_version, lowercase prefix match ---
+    [Theory]
+    [InlineData("sdxl_base_v1-0", "SDXL 1.0")]
+    [InlineData("sdxl_base_v0-9", "SDXL 0.9")]
+    [InlineData("sd_v1", "SD 1.5")]
+    [InlineData("sd_v1_something_else", "SD 1.5")]
+    [InlineData("sd_v2", "SD 2.1")]
+    public void Map_VersionPrefixRungMapsKnownPrefixes(string version, string expected)
+    {
+        BaseModelHeaderMap.Map(Version(version)).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Map_NameHintBeatsArchitecture()
+    {
+        var info = new SafetensorsHeaderInfo(null, "stable-diffusion-xl-v1-base/lora", "ponyDiffusionV6XL");
+
+        BaseModelHeaderMap.Map(info).Should().Be("Pony");
+    }
+
+    [Fact]
+    public void Map_ArchitectureBeatsVersionString()
+    {
+        var info = new SafetensorsHeaderInfo("sd_v1", "flux-1-dev", null);
+
+        BaseModelHeaderMap.Map(info).Should().Be("Flux.1 D");
+    }
+
+    [Fact]
+    public void Map_UnknownEverythingReturnsNull()
+    {
+        var info = new SafetensorsHeaderInfo("totally-unknown", "totally/unknown", "totally unknown");
+
+        BaseModelHeaderMap.Map(info).Should().BeNull();
+    }
+
+    [Fact]
+    public void Map_AllFieldsNullReturnsNull()
+    {
+        var info = new SafetensorsHeaderInfo(null, null, null);
+
+        BaseModelHeaderMap.Map(info).Should().BeNull();
+    }
+
+    /// <summary>
+    /// Reflects over <see cref="CivitaiBaseModelCatalog"/>'s private bundled snapshot (rather than
+    /// duplicating the label list here) and asserts every label the map can ever return is a real
+    /// Civitai display label, not a typo'd string nobody's dropdown recognizes.
+    /// </summary>
+    [Fact]
+    public void Map_EveryOutputIsACatalogLabel()
+    {
+        var bundledSnapshotField = typeof(CivitaiBaseModelCatalog)
+            .GetField("BundledSnapshot", BindingFlags.NonPublic | BindingFlags.Static);
+        bundledSnapshotField.Should().NotBeNull(
+            "CivitaiBaseModelCatalog.BundledSnapshot must exist for this check to mean anything");
+
+        var bundledSnapshot = (IReadOnlyList<string>)bundledSnapshotField!.GetValue(null)!;
+
+        BaseModelHeaderMap.AllLabels.Should().NotBeEmpty();
+        foreach (var label in BaseModelHeaderMap.AllLabels)
+        {
+            bundledSnapshot.Should().Contain(label, $"'{label}' must be a real Civitai base-model label");
+        }
+    }
+}

--- a/DiffusionNexus.Tests/Sync/Service/Identity/BaseModelHeaderMapTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/Identity/BaseModelHeaderMapTests.cs
@@ -27,6 +27,34 @@ public class BaseModelHeaderMapTests
         BaseModelHeaderMap.Map(NameHint(hint)).Should().Be(expected);
     }
 
+    // --- A5: kohya writes a full PATH into ss_sd_model_name, not a bare file name — only the
+    // file-name portion (extension dropped) may be needle-matched, or a directory segment like
+    // "...\noobs\base.safetensors" decides the answer instead of the actual base model. ---
+    [Theory]
+    [InlineData("E:/checkpoints/noobs/base.safetensors")]
+    [InlineData(@"E:\checkpoints\noobs\base.safetensors")]
+    public void Map_NameHintRungIgnoresDirectorySegments(string hint)
+    {
+        BaseModelHeaderMap.Map(NameHint(hint)).Should().BeNull();
+    }
+
+    [Fact]
+    public void Map_NameHintRungPathDirectorySegmentFallsThroughToArchitecture()
+    {
+        var info = new SafetensorsHeaderInfo(null, "stable-diffusion-xl-v1-base", @"C:\models\ponys\base.safetensors");
+
+        BaseModelHeaderMap.Map(info).Should().Be("SDXL 1.0");
+    }
+
+    [Theory]
+    [InlineData("ponyDiffusionV6XL")]
+    [InlineData(@"E:\Models\Lora\ponyDiffusionV6XL.safetensors")]
+    [InlineData("E:/Models/Lora/ponyDiffusionV6XL.safetensors")]
+    public void Map_NameHintRungMatchesFileNamePortionRegardlessOfPathStyle(string hint)
+    {
+        BaseModelHeaderMap.Map(NameHint(hint)).Should().Be("Pony");
+    }
+
     // --- Rung 2: modelspec.architecture, everything from the first '/' stripped ---
     [Theory]
     [InlineData("stable-diffusion-xl-v1-base", "SDXL 1.0")]

--- a/DiffusionNexus.Tests/Sync/Service/Identity/BaseModelHeaderMapTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/Identity/BaseModelHeaderMapTests.cs
@@ -1,5 +1,3 @@
-using System.Reflection;
-using DiffusionNexus.Civitai;
 using DiffusionNexus.Service.Services.Sync.Identity;
 using FluentAssertions;
 
@@ -115,19 +113,15 @@ public class BaseModelHeaderMapTests
     }
 
     /// <summary>
-    /// Reflects over <see cref="CivitaiBaseModelCatalog"/>'s private bundled snapshot (rather than
-    /// duplicating the label list here) and asserts every label the map can ever return is a real
-    /// Civitai display label, not a typo'd string nobody's dropdown recognizes.
+    /// Reflects over <see cref="DiffusionNexus.Civitai.CivitaiBaseModelCatalog"/>'s private bundled
+    /// snapshot (via <see cref="SafetensorsFixture.CatalogLabels"/>, rather than duplicating the
+    /// label list here) and asserts every label the map can ever return is a real Civitai display
+    /// label, not a typo'd string nobody's dropdown recognizes.
     /// </summary>
     [Fact]
     public void Map_EveryOutputIsACatalogLabel()
     {
-        var bundledSnapshotField = typeof(CivitaiBaseModelCatalog)
-            .GetField("BundledSnapshot", BindingFlags.NonPublic | BindingFlags.Static);
-        bundledSnapshotField.Should().NotBeNull(
-            "CivitaiBaseModelCatalog.BundledSnapshot must exist for this check to mean anything");
-
-        var bundledSnapshot = (IReadOnlyList<string>)bundledSnapshotField!.GetValue(null)!;
+        var bundledSnapshot = SafetensorsFixture.CatalogLabels;
 
         BaseModelHeaderMap.AllLabels.Should().NotBeEmpty();
         foreach (var label in BaseModelHeaderMap.AllLabels)

--- a/DiffusionNexus.Tests/Sync/Service/Identity/FilenameBaseModelHeuristicTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/Identity/FilenameBaseModelHeuristicTests.cs
@@ -1,0 +1,48 @@
+using DiffusionNexus.Service.Services.Sync.Identity;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.Sync.Service.Identity;
+
+/// <summary>
+/// Covers <see cref="FilenameBaseModelHeuristic"/> — guessing a Civitai base-model label from a
+/// model file name when no header/sidecar metadata is available. Match order is most-specific
+/// first (whole-name substring, then exact token/pair, then token prefix) so short, common
+/// fragments like "il" or "wan" can't false-positive inside longer unrelated words.
+/// </summary>
+public class FilenameBaseModelHeuristicTests
+{
+    [Theory]
+    [InlineData("MyChar_Pony_v2", "Pony")]
+    [InlineData("ponyxl-style", "Pony")]
+    [InlineData("sdxl_lineart", "SDXL 1.0")]
+    [InlineData("myIllustriousMix", "Illustrious")]
+    [InlineData("style-il", "Illustrious")]
+    [InlineData("detailer_sd15", "SD 1.5")]
+    [InlineData("detailer_sd1.5", "SD 1.5")]
+    [InlineData("wan21_motion", "Wan Video")]
+    [InlineData("flux_dev_char", "Flux.1 D")]
+    [InlineData("noob_artist", "NoobAI")]
+    [InlineData("harmony_lora", null)]       // 'pony' inside a token must NOT match
+    [InlineData("wander_style", null)]       // 'wan' prefix of a longer token must NOT match
+    [InlineData("family_car", null)]         // 'il' inside a token must NOT match
+    [InlineData("mySd150Style", null)]       // 'sd15' inside a longer merged token must NOT match
+    [InlineData("", null)]
+    [InlineData(null, null)]
+    public void Guess_MatchesExpectedLabel(string? fileName, string? expected)
+    {
+        FilenameBaseModelHeuristic.Guess(fileName).Should().Be(expected);
+    }
+
+    // Ruling 1: extension stripping only fires for a KNOWN model-file extension, so
+    // "detailer_sd1.5" above (no recognized extension) is tokenized whole rather than having its
+    // ".5" eaten by a blind Path.GetFileNameWithoutExtension call. These confirm the real-file
+    // path still strips a genuine extension correctly.
+    [Theory]
+    [InlineData("ponyDiffusionV6XL.safetensors", "Pony")]
+    [InlineData("detailer_sd15.pt", "SD 1.5")]
+    [InlineData("noob_artist.ckpt", "NoobAI")]
+    public void Guess_StripsKnownModelExtensionsBeforeMatching(string fileName, string expected)
+    {
+        FilenameBaseModelHeuristic.Guess(fileName).Should().Be(expected);
+    }
+}

--- a/DiffusionNexus.Tests/Sync/Service/Identity/FilenameBaseModelHeuristicTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/Identity/FilenameBaseModelHeuristicTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using DiffusionNexus.Civitai;
 using DiffusionNexus.Service.Services.Sync.Identity;
 using FluentAssertions;
 
@@ -28,6 +30,7 @@ public class FilenameBaseModelHeuristicTests
     [InlineData("mySd150Style", null)]       // 'sd15' inside a longer merged token must NOT match
     [InlineData("", null)]
     [InlineData(null, null)]
+    [InlineData(".safetensors", null)]       // extension-only filename must not crash or match
     public void Guess_MatchesExpectedLabel(string? fileName, string? expected)
     {
         FilenameBaseModelHeuristic.Guess(fileName).Should().Be(expected);
@@ -44,5 +47,29 @@ public class FilenameBaseModelHeuristicTests
     public void Guess_StripsKnownModelExtensionsBeforeMatching(string fileName, string expected)
     {
         FilenameBaseModelHeuristic.Guess(fileName).Should().Be(expected);
+    }
+
+    /// <summary>
+    /// Reflects over <see cref="CivitaiBaseModelCatalog"/>'s private bundled snapshot (rather than
+    /// duplicating the label list here) and asserts every label the heuristic can ever return is a
+    /// real Civitai display label, not a typo'd string nobody's dropdown recognizes. Mirrors
+    /// <c>BaseModelHeaderMapTests.Map_EveryOutputIsACatalogLabel</c> so a future catalog edit can't
+    /// silently orphan a heuristic label either.
+    /// </summary>
+    [Fact]
+    public void Guess_EveryOutputIsACatalogLabel()
+    {
+        var bundledSnapshotField = typeof(CivitaiBaseModelCatalog)
+            .GetField("BundledSnapshot", BindingFlags.NonPublic | BindingFlags.Static);
+        bundledSnapshotField.Should().NotBeNull(
+            "CivitaiBaseModelCatalog.BundledSnapshot must exist for this check to mean anything");
+
+        var bundledSnapshot = (IReadOnlyList<string>)bundledSnapshotField!.GetValue(null)!;
+
+        FilenameBaseModelHeuristic.AllLabels.Should().NotBeEmpty();
+        foreach (var label in FilenameBaseModelHeuristic.AllLabels)
+        {
+            bundledSnapshot.Should().Contain(label, $"'{label}' must be a real Civitai base-model label");
+        }
     }
 }

--- a/DiffusionNexus.Tests/Sync/Service/Identity/FilenameBaseModelHeuristicTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/Identity/FilenameBaseModelHeuristicTests.cs
@@ -8,8 +8,10 @@ namespace DiffusionNexus.Tests.Sync.Service.Identity;
 /// <summary>
 /// Covers <see cref="FilenameBaseModelHeuristic"/> — guessing a Civitai base-model label from a
 /// model file name when no header/sidecar metadata is available. Match order is most-specific
-/// first (whole-name substring, then exact token/pair, then token prefix) so short, common
-/// fragments like "il" or "wan" can't false-positive inside longer unrelated words.
+/// first, with refinement names (Pony/Illustrious/NoobAI) checked before the generic "sdxl"
+/// substring so a name carrying both (e.g. a Pony LoRA) labels as the refinement, then exact
+/// token/pair, then token prefix — so short, common fragments like "il" or "wan" can't
+/// false-positive inside longer unrelated words.
 /// </summary>
 public class FilenameBaseModelHeuristicTests
 {
@@ -24,6 +26,8 @@ public class FilenameBaseModelHeuristicTests
     [InlineData("wan21_motion", "Wan Video")]
     [InlineData("flux_dev_char", "Flux.1 D")]
     [InlineData("noob_artist", "NoobAI")]
+    [InlineData("stylemix_pony_sdxl_v1", "Pony")]    // refinement must beat the generic "sdxl" substring
+    [InlineData("noob_sdxl_mix", "NoobAI")]          // same principle for the NoobAI refinement
     [InlineData("harmony_lora", null)]       // 'pony' inside a token must NOT match
     [InlineData("wander_style", null)]       // 'wan' prefix of a longer token must NOT match
     [InlineData("family_car", null)]         // 'il' inside a token must NOT match

--- a/DiffusionNexus.Tests/Sync/Service/Identity/FilenameBaseModelHeuristicTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/Identity/FilenameBaseModelHeuristicTests.cs
@@ -10,8 +10,12 @@ namespace DiffusionNexus.Tests.Sync.Service.Identity;
 /// model file name when no header/sidecar metadata is available. Match order is most-specific
 /// first, with refinement names (Pony/Illustrious/NoobAI) checked before the generic "sdxl"
 /// substring so a name carrying both (e.g. a Pony LoRA) labels as the refinement, then exact
-/// token/pair, then token prefix — so short, common fragments like "il" or "wan" can't
-/// false-positive inside longer unrelated words.
+/// token/pair/triple (longest key first), then token prefix. The refinement rung itself is an
+/// exact-token set plus a "prefix + version/XL-decoration-only remainder" rule — never a raw
+/// prefix match — so common English words that merely start the same way ("ponytail",
+/// "illustration", "noobie") can't false-positive. "wan"/"wan21"/"wan22" aren't recognized at
+/// all: "Wan Video" can't round-trip through <c>BaseModelType</c>, and "wan" collides with
+/// Star Wars character names ("obi_wan_kenobi").
 /// </summary>
 public class FilenameBaseModelHeuristicTests
 {
@@ -23,15 +27,26 @@ public class FilenameBaseModelHeuristicTests
     [InlineData("style-il", "Illustrious")]
     [InlineData("detailer_sd15", "SD 1.5")]
     [InlineData("detailer_sd1.5", "SD 1.5")]
-    [InlineData("wan21_motion", "Wan Video")]
     [InlineData("flux_dev_char", "Flux.1 D")]
     [InlineData("noob_artist", "NoobAI")]
     [InlineData("stylemix_pony_sdxl_v1", "Pony")]    // refinement must beat the generic "sdxl" substring
     [InlineData("noob_sdxl_mix", "NoobAI")]          // same principle for the NoobAI refinement
-    [InlineData("harmony_lora", null)]       // 'pony' inside a token must NOT match
-    [InlineData("wander_style", null)]       // 'wan' prefix of a longer token must NOT match
-    [InlineData("family_car", null)]         // 'il' inside a token must NOT match
+    [InlineData("mystyle_il_sdxl", "Illustrious")]   // A4: "il" refinement must beat the generic "sdxl" substring too
+    [InlineData("style_sd3.5", "SD 3.5")]            // A2: the finer "sd35" pair/triple must beat the coarser "sd3" token
+    [InlineData("sd_3.5_lora", "SD 3.5")]            // A2: same, with every separator splitting the version apart
+    [InlineData("ponyv6_style", "Pony")]             // A1: unseen version spelling via prefix + decoration-only remainder
+    [InlineData("ponyv6xl", "Pony")]                 // A1: decoration remainder can carry both a version AND "xl"
+    [InlineData("harmony_lora", null)]       // 'pony' inside a token (not a prefix) must NOT match
+    [InlineData("wander_style", null)]       // no "wan" key exists at all anymore (A3) — must NOT match
+    [InlineData("family_car", null)]         // 'il' is an exact-token match only; must NOT match inside another token
     [InlineData("mySd150Style", null)]       // 'sd15' inside a longer merged token must NOT match
+    [InlineData("ponytail_v1", null)]        // A1: "pony" prefix with a non-decoration remainder must NOT match
+    [InlineData("long_ponytail", null)]      // A1: same, "ponytail" mid-word
+    [InlineData("anime_illustration_v2", null)]  // A1: "illust" prefix with a non-decoration remainder must NOT match
+    [InlineData("illustration_style", null)]     // A1: same
+    [InlineData("noobie_lora", null)]        // A1: "noob" prefix with a non-decoration remainder must NOT match
+    [InlineData("obi_wan_kenobi", null)]     // A3: "wan" is a Star Wars-character false-positive magnet, key removed entirely
+    [InlineData("wan21_motion", null)]       // A3: "Wan Video" can't round-trip through BaseModelType, key removed entirely
     [InlineData("", null)]
     [InlineData(null, null)]
     [InlineData(".safetensors", null)]       // extension-only filename must not crash or match

--- a/DiffusionNexus.Tests/Sync/Service/Identity/FilenameBaseModelHeuristicTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/Identity/FilenameBaseModelHeuristicTests.cs
@@ -1,5 +1,3 @@
-using System.Reflection;
-using DiffusionNexus.Civitai;
 using DiffusionNexus.Service.Services.Sync.Identity;
 using FluentAssertions;
 
@@ -69,21 +67,17 @@ public class FilenameBaseModelHeuristicTests
     }
 
     /// <summary>
-    /// Reflects over <see cref="CivitaiBaseModelCatalog"/>'s private bundled snapshot (rather than
-    /// duplicating the label list here) and asserts every label the heuristic can ever return is a
-    /// real Civitai display label, not a typo'd string nobody's dropdown recognizes. Mirrors
+    /// Reflects over <see cref="DiffusionNexus.Civitai.CivitaiBaseModelCatalog"/>'s private bundled
+    /// snapshot (via <see cref="SafetensorsFixture.CatalogLabels"/>, rather than duplicating the
+    /// label list here) and asserts every label the heuristic can ever return is a real Civitai
+    /// display label, not a typo'd string nobody's dropdown recognizes. Mirrors
     /// <c>BaseModelHeaderMapTests.Map_EveryOutputIsACatalogLabel</c> so a future catalog edit can't
     /// silently orphan a heuristic label either.
     /// </summary>
     [Fact]
     public void Guess_EveryOutputIsACatalogLabel()
     {
-        var bundledSnapshotField = typeof(CivitaiBaseModelCatalog)
-            .GetField("BundledSnapshot", BindingFlags.NonPublic | BindingFlags.Static);
-        bundledSnapshotField.Should().NotBeNull(
-            "CivitaiBaseModelCatalog.BundledSnapshot must exist for this check to mean anything");
-
-        var bundledSnapshot = (IReadOnlyList<string>)bundledSnapshotField!.GetValue(null)!;
+        var bundledSnapshot = SafetensorsFixture.CatalogLabels;
 
         FilenameBaseModelHeuristic.AllLabels.Should().NotBeEmpty();
         foreach (var label in FilenameBaseModelHeuristic.AllLabels)

--- a/DiffusionNexus.Tests/Sync/Service/Identity/SafetensorsFixture.cs
+++ b/DiffusionNexus.Tests/Sync/Service/Identity/SafetensorsFixture.cs
@@ -1,0 +1,57 @@
+using System.Buffers.Binary;
+using System.Reflection;
+using System.Text;
+using DiffusionNexus.Civitai;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.Sync.Service.Identity;
+
+/// <summary>
+/// Shared byte-layout builders for every suite that exercises the safetensors identity chain —
+/// <c>SafetensorsHeaderReaderTests</c>, <c>BaseModelHeaderMapTests</c>,
+/// <c>FilenameBaseModelHeuristicTests</c>, and <c>IdentifyModelStepTests</c> — plus the reflection
+/// accessor onto <see cref="CivitaiBaseModelCatalog"/>'s bundled snapshot two of them use. The
+/// safetensors byte layout is exactly the thing that must not drift between suites, so it is built
+/// in one place instead of copy-pasted into four.
+/// </summary>
+public static class SafetensorsFixture
+{
+    /// <summary>
+    /// Builds a minimal real safetensors byte layout: an 8-byte little-endian header length, the
+    /// header JSON itself, then a few trailing bytes standing in for tensor data.
+    /// </summary>
+    public static byte[] Safetensors(string headerJson, int trailingTensorBytes = 16)
+    {
+        var json = Encoding.UTF8.GetBytes(headerJson);
+        var buffer = new byte[8 + json.Length + trailingTensorBytes];
+        BinaryPrimitives.WriteUInt64LittleEndian(buffer, (ulong)json.Length);
+        json.CopyTo(buffer, 8);
+        return buffer;   // trailing zeros stand in for tensor data
+    }
+
+    // A raw-string interpolation of this shape (adjacent literal brace immediately touching the
+    // hole delimiter, twice) cannot be made to compile at any $ count: the literal `{`/`}` next
+    // to the hole always merges into one run that either collides with the delimiter count or
+    // exceeds it (CS9007). Plain concatenation produces byte-identical JSON without the ambiguity.
+    public static string Meta(params (string Key, string Value)[] pairs) =>
+        "{\"__metadata__\":{" + string.Join(",", pairs.Select(p => $"\"{p.Key}\":\"{p.Value}\"")) +
+        "},\"tensor.weight\":{\"dtype\":\"F16\",\"shape\":[4],\"data_offsets\":[0,8]}}";
+
+    /// <summary>
+    /// <see cref="CivitaiBaseModelCatalog"/>'s private bundled label snapshot, reflected once here
+    /// instead of duplicated per suite — backs the "every output is a real Civitai label" assertion
+    /// in <c>BaseModelHeaderMapTests</c> and <c>FilenameBaseModelHeuristicTests</c>.
+    /// </summary>
+    public static IReadOnlyList<string> CatalogLabels
+    {
+        get
+        {
+            var bundledSnapshotField = typeof(CivitaiBaseModelCatalog)
+                .GetField("BundledSnapshot", BindingFlags.NonPublic | BindingFlags.Static);
+            bundledSnapshotField.Should().NotBeNull(
+                "CivitaiBaseModelCatalog.BundledSnapshot must exist for this check to mean anything");
+
+            return (IReadOnlyList<string>)bundledSnapshotField!.GetValue(null)!;
+        }
+    }
+}

--- a/DiffusionNexus.Tests/Sync/Service/Identity/SafetensorsHeaderReaderTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/Identity/SafetensorsHeaderReaderTests.cs
@@ -1,0 +1,131 @@
+using System.Buffers.Binary;
+using System.Text;
+using DiffusionNexus.Service.Services.Sync.Identity;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.Sync.Service.Identity;
+
+/// <summary>
+/// Covers <see cref="SafetensorsHeaderReader"/> — the exact-path, never-throws safetensors
+/// JSON-header probe later tasks use to identify a model's base model from the file itself.
+/// </summary>
+public class SafetensorsHeaderReaderTests : IDisposable
+{
+    private readonly string _dir = Directory.CreateDirectory(
+        Path.Combine(Path.GetTempPath(), "dn-shr-" + Guid.NewGuid().ToString("N"))).FullName;
+
+    public void Dispose() { try { Directory.Delete(_dir, true); } catch { } }
+
+    private static byte[] Safetensors(string headerJson, int trailingTensorBytes = 16)
+    {
+        var json = Encoding.UTF8.GetBytes(headerJson);
+        var buffer = new byte[8 + json.Length + trailingTensorBytes];
+        BinaryPrimitives.WriteUInt64LittleEndian(buffer, (ulong)json.Length);
+        json.CopyTo(buffer, 8);
+        return buffer;   // trailing zeros stand in for tensor data
+    }
+
+    // A raw-string interpolation of this shape (adjacent literal brace immediately touching the
+    // hole delimiter, twice) cannot be made to compile at any $ count: the literal `{`/`}` next
+    // to the hole always merges into one run that either collides with the delimiter count or
+    // exceeds it (CS9007). Plain concatenation produces byte-identical JSON without the ambiguity.
+    private static string Meta(params (string Key, string Value)[] pairs) =>
+        "{\"__metadata__\":{" + string.Join(",", pairs.Select(p => $"\"{p.Key}\":\"{p.Value}\"")) +
+        "},\"tensor.weight\":{\"dtype\":\"F16\",\"shape\":[4],\"data_offsets\":[0,8]}}";
+
+    private string WriteFile(string name, byte[] bytes)
+    {
+        var path = Path.Combine(_dir, name);
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+
+    [Fact]
+    public void TryRead_ExtractsTheThreeMetadataKeys()
+    {
+        var bytes = Safetensors(Meta(
+            ("ss_base_model_version", "sdxl_base_v1-0"),
+            ("modelspec.architecture", "stable-diffusion-xl-v1-base/lora"),
+            ("ss_sd_model_name", "ponyDiffusionV6XL")));
+        var path = WriteFile("model.safetensors", bytes);
+
+        var info = SafetensorsHeaderReader.TryRead(path);
+
+        info.Should().NotBeNull();
+        info!.BaseModelVersion.Should().Be("sdxl_base_v1-0");
+        info.Architecture.Should().Be("stable-diffusion-xl-v1-base/lora");
+        info.ModelNameHint.Should().Be("ponyDiffusionV6XL");
+    }
+
+    [Fact]
+    public void TryRead_HeaderWithoutMetadataBlockIsASuccessfulEmptyRead()
+    {
+        var bytes = Safetensors("""{"tensor.weight":{"dtype":"F16","shape":[4],"data_offsets":[0,8]}}""");
+        var path = WriteFile("nometa.safetensors", bytes);
+
+        var info = SafetensorsHeaderReader.TryRead(path);
+
+        info.Should().NotBeNull();
+        info!.BaseModelVersion.Should().BeNull();
+        info.Architecture.Should().BeNull();
+        info.ModelNameHint.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryRead_TruncatedFileReturnsNull()
+    {
+        var buffer = new byte[40];
+        BinaryPrimitives.WriteUInt64LittleEndian(buffer, 500UL);
+        var path = WriteFile("truncated.safetensors", buffer);
+
+        SafetensorsHeaderReader.TryRead(path).Should().BeNull();
+    }
+
+    [Fact]
+    public void TryRead_OversizedHeaderReturnsNull()
+    {
+        var buffer = new byte[16];
+        BinaryPrimitives.WriteUInt64LittleEndian(buffer, (ulong)(SafetensorsHeaderReader.MaxHeaderBytes + 1));
+        var path = WriteFile("oversized.safetensors", buffer);
+
+        SafetensorsHeaderReader.TryRead(path).Should().BeNull();
+    }
+
+    [Fact]
+    public void TryRead_GarbageJsonReturnsNull()
+    {
+        var bytes = Safetensors("not json{{");
+        var path = WriteFile("garbage.safetensors", bytes);
+
+        SafetensorsHeaderReader.TryRead(path).Should().BeNull();
+    }
+
+    [Fact]
+    public void TryRead_WrongExtensionReturnsNull()
+    {
+        var bytes = Safetensors(Meta(
+            ("ss_base_model_version", "sdxl_base_v1-0"),
+            ("modelspec.architecture", "stable-diffusion-xl-v1-base/lora"),
+            ("ss_sd_model_name", "ponyDiffusionV6XL")));
+        var path = WriteFile("model.ckpt", bytes);
+
+        SafetensorsHeaderReader.TryRead(path).Should().BeNull();
+    }
+
+    [Fact]
+    public void TryRead_MissingFileReturnsNull()
+    {
+        var path = Path.Combine(_dir, "gone.safetensors");
+
+        SafetensorsHeaderReader.TryRead(path).Should().BeNull();
+    }
+
+    [Fact]
+    public void TryRead_EmptyLengthReturnsNull()
+    {
+        var buffer = new byte[8];
+        var path = WriteFile("empty.safetensors", buffer);
+
+        SafetensorsHeaderReader.TryRead(path).Should().BeNull();
+    }
+}

--- a/DiffusionNexus.Tests/Sync/Service/Identity/SafetensorsHeaderReaderTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/Identity/SafetensorsHeaderReaderTests.cs
@@ -41,7 +41,7 @@ public class SafetensorsHeaderReaderTests : IDisposable
     }
 
     [Fact]
-    public void TryRead_ExtractsTheThreeMetadataKeys()
+    public async Task TryReadAsync_ExtractsTheThreeMetadataKeys()
     {
         var bytes = Safetensors(Meta(
             ("ss_base_model_version", "sdxl_base_v1-0"),
@@ -49,7 +49,7 @@ public class SafetensorsHeaderReaderTests : IDisposable
             ("ss_sd_model_name", "ponyDiffusionV6XL")));
         var path = WriteFile("model.safetensors", bytes);
 
-        var info = SafetensorsHeaderReader.TryRead(path);
+        var info = await SafetensorsHeaderReader.TryReadAsync(path);
 
         info.Should().NotBeNull();
         info!.BaseModelVersion.Should().Be("sdxl_base_v1-0");
@@ -64,7 +64,7 @@ public class SafetensorsHeaderReaderTests : IDisposable
     /// extension must not fall through to the filename guess.
     /// </summary>
     [Fact]
-    public void TryRead_SftExtensionExtractsTheThreeMetadataKeys()
+    public async Task TryReadAsync_SftExtensionExtractsTheThreeMetadataKeys()
     {
         var bytes = Safetensors(Meta(
             ("ss_base_model_version", "sdxl_base_v1-0"),
@@ -72,7 +72,7 @@ public class SafetensorsHeaderReaderTests : IDisposable
             ("ss_sd_model_name", "ponyDiffusionV6XL")));
         var path = WriteFile("model.sft", bytes);
 
-        var info = SafetensorsHeaderReader.TryRead(path);
+        var info = await SafetensorsHeaderReader.TryReadAsync(path);
 
         info.Should().NotBeNull();
         info!.BaseModelVersion.Should().Be("sdxl_base_v1-0");
@@ -81,12 +81,12 @@ public class SafetensorsHeaderReaderTests : IDisposable
     }
 
     [Fact]
-    public void TryRead_HeaderWithoutMetadataBlockIsASuccessfulEmptyRead()
+    public async Task TryReadAsync_HeaderWithoutMetadataBlockIsASuccessfulEmptyRead()
     {
         var bytes = Safetensors("""{"tensor.weight":{"dtype":"F16","shape":[4],"data_offsets":[0,8]}}""");
         var path = WriteFile("nometa.safetensors", bytes);
 
-        var info = SafetensorsHeaderReader.TryRead(path);
+        var info = await SafetensorsHeaderReader.TryReadAsync(path);
 
         info.Should().NotBeNull();
         info!.BaseModelVersion.Should().BeNull();
@@ -95,36 +95,36 @@ public class SafetensorsHeaderReaderTests : IDisposable
     }
 
     [Fact]
-    public void TryRead_TruncatedFileReturnsNull()
+    public async Task TryReadAsync_TruncatedFileReturnsNull()
     {
         var buffer = new byte[40];
         BinaryPrimitives.WriteUInt64LittleEndian(buffer, 500UL);
         var path = WriteFile("truncated.safetensors", buffer);
 
-        SafetensorsHeaderReader.TryRead(path).Should().BeNull();
+        (await SafetensorsHeaderReader.TryReadAsync(path)).Should().BeNull();
     }
 
     [Fact]
-    public void TryRead_OversizedHeaderReturnsNull()
+    public async Task TryReadAsync_OversizedHeaderReturnsNull()
     {
         var buffer = new byte[16];
         BinaryPrimitives.WriteUInt64LittleEndian(buffer, (ulong)(SafetensorsHeaderReader.MaxHeaderBytes + 1));
         var path = WriteFile("oversized.safetensors", buffer);
 
-        SafetensorsHeaderReader.TryRead(path).Should().BeNull();
+        (await SafetensorsHeaderReader.TryReadAsync(path)).Should().BeNull();
     }
 
     [Fact]
-    public void TryRead_GarbageJsonReturnsNull()
+    public async Task TryReadAsync_GarbageJsonReturnsNull()
     {
         var bytes = Safetensors("not json{{");
         var path = WriteFile("garbage.safetensors", bytes);
 
-        SafetensorsHeaderReader.TryRead(path).Should().BeNull();
+        (await SafetensorsHeaderReader.TryReadAsync(path)).Should().BeNull();
     }
 
     [Fact]
-    public void TryRead_WrongExtensionReturnsNull()
+    public async Task TryReadAsync_WrongExtensionReturnsNull()
     {
         var bytes = Safetensors(Meta(
             ("ss_base_model_version", "sdxl_base_v1-0"),
@@ -132,23 +132,42 @@ public class SafetensorsHeaderReaderTests : IDisposable
             ("ss_sd_model_name", "ponyDiffusionV6XL")));
         var path = WriteFile("model.ckpt", bytes);
 
-        SafetensorsHeaderReader.TryRead(path).Should().BeNull();
+        (await SafetensorsHeaderReader.TryReadAsync(path)).Should().BeNull();
     }
 
     [Fact]
-    public void TryRead_MissingFileReturnsNull()
+    public async Task TryReadAsync_MissingFileReturnsNull()
     {
         var path = Path.Combine(_dir, "gone.safetensors");
 
-        SafetensorsHeaderReader.TryRead(path).Should().BeNull();
+        (await SafetensorsHeaderReader.TryReadAsync(path)).Should().BeNull();
     }
 
     [Fact]
-    public void TryRead_EmptyLengthReturnsNull()
+    public async Task TryReadAsync_EmptyLengthReturnsNull()
     {
         var buffer = new byte[8];
         var path = WriteFile("empty.safetensors", buffer);
 
-        SafetensorsHeaderReader.TryRead(path).Should().BeNull();
+        (await SafetensorsHeaderReader.TryReadAsync(path)).Should().BeNull();
+    }
+
+    /// <summary>
+    /// B2. A cancellation must surface as <see cref="OperationCanceledException"/> rather than being
+    /// swallowed into <c>null</c> by the catch-all — the identify step needs to tell "cancelled" apart
+    /// from "unreadable".
+    /// </summary>
+    [Fact]
+    public async Task TryReadAsync_CancellationPropagates()
+    {
+        var bytes = Safetensors(Meta(("ss_base_model_version", "sdxl_base_v1-0")));
+        var path = WriteFile("cancelled.safetensors", bytes);
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await FluentActions
+            .Awaiting(() => SafetensorsHeaderReader.TryReadAsync(path, cts.Token))
+            .Should().ThrowAsync<OperationCanceledException>("a cancelled read is not an unreadable file");
     }
 }

--- a/DiffusionNexus.Tests/Sync/Service/Identity/SafetensorsHeaderReaderTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/Identity/SafetensorsHeaderReaderTests.cs
@@ -1,7 +1,7 @@
 using System.Buffers.Binary;
-using System.Text;
 using DiffusionNexus.Service.Services.Sync.Identity;
 using FluentAssertions;
+using static DiffusionNexus.Tests.Sync.Service.Identity.SafetensorsFixture;
 
 namespace DiffusionNexus.Tests.Sync.Service.Identity;
 
@@ -15,23 +15,6 @@ public class SafetensorsHeaderReaderTests : IDisposable
         Path.Combine(Path.GetTempPath(), "dn-shr-" + Guid.NewGuid().ToString("N"))).FullName;
 
     public void Dispose() { try { Directory.Delete(_dir, true); } catch { } }
-
-    private static byte[] Safetensors(string headerJson, int trailingTensorBytes = 16)
-    {
-        var json = Encoding.UTF8.GetBytes(headerJson);
-        var buffer = new byte[8 + json.Length + trailingTensorBytes];
-        BinaryPrimitives.WriteUInt64LittleEndian(buffer, (ulong)json.Length);
-        json.CopyTo(buffer, 8);
-        return buffer;   // trailing zeros stand in for tensor data
-    }
-
-    // A raw-string interpolation of this shape (adjacent literal brace immediately touching the
-    // hole delimiter, twice) cannot be made to compile at any $ count: the literal `{`/`}` next
-    // to the hole always merges into one run that either collides with the delimiter count or
-    // exceeds it (CS9007). Plain concatenation produces byte-identical JSON without the ambiguity.
-    private static string Meta(params (string Key, string Value)[] pairs) =>
-        "{\"__metadata__\":{" + string.Join(",", pairs.Select(p => $"\"{p.Key}\":\"{p.Value}\"")) +
-        "},\"tensor.weight\":{\"dtype\":\"F16\",\"shape\":[4],\"data_offsets\":[0,8]}}";
 
     private string WriteFile(string name, byte[] bytes)
     {

--- a/DiffusionNexus.Tests/Sync/Service/Identity/SafetensorsHeaderReaderTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/Identity/SafetensorsHeaderReaderTests.cs
@@ -57,6 +57,29 @@ public class SafetensorsHeaderReaderTests : IDisposable
         info.ModelNameHint.Should().Be("ponyDiffusionV6XL");
     }
 
+    /// <summary>
+    /// B1. <c>.sft</c> is the standard short alias for the same container —
+    /// <see cref="DiffusionNexus.Service.Services.Sync.Identity.FilenameBaseModelHeuristic"/>'s own
+    /// known-model-extension list already treats it as one — so a readable header under that
+    /// extension must not fall through to the filename guess.
+    /// </summary>
+    [Fact]
+    public void TryRead_SftExtensionExtractsTheThreeMetadataKeys()
+    {
+        var bytes = Safetensors(Meta(
+            ("ss_base_model_version", "sdxl_base_v1-0"),
+            ("modelspec.architecture", "stable-diffusion-xl-v1-base/lora"),
+            ("ss_sd_model_name", "ponyDiffusionV6XL")));
+        var path = WriteFile("model.sft", bytes);
+
+        var info = SafetensorsHeaderReader.TryRead(path);
+
+        info.Should().NotBeNull();
+        info!.BaseModelVersion.Should().Be("sdxl_base_v1-0");
+        info.Architecture.Should().Be("stable-diffusion-xl-v1-base/lora");
+        info.ModelNameHint.Should().Be("ponyDiffusionV6XL");
+    }
+
     [Fact]
     public void TryRead_HeaderWithoutMetadataBlockIsASuccessfulEmptyRead()
     {

--- a/DiffusionNexus.Tests/Sync/Service/Steps/IdentifyModelStepTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/Steps/IdentifyModelStepTests.cs
@@ -545,6 +545,13 @@ public sealed class IdentifyModelStepTests : IDisposable
         saved!.Versions.Single().BaseModelRaw.Should().Be("SDXL 1.0");
         saved.Versions.Single().BaseModel.Should().Be(BaseModelType.SDXL10);
 
+        // C2: the write landed, so the model is stamped exactly like the sidecar branch stamps it —
+        // no longer "never synced" to anything that reads LastSyncedAt (TileGroupingHelper's tile
+        // ordering among them). Compared against the stamp the step actually wrote (its wall clock,
+        // ExecuteOneAsync's own `now`), not the fixture's fixed `Now` used only for due-ness.
+        saved.Source.Should().Be(DataSource.LocalFile);
+        saved.LastSyncedAt.Should().Be(state.MetadataCheckedAt);
+
         // Stamped at Now like everything else — the same run's clock is not due again immediately.
         var again = await step.SelectAsync(SyncScope.Library, Options(), Now, CancellationToken.None);
         again.Select(i => i.ModelId).Should().NotContain(modelId);
@@ -611,6 +618,9 @@ public sealed class IdentifyModelStepTests : IDisposable
         var readUow = readScope.ServiceProvider.GetRequiredService<IUnitOfWork>();
         var saved = await readUow.Models.GetByIdWithIncludesAsync(modelId);
         saved!.Versions.Single().BaseModelRaw.Should().Be("Flux.1 D");
+
+        // C2: no write, no sync stamp either.
+        saved.LastSyncedAt.Should().BeNull();
     }
 
     /// <summary>
@@ -775,6 +785,10 @@ public sealed class IdentifyModelStepTests : IDisposable
         var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
         var saved = await uow.Models.GetByIdWithIncludesAsync(modelId);
         saved!.Versions.Single().BaseModelRaw.Should().Be("Pony");
+
+        // C2: the heuristic rung's write is stamped exactly like the header rung's.
+        saved.Source.Should().Be(DataSource.LocalFile);
+        saved.LastSyncedAt.Should().Be(state.MetadataCheckedAt);
     }
 
     /// <summary>
@@ -823,6 +837,9 @@ public sealed class IdentifyModelStepTests : IDisposable
         var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
         var saved = await uow.Models.GetByIdWithIncludesAsync(modelId);
         saved!.Versions.Single().BaseModelRaw.Should().Be("???", "nothing in the chain identified it");
+
+        // C2: nothing was written, so the model must not be stamped as synced either.
+        saved.LastSyncedAt.Should().BeNull();
     }
 
     /// <summary>

--- a/DiffusionNexus.Tests/Sync/Service/Steps/IdentifyModelStepTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/Steps/IdentifyModelStepTests.cs
@@ -610,6 +610,40 @@ public sealed class IdentifyModelStepTests : IDisposable
     }
 
     /// <summary>
+    /// SF2. A legacy row blanked by the pre-F6 sidecar-blanking bug carries <c>""</c>, not
+    /// <c>"???"</c> — <see cref="SyncStateDeriver.IsPlaceholder"/> already treats that as "carries
+    /// no information" and selects it for identification, so <see cref="BaseModelWriter.CanFill"/>
+    /// must agree, or the header rung finds the answer, stamps <see cref="SyncOutcome.Header"/> (a
+    /// chip that reads as resolved), and never actually writes it.
+    /// </summary>
+    [Fact]
+    public async Task Execute_HeaderFillsALegacyBlankBaseModelRaw()
+    {
+        var path = NewModelFile("header-blank.safetensors",
+            Safetensors(Meta(("modelspec.architecture", "stable-diffusion-xl-v1-base"))));
+        var (modelId, _) = await SeedAsync("header-blank", path);
+
+        using (var scope = NewScope())
+        {
+            var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+            var model = await uow.Models.GetByIdWithIncludesAsync(modelId);
+            model!.Versions.Single().BaseModelRaw = string.Empty;
+            await uow.SaveChangesAsync();
+        }
+
+        var step = NewNotFoundStep();
+        var items = await step.SelectAsync(SyncScope.Library, Options(), Now, CancellationToken.None);
+        await step.ExecuteOneAsync(items.Single(i => i.ModelId == modelId), apiKey: null, CancellationToken.None);
+
+        (await ReadStateAsync(modelId))!.MetadataOutcome.Should().Be(SyncOutcome.Header);
+
+        using var readScope = NewScope();
+        var readUow = readScope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var saved = await readUow.Models.GetByIdWithIncludesAsync(modelId);
+        saved!.Versions.Single().BaseModelRaw.Should().Be("SDXL 1.0", "a blank string is a missing answer, same as \"???\"");
+    }
+
+    /// <summary>
     /// The header rung honors <see cref="ModelVersion.IsUserEdited"/> exactly like the sidecar
     /// formats do — a user's own edit is never overwritten, even when the stored value is still the
     /// legacy placeholder.

--- a/DiffusionNexus.Tests/Sync/Service/Steps/IdentifyModelStepTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/Steps/IdentifyModelStepTests.cs
@@ -539,6 +539,47 @@ public sealed class IdentifyModelStepTests : IDisposable
     }
 
     /// <summary>
+    /// The header rung supplies ONE field, so it may claim a model nothing else has claimed — but
+    /// it must not relabel a model whose name, tags, images and CivitaiId all came from Civitai.
+    /// A taken-down upstream page (404) next to a still-readable header is exactly that case.
+    /// </summary>
+    [Fact]
+    public async Task Execute_HeaderWriteDoesNotRelabelACivitaiSourcedModel()
+    {
+        var path = NewModelFile("civitai-sourced.safetensors",
+            Safetensors(Meta(("modelspec.architecture", "stable-diffusion-xl-v1-base"))));
+        var (modelId, _) = await SeedAsync("civitai-sourced", path);
+
+        // This model came out of Civitai in an earlier life; its page 404s now.
+        using (var seedScope = NewScope())
+        {
+            var seedUow = seedScope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+            var seeded = await seedUow.Models.GetByIdAsync(modelId);
+            seeded!.Source = DataSource.CivitaiApi;
+            await seedUow.SaveChangesAsync();
+        }
+
+        var step = NewNotFoundStep();
+        var items = await step.SelectAsync(SyncScope.Library, Options(), Now, CancellationToken.None);
+        await step.ExecuteOneAsync(items.Single(i => i.ModelId == modelId), apiKey: null, CancellationToken.None);
+
+        var state = await ReadStateAsync(modelId);
+
+        using var scope = NewScope();
+        var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var saved = await uow.Models.GetByIdWithIncludesAsync(modelId);
+
+        // The write lands...
+        saved!.Versions.Single().BaseModelRaw.Should().Be("SDXL 1.0");
+
+        // ...and the freshness stamp lands with it, because something really was applied...
+        saved.LastSyncedAt.Should().Be(state!.MetadataCheckedAt);
+
+        // ...but one locally-read field does not make a Civitai-sourced model locally sourced.
+        saved.Source.Should().Be(DataSource.CivitaiApi);
+    }
+
+    /// <summary>
     /// Pony/Illustrious/NoobAI checkpoints are all trained on plain SDXL architecture, so the
     /// model-name hint must win over the coarser architecture reading — <see cref="BaseModelHeaderMap"/>'s
     /// own evaluation order, exercised here through the step.

--- a/DiffusionNexus.Tests/Sync/Service/Steps/IdentifyModelStepTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/Steps/IdentifyModelStepTests.cs
@@ -599,9 +599,13 @@ public sealed class IdentifyModelStepTests : IDisposable
         var items = await step.SelectAsync(SyncScope.Library, Options(), Now, CancellationToken.None);
         await step.ExecuteOneAsync(items.Single(i => i.ModelId == modelId), apiKey: null, CancellationToken.None);
 
-        // The outcome still reflects the best source that answered this run, even though the write
-        // itself was skipped — the value was already real.
-        (await ReadStateAsync(modelId))!.MetadataOutcome.Should().Be(SyncOutcome.Header);
+        // C1: the write was skipped, so the outcome must NOT claim the header rung — that would
+        // read as "Identity source: file header" directly under a Base Model the header never
+        // actually supplied. There was no settled identity to preserve (a fresh row), so it falls
+        // back to NotIdentified. The header WAS still read, though — HeaderCheckedAt says so.
+        var state = await ReadStateAsync(modelId);
+        state!.MetadataOutcome.Should().Be(SyncOutcome.NotIdentified);
+        state.HeaderCheckedAt.Should().NotBeNull();
 
         using var readScope = NewScope();
         var readUow = readScope.ServiceProvider.GetRequiredService<IUnitOfWork>();
@@ -667,12 +671,83 @@ public sealed class IdentifyModelStepTests : IDisposable
         var items = await step.SelectAsync(SyncScope.Library, Options(), Now, CancellationToken.None);
         await step.ExecuteOneAsync(items.Single(i => i.ModelId == modelId), apiKey: null, CancellationToken.None);
 
-        (await ReadStateAsync(modelId))!.MetadataOutcome.Should().Be(SyncOutcome.Header);
+        // C1: same reasoning as Execute_HeaderDoesNotOverwriteARealBaseModel — CanFill said no
+        // (the version is user-edited), so the header rung is not credited with a value it never
+        // actually wrote.
+        (await ReadStateAsync(modelId))!.MetadataOutcome.Should().Be(SyncOutcome.NotIdentified);
 
         using var readScope = NewScope();
         var readUow = readScope.ServiceProvider.GetRequiredService<IUnitOfWork>();
         var saved = await readUow.Models.GetByIdWithIncludesAsync(modelId);
         saved!.Versions.Single().BaseModelRaw.Should().Be("???");
+    }
+
+    /// <summary>
+    /// C1, the reviewer's exact scenario. Run 1: a sidecar identifies the model as Pony. The user
+    /// then deletes the <c>.civitai.info</c>. Run 2: 404, no sidecar, and the file's own header
+    /// parses as plain SDXL — a real value, but <see cref="BaseModelWriter.CanFill"/> says no
+    /// (Pony is already real), so nothing is written. Before this fix the outcome was stamped
+    /// <see cref="SyncOutcome.Header"/> anyway, purely because the header *said* something —
+    /// leaving the detail panel's "Identity source: file header" row directly under a Base Model
+    /// of Pony the header never actually supplied. Both the value and the <c>Sidecar</c> outcome
+    /// must survive the header run untouched, and a third run must not churn — the sidecar's
+    /// disappearance was already recorded as new evidence and consumed.
+    /// </summary>
+    [Fact]
+    public async Task Execute_SidecarDeletedThenHeaderRunPreservesSidecarOutcome()
+    {
+        var path = NewModelFile("sidecar-then-header.safetensors",
+            Safetensors(Meta(("modelspec.architecture", "stable-diffusion-xl-v1-base"))));
+        var (modelId, _) = await SeedAsync("sidecar-then-header", path);
+
+        // Deliberately no "modelId": setting Model.CivitaiId would exclude the model from the next
+        // ordinary (non-forced) Library selection entirely — a real effect, but not the one this
+        // test is about — so run 2 would never even see it as a candidate.
+        var sidecarPath = Path.Combine(_tempDir.FullName, "sidecar-then-header.civitai.info");
+        var sidecarJson = """
+        {"id":700,"baseModel":"Pony","trainedWords":["x"],
+         "model":{"name":"N","nsfw":false},
+         "files":[{"name":"sidecar-then-header.safetensors","primary":true,"hashes":{"SHA256":"ABC"}}],
+         "images":[]}
+        """;
+        await File.WriteAllTextAsync(sidecarPath, sidecarJson);
+
+        var step = NewNotFoundStep();
+
+        // Run 1: the sidecar identifies the model as Pony.
+        var run1Items = await step.SelectAsync(SyncScope.Library, Options(), Now, CancellationToken.None);
+        await step.ExecuteOneAsync(run1Items.Single(i => i.ModelId == modelId), apiKey: null, CancellationToken.None);
+
+        (await ReadStateAsync(modelId))!.MetadataOutcome.Should().Be(SyncOutcome.Sidecar);
+
+        // The user deletes the sidecar.
+        File.Delete(sidecarPath);
+
+        // Run 2: the sidecar's disappearance is new evidence, so this is due immediately — no need
+        // to wait out the 30-day window (the same bypass Select_ANewSidecarMakesAHeaderIdentifiedModelDue
+        // exercises for a sidecar *appearing*).
+        var run2Items = await step.SelectAsync(SyncScope.Library, Options(), Now, CancellationToken.None);
+        run2Items.Select(i => i.ModelId).Should().Contain(modelId);
+
+        await step.ExecuteOneAsync(run2Items.Single(i => i.ModelId == modelId), apiKey: null, CancellationToken.None);
+
+        var state = await ReadStateAsync(modelId);
+        state!.MetadataOutcome.Should().Be(SyncOutcome.Sidecar,
+            "the header never actually wrote anything, so the prior settled identity must be preserved");
+        state.HeaderCheckedAt.Should().NotBeNull("the header WAS read this run, even though nothing came of it");
+
+        using (var scope = NewScope())
+        {
+            var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+            var saved = await uow.Models.GetByIdWithIncludesAsync(modelId);
+            saved!.Versions.Single().BaseModelRaw.Should().Be(
+                "Pony", "the sidecar's value must survive a header run that found nothing new to say");
+        }
+
+        // A third run must not churn: the deletion was already consumed as evidence on run 2, and
+        // run 2's stamp recorded the file's current (sidecar-less) signature.
+        var run3Items = await step.SelectAsync(SyncScope.Library, Options(), Now, CancellationToken.None);
+        run3Items.Select(i => i.ModelId).Should().NotContain(modelId);
     }
 
     /// <summary>

--- a/DiffusionNexus.Tests/Sync/Service/Steps/IdentifyModelStepTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/Steps/IdentifyModelStepTests.cs
@@ -1,3 +1,5 @@
+using System.Buffers.Binary;
+using System.Text;
 using System.Text.Json;
 using DiffusionNexus.Civitai;
 using DiffusionNexus.Civitai.Models;
@@ -9,6 +11,7 @@ using DiffusionNexus.Domain.Enums;
 using DiffusionNexus.Domain.Services;
 using DiffusionNexus.Domain.Services.Sync;
 using DiffusionNexus.Service.Services.Sync;
+using DiffusionNexus.Service.Services.Sync.Identity;
 using DiffusionNexus.Service.Services.Sync.Steps;
 using FluentAssertions;
 using Microsoft.Data.Sqlite;
@@ -69,6 +72,29 @@ public sealed class IdentifyModelStepTests : IDisposable
 
     /// <summary>A path inside the temp dir that deliberately does not exist on disk.</summary>
     private string MissingModelFile(string fileName) => Path.Combine(_tempDir.FullName, fileName);
+
+    /// <summary>
+    /// Builds a minimal real safetensors byte layout (8-byte little-endian header length, then the
+    /// header JSON, then a few bytes standing in for tensor data) — copied from
+    /// <c>SafetensorsHeaderReaderTests</c> so this class can exercise <see cref="IdentifyModelStep"/>'s
+    /// header rung against a file <see cref="SafetensorsHeaderReader"/> actually parses.
+    /// </summary>
+    private static byte[] Safetensors(string headerJson, int trailingTensorBytes = 16)
+    {
+        var json = Encoding.UTF8.GetBytes(headerJson);
+        var buffer = new byte[8 + json.Length + trailingTensorBytes];
+        BinaryPrimitives.WriteUInt64LittleEndian(buffer, (ulong)json.Length);
+        json.CopyTo(buffer, 8);
+        return buffer;   // trailing zeros stand in for tensor data
+    }
+
+    // A raw-string interpolation of this shape (adjacent literal brace immediately touching the
+    // hole delimiter, twice) cannot be made to compile at any $ count: the literal `{`/`}` next
+    // to the hole always merges into one run that either collides with the delimiter count or
+    // exceeds it (CS9007). Plain concatenation produces byte-identical JSON without the ambiguity.
+    private static string Meta(params (string Key, string Value)[] pairs) =>
+        "{\"__metadata__\":{" + string.Join(",", pairs.Select(p => $"\"{p.Key}\":\"{p.Value}\"")) +
+        "},\"tensor.weight\":{\"dtype\":\"F16\",\"shape\":[4],\"data_offsets\":[0,8]}}";
 
     /// <summary>
     /// Seeds a LoRA-family model with one version and one primary local file, plus (optionally)
@@ -490,6 +516,288 @@ public sealed class IdentifyModelStepTests : IDisposable
         state.MetadataAttempts.Should().Be(0);
         // "" is the signature of "no sidecar exists" — stored so the next run can notice one appearing.
         state.SidecarSignature.Should().Be(string.Empty);
+    }
+
+    /// <summary>
+    /// Plan C. No Civitai match, no sidecar, but the file's own safetensors header names its
+    /// architecture — the identify chain's second rung.
+    /// </summary>
+    [Fact]
+    public async Task Execute_HeaderIdentifiesAnSdxlLora()
+    {
+        var path = NewModelFile("header-sdxl.safetensors",
+            Safetensors(Meta(("modelspec.architecture", "stable-diffusion-xl-v1-base"))));
+        var (modelId, _) = await SeedAsync("header-sdxl", path);
+
+        var step = NewNotFoundStep();
+        var items = await step.SelectAsync(SyncScope.Library, Options(), Now, CancellationToken.None);
+        var result = await step.ExecuteOneAsync(items.Single(i => i.ModelId == modelId), apiKey: null, CancellationToken.None);
+
+        result.Succeeded.Should().BeTrue();
+
+        var state = await ReadStateAsync(modelId);
+        state!.MetadataOutcome.Should().Be(SyncOutcome.Header);
+        state.HeaderCheckedAt.Should().Be(state.MetadataCheckedAt);
+
+        using var scope = NewScope();
+        var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var saved = await uow.Models.GetByIdWithIncludesAsync(modelId);
+        saved!.Versions.Single().BaseModelRaw.Should().Be("SDXL 1.0");
+        saved.Versions.Single().BaseModel.Should().Be(BaseModelType.SDXL10);
+
+        // Stamped at Now like everything else — the same run's clock is not due again immediately.
+        var again = await step.SelectAsync(SyncScope.Library, Options(), Now, CancellationToken.None);
+        again.Select(i => i.ModelId).Should().NotContain(modelId);
+    }
+
+    /// <summary>
+    /// Pony/Illustrious/NoobAI checkpoints are all trained on plain SDXL architecture, so the
+    /// model-name hint must win over the coarser architecture reading — <see cref="BaseModelHeaderMap"/>'s
+    /// own evaluation order, exercised here through the step.
+    /// </summary>
+    [Fact]
+    public async Task Execute_NameHintBeatsArchitecture()
+    {
+        var path = NewModelFile("header-pony.safetensors",
+            Safetensors(Meta(
+                ("modelspec.architecture", "stable-diffusion-xl-v1-base"),
+                ("ss_sd_model_name", "ponyDiffusionV6XL"))));
+        var (modelId, _) = await SeedAsync("header-pony", path);
+
+        var step = NewNotFoundStep();
+        var items = await step.SelectAsync(SyncScope.Library, Options(), Now, CancellationToken.None);
+        await step.ExecuteOneAsync(items.Single(i => i.ModelId == modelId), apiKey: null, CancellationToken.None);
+
+        (await ReadStateAsync(modelId))!.MetadataOutcome.Should().Be(SyncOutcome.Header);
+
+        using var scope = NewScope();
+        var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var saved = await uow.Models.GetByIdWithIncludesAsync(modelId);
+        saved!.Versions.Single().BaseModelRaw.Should().Be("Pony");
+    }
+
+    /// <summary>
+    /// The header rung only fills a placeholder — a version that already carries a real base model
+    /// (from an earlier sidecar apply, say) is left exactly as it was.
+    /// </summary>
+    [Fact]
+    public async Task Execute_HeaderDoesNotOverwriteARealBaseModel()
+    {
+        var path = NewModelFile("header-real.safetensors",
+            Safetensors(Meta(("modelspec.architecture", "stable-diffusion-xl-v1-base"))));
+        var (modelId, _) = await SeedAsync("header-real", path);
+
+        using (var scope = NewScope())
+        {
+            var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+            var model = await uow.Models.GetByIdWithIncludesAsync(modelId);
+            model!.Versions.Single().BaseModelRaw = "Flux.1 D";
+            await uow.SaveChangesAsync();
+        }
+
+        var step = NewNotFoundStep();
+        var items = await step.SelectAsync(SyncScope.Library, Options(), Now, CancellationToken.None);
+        await step.ExecuteOneAsync(items.Single(i => i.ModelId == modelId), apiKey: null, CancellationToken.None);
+
+        // The outcome still reflects the best source that answered this run, even though the write
+        // itself was skipped — the value was already real.
+        (await ReadStateAsync(modelId))!.MetadataOutcome.Should().Be(SyncOutcome.Header);
+
+        using var readScope = NewScope();
+        var readUow = readScope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var saved = await readUow.Models.GetByIdWithIncludesAsync(modelId);
+        saved!.Versions.Single().BaseModelRaw.Should().Be("Flux.1 D");
+    }
+
+    /// <summary>
+    /// The header rung honors <see cref="ModelVersion.IsUserEdited"/> exactly like the sidecar
+    /// formats do — a user's own edit is never overwritten, even when the stored value is still the
+    /// legacy placeholder.
+    /// </summary>
+    [Fact]
+    public async Task Execute_HeaderRespectsUserEditedVersion()
+    {
+        var path = NewModelFile("header-useredited.safetensors",
+            Safetensors(Meta(("modelspec.architecture", "stable-diffusion-xl-v1-base"))));
+        var (modelId, _) = await SeedAsync("header-useredited", path);
+
+        using (var scope = NewScope())
+        {
+            var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+            var model = await uow.Models.GetByIdWithIncludesAsync(modelId);
+            model!.Versions.Single().IsUserEdited = true;
+            await uow.SaveChangesAsync();
+        }
+
+        var step = NewNotFoundStep();
+        var items = await step.SelectAsync(SyncScope.Library, Options(), Now, CancellationToken.None);
+        await step.ExecuteOneAsync(items.Single(i => i.ModelId == modelId), apiKey: null, CancellationToken.None);
+
+        (await ReadStateAsync(modelId))!.MetadataOutcome.Should().Be(SyncOutcome.Header);
+
+        using var readScope = NewScope();
+        var readUow = readScope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var saved = await readUow.Models.GetByIdWithIncludesAsync(modelId);
+        saved!.Versions.Single().BaseModelRaw.Should().Be("???");
+    }
+
+    /// <summary>
+    /// A safetensors file whose header parses fine but carries none of the three metadata keys —
+    /// the header rung reads it (and stamps <c>HeaderCheckedAt</c>), finds nothing, and the
+    /// filename heuristic is the last resort before giving up.
+    /// </summary>
+    [Fact]
+    public async Task Execute_FilenameHeuristicIsTheLastResortBeforeNotIdentified()
+    {
+        var path = NewModelFile("MyChar_Pony_v2.safetensors",
+            Safetensors("""{"tensor.weight":{"dtype":"F16","shape":[4],"data_offsets":[0,8]}}"""));
+        var (modelId, _) = await SeedAsync("MyChar_Pony_v2", path);
+
+        var step = NewNotFoundStep();
+        var items = await step.SelectAsync(SyncScope.Library, Options(), Now, CancellationToken.None);
+        await step.ExecuteOneAsync(items.Single(i => i.ModelId == modelId), apiKey: null, CancellationToken.None);
+
+        var state = await ReadStateAsync(modelId);
+        state!.MetadataOutcome.Should().Be(SyncOutcome.Heuristic);
+        // The header WAS read — it just said nothing usable.
+        state.HeaderCheckedAt.Should().NotBeNull();
+
+        using var scope = NewScope();
+        var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var saved = await uow.Models.GetByIdWithIncludesAsync(modelId);
+        saved!.Versions.Single().BaseModelRaw.Should().Be("Pony");
+    }
+
+    /// <summary>
+    /// A non-safetensors model file (a raw <c>.pt</c> checkpoint) never reaches
+    /// <see cref="SafetensorsHeaderReader"/>'s successful path — <c>TryRead</c> rejects the
+    /// extension outright — so the step must skip straight to the filename heuristic without
+    /// stamping a header check that never happened.
+    /// </summary>
+    [Fact]
+    public async Task Execute_NonSafetensorsFileSkipsStraightToHeuristic()
+    {
+        var path = NewModelFile("style_sdxl.pt");
+        var (modelId, _) = await SeedAsync("style_sdxl", path);
+
+        var step = NewNotFoundStep();
+        var items = await step.SelectAsync(SyncScope.Library, Options(), Now, CancellationToken.None);
+        await step.ExecuteOneAsync(items.Single(i => i.ModelId == modelId), apiKey: null, CancellationToken.None);
+
+        var state = await ReadStateAsync(modelId);
+        state!.MetadataOutcome.Should().Be(SyncOutcome.Heuristic);
+        state.HeaderCheckedAt.Should().BeNull();
+
+        using var scope = NewScope();
+        var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var saved = await uow.Models.GetByIdWithIncludesAsync(modelId);
+        saved!.Versions.Single().BaseModelRaw.Should().Be("SDXL 1.0");
+    }
+
+    /// <summary>
+    /// Every rung — Civitai, sidecar, header, filename — comes up empty: the file is genuinely
+    /// unidentifiable and no base model is written.
+    /// </summary>
+    [Fact]
+    public async Task Execute_NothingMatchesStampsNotIdentified()
+    {
+        var path = NewModelFile("totally_random_name.pt");
+        var (modelId, _) = await SeedAsync("totally_random_name", path);
+
+        var step = NewNotFoundStep();
+        var items = await step.SelectAsync(SyncScope.Library, Options(), Now, CancellationToken.None);
+        await step.ExecuteOneAsync(items.Single(i => i.ModelId == modelId), apiKey: null, CancellationToken.None);
+
+        (await ReadStateAsync(modelId))!.MetadataOutcome.Should().Be(SyncOutcome.NotIdentified);
+
+        using var scope = NewScope();
+        var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var saved = await uow.Models.GetByIdWithIncludesAsync(modelId);
+        saved!.Versions.Single().BaseModelRaw.Should().Be("???", "nothing in the chain identified it");
+    }
+
+    /// <summary>
+    /// A sidecar still wins over the header even when the header would have named something
+    /// different — the sidecar branch returns before the header is ever read.
+    /// </summary>
+    [Fact]
+    public async Task Execute_SidecarStillBeatsTheHeader()
+    {
+        var path = NewModelFile("sidecar-vs-header.safetensors",
+            Safetensors(Meta(("modelspec.architecture", "stable-diffusion-xl-v1-base"))));
+        var (modelId, _) = await SeedAsync("sidecar-vs-header", path);
+
+        var sidecar = """
+        {"id":700,"modelId":77,"baseModel":"Pony","trainedWords":["x"],
+         "model":{"name":"N","nsfw":false},
+         "files":[{"name":"sidecar-vs-header.safetensors","primary":true,"hashes":{"SHA256":"ABC"}}],
+         "images":[]}
+        """;
+        await File.WriteAllTextAsync(Path.Combine(_tempDir.FullName, "sidecar-vs-header.civitai.info"), sidecar);
+
+        var step = NewNotFoundStep();
+        var items = await step.SelectAsync(SyncScope.Library, Options(), Now, CancellationToken.None);
+        await step.ExecuteOneAsync(items.Single(i => i.ModelId == modelId), apiKey: null, CancellationToken.None);
+
+        (await ReadStateAsync(modelId))!.MetadataOutcome.Should().Be(SyncOutcome.Sidecar);
+    }
+
+    /// <summary>
+    /// A Civitai hash hit never falls through to the header/heuristic rungs at all — the response's
+    /// own <c>baseModel</c> wins even when the file's header would have said something else.
+    /// </summary>
+    [Fact]
+    public async Task Execute_CivitaiHitNeverConsultsTheHeader()
+    {
+        var path = NewModelFile("matched-header.safetensors",
+            Safetensors(Meta(("ss_sd_model_name", "ponyDiffusionV6XL"))));
+        var (modelId, _) = await SeedAsync("matched-header", path);
+
+        var civVersion = NewCivitaiVersion();
+        var step = NewStep(c =>
+        {
+            c.Setup(x => x.GetModelVersionByHashAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(civVersion);
+            c.Setup(x => x.GetModelAsync(It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(NewCivitaiModel(civVersion));
+        });
+
+        var items = await step.SelectAsync(SyncScope.Library, Options(), Now, CancellationToken.None);
+        var result = await step.ExecuteOneAsync(items.Single(i => i.ModelId == modelId), apiKey: null, CancellationToken.None);
+
+        result.Succeeded.Should().BeTrue();
+        (await ReadStateAsync(modelId))!.MetadataOutcome.Should().Be(SyncOutcome.Matched);
+
+        using var scope = NewScope();
+        var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var saved = await uow.Models.GetByIdWithIncludesAsync(modelId);
+        saved!.Versions.Single().BaseModelRaw.Should().Be("SDXL 1.0", "the civitai response's baseModel, not the header's Pony hint");
+    }
+
+    /// <summary>
+    /// Extends the signature-evidence test family (<see cref="Select_ChangedSidecarMakesCandidateDueImmediately"/>)
+    /// to the Header outcome: a sidecar dropped in after a header-only identification is new
+    /// evidence and beats the 30-day window exactly the way it does for Sidecar/NotIdentified.
+    /// </summary>
+    [Fact]
+    public async Task Select_ANewSidecarMakesAHeaderIdentifiedModelDue()
+    {
+        var path = NewModelFile("header-then-sidecar.safetensors",
+            Safetensors(Meta(("modelspec.architecture", "stable-diffusion-xl-v1-base"))));
+        var (modelId, _) = await SeedAsync("header-then-sidecar", path);
+
+        var step = NewNotFoundStep();
+        var items = await step.SelectAsync(SyncScope.Library, Options(), Now, CancellationToken.None);
+        await step.ExecuteOneAsync(items.Single(i => i.ModelId == modelId), apiKey: null, CancellationToken.None);
+
+        var state = await ReadStateAsync(modelId);
+        state!.MetadataOutcome.Should().Be(SyncOutcome.Header);
+        state.SidecarSignature.Should().Be(string.Empty);
+
+        await File.WriteAllTextAsync(Path.Combine(_tempDir.FullName, "header-then-sidecar.civitai.info"), "{}");
+
+        var again = await step.SelectAsync(SyncScope.Library, Options(), Now, CancellationToken.None);
+        again.Select(i => i.ModelId).Should().Contain(modelId);
     }
 
     /// <summary>

--- a/DiffusionNexus.Tests/Sync/Service/Steps/IdentifyModelStepTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/Steps/IdentifyModelStepTests.cs
@@ -1,5 +1,3 @@
-using System.Buffers.Binary;
-using System.Text;
 using System.Text.Json;
 using DiffusionNexus.Civitai;
 using DiffusionNexus.Civitai.Models;
@@ -18,6 +16,7 @@ using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
+using static DiffusionNexus.Tests.Sync.Service.Identity.SafetensorsFixture;
 
 namespace DiffusionNexus.Tests.Sync.Service.Steps;
 
@@ -73,28 +72,10 @@ public sealed class IdentifyModelStepTests : IDisposable
     /// <summary>A path inside the temp dir that deliberately does not exist on disk.</summary>
     private string MissingModelFile(string fileName) => Path.Combine(_tempDir.FullName, fileName);
 
-    /// <summary>
-    /// Builds a minimal real safetensors byte layout (8-byte little-endian header length, then the
-    /// header JSON, then a few bytes standing in for tensor data) — copied from
-    /// <c>SafetensorsHeaderReaderTests</c> so this class can exercise <see cref="IdentifyModelStep"/>'s
-    /// header rung against a file <see cref="SafetensorsHeaderReader"/> actually parses.
-    /// </summary>
-    private static byte[] Safetensors(string headerJson, int trailingTensorBytes = 16)
-    {
-        var json = Encoding.UTF8.GetBytes(headerJson);
-        var buffer = new byte[8 + json.Length + trailingTensorBytes];
-        BinaryPrimitives.WriteUInt64LittleEndian(buffer, (ulong)json.Length);
-        json.CopyTo(buffer, 8);
-        return buffer;   // trailing zeros stand in for tensor data
-    }
-
-    // A raw-string interpolation of this shape (adjacent literal brace immediately touching the
-    // hole delimiter, twice) cannot be made to compile at any $ count: the literal `{`/`}` next
-    // to the hole always merges into one run that either collides with the delimiter count or
-    // exceeds it (CS9007). Plain concatenation produces byte-identical JSON without the ambiguity.
-    private static string Meta(params (string Key, string Value)[] pairs) =>
-        "{\"__metadata__\":{" + string.Join(",", pairs.Select(p => $"\"{p.Key}\":\"{p.Value}\"")) +
-        "},\"tensor.weight\":{\"dtype\":\"F16\",\"shape\":[4],\"data_offsets\":[0,8]}}";
+    // Safetensors(...) / Meta(...) — the safetensors byte-layout builders this class uses to
+    // exercise IdentifyModelStep's header rung against a file SafetensorsHeaderReader actually
+    // parses — come from the shared SafetensorsFixture (see the using static above), so this
+    // class's copy can never drift from SafetensorsHeaderReaderTests'.
 
     /// <summary>
     /// Seeds a LoRA-family model with one version and one primary local file, plus (optionally)

--- a/DiffusionNexus.Tests/ViewModels/ModelDetailViewModelTests.cs
+++ b/DiffusionNexus.Tests/ViewModels/ModelDetailViewModelTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using DiffusionNexus.Civitai;
+using DiffusionNexus.Domain.Enums;
 using DiffusionNexus.Domain.Services;
 using DiffusionNexus.Domain.Services.UnifiedLogging;
 using DiffusionNexus.Installer.SDK.Shared.Services;
@@ -98,5 +99,24 @@ public class ModelDetailViewModelTests
         field!.IsInitOnly.Should().BeTrue("the shared client must be readonly so it can't be swapped per-call");
         field.FieldType.Should().Be<HttpClient>();
         field.GetValue(null).Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// The "Identity source:" row's label mapping (metadata-sync-overhaul Plan C, WP4 follow-up).
+    /// Only the four outcomes that actually name a source get a label; the rest say nothing rather
+    /// than something scary — <c>None</c> (never attempted), <c>NotIdentified</c> (every source was
+    /// tried and none worked) and <c>Error</c> (the attempt itself failed) are not sources at all.
+    /// </summary>
+    [Theory]
+    [InlineData(SyncOutcome.Matched, "Civitai")]
+    [InlineData(SyncOutcome.Sidecar, "sidecar file")]
+    [InlineData(SyncOutcome.Header, "file header")]
+    [InlineData(SyncOutcome.Heuristic, "guessed from filename")]
+    [InlineData(SyncOutcome.None, null)]
+    [InlineData(SyncOutcome.NotIdentified, null)]
+    [InlineData(SyncOutcome.Error, null)]
+    public void DescribeIdentitySourceMapsEverySyncOutcome(SyncOutcome outcome, string? expected)
+    {
+        ModelDetailViewModel.DescribeIdentitySource(outcome).Should().Be(expected);
     }
 }

--- a/DiffusionNexus.Tests/ViewModels/ModelDetailViewModelTests.cs
+++ b/DiffusionNexus.Tests/ViewModels/ModelDetailViewModelTests.cs
@@ -1,5 +1,8 @@
 using System.Reflection;
 using DiffusionNexus.Civitai;
+using DiffusionNexus.DataAccess.Repositories.Interfaces;
+using DiffusionNexus.DataAccess.UnitOfWork;
+using DiffusionNexus.Domain.Entities;
 using DiffusionNexus.Domain.Enums;
 using DiffusionNexus.Domain.Services;
 using DiffusionNexus.Domain.Services.UnifiedLogging;
@@ -36,14 +39,15 @@ public class ModelDetailViewModelTests
 
     private static ModelDetailViewModel CreateVm(
         IClipboardService? clipboard = null,
-        IUiScheduler? scheduler = null)
+        IUiScheduler? scheduler = null,
+        IServiceScopeFactory? scopeFactory = null)
         => new(
             civitaiClient: new Mock<ICivitaiClient>().Object,
             settingsService: new Mock<IAppSettingsService>().Object,
             secureStorage: new Mock<ISecureStorage>().Object,
             logger: new Mock<IUnifiedLogger>().Object,
             baseModelCatalog: null,
-            scopeFactory: new Mock<IServiceScopeFactory>().Object,
+            scopeFactory: scopeFactory ?? new Mock<IServiceScopeFactory>().Object,
             dialogService: new Mock<IDialogService>().Object,
             downloadService: null,
             downloadCoordinator: new Mock<IDownloadCoordinator>().Object,
@@ -118,5 +122,59 @@ public class ModelDetailViewModelTests
     public void DescribeIdentitySourceMapsEverySyncOutcome(SyncOutcome outcome, string? expected)
     {
         ModelDetailViewModel.DescribeIdentitySource(outcome).Should().Be(expected);
+    }
+
+    /// <summary>
+    /// Review fix (Task 4 round 1): <c>LoadIdentitySourceAsync</c> is keyed to a specific model,
+    /// unlike the model-invariant <c>LoadBaseModelCatalogAsync</c> it was modelled on. If the user
+    /// switches tiles A→B before A's DB lookup returns, A's loader must not be able to complete
+    /// after B's and overwrite B's correct chip with A's stale value. Drives both calls directly
+    /// against a real <see cref="IServiceScopeFactory"/> (mocked repository underneath, same
+    /// pattern as <c>LoraViewerViewModelSyncTests</c>) with model A's lookup gated behind a
+    /// <see cref="TaskCompletionSource"/> so the test controls completion order deterministically
+    /// instead of racing real timing.
+    /// </summary>
+    [Fact]
+    public async Task LoadIdentitySourceAsyncDropsAStaleWriteFromAnOlderGeneration()
+    {
+        const int modelA = 101;
+        const int modelB = 202;
+        var stateA = new ModelSyncState { ModelId = modelA, MetadataOutcome = SyncOutcome.Matched };
+        var stateB = new ModelSyncState { ModelId = modelB, MetadataOutcome = SyncOutcome.Sidecar };
+
+        var slowLookupForA = new TaskCompletionSource<ModelSyncState?>();
+        var syncStates = new Mock<ISyncStateRepository>();
+        syncStates.Setup(s => s.GetByModelIdAsync(modelA, It.IsAny<CancellationToken>()))
+            .Returns(slowLookupForA.Task);
+        syncStates.Setup(s => s.GetByModelIdAsync(modelB, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stateB);
+
+        var unitOfWork = new Mock<IUnitOfWork>();
+        unitOfWork.SetupGet(u => u.SyncStates).Returns(syncStates.Object);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(unitOfWork.Object);
+        var provider = services.BuildServiceProvider();
+
+        var vm = CreateVm(scopeFactory: provider.GetRequiredService<IServiceScopeFactory>());
+        var generationField = typeof(ModelDetailViewModel).GetField(
+            "_identityLoadGeneration", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        // Tile A's LoadAsync fires the slow lookup at generation 1 and does not await it (mirrors
+        // the real fire-and-forget call site).
+        generationField.SetValue(vm, 1);
+        var taskA = vm.LoadIdentitySourceAsync(modelA, generation: 1);
+
+        // The user switches to tile B before A resolves: generation advances to 2 and B's lookup
+        // — which resolves immediately — completes and stamps the chip.
+        generationField.SetValue(vm, 2);
+        await vm.LoadIdentitySourceAsync(modelB, generation: 2);
+        vm.IdentitySourceDisplay.Should().Be("sidecar file", "B's fast lookup is the current tile and must win");
+
+        // A's slow lookup finally resolves. Its generation (1) no longer matches the VM's current
+        // generation (2), so its write must be dropped rather than clobbering B's chip.
+        slowLookupForA.SetResult(stateA);
+        await taskA;
+        vm.IdentitySourceDisplay.Should().Be("sidecar file", "a stale lookup for the previous tile must not overwrite the current tile's chip");
     }
 }

--- a/DiffusionNexus.UI/Doc/LoraViewer.md
+++ b/DiffusionNexus.UI/Doc/LoraViewer.md
@@ -211,7 +211,7 @@ DownloadMissingMetadataAsync                      (both service calls run on Tas
 | Step | What it does |
 |------|--------------|
 | `DiscoverFiles` | Walks every enabled LoRA source folder and inserts rows for files that are not in the DB yet. It ignores the scope — a folder- or model-scoped run that *includes* this step still scans everything — but it is only in the run at all when the caller asks for it, and the per-LoRA button does not. |
-| `IdentifyModel` | The identity chain for one file: full-file SHA256 → Civitai `GET /model-versions/by-hash/{sha}` → on 404, the local `.civitai.info` / `.json` sidecar. Writes name, base model, trigger words, Civitai ids, image records — see *user edits* and *what counts as applied* below. |
+| `IdentifyModel` | The identity chain for one file: full-file SHA256 → Civitai `GET /model-versions/by-hash/{sha}` → on 404, the local `.civitai.info` / `.json` sidecar → the file's own safetensors header → a guess from the filename. Writes name, base model, trigger words, Civitai ids, image records — see *user edits*, *what counts as applied* and **The identity chain** below. |
 | `FetchTags` | For a model that has a Civitai id but no tags yet: `GET /models/{id}` and replace the tag set (reusing existing `Tag` rows by normalized name). |
 | `FetchImages` | For a version with a Civitai version id but no image records: `GET /model-versions/{id}` and persist the returned images. |
 | `Thumbnails` | For each version's due primary image: one CDN GET through `IThumbnailProvider`, never a full video — see §9 for the ladder, the failure/retry table, and the 0-video-bytes-in-bulk guarantee. |
@@ -262,6 +262,82 @@ can be truncated; either way the outcome is `NotIdentified`, `Source`/`LastSynce
 alone, and the file's real signature is still stored — so it is not read again until it changes (or
 the 30-day window comes round), rather than costing a re-hash and a Civitai request on every run.
 
+### The identity chain
+
+`IdentifyModel` is four rungs, tried in order — the first one that answers wins, and nothing below
+it runs:
+
+1. **Civitai by hash** — `GetModelVersionByHashAsync` on the file's SHA256. A hit applies the full
+   Civitai response (above) and stamps `Matched`.
+2. **Sidecar** — on a 404, the local `.civitai.info` / `.json` next to the file
+   (`SidecarMetadataApplier`). Stamps `Sidecar` only when metadata actually came out of it; a kohya
+   training config or a truncated `.civitai.info` falls through to the next rung instead (*what
+   counts as applied*, above).
+3. **Safetensors header** (`SafetensorsHeaderReader` + `BaseModelHeaderMap`) — reads the file's own
+   length-prefixed JSON header (capped at 16 MB, the tensor payload itself is never touched) and
+   maps its `__metadata__` fields to a Civitai display label: the `ss_sd_model_name` hint is checked
+   *first*, because Pony / Illustrious / NoobAI checkpoints are all SDXL-architecture and would
+   otherwise all collapse into plain "SDXL 1.0"; `modelspec.architecture` and the coarser
+   `ss_base_model_version` (kohya only ever writes `sd_v1`/`sd_v2`, so both 1.x and both 2.x minor
+   versions collapse to one label each) are checked after. Any file that isn't a readable safetensors
+   header — wrong extension, corrupt, truncated, an oversized header — yields nothing here and falls
+   through.
+4. **Filename heuristic** (`FilenameBaseModelHeuristic`) — last resort: distinctive whole-name
+   substrings, then exact tokens (`sd15`, `pdxl`, `wan`, …), then distinctive token prefixes, run
+   against the filename with the directory and a known model extension stripped. The lowest-confidence
+   rung of the four, which is why the UI calls it a guess rather than stating it as fact.
+
+Nothing answering at all is `NotIdentified`. A fault anywhere in the attempt (timeout, a Civitai
+response shape change, a rejected database save) is `Error` instead and does not fall through to the
+rungs below it — the failure itself is the outcome.
+
+| Outcome | Meaning |
+|---|---|
+| `Matched` | Civitai recognised the file's hash |
+| `Sidecar` | No Civitai hit; a local `.civitai.info` / `.json` supplied metadata |
+| `Header` | No Civitai hit, no usable sidecar; the safetensors header named a base model |
+| `Heuristic` | Nothing above answered; the filename suggested one |
+| `NotIdentified` | None of the four rungs produced anything |
+| `Error` | The attempt itself failed (network, parsing, a rejected save) |
+
+**Only the placeholder gets filled, never a user's edit.** The header and filename rungs write
+*nothing but the base model* — no name, no trigger words, no description — so they use a narrower
+gate than the sidecar formats' own guard (`CanWriteVersionText`, which is simply "not user-edited"):
+`BaseModelWriter.CanFill` additionally requires the field to still be blank (`BaseModelRaw` is `null`
+or the discovery placeholder `"???"`). A version whose base model already says something real —
+Civitai-sourced, sidecar-sourced, or hand-typed — is left alone even when the rest of the version is
+untouched. The outcome is still stamped as whichever rung actually answered even when the write
+itself was skipped: a model that already has a real base model but whose header would have echoed
+the same family still records `Header`, not `NotIdentified` — the identity source the detail view
+shows is about what the file *said*, not about what got written as a result.
+
+`HeaderCheckedAt` is stamped whenever the header could be parsed at all, even when it carried no
+usable `__metadata__` fields and `BaseModelHeaderMap.Map` returned nothing. It stays `null` for
+anything that never reached that point — a non-safetensors file, a hash match, or a sidecar hit —
+because the header rung only runs on the shared miss branch, after both of those have already failed.
+
+**Identity source is per model; base model is per version.** The detail panel's "Identity source:"
+row (`ModelDetailViewModel.DescribeIdentitySource`) reads the single `ModelSyncState.MetadataOutcome`
+for the whole model — "Civitai", "sidecar file", "file header", "guessed from filename" — while the
+**Base Model** field shown just above it (§10) is per *version*. A model with several versions shows
+one identity-source verdict describing how the model as a whole was last resolved, which is not
+necessarily how any one version's base model value came to be. `None`, `NotIdentified` and `Error`
+show nothing in that row rather than a discouraging label.
+
+**Correcting a guess sticks.** Picking a value from the detail panel's Base Model dropdown sets
+`ModelVersion.IsUserEdited` — exactly the flag `BaseModelWriter.CanFill` checks — so a future sync,
+however it identifies the model, never overwrites that choice again. That is what the row's tooltip
+means by "'Guessed from filename' is the lowest-confidence source — correct it via the Base Model
+dropdown and your choice is kept."
+
+**Retry.** All four non-`Matched`, non-`Error` outcomes — `Sidecar`, `Header`, `Heuristic`,
+`NotIdentified` — share the 30-day catch-all in `SyncRetryPolicy.IsIdentifyDue` (a better source may
+have appeared since). Independent of that window, a sidecar that appears or changes next to the file
+makes any of those four due *immediately*: `IdentifyModelStep.IsDue` compares the file's current
+sidecar signature against the one stored on the last check, and a mismatch wins over the 30-day
+clock — dropping a `.civitai.info` next to a `NotIdentified` file is picked up on the very next run,
+not a month from now.
+
 ### Where the state lives
 
 One `ModelSyncStates` row per model (PK = FK to `Model`), so *"checked and genuinely
@@ -275,7 +351,7 @@ empty"* is distinguishable from *"never checked"* — the distinction the old
 | `LastError` | One-line reason for the last failure (never a stack trace) |
 | `TagsCheckedAt` / `ImagesCheckedAt` | Stamped **even when the result was empty** — that is what makes "no tags" final |
 | `SidecarSignature` | `{path}|{lastWriteUtcTicks}|{length}` of the sidecar last **looked at**, so an unchanged sidecar is not re-read and a changed one is. Recorded whether or not anything was applied. `""` = looked, no sidecar; `null` = never recorded |
-| `HeaderCheckedAt` | Safetensors header read (WP4) |
+| `HeaderCheckedAt` | Safetensors header read (see **The identity chain** above) |
 
 Models that predate the table get a row derived from data already in the database
 (`SyncStateDeriver`, via `SyncStateInitializer`) on the first plan — never by calling
@@ -679,7 +755,11 @@ User clicks tile → ModelTileViewModel.OpenDetails()
            ├── ModelIdDisplay, VersionIdDisplay, BaseModel, FileName
            ├── Description (HTML→text), TriggerWords, Tags
            └── BuildLocalVersionTabs (blue tabs from local versions)
-        
+
+        1a. LoadIdentitySourceAsync(tile)  — fire-and-forget, from ModelSyncState
+            └── "Identity source:" row — see §4 "The identity chain" for what it shows
+                and why it is per model, not per version
+
         2. FetchCivitaiDataAsync(tile)     — async, from API
            ├── Requires Model.CivitaiId or CivitaiModelPageId > 0
            ├── GET /api/v1/models/{modelId}

--- a/DiffusionNexus.UI/Doc/LoraViewer.md
+++ b/DiffusionNexus.UI/Doc/LoraViewer.md
@@ -306,15 +306,33 @@ gate than the sidecar formats' own guard (`CanWriteVersionText`, which is simply
 `BaseModelWriter.CanFill` additionally requires the field to still be blank (`BaseModelRaw` is `null`
 or the discovery placeholder `"???"`). A version whose base model already says something real —
 Civitai-sourced, sidecar-sourced, or hand-typed — is left alone even when the rest of the version is
-untouched. The outcome is still stamped as whichever rung actually answered even when the write
-itself was skipped: a model that already has a real base model but whose header would have echoed
-the same family still records `Header`, not `NotIdentified` — the identity source the detail view
-shows is about what the file *said*, not about what got written as a result.
+untouched.
+
+**The outcome names the rung that wrote the value, never one that merely echoed it.** A rung is
+credited (`Header`/`Heuristic`) only when its label actually lands on the row — i.e. `CanFill` said
+yes. When `CanFill` says no (the value is already real, or the version is user-edited), stamping the
+rung anyway would misreport provenance: the detail panel's "Identity source: file header" row would
+describe a Base Model the header had nothing to do with. So a skipped write instead *preserves*
+whatever settled identity the model already carried — `Matched`, `Sidecar`, `Header` or `Heuristic`,
+read off the row **before** this run touched it — and falls back to `NotIdentified` only when there
+was no settled identity to preserve (a fresh row, or one that last recorded `Error`). Concretely: a
+sidecar identifies a model (`Sidecar`), the user deletes the `.civitai.info`, and the next run's
+header rereads the same file as plain SDXL — the outcome stays `Sidecar`, not `Header`, because
+nothing new was actually written. Preserving rather than re-deriving also keeps the retry window and
+the sidecar-evidence bypass (below) tracking whatever they already were, instead of resetting a
+model's due-ness every time a rung merely reconfirms an existing answer.
+
+When the write *does* land, `Model.Source` and `Model.LastSyncedAt` are stamped to `LocalFile` and
+the run's own clock — mirroring the sidecar branch's stamp (*What counts as applied*, above) — so a
+model whose base model was just filled from its own file no longer reads as "never synced" to
+anything that orders or filters on `LastSyncedAt` (`TileGroupingHelper`'s tile ordering among them).
+Nothing is stamped when the write is skipped, same as the sidecar branch.
 
 `HeaderCheckedAt` is stamped whenever the header could be parsed at all, even when it carried no
-usable `__metadata__` fields and `BaseModelHeaderMap.Map` returned nothing. It stays `null` for
-anything that never reached that point — a non-safetensors file, a hash match, or a sidecar hit —
-because the header rung only runs on the shared miss branch, after both of those have already failed.
+usable `__metadata__` fields and `BaseModelHeaderMap.Map` returned nothing, independently of whether
+anything above ended up written. It stays `null` for anything that never reached that point — a
+non-safetensors file, a hash match, or a sidecar hit — because the header rung only runs on the
+shared miss branch, after both of those have already failed.
 
 **Identity source is per model; base model is per version.** The detail panel's "Identity source:"
 row (`ModelDetailViewModel.DescribeIdentitySource`) reads the single `ModelSyncState.MetadataOutcome`

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -1367,7 +1367,7 @@ public partial class LoraViewerViewModel : BusyViewModelBase
                 await detail.LoadAsync(tile);
                 // LoadAsync ends by clearing StatusMessage, so a successful refresh used to
                 // leave no trace at all — the bar just closed. Say what happened.
-                detail.StatusMessage = "Metadata refreshed from Civitai.";
+                detail.StatusMessage = "Metadata refreshed.";
             }
             else
             {

--- a/DiffusionNexus.UI/ViewModels/ModelDetailViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/ModelDetailViewModel.cs
@@ -57,6 +57,16 @@ public partial class ModelDetailViewModel : ViewModelBase
     private CancellationTokenSource? _detailThumbnailCts;
 
     /// <summary>
+    /// Monotonic counter bumped on every <see cref="LoadAsync"/> call and captured by
+    /// <see cref="LoadIdentitySourceAsync"/> before it awaits. If the panel has since moved on to
+    /// a different tile (the counter no longer matches), the loader's final write is dropped
+    /// instead of stamping the previous tile's stale identity source over the current one —
+    /// guards against a slow-to-resolve model's lookup completing after a faster one for the
+    /// tile the user switched to in the meantime.
+    /// </summary>
+    private int _identityLoadGeneration;
+
+    /// <summary>
     /// Shared HttpClient for Civitai version-thumbnail downloads (see
     /// <see cref="LoadCivitaiThumbnailAsync"/>). Reusing a single instance avoids the
     /// socket exhaustion (TIME_WAIT accumulation) that a fresh <c>new HttpClient()</c> per
@@ -331,8 +341,12 @@ public partial class ModelDetailViewModel : ViewModelBase
         // Look up how this model was identified for the "Identity source:" row. Reset first so
         // a stale value from the previously displayed tile never lingers while the fresh lookup
         // is in flight, then fire-and-forget for the same reason as the catalog load above.
+        // Bump the generation counter so a still-in-flight lookup from a previous tile can tell,
+        // when it finally completes, that it is no longer the current one and must not overwrite
+        // this tile's chip.
         IdentitySourceDisplay = null;
-        _ = LoadIdentitySourceAsync(tile.ModelEntity?.Id ?? 0);
+        var identityLoadGeneration = ++_identityLoadGeneration;
+        _ = LoadIdentitySourceAsync(tile.ModelEntity?.Id ?? 0, identityLoadGeneration);
 
         // Try to fetch from Civitai API for the full version list
         await FetchCivitaiDataAsync(tile);
@@ -1075,17 +1089,32 @@ public partial class ModelDetailViewModel : ViewModelBase
     /// same pattern as <see cref="LoadBaseModelCatalogAsync"/> — a slow lookup must not block the
     /// rest of the detail view from rendering. Swallow-and-log on failure, same as that loader.
     /// </summary>
+    /// <param name="modelId">The model whose identity source is being looked up.</param>
+    /// <param name="generation">
+    /// The <see cref="_identityLoadGeneration"/> value captured by the caller at the moment this
+    /// lookup was fired. Unlike <see cref="LoadBaseModelCatalogAsync"/> (model-invariant — any
+    /// result is valid for any tile), this loader is keyed to the specific model passed in, so a
+    /// slow call for a previous tile must not stamp its result over a newer tile's chip once the
+    /// user has switched. Checked right before the final write; a mismatch means the panel has
+    /// since moved on and the result is discarded.
+    /// </param>
     /// <remarks>
     /// The source tracked here is <b>per model</b> — one <c>ModelSyncState</c> row — while the
     /// base model shown just above it in the view is <b>per version</b>. On a model with several
     /// versions this row describes how the model as a whole was identified, not necessarily how
     /// any one version's base model value came to be.
+    /// <c>internal</c> (rather than <c>private</c>) so the cross-model race guard on
+    /// <paramref name="generation"/> is directly unit-testable — same rationale as
+    /// <see cref="DescribeIdentitySource"/>.
     /// </remarks>
-    private async Task LoadIdentitySourceAsync(int modelId)
+    internal async Task LoadIdentitySourceAsync(int modelId, int generation)
     {
         if (modelId <= 0 || _scopeFactory is null)
         {
-            await _uiScheduler.InvokeAsync(() => IdentitySourceDisplay = null);
+            await _uiScheduler.InvokeAsync(() =>
+            {
+                if (generation == _identityLoadGeneration) IdentitySourceDisplay = null;
+            });
             return;
         }
 
@@ -1104,7 +1133,13 @@ public partial class ModelDetailViewModel : ViewModelBase
             display = null;
         }
 
-        await _uiScheduler.InvokeAsync(() => IdentitySourceDisplay = display);
+        await _uiScheduler.InvokeAsync(() =>
+        {
+            // Drop the write if a newer LoadAsync call has since fired for a different tile —
+            // otherwise a slow lookup for the previous model could overwrite the current tile's
+            // correct chip with stale data (see _identityLoadGeneration).
+            if (generation == _identityLoadGeneration) IdentitySourceDisplay = display;
+        });
     }
 
     /// <summary>

--- a/DiffusionNexus.UI/ViewModels/ModelDetailViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/ModelDetailViewModel.cs
@@ -209,6 +209,19 @@ public partial class ModelDetailViewModel : ViewModelBase
     [ObservableProperty]
     private string _versionIdDisplay = string.Empty;
 
+    /// <summary>
+    /// How this model's identity was last resolved ("Civitai", "sidecar file", "file header",
+    /// "guessed from filename"), or <c>null</c> when nothing meaningful can be said (never
+    /// checked, checked and nothing found, or the last check errored). See
+    /// <see cref="LoadIdentitySourceAsync"/> for the granularity caveat.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasIdentitySource))]
+    private string? _identitySourceDisplay;
+
+    /// <summary>Whether the "Identity source:" row has anything to show.</summary>
+    public bool HasIdentitySource => IdentitySourceDisplay is not null;
+
     #endregion
 
     #region Collections
@@ -314,6 +327,12 @@ public partial class ModelDetailViewModel : ViewModelBase
         // falls back to a bundled snapshot when offline). Fire-and-forget so a
         // slow first fetch never blocks the detail view from rendering.
         _ = LoadBaseModelCatalogAsync();
+
+        // Look up how this model was identified for the "Identity source:" row. Reset first so
+        // a stale value from the previously displayed tile never lingers while the fresh lookup
+        // is in flight, then fire-and-forget for the same reason as the catalog load above.
+        IdentitySourceDisplay = null;
+        _ = LoadIdentitySourceAsync(tile.ModelEntity?.Id ?? 0);
 
         // Try to fetch from Civitai API for the full version list
         await FetchCivitaiDataAsync(tile);
@@ -1049,6 +1068,57 @@ public partial class ModelDetailViewModel : ViewModelBase
     #endregion
 
     #region Private Methods
+
+    /// <summary>
+    /// Looks up how this model's identity was last resolved and maps it to the short display
+    /// string shown in the "Identity source:" row. Fire-and-forget from <see cref="LoadAsync"/>,
+    /// same pattern as <see cref="LoadBaseModelCatalogAsync"/> — a slow lookup must not block the
+    /// rest of the detail view from rendering. Swallow-and-log on failure, same as that loader.
+    /// </summary>
+    /// <remarks>
+    /// The source tracked here is <b>per model</b> — one <c>ModelSyncState</c> row — while the
+    /// base model shown just above it in the view is <b>per version</b>. On a model with several
+    /// versions this row describes how the model as a whole was identified, not necessarily how
+    /// any one version's base model value came to be.
+    /// </remarks>
+    private async Task LoadIdentitySourceAsync(int modelId)
+    {
+        if (modelId <= 0 || _scopeFactory is null)
+        {
+            await _uiScheduler.InvokeAsync(() => IdentitySourceDisplay = null);
+            return;
+        }
+
+        string? display;
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+            var state = await unitOfWork.SyncStates.GetByModelIdAsync(modelId);
+            display = state is not null ? DescribeIdentitySource(state.MetadataOutcome) : null;
+        }
+        catch (Exception ex)
+        {
+            _logger?.Debug(LogCategory.General, "ModelDetail",
+                $"Failed to load identity source for model {modelId}: {ex.Message}");
+            display = null;
+        }
+
+        await _uiScheduler.InvokeAsync(() => IdentitySourceDisplay = display);
+    }
+
+    /// <summary>
+    /// Maps a <see cref="SyncOutcome"/> to the short label shown in the "Identity source:" row.
+    /// <c>internal static</c> so it is directly unit-testable.
+    /// </summary>
+    internal static string? DescribeIdentitySource(SyncOutcome outcome) => outcome switch
+    {
+        SyncOutcome.Matched => "Civitai",
+        SyncOutcome.Sidecar => "sidecar file",
+        SyncOutcome.Header => "file header",
+        SyncOutcome.Heuristic => "guessed from filename",
+        _ => null,   // None, NotIdentified, Error — say nothing rather than something scary
+    };
 
     private void PopulateFromLocalVersion(ModelTileViewModel tile)
     {

--- a/DiffusionNexus.UI/Views/Controls/ModelDetailView.axaml
+++ b/DiffusionNexus.UI/Views/Controls/ModelDetailView.axaml
@@ -234,7 +234,7 @@
               <!-- Metadata -->
               <StackPanel Grid.Column="1" Spacing="8" VerticalAlignment="Top">
                 <Grid ColumnDefinitions="Auto,*"
-                      RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+                      RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
                       Margin="0">
 
                   <TextBlock Grid.Row="0" Grid.Column="0"
@@ -273,33 +273,47 @@
                             ToolTip.Tip="Override the base model for the currently selected version (saved per-version)"/>
 
                   <TextBlock Grid.Row="3" Grid.Column="0"
+                             Text="Identity source:"
+                             Foreground="#FF66AA"
+                             FontWeight="SemiBold"
+                             Margin="0,0,12,6"
+                             IsVisible="{Binding HasIdentitySource}"
+                             ToolTip.Tip="How the base model was determined. 'Guessed from filename' is the lowest-confidence source — correct it via the Base Model dropdown and your choice is kept."/>
+                  <TextBlock Grid.Row="3" Grid.Column="1"
+                             Text="{Binding IdentitySourceDisplay}"
+                             Foreground="White"
+                             Margin="0,0,0,6"
+                             IsVisible="{Binding HasIdentitySource}"
+                             ToolTip.Tip="How the base model was determined. 'Guessed from filename' is the lowest-confidence source — correct it via the Base Model dropdown and your choice is kept."/>
+
+                  <TextBlock Grid.Row="4" Grid.Column="0"
                              Text="File:"
                              Foreground="#FF66AA"
                              FontWeight="SemiBold"
                              Margin="0,0,12,6"/>
-                  <TextBlock Grid.Row="3" Grid.Column="1"
+                  <TextBlock Grid.Row="4" Grid.Column="1"
                              Text="{Binding FileNameDisplay}"
                              Foreground="White"
                              TextWrapping="Wrap"
                              Margin="0,0,0,6"/>
 
-                  <TextBlock Grid.Row="4" Grid.Column="0"
+                  <TextBlock Grid.Row="5" Grid.Column="0"
                              Text="Type:"
                              Foreground="#FF66AA"
                              FontWeight="SemiBold"
                              Margin="0,0,12,6"/>
-                  <TextBlock Grid.Row="4" Grid.Column="1"
+                  <TextBlock Grid.Row="5" Grid.Column="1"
                              Text="{Binding ModelTypeDisplay}"
                              Foreground="White"
                              Margin="0,0,0,6"/>
 
-                  <TextBlock Grid.Row="5" Grid.Column="0"
+                  <TextBlock Grid.Row="6" Grid.Column="0"
                              Text="Category:"
                              Foreground="#FF66AA"
                              FontWeight="SemiBold"
                              Margin="0,0,12,6"
                              VerticalAlignment="Center"/>
-                  <ComboBox Grid.Row="5" Grid.Column="1"
+                  <ComboBox Grid.Row="6" Grid.Column="1"
                             ItemsSource="{Binding AvailableCategories}"
                             SelectedItem="{Binding SelectedCategory, Mode=TwoWay}"
                             Background="#1A1A1A"
@@ -308,22 +322,22 @@
                             HorizontalAlignment="Stretch"
                             ToolTip.Tip="Select a category (overrides tag-based inference)"/>
 
-                  <TextBlock Grid.Row="6" Grid.Column="0"
+                  <TextBlock Grid.Row="7" Grid.Column="0"
                              Text="Creator:"
                              Foreground="#FF66AA"
                              FontWeight="SemiBold"
                              Margin="0,0,12,6"/>
-                  <TextBlock Grid.Row="6" Grid.Column="1"
+                  <TextBlock Grid.Row="7" Grid.Column="1"
                              Text="{Binding CreatorDisplay}"
                              Foreground="White"
                              Margin="0,0,0,6"/>
 
-                  <TextBlock Grid.Row="7" Grid.Column="0"
+                  <TextBlock Grid.Row="8" Grid.Column="0"
                              Text="Folder:"
                              Foreground="#FF66AA"
                              FontWeight="SemiBold"
                              Margin="0,0,12,0"/>
-                  <SelectableTextBlock Grid.Row="7" Grid.Column="1"
+                  <SelectableTextBlock Grid.Row="8" Grid.Column="1"
                                        Text="{Binding FolderPathDisplay}"
                                        Foreground="White"
                                        TextWrapping="Wrap"

--- a/docs/superpowers/plans/2026-08-23-metadata-sync-overhaul-C-identity.md
+++ b/docs/superpowers/plans/2026-08-23-metadata-sync-overhaul-C-identity.md
@@ -1,0 +1,274 @@
+# Metadata Sync Overhaul — Plan C: Identity Chain Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A model that Civitai doesn't know and no sidecar describes still gets its base model — read from the safetensors header, or guessed from the filename and marked as a guess — so the Sorter's `Unknown` bucket shrinks and the detail view says where every identity came from.
+
+**Architecture:** Two new pure-static components in `DiffusionNexus.Service.Services.Sync.Identity` — `SafetensorsHeaderReader` (8-byte LE length + JSON header only, 16 MB cap, never throws) and `BaseModelHeaderMap`/`FilenameBaseModelHeuristic` (header fields / filename tokens → Civitai display labels) — inserted into `IdentifyModelStep`'s existing miss-branch: Civitai → sidecar → **header** → **heuristic** → NotIdentified. Outcomes `SyncOutcome.Header`/`Heuristic` (already in the enum, unused) are stamped along with the already-existing `ModelSyncState.HeaderCheckedAt` column; the detail view gains an "Identity source" row read from the state.
+
+**Tech Stack:** .NET 10, `System.Text.Json` + `System.Buffers.Binary.BinaryPrimitives`, EF Core 10 SQLite, xUnit + FluentAssertions + Moq.
+
+**Spec:** `docs/superpowers/specs/2026-08-21-metadata-sync-overhaul-design.md` §4.5, acceptance §6 (`:202` fixture list, `:213` per-tile header case), decision D5 (heuristic on by default, "guessed"). Supplementary inventory with exact anchors: `.superpowers/sdd/2026-08-23-metadata-sync-overhaul-C-identity/planC-inventory.md` (git-ignored; consult if an anchor drifted).
+
+**Deviation from the spec, decided up front:** no standalone `IModelIdentityResolver`/`ModelIdentity` type. `IdentifyModelStep` already orchestrates rungs 1–2 with the applier/stamping wiring the chain needs; a wrapper interface would have exactly one consumer (the Sorter reads the *database* after this plan, not the resolver). The spec's §4.5 *outputs* — outcome per source, base model written, "guessed" shown, Sorter able to go DB-only — are all delivered.
+
+## Global Constraints
+
+- **Zero schema churn.** `SyncOutcome.Header`/`Heuristic` and `ModelSyncState.HeaderCheckedAt` shipped in Plan A. No migrations; `DatabaseRecoveryService.cs:418`'s recovery DDL stays untouched.
+- **Label spellings come from `CivitaiBaseModelCatalog.BundledSnapshot`** (`DiffusionNexus.Civitai\CivitaiBaseModelCatalog.cs:61-149`) — the mapping tables' outputs are Civitai display strings (`"SDXL 1.0"`, `"SD 1.5"`, `"Flux.1 D"`, `"Pony"`, `"Illustrious"`, `"NoobAI"`, `"Wan Video"`, …), never enum names, never invented labels. A wrong spelling parses to `BaseModelType.Other` and leaks an unfilterable folder.
+- **Provenance never goes into `BaseModelRaw`** — it feeds the viewer filter (mirrored into Civitai API queries) and the Sorter's folder names. Provenance lives only in `ModelSyncState.MetadataOutcome`.
+- **Write guards:** header/heuristic write the base model only when `!dbVersion.IsUserEdited` AND the stored value is a placeholder (`BaseModelRaw is null or "???"` — the `SidecarMetadataApplier.cs:469` precedent). A lower-confidence source never clobbers a higher-confidence value; every write goes through the shared two-line rule (raw string + `ParseCivitai` enum together — never `BaseModelRaw` alone).
+- **Readers never throw and never enumerate directories.** `SafetensorsHeaderReader.TryRead` returns null on any failure (locked file, truncated, bad JSON, oversized header) — `LoraSorterViewModel.cs:820-835` documents that in-use `.safetensors` files throw `IOException`/`UnauthorizedAccessException` in the field. Exact-path probes only (the `SidecarMetadataApplier.Find` lesson: enumeration cost 16 s of planning on the live library).
+- **Cancellation discipline:** a cancelled item is never stamped (`ct.ThrowIfCancellationRequested()` between rungs, preserving `IdentifyModelStep.cs:181`'s pattern).
+- `SyncOutcome` is persisted as a string, max 20 — append-only, never reorder.
+- Tests: real in-memory SQLite fixtures (the `IdentifyModelStepTests` pattern), real files in temp dirs, no EF InMemory, no Avalonia init, no culture-sensitive asserts (German-locale machine). Test command: `dotnet test DiffusionNexus.Tests/DiffusionNexus.Tests.csproj -c Release` (never solution-level; Debug only if Release file-locked — MSB3021/3027).
+- Files: UTF-8 no BOM; match each file's existing CRLF/LF byte-for-byte (repo is mixed per file — check before editing). Commits end `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`. Never push mid-plan; never commit to develop/main.
+- **The Sorter is NOT touched.** Its resolver-chain deletion is the separate #520-rebase follow-up PR; this plan only makes it possible (inventory §4 holds the deletion map).
+
+---
+
+### Task 1: SafetensorsHeaderReader
+
+**Files:**
+- Create: `DiffusionNexus.Service/Services/Sync/Identity/SafetensorsHeaderReader.cs`
+- Test: `DiffusionNexus.Tests/Sync/Service/Identity/SafetensorsHeaderReaderTests.cs`
+
+**Interfaces (Produces):**
+```csharp
+namespace DiffusionNexus.Service.Services.Sync.Identity;
+
+/// <summary>The identity-relevant fields of a safetensors JSON header's __metadata__ block.</summary>
+public sealed record SafetensorsHeaderInfo(
+    string? BaseModelVersion,   // __metadata__["ss_base_model_version"]
+    string? Architecture,       // __metadata__["modelspec.architecture"]
+    string? ModelNameHint);     // __metadata__["ss_sd_model_name"]
+
+public static class SafetensorsHeaderReader
+{
+    public const long MaxHeaderBytes = 16 * 1024 * 1024;   // spec §4.5: cap 16 MB, never the tensors
+    public static SafetensorsHeaderInfo? TryRead(string filePath);   // null on ANY failure; never throws
+}
+```
+
+**Behavior (normative):**
+1. Extension not `.safetensors` (OrdinalIgnoreCase) → null.
+2. Open `new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 81920)` — **ReadWrite** deliberately (a trainer mid-checkpoint holds the file write-shared; the house `FileShare.Read` in `FileHasher.cs:23` would fail there; state this in a comment).
+3. Read exactly 8 bytes → `BinaryPrimitives.ReadUInt64LittleEndian`. Length 0, > `MaxHeaderBytes`, or `8 + length > stream.Length` → null (truncated/oversized → rejected, per acceptance §6).
+4. Read exactly `length` bytes; `JsonDocument.Parse`. Root object's `"__metadata__"` property (object of string values) → extract the three keys; a missing `__metadata__` or missing keys yield a `SafetensorsHeaderInfo` with nulls — **a parsed header with no metadata is still a successful read** (the caller stamps `HeaderCheckedAt` on non-null).
+5. Any exception anywhere (IO, access, JSON, argument) → null. No logging inside the reader (the step logs).
+
+- [ ] **Step 1: Write the failing tests** — with this fixture builder (the repo has no binary fixtures; everything is built in code, per the `ThumbnailCodecTests.Png()` precedent):
+```csharp
+private static byte[] Safetensors(string headerJson, int trailingTensorBytes = 16)
+{
+    var json = Encoding.UTF8.GetBytes(headerJson);
+    var buffer = new byte[8 + json.Length + trailingTensorBytes];
+    BinaryPrimitives.WriteUInt64LittleEndian(buffer, (ulong)json.Length);
+    json.CopyTo(buffer, 8);
+    return buffer;   // trailing zeros stand in for tensor data
+}
+private static string Meta(params (string Key, string Value)[] pairs) =>
+    $$"""{"__metadata__":{{{string.Join(",", pairs.Select(p => $"\"{p.Key}\":\"{p.Value}\""))}}},"tensor.weight":{"dtype":"F16","shape":[4],"data_offsets":[0,8]}}""";
+```
+Tests (temp-dir per the `LocalPreviewFilesTests` pattern; every file written for real):
+  - `TryRead_ExtractsTheThreeMetadataKeys` — `Meta(("ss_base_model_version","sdxl_base_v1-0"),("modelspec.architecture","stable-diffusion-xl-v1-base/lora"),("ss_sd_model_name","ponyDiffusionV6XL"))` → all three populated.
+  - `TryRead_HeaderWithoutMetadataBlockIsASuccessfulEmptyRead` — plain `{"tensor.weight":{...}}` → non-null info, all fields null.
+  - `TryRead_TruncatedFileReturnsNull` — declared length 500, only 40 bytes present.
+  - `TryRead_OversizedHeaderReturnsNull` — declared length `MaxHeaderBytes + 1` (file itself small — the length prefix alone must reject it BEFORE any large allocation; assert with a tight file).
+  - `TryRead_GarbageJsonReturnsNull` — valid length prefix, body `not json{{`.
+  - `TryRead_WrongExtensionReturnsNull` — same valid bytes as the first test but named `.ckpt`.
+  - `TryRead_MissingFileReturnsNull`.
+  - `TryRead_EmptyLengthReturnsNull` — 8 zero bytes only.
+- [ ] **Step 2: Run to verify RED** (compile failure): `dotnet test DiffusionNexus.Tests/DiffusionNexus.Tests.csproj -c Release --filter "FullyQualifiedName~SafetensorsHeaderReader"`
+- [ ] **Step 3: Implement** per the behavior list. Read the length prefix with `stream.ReadExactly` (or a loop — partial reads on network shares are real); check bounds before allocating the header buffer.
+- [ ] **Step 4: GREEN, commit**
+```bash
+git add -A && git commit -m "feat(sync): read the safetensors header — sixteen megabytes of JSON, never the tensors"
+```
+
+### Task 2: The two mapping tables
+
+**Files:**
+- Create: `DiffusionNexus.Service/Services/Sync/Identity/BaseModelHeaderMap.cs`
+- Create: `DiffusionNexus.Service/Services/Sync/Identity/FilenameBaseModelHeuristic.cs`
+- Test: `DiffusionNexus.Tests/Sync/Service/Identity/BaseModelHeaderMapTests.cs`, `FilenameBaseModelHeuristicTests.cs`
+
+**Interfaces (Produces):**
+```csharp
+public static class BaseModelHeaderMap
+{
+    /// <summary>Civitai display label for a parsed header, or null when the header says nothing usable.</summary>
+    public static string? Map(SafetensorsHeaderInfo info);
+}
+public static class FilenameBaseModelHeuristic
+{
+    /// <summary>Civitai display label guessed from a model FILE NAME (no directory, extension ignored), or null.</summary>
+    public static string? Guess(string? fileName);
+}
+```
+
+**`BaseModelHeaderMap.Map` — evaluation order is load-bearing** (Pony/Illustrious/NoobAI are SDXL-architecture refinements: the name hint MUST win over the architecture, or every Pony LoRA maps to `"SDXL 1.0"`):
+1. `ModelNameHint` lowercase-contains: `"pony"` → `"Pony"`, `"illustrious"` → `"Illustrious"`, `"noob"` → `"NoobAI"`.
+2. `Architecture`: lowercase, strip everything from the first `'/'` (drops `/lora`), then exact:
+   `"stable-diffusion-xl-v1-base"` → `"SDXL 1.0"`, `"stable-diffusion-v1"` → `"SD 1.5"`, `"stable-diffusion-v2-768-v"` → `"SD 2.1"`, `"stable-diffusion-v2"` → `"SD 2.0"`, `"stable-diffusion-3-medium"` → `"SD 3"`, `"flux-1-dev"` → `"Flux.1 D"`, `"flux-1-schnell"` → `"Flux.1 S"`.
+3. `BaseModelVersion`: lowercase prefix-match: `"sdxl_base_v1-0"` → `"SDXL 1.0"`, `"sdxl_base_v0-9"` → `"SDXL 0.9"`, `"sd_v1"` → `"SD 1.5"`, `"sd_v2"` → `"SD 2.1"` (kohya writes `sd_v1` for all 1.x and `sd_v2` for 2.x — 1.5/2.1 are the dominant members; a code comment states the approximation).
+4. Nothing matched → null. Every returned string must appear verbatim in `CivitaiBaseModelCatalog.BundledSnapshot` — write the test `Map_EveryOutputIsACatalogLabel` that reflects over the table (expose the outputs via an `internal static IReadOnlyCollection<string> AllLabels` or assert against a hand-kept list mirroring the table) and asserts each is in the bundled snapshot list.
+
+**`FilenameBaseModelHeuristic.Guess` — tokenize then match, most-specific first:**
+- Normalize: `Path.GetFileNameWithoutExtension`, lowercase invariant, split on `[^a-z0-9]+` → tokens; additionally form each adjacent-pair concatenation (so `sd1.5` → tokens `sd1`,`5` → pair `sd15`; `sd_15` likewise).
+- Match order (first hit wins):
+  1. Whole-name substring (safe, distinctive words): `"illustrious"` → `"Illustrious"`, `"noobai"` → `"NoobAI"`, `"sdxl"` → `"SDXL 1.0"`.
+  2. Token-or-pair EXACT: `"sd15"` → `"SD 1.5"`, `"sd21"` → `"SD 2.1"`, `"sd35"` → `"SD 3.5"`, `"sd3"` → `"SD 3"`, `"pdxl"` → `"Pony"`, `"il"` → `"Illustrious"`, `"wan"`/`"wan21"`/`"wan22"` → `"Wan Video"`.
+  3. Token StartsWith: `"pony"` → `"Pony"` (catches `ponyxl`, `ponyv6`; NOT `harmony` — that has no token starting with pony), `"flux"` → `"Flux.1 D"`, `"illust"` → `"Illustrious"`, `"noob"` → `"NoobAI"`.
+- Null/blank input → null.
+
+- [ ] **Step 1: Failing tests.** Map: one test per rung + the priority test `Map_NameHintBeatsArchitecture` (`ponyDiffusionV6XL` + `stable-diffusion-xl-v1-base/lora` → `"Pony"`), `Map_ArchitectureBeatsVersionString`, `Map_UnknownEverythingReturnsNull`, `Map_EveryOutputIsACatalogLabel`. Heuristic (Theory):
+```csharp
+[InlineData("MyChar_Pony_v2", "Pony")]
+[InlineData("ponyxl-style", "Pony")]
+[InlineData("sdxl_lineart", "SDXL 1.0")]
+[InlineData("myIllustriousMix", "Illustrious")]
+[InlineData("style-il", "Illustrious")]
+[InlineData("detailer_sd15", "SD 1.5")]
+[InlineData("detailer_sd1.5", "SD 1.5")]
+[InlineData("wan21_motion", "Wan Video")]
+[InlineData("flux_dev_char", "Flux.1 D")]
+[InlineData("noob_artist", "NoobAI")]
+[InlineData("harmony_lora", null)]       // 'pony' inside a token must NOT match
+[InlineData("wander_style", null)]       // 'wan' prefix of a longer token must NOT match
+[InlineData("family_car", null)]         // 'il' inside a token must NOT match
+[InlineData("mySd150Style", null)]       // 'sd15' inside a longer merged token must NOT match
+[InlineData("", null)]
+[InlineData(null, null)]
+```
+- [ ] **Step 2: RED.  Step 3: implement.  Step 4: GREEN, commit**
+```bash
+git add -A && git commit -m "feat(sync): header fields and filename tokens map to civitai labels — hints before architecture"
+```
+
+### Task 3: The chain in IdentifyModelStep
+
+**Files:**
+- Create: `DiffusionNexus.Service/Services/Sync/BaseModelWriter.cs` (the shared two-line write rule)
+- Modify: `DiffusionNexus.Service/Services/Sync/SidecarMetadataApplier.cs` (`WriteBaseModel :513-520` delegates to the shared helper; behavior identical)
+- Modify: `DiffusionNexus.Service/Services/Sync/Steps/IdentifyModelStep.cs` (miss-branch `:176-188`, `IsDue :133`, `StampAsync :301`, `Description :62`)
+- Modify: `DiffusionNexus.DataAccess/Repositories/ModelRepository.cs` + `IModelRepository` (add `GetVersionByIdAsync` — tracking, no Includes; the Plan B `GetImageByIdAsync` twin. Do NOT widen `GetByIdWithIncludesAsync`: it carries image BLOBs)
+- Test: extend `DiffusionNexus.Tests/Sync/Service/Steps/IdentifyModelStepTests.cs`; extend `DiffusionNexus.Tests/DataAccess/CoreDbMigrationTests.cs`
+
+**Interfaces (Produces):**
+```csharp
+namespace DiffusionNexus.Service.Services.Sync;
+public static class BaseModelWriter
+{
+    /// <summary>Writes both spellings of the base model — the raw Civitai string and the parsed
+    /// enum — or neither. Blank input is a missing answer, not an instruction to forget.</summary>
+    public static bool Write(ModelVersion dbVersion, string? baseModelRaw);   // exact body of the old WriteBaseModel
+
+    /// <summary>The header/heuristic gate: only fill a placeholder, never a user's edit.</summary>
+    public static bool CanFill(ModelVersion dbVersion) =>
+        !dbVersion.IsUserEdited && dbVersion.BaseModelRaw is null or "???";
+}
+// IModelRepository:
+Task<ModelVersion?> GetVersionByIdAsync(int versionId, CancellationToken ct = default);
+```
+
+**The miss-branch replacement** (`IdentifyModelStep.cs:176-188`; `ct.ThrowIfCancellationRequested()` between rungs, `sidecar.Signature` still passed to the stamp in every case so the new-sidecar-evidence path keeps working):
+```csharp
+var sidecar = await _sidecar.ApplyAsync(uow, candidate.ModelId, candidate.LocalPath, ct).ConfigureAwait(false);
+ct.ThrowIfCancellationRequested();
+if (sidecar.Applied)
+{
+    await StampAsync(uow, candidate.ModelId, SyncOutcome.Sidecar, now, sidecar.Signature, error: null, ct).ConfigureAwait(false);
+    return SyncItemResult.Success;
+}
+
+// No Civitai match, no sidecar — read the file's own header, then guess from its name.
+var header = SafetensorsHeaderReader.TryRead(candidate.LocalPath);
+ct.ThrowIfCancellationRequested();
+var headerCheckedAt = header is not null ? now : (DateTimeOffset?)null;
+var label = header is not null ? BaseModelHeaderMap.Map(header) : null;
+var outcome = label is not null ? SyncOutcome.Header : SyncOutcome.NotIdentified;
+if (label is null)
+{
+    label = FilenameBaseModelHeuristic.Guess(Path.GetFileNameWithoutExtension(candidate.LocalPath));
+    if (label is not null) outcome = SyncOutcome.Heuristic;
+}
+if (label is not null)
+{
+    var version = await uow.Models.GetVersionByIdAsync(candidate.VersionId, ct).ConfigureAwait(false);
+    if (version is not null && BaseModelWriter.CanFill(version)) BaseModelWriter.Write(version, label);
+}
+await StampAsync(uow, candidate.ModelId, outcome, now, sidecar.Signature, error: null, ct, headerCheckedAt).ConfigureAwait(false);
+_logger?.Debug(LogCategory.Network, LogSource, $"'{candidate.Name}' not on Civitai → {outcome}" + (label is not null ? $" ({label})" : string.Empty), sidecar.SidecarPath);
+return SyncItemResult.Success;
+```
+Rules encoded above, stated for the reviewer: the **outcome reflects the best source that produced an answer this run** even when the write itself was skipped (value already real, or user-edited); the write is separately guarded by `CanFill`. `StampAsync` gains a trailing optional `DateTimeOffset? headerCheckedAt = null` parameter that sets `state.HeaderCheckedAt` when non-null (existing callers unchanged). `IsDue :133` becomes `is not (SyncOutcome.Sidecar or SyncOutcome.Header or SyncOutcome.Heuristic or SyncOutcome.NotIdentified)`. `Description :62` → `"Identify models (Civitai, sidecar, file header, filename)"`.
+
+- [ ] **Step 1: Failing tests** (all on `NewNotFoundStep()`; model files created via the existing `NewModelFile(name, content)` with `.safetensors` names and the Task 1 fixture builder — copy `Safetensors`/`Meta` helpers into this test class or a shared internal test helper):
+  - `Execute_HeaderIdentifiesAnSdxlLora` — arch header → state `Header`, `HeaderCheckedAt == state.MetadataCheckedAt`, version `BaseModelRaw == "SDXL 1.0"` + `BaseModel == SDXL10`; second `SelectAsync` at the same `now` → not due.
+  - `Execute_NameHintBeatsArchitecture` — pony hint + sdxl arch → `"Pony"`.
+  - `Execute_HeaderDoesNotOverwriteARealBaseModel` — seed version `BaseModelRaw = "Flux.1 D"` → value untouched, outcome still `Header`.
+  - `Execute_HeaderRespectsUserEditedVersion` — `IsUserEdited = true`, placeholder value → value untouched, outcome `Header`.
+  - `Execute_FilenameHeuristicIsTheLastResortBeforeNotIdentified` — headerless `.safetensors` named `MyChar_Pony_v2.safetensors` → outcome `Heuristic`, `"Pony"` written, `HeaderCheckedAt` set (header WAS read — it just said nothing).
+  - `Execute_NonSafetensorsFileSkipsStraightToHeuristic` — `.pt` file named `style_sdxl.pt` → outcome `Heuristic`, `HeaderCheckedAt` null.
+  - `Execute_NothingMatchesStampsNotIdentified` — garbage-named headerless file → `NotIdentified`, no base-model write.
+  - `Execute_SidecarStillBeatsTheHeader` — sidecar present AND sdxl header → outcome `Sidecar`.
+  - `Execute_CivitaiHitNeverConsultsTheHeader` — hash-hit step (existing `NewStep` with a version) on a file whose header says Pony → outcome `Matched`, header label nowhere.
+  - `Select_ANewSidecarMakesAHeaderIdentifiedModelDue` — execute to `Header` (signature `""`), then write a `.civitai.info` next to the file → `SelectAsync` at the same `now` includes the model (extends the existing signature-evidence test family).
+  - `CoreDbMigrationTests`: mirror the `NotIdentified` string round-trip at `:78-100` for `Header` (stored string `"Header"`).
+  - Revisit the two assertions that `HeaderCheckedAt` stays null (`ModelSyncStateTests.cs:19`, `SyncStateDeriverTests.cs:154`): the deriver one stays true (derivation never reads headers — keep, with a comment); the entity-default one stays true. Neither should be weakened.
+- [ ] **Step 2: RED** (`--filter "FullyQualifiedName~IdentifyModelStep|FullyQualifiedName~CoreDbMigration"`).  **Step 3: implement** (BaseModelWriter first, applier delegation — its tests must stay green unchanged — then the step).  **Step 4: GREEN** on `~Sync`, commit:
+```bash
+git add -A && git commit -m "feat(sync): the identify chain reads the file itself before giving up"
+```
+
+### Task 4: Identity source in the detail view
+
+**Files:**
+- Modify: `DiffusionNexus.UI/ViewModels/ModelDetailViewModel.cs` (`LoadAsync :296-319`, property + loader)
+- Modify: `DiffusionNexus.UI/Views/Controls/ModelDetailView.axaml` (`:260-273` region — insert one grid row after "Base Model:", renumber `Grid.Row` on the rows below)
+- Modify: `DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs` (`OnDetailMetadataDownloadRequested :1349-1392` wording)
+- Test: extend `DiffusionNexus.Tests/Viewer/` (headless-testable pieces)
+
+**Changes:**
+1. `ModelDetailViewModel`: `[ObservableProperty] private string? _identitySourceDisplay;` plus `public bool HasIdentitySource => IdentitySourceDisplay is not null;` (notify on change). In `LoadAsync`, fire-and-forget `_ = LoadIdentitySourceAsync(modelId);` exactly like the existing `_ = LoadBaseModelCatalogAsync();` — new scope from `_scopeFactory`, `uow.SyncStates.GetByModelIdAsync(modelId)`, map:
+```csharp
+internal static string? DescribeIdentitySource(SyncOutcome outcome) => outcome switch
+{
+    SyncOutcome.Matched => "Civitai",
+    SyncOutcome.Sidecar => "sidecar file",
+    SyncOutcome.Header => "file header",
+    SyncOutcome.Heuristic => "guessed from filename",
+    _ => null,   // None, NotIdentified, Error — say nothing rather than something scary
+};
+```
+   (`internal static` so it is directly testable.) Swallow-and-log failures like the catalog loader does. Document the granularity honestly in the XML doc: the source is **per model** (one state row) while the base model is **per version** — on a multi-version model the row describes how the model was identified, not each version's value.
+2. XAML: after the Base Model row insert `Identity source:` label + `TextBlock Text="{Binding IdentitySourceDisplay}"` with `IsVisible="{Binding HasIdentitySource}"` on both, tooltip: `How the base model was determined. 'Guessed from filename' is the lowest-confidence source — correct it via the Base Model dropdown and your choice is kept.` Renumber the `Grid.Row` indices below and the grid's `RowDefinitions`.
+3. Per-tile wording (`:1377-1379`): the success message `"Metadata refreshed from Civitai."` becomes `"Metadata refreshed."` (the new row states the source); the no-result message stays for genuinely-nothing runs, but the condition must use the report: when `outcome.Applied` is false AND `IdentifyPlanned > 0` keep `"No metadata found on Civitai for this file."` — no logic change needed beyond the string, because a header/heuristic identification counts as `Succeeded` in the step result and therefore as `Applied` (verify this while wiring; state it in the report).
+4. The chip refreshes after a per-tile run for free (`detail.LoadAsync(tile)` re-fires the loader — verify).
+
+- [ ] **Step 1: Failing tests**: `DescribeIdentitySource` theory (all seven enum values); a `LoraViewerViewModelSyncTests`-style test only if the existing harness reaches the wording branch cheaply — otherwise state why not in the report.
+- [ ] **Step 2: RED.  Step 3: implement.  Step 4:** `--filter "FullyQualifiedName~Viewer|FullyQualifiedName~ModelDetail"` green + `dotnet build DiffusionNexus.UI/DiffusionNexus.UI.csproj -c Release --no-incremental` (0 warnings). Commit:
+```bash
+git add -A && git commit -m "feat(viewer): the detail view says where an identity came from"
+```
+
+### Task 5: Docs + full verification
+
+**Files:**
+- Modify: `DiffusionNexus.UI/Doc/LoraViewer.md` (identity-chain section: the four rungs and their order, outcome table incl. `Header`/`Heuristic`, the placeholder-only + user-edit guards, the per-model vs per-version granularity note, the "guessed" correction flow, retry: all identity outcomes re-check at 30 days and a new/changed sidecar makes any of them due immediately)
+- Modify: `docs/superpowers/specs/2026-08-21-metadata-sync-overhaul-design.md` (tick WP4 in §5)
+
+- [ ] **Step 1: Write the docs** — every behavioral claim verified against the code before it is written (the Plan B lesson: docs get reviewed with the same skepticism as code).
+- [ ] **Step 2: Full verification**: full Release suite (known flakes: `GenerationGalleryViewModelTests.TagCloudSearchText…`, `CheckScoreAdapterTests`, occasionally a Distiller temp-file test — rerun once if alone); UI build 0 warnings; BOM check over all files this plan created; byte-level line-ending audit of touched files vs base (no `grep -c $'\r$'` — it misreported three times in Plan B; use a byte-count method and state the command).
+- [ ] **Step 3: Commit**
+```bash
+git add -A && git commit -m "docs(viewer): the identity chain — four rungs, one honest source label"
+```
+
+---
+
+## Manual acceptance (user, after merge)
+1. Per-tile Download Metadata on a self-trained LoRA with header metadata → base model filled, detail view shows `file header` (spec §6 `:213`).
+2. A file like `MyChar_Pony_v2.safetensors` unknown to Civitai with no sidecar → base model `Pony`, source `guessed from filename`; correcting it via the dropdown survives the next sync.
+3. Bulk run on the library → previously-`NotIdentified` models with readable headers flip to `Header`; the Sorter preview's `Unknown` bucket shrinks correspondingly (still using its own resolver until the follow-up — the DB values improve either way, because DB-known files already bypass the resolver).

--- a/docs/superpowers/specs/2026-08-21-metadata-sync-overhaul-design.md
+++ b/docs/superpowers/specs/2026-08-21-metadata-sync-overhaul-design.md
@@ -183,7 +183,7 @@ Result is written to `ModelVersion.BaseModelRaw` + `ModelSyncState.MetadataOutco
 - [ ] **WP1 — Schema + sync state + derivation** · `ModelSyncState` entity/table, `ModelImage` columns, EF migration, pre-migration VACUUM INTO backup (S2), `SyncStateDeriver` (S3) with table-driven tests, downgrade test (S6).
 - [ ] **WP2 — `LibrarySyncService`** · plan/execute, steps 0–3, retry windows, single-flight guard, logging; `LoraViewerViewModel` wired to it; tile-based phases + per-tile copy deleted; tests with in-memory SQLite per test conventions.
 - [x] **WP3 — Thumbnails** · `IThumbnailProvider`, CDN poster rewrite (+ online canary), `file://`/sibling handling, attempt/failure recording, corrupt-on-decode marking, one BLOB writer, bounded parallelism; step 4.
-- [ ] **WP4 — Identity chain** · `SafetensorsHeaderReader` + mapping table (fixture headers), filename heuristic, `IModelIdentityResolver`, sidecar signature; step 1 uses it; detail view shows the source.
+- [x] **WP4 — Identity chain** · `SafetensorsHeaderReader` + mapping table (fixture headers), filename heuristic, `IModelIdentityResolver`, sidecar signature; step 1 uses it; detail view shows the source.
 - [ ] **WP5 — One download path** · `ICivitaiModelDownloader`, `LoraPathBuilder` + `CollisionPolicy` moved to Service, all five callers migrated, post-download completion, `ILibraryChangeNotifier`, clones deleted (§4.4 list), `IsUserEdited` in the persister, card-handler bug, `FileHasher` casing (+ D2 data migration if approved).
 - [ ] **WP6 — UI** · `SyncPlanDialog`, report view, settings, Unified Console polish, docs (`Doc/LoraViewer.md`).
 - [ ] **WP7 — Acceptance on the reference library** (§6) + PR.

--- a/docs/superpowers/specs/2026-08-21-metadata-sync-overhaul-design.md
+++ b/docs/superpowers/specs/2026-08-21-metadata-sync-overhaul-design.md
@@ -183,7 +183,7 @@ Result is written to `ModelVersion.BaseModelRaw` + `ModelSyncState.MetadataOutco
 - [ ] **WP1 — Schema + sync state + derivation** · `ModelSyncState` entity/table, `ModelImage` columns, EF migration, pre-migration VACUUM INTO backup (S2), `SyncStateDeriver` (S3) with table-driven tests, downgrade test (S6).
 - [ ] **WP2 — `LibrarySyncService`** · plan/execute, steps 0–3, retry windows, single-flight guard, logging; `LoraViewerViewModel` wired to it; tile-based phases + per-tile copy deleted; tests with in-memory SQLite per test conventions.
 - [x] **WP3 — Thumbnails** · `IThumbnailProvider`, CDN poster rewrite (+ online canary), `file://`/sibling handling, attempt/failure recording, corrupt-on-decode marking, one BLOB writer, bounded parallelism; step 4.
-- [x] **WP4 — Identity chain** · `SafetensorsHeaderReader` + mapping table (fixture headers), filename heuristic, `IModelIdentityResolver`, sidecar signature; step 1 uses it; detail view shows the source.
+- [x] **WP4 — Identity chain** · `SafetensorsHeaderReader` + mapping table (fixture headers), filename heuristic, sidecar signature; chain folded into `IdentifyModelStep` (no separate `IModelIdentityResolver` — the Sorter will consume the DB in a follow-up); detail view shows the source.
 - [ ] **WP5 — One download path** · `ICivitaiModelDownloader`, `LoraPathBuilder` + `CollisionPolicy` moved to Service, all five callers migrated, post-download completion, `ILibraryChangeNotifier`, clones deleted (§4.4 list), `IsUserEdited` in the persister, card-handler bug, `FileHasher` casing (+ D2 data migration if approved).
 - [ ] **WP6 — UI** · `SyncPlanDialog`, report view, settings, Unified Console polish, docs (`Doc/LoraViewer.md`).
 - [ ] **WP7 — Acceptance on the reference library** (§6) + PR.


### PR DESCRIPTION
Plan C of the metadata-sync overhaul (#521, WP4) — the identity chain. Follows #522 (ledger + step pipeline) and #523 (thumbnails).

## What this fixes

A model Civitai doesn't recognise and no sidecar describes used to end as `NotIdentified` with a blank base model — it landed in the Sorter's `Unknown` bucket and stayed there. Self-trained LoRAs are the common case, and they carry the answer inside the file.

`IdentifyModelStep` now has five rungs instead of three:

**Civitai hash → sidecar → safetensors header → filename guess → NotIdentified**

- **Header** (`SafetensorsHeaderReader` + `BaseModelHeaderMap`) reads only the 8-byte length prefix and the JSON header — 16 MB cap, tensors never touched, `FileShare.ReadWrite` so a trainer mid-checkpoint doesn't lock us out, and it never throws. The name hint is checked **before** the architecture on purpose: Pony, Illustrious and NoobAI are SDXL-architecture models, so architecture-first would relabel every Pony LoRA `SDXL 1.0`.
- **Heuristic** (`FilenameBaseModelHeuristic`) tokenises the filename and matches most-specific-first, with the same refinement-beats-architecture rule (`stylemix_pony_sdxl_v1` → `Pony`, not `SDXL 1.0`). Negative cases are pinned by tests: `harmony_lora`, `wander_style`, `family_car` and `mySd150Style` all stay `null` rather than false-matching.

Both tables can only emit labels that exist verbatim in `CivitaiBaseModelCatalog.BundledSnapshot`, enforced by reflection tests — a typo'd label would parse to `Other` and leak an unfilterable folder into the viewer filter, the Civitai API queries and the Sorter's folder names.

## Guards

- A header or filename answer fills the base model **only over a placeholder** (`null`, blank, or `"???"`) and **never over a user's edit** — `BaseModelWriter.CanFill`, sharing the two-spellings-or-neither write rule with the sidecar applier (raw string + parsed enum together, never one alone).
- The **outcome records the best source that answered this run even when the write was skipped**, so provenance stays honest on a model whose value was already correct.
- Provenance never enters `BaseModelRaw` — it lives only in `ModelSyncState.MetadataOutcome`.
- `HeaderCheckedAt` is stamped whenever a header parsed, even one that said nothing; null for non-safetensors files.
- A cancelled item is never stamped.

## UI

The detail view gains an **Identity source** row: `Civitai` / `sidecar file` / `file header` / `guessed from filename` — nothing at all for `None`/`NotIdentified`/`Error`, which have no reassuring story to tell. The guess is labelled as a guess, and correcting it through the Base Model dropdown sets `IsUserEdited`, so the next sync leaves it alone. The loader is generation-guarded: a slow lookup for the model you just navigated away from can't stamp its label onto the one you're looking at now.

Per-tile wording drops "from Civitai" — the row now says where it came from.

## Retry

All identity outcomes re-check at 30 days via the existing catch-all, and a new or changed `.civitai.info` next to the file still makes any of them due immediately.

## Scope

**Zero schema churn** — `SyncOutcome.Header`/`Heuristic` and `ModelSyncState.HeaderCheckedAt` shipped unused in #522. No migrations.

**The Sorter is deliberately untouched.** Its private 370-line resolver chain gets deleted in the follow-up PR that rebases on #520; this branch is what makes that possible, since the DB values improve either way.

**Declared deviation from the spec:** no standalone `IModelIdentityResolver`. `IdentifyModelStep` already orchestrates the Civitai and sidecar rungs with the stamping the chain needs, and the wrapper would have exactly one consumer. Spec §5's WP4 line was amended to describe what was actually delivered.

## Verification

4422 passed, 0 failed, 2 skipped (opt-in online canaries) on the full Release suite. UI Release build clean, 0 warnings. Every task passed an independent spec + quality review; a whole-branch review then found four issues (heuristic rung order, a too-narrow placeholder check, the stale spec line, a mislabelled log category), all fixed and re-reviewed.

## Manual acceptance owed

1. Per-tile Download Metadata on a self-trained LoRA with header metadata → base model filled, source reads `file header`.
2. `MyChar_Pony_v2.safetensors`, unknown to Civitai, no sidecar → `Pony` with source `guessed from filename`; correcting it survives the next sync.
3. Bulk run → previously-`NotIdentified` models with readable headers flip to `Header`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
