### PR TITLE
Plan E (WP6): sync plan dialog, report view, settings

### DIFF
--- a/DiffusionNexus.Civitai/Models/CivitaiModelImage.cs
+++ b/DiffusionNexus.Civitai/Models/CivitaiModelImage.cs
@@ -81,7 +81,13 @@ public sealed record CivitaiImageMeta
     [JsonPropertyName("negativePrompt")]
     public string? NegativePrompt { get; init; }
 
+    /// <summary>
+    /// Generation seed. Tolerant converter: live payloads carry seeds beyond
+    /// <c>Int64.MaxValue</c> (JS float64 artifacts) — those read as null
+    /// instead of failing the whole model version.
+    /// </summary>
     [JsonPropertyName("seed")]
+    [JsonConverter(typeof(TolerantNullableInt64JsonConverter))]
     public long? Seed { get; init; }
 
     [JsonPropertyName("steps")]

--- a/DiffusionNexus.Civitai/Models/TolerantNumberConverters.cs
+++ b/DiffusionNexus.Civitai/Models/TolerantNumberConverters.cs
@@ -40,6 +40,45 @@ public sealed class TolerantInt32JsonConverter : JsonConverter<int>
 }
 
 /// <summary>
+/// Tolerant reader for nullable identifier-like fields such as
+/// <c>meta.seed</c> on gallery images. Seeds pass through JavaScript float64
+/// on Civitai's side, so live responses carry values beyond
+/// <c>Int64.MaxValue</c> (a real by-hash payload served
+/// <c>"seed":12859270413054550000</c>) — the default converter throws and one
+/// such image kills deserialization of the entire model version. Unlike the
+/// stat converters, an unusable value reads as <c>null</c> rather than 0: the
+/// field is already nullable, and a clamped or rounded seed would be a wrong
+/// value presented as a real one.
+/// </summary>
+public sealed class TolerantNullableInt64JsonConverter : JsonConverter<long?>
+{
+    public override long? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.Number:
+                // Out-of-range or fractional numbers fall through to null.
+                return reader.TryGetInt64(out var value) ? value : null;
+
+            case JsonTokenType.String:
+                return long.TryParse(reader.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+                    ? parsed
+                    : null;
+
+            default:
+                reader.Skip();
+                return null;
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, long? value, JsonSerializerOptions options)
+    {
+        if (value.HasValue) writer.WriteNumberValue(value.Value);
+        else writer.WriteNullValue();
+    }
+}
+
+/// <summary>
 /// Floating-point companion of <see cref="TolerantInt32JsonConverter"/> for
 /// stat fields like <c>rating</c> — same rules, reading null as 0.
 /// </summary>

--- a/DiffusionNexus.DataAccess/Migrations/Core/20260825133731_AddSyncSettings.Designer.cs
+++ b/DiffusionNexus.DataAccess/Migrations/Core/20260825133731_AddSyncSettings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DiffusionNexus.DataAccess.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DiffusionNexus.DataAccess.Migrations.Core
 {
     [DbContext(typeof(DiffusionNexusCoreDbContext))]
-    partial class DiffusionNexusCoreDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260825133731_AddSyncSettings")]
+    partial class AddSyncSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.11");

--- a/DiffusionNexus.DataAccess/Migrations/Core/20260825133731_AddSyncSettings.cs
+++ b/DiffusionNexus.DataAccess/Migrations/Core/20260825133731_AddSyncSettings.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DiffusionNexus.DataAccess.Migrations.Core
+{
+    /// <inheritdoc />
+    public partial class AddSyncSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "LastLibrarySyncAt",
+                table: "AppSettings",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "SyncErrorRetryDays",
+                table: "AppSettings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 1);
+
+            migrationBuilder.AddColumn<int>(
+                name: "SyncNotIdentifiedRetryDays",
+                table: "AppSettings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 30);
+
+            migrationBuilder.AddColumn<int>(
+                name: "SyncThumbnailConcurrency",
+                table: "AppSettings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 4);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LastLibrarySyncAt",
+                table: "AppSettings");
+
+            migrationBuilder.DropColumn(
+                name: "SyncErrorRetryDays",
+                table: "AppSettings");
+
+            migrationBuilder.DropColumn(
+                name: "SyncNotIdentifiedRetryDays",
+                table: "AppSettings");
+
+            migrationBuilder.DropColumn(
+                name: "SyncThumbnailConcurrency",
+                table: "AppSettings");
+        }
+    }
+}

--- a/DiffusionNexus.DataAccess/Recovery/DatabaseRecoveryService.cs
+++ b/DiffusionNexus.DataAccess/Recovery/DatabaseRecoveryService.cs
@@ -286,7 +286,11 @@ public sealed class DatabaseRecoveryService
                 { "ComfyUiServerUrl", "ALTER TABLE AppSettings ADD COLUMN ComfyUiServerUrl TEXT NOT NULL DEFAULT 'http://127.0.0.1:8188/'" },
                 { "LoraUpdateCheckStalenessDays", "ALTER TABLE AppSettings ADD COLUMN LoraUpdateCheckStalenessDays INTEGER NOT NULL DEFAULT 3" },
                 { "FavoriteLoraSourcePath", "ALTER TABLE AppSettings ADD COLUMN FavoriteLoraSourcePath TEXT" },
-                { "EncryptedHuggingfaceApiKey", "ALTER TABLE AppSettings ADD COLUMN EncryptedHuggingfaceApiKey TEXT" }
+                { "EncryptedHuggingfaceApiKey", "ALTER TABLE AppSettings ADD COLUMN EncryptedHuggingfaceApiKey TEXT" },
+                { "SyncNotIdentifiedRetryDays", "ALTER TABLE AppSettings ADD COLUMN SyncNotIdentifiedRetryDays INTEGER NOT NULL DEFAULT 30" },
+                { "SyncErrorRetryDays", "ALTER TABLE AppSettings ADD COLUMN SyncErrorRetryDays INTEGER NOT NULL DEFAULT 1" },
+                { "SyncThumbnailConcurrency", "ALTER TABLE AppSettings ADD COLUMN SyncThumbnailConcurrency INTEGER NOT NULL DEFAULT 4" },
+                { "LastLibrarySyncAt", "ALTER TABLE AppSettings ADD COLUMN LastLibrarySyncAt TEXT" }
             };
 
             foreach (var col in requiredColumns)

--- a/DiffusionNexus.Domain/Entities/AppSettings.cs
+++ b/DiffusionNexus.Domain/Entities/AppSettings.cs
@@ -79,6 +79,26 @@ public class AppSettings
     /// </summary>
     public int LoraUpdateCheckStalenessDays { get; set; } = 3;
 
+    // --- Metadata Sync Settings (issue #521 Plan E) ---
+
+    /// <summary>
+    /// Days before the bulk sync re-checks a model whose identity attempt found nothing
+    /// (NotIdentified/Sidecar/Header/Heuristic outcomes). Default 30 (spec §4.1 retry policy).
+    /// </summary>
+    public int SyncNotIdentifiedRetryDays { get; set; } = 30;
+
+    /// <summary>Days before the bulk sync retries a model whose last attempt errored. Default 1.</summary>
+    public int SyncErrorRetryDays { get; set; } = 1;
+
+    /// <summary>
+    /// How many thumbnail CDN downloads the bulk sync runs in parallel (1–8, default 4).
+    /// Applies to the Thumbnails step only; API steps are paced, never parallel.
+    /// </summary>
+    public int SyncThumbnailConcurrency { get; set; } = 4;
+
+    /// <summary>When the last user-started library-wide metadata sync completed uncancelled, if ever.</summary>
+    public DateTimeOffset? LastLibrarySyncAt { get; set; }
+
     #endregion
 
     #region LoRA Sort Settings

--- a/DiffusionNexus.Domain/Models/SettingsExportData.cs
+++ b/DiffusionNexus.Domain/Models/SettingsExportData.cs
@@ -159,8 +159,18 @@ public static class SettingsExportSchema
     /// <summary>
     /// Current schema version. Bump when adding new fields.
     /// v2: split AutoBackupEnabled into BackupDatasetImagesEnabled + BackupDatabaseEnabled.
+    /// v3: metadata-sync retry windows + thumbnail concurrency.
     /// </summary>
-    public const int CurrentVersion = 2;
+    /// <remarks>
+    /// Bumping is cheap in both directions. The importer enforces only
+    /// <see cref="MinSupportedVersion"/> — there is no upper bound — so v1 and v2 files still
+    /// import into this build, and an older build reading a v3 file simply ignores the three
+    /// unknown JSON properties. What the bump buys is the distinction a later migration would
+    /// otherwise have no signal for: whether a field is absent because the file predates the
+    /// feature or because the user chose nothing — exactly what
+    /// <see cref="SettingsExportData.LegacyAutoBackupEnabled"/> needed for the v1→v2 split.
+    /// </remarks>
+    public const int CurrentVersion = 3;
 
     /// <summary>
     /// Minimum schema version that can still be imported.

--- a/DiffusionNexus.Domain/Models/SettingsExportData.cs
+++ b/DiffusionNexus.Domain/Models/SettingsExportData.cs
@@ -50,6 +50,21 @@ public sealed record SettingsExportData
     public bool MergeLoraSources { get; init; }
     public int LoraUpdateCheckStalenessDays { get; init; } = 3;
 
+    // ?? Metadata Sync ????????????????????????????????????????
+
+    /// <summary>Days before the bulk metadata sync re-checks a not-identified model. Default 30.</summary>
+    public int SyncNotIdentifiedRetryDays { get; init; } = 30;
+
+    /// <summary>Days before the bulk metadata sync retries a model whose last attempt errored. Default 1.</summary>
+    public int SyncErrorRetryDays { get; init; } = 1;
+
+    /// <summary>Parallel thumbnail downloads during a bulk sync. Default 4.</summary>
+    public int SyncThumbnailConcurrency { get; init; } = 4;
+
+    // Deliberately no LastLibrarySyncAt here: it is machine-local bookkeeping
+    // (stamped by the sync flow itself, not a user-chosen setting), so it is
+    // not part of the portable export/import contract.
+
     // ?? LoRA Sort ????????????????????????????????????????????
 
     public string? LoraSortSourcePath { get; init; }

--- a/DiffusionNexus.Domain/Services/IAppSettingsService.cs
+++ b/DiffusionNexus.Domain/Services/IAppSettingsService.cs
@@ -31,6 +31,11 @@ public interface IAppSettingsService
     Task UpdateLastBackupAtAsync(DateTimeOffset lastBackupAt, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Stamps when the last user-started library sync completed, without touching any other setting.
+    /// </summary>
+    Task UpdateLastLibrarySyncAtAsync(DateTimeOffset lastLibrarySyncAt, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets the decrypted Civitai API key.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>

--- a/DiffusionNexus.Domain/Services/Sync/SyncAlreadyRunningException.cs
+++ b/DiffusionNexus.Domain/Services/Sync/SyncAlreadyRunningException.cs
@@ -1,0 +1,22 @@
+namespace DiffusionNexus.Domain.Services.Sync;
+
+/// <summary>
+/// Thrown by <see cref="ILibrarySyncService.ExecuteAsync"/> when a run is already holding the
+/// service's single-flight slot. A "not now", not a fault — the caller reports it and moves on.
+/// </summary>
+/// <remarks>
+/// It has its own type because a bare <see cref="InvalidOperationException"/> is far wider than the
+/// gate: <c>GetRequiredService&lt;IUnitOfWork&gt;()</c> inside a step's selection, a DI registration
+/// regression, a <c>Single()</c> over an empty sequence — all of them are
+/// <see cref="InvalidOperationException"/> too, and a caller catching the base type told the user
+/// "a sync is already running" about a genuine bug, logged it at Info without the exception, and
+/// re-enabled the button so the same wrong answer came back forever.
+/// It still derives from <see cref="InvalidOperationException"/> so existing callers keep working.
+/// </remarks>
+public sealed class SyncAlreadyRunningException : InvalidOperationException
+{
+    public SyncAlreadyRunningException()
+        : base("A library sync is already running.")
+    {
+    }
+}

--- a/DiffusionNexus.Domain/Services/Sync/SyncOptions.cs
+++ b/DiffusionNexus.Domain/Services/Sync/SyncOptions.cs
@@ -1,13 +1,17 @@
 namespace DiffusionNexus.Domain.Services.Sync;
 
 /// <summary>Which steps a sync run performs, and whether previously-checked items are forced to re-run.</summary>
+/// <param name="ThumbnailConcurrency">
+/// Thumbnails-step download parallelism, clamped to 1–8 by the service. API steps ignore it.
+/// </param>
 public sealed record SyncOptions(
     IReadOnlySet<SyncStepKind> Steps,          // which steps to run
     bool ForceIdentify = false,                // re-run identity even when NotIdentified/Matched-by-fallback
     bool ForceTags = false,
     bool ForceImages = false,
     bool ForceThumbnails = false,
-    SyncRetryPolicy? RetryPolicy = null)
+    SyncRetryPolicy? RetryPolicy = null,
+    int ThumbnailConcurrency = 4)
 {
     public static SyncOptions All { get; } = new(new HashSet<SyncStepKind>(Enum.GetValues<SyncStepKind>()));
     public SyncRetryPolicy Policy => RetryPolicy ?? SyncRetryPolicy.Default;

--- a/DiffusionNexus.Domain/Services/Sync/SyncOptions.cs
+++ b/DiffusionNexus.Domain/Services/Sync/SyncOptions.cs
@@ -15,4 +15,13 @@ public sealed record SyncOptions(
 {
     public static SyncOptions All { get; } = new(new HashSet<SyncStepKind>(Enum.GetValues<SyncStepKind>()));
     public SyncRetryPolicy Policy => RetryPolicy ?? SyncRetryPolicy.Default;
+
+    /// <summary>
+    /// Every step kind but one — derived from the enum, so a sixth member joins both surfaces that
+    /// use it (the bulk button's plan and the plan dialog's rows) without anyone remembering to.
+    /// The hand-written four-element copies this replaces would have left a new step silently
+    /// absent from both, with no compile error and no failing test.
+    /// </summary>
+    public static IReadOnlySet<SyncStepKind> AllStepsExcept(SyncStepKind excluded)
+        => Enum.GetValues<SyncStepKind>().Where(k => k != excluded).ToHashSet();
 }

--- a/DiffusionNexus.Domain/Services/Sync/SyncPlan.cs
+++ b/DiffusionNexus.Domain/Services/Sync/SyncPlan.cs
@@ -6,6 +6,12 @@ public sealed record SyncPlanStep(SyncStepKind Kind, int Count, TimeSpan Estimat
 /// <summary>The result of <see cref="ILibrarySyncService.PlanAsync"/> — what a sync run against a scope would do.</summary>
 public sealed record SyncPlan(SyncScope Scope, SyncOptions Options, IReadOnlyList<SyncPlanStep> Steps, DateTimeOffset PlannedAt)
 {
-    public bool HasWork => Steps.Any(s => s.Count > 0 || s.Kind == SyncStepKind.DiscoverFiles);
+    /// <summary>
+    /// Whether any step has counted work. DiscoverFiles is deliberately not special-cased: its
+    /// count is always 0 (it scans, it cannot be counted in advance), so a discovery-bearing plan
+    /// must be executed on its own terms, not smuggled in as "work" here — that special case made
+    /// this property constant-true for every SyncOptions.All plan and the up-to-date branch dead.
+    /// </summary>
+    public bool HasWork => Steps.Any(s => s.Count > 0);
     public TimeSpan EstimatedDuration => TimeSpan.FromTicks(Steps.Sum(s => s.EstimatedDuration.Ticks));
 }

--- a/DiffusionNexus.Domain/Services/Sync/SyncRetryPolicy.cs
+++ b/DiffusionNexus.Domain/Services/Sync/SyncRetryPolicy.cs
@@ -8,6 +8,17 @@ public sealed record SyncRetryPolicy(TimeSpan NotIdentifiedRetryAfter, TimeSpan 
 {
     public static SyncRetryPolicy Default { get; } = new(TimeSpan.FromDays(30), TimeSpan.FromDays(1), 3);
 
+    /// <summary>
+    /// Builds a policy from the user's saved settings. Floors both windows at one day: zero would
+    /// mean "always due", which turns every plan into a full re-run — when that is wanted it is a
+    /// Force checkbox on the plan dialog, not a saved setting. <see cref="MaxErrorAttempts"/> stays
+    /// at the default: it caps API hammering inside one run window and is not a user-facing knob.
+    /// </summary>
+    public static SyncRetryPolicy FromDays(int notIdentifiedDays, int errorDays) =>
+        new(TimeSpan.FromDays(Math.Max(1, notIdentifiedDays)),
+            TimeSpan.FromDays(Math.Max(1, errorDays)),
+            Default.MaxErrorAttempts);
+
     /// <summary>Whether an identity attempt is due given the stored outcome.</summary>
     public bool IsIdentifyDue(SyncOutcome outcome, DateTimeOffset? checkedAt, int attempts, DateTimeOffset now, bool force)
     {

--- a/DiffusionNexus.Domain/Services/Sync/SyncRetryPolicy.cs
+++ b/DiffusionNexus.Domain/Services/Sync/SyncRetryPolicy.cs
@@ -9,14 +9,29 @@ public sealed record SyncRetryPolicy(TimeSpan NotIdentifiedRetryAfter, TimeSpan 
     public static SyncRetryPolicy Default { get; } = new(TimeSpan.FromDays(30), TimeSpan.FromDays(1), 3);
 
     /// <summary>
-    /// Builds a policy from the user's saved settings. Floors both windows at one day: zero would
-    /// mean "always due", which turns every plan into a full re-run — when that is wanted it is a
-    /// Force checkbox on the plan dialog, not a saved setting. <see cref="MaxErrorAttempts"/> stays
-    /// at the default: it caps API hammering inside one run window and is not a user-facing knob.
+    /// Builds a policy from the user's saved settings. Clamps both windows to 1–3650 days:
+    /// <see cref="MaxErrorAttempts"/> stays at the default, because it caps API hammering inside
+    /// one run window and is not a user-facing knob.
     /// </summary>
+    /// <remarks>
+    /// The floor: zero would mean "always due", which turns every plan into a full re-run — when
+    /// that is wanted it is a Force checkbox on the plan dialog, not a saved setting.
+    /// <para>
+    /// The cap: these values are not guaranteed to come from the settings combo boxes.
+    /// <c>SettingsExportService.ImportAsync</c> copies them straight out of a JSON file with no
+    /// range check, and <c>AppSettingsService.SaveSettingsAsync</c> persists them unvalidated —
+    /// so a hand-edited or corrupted <c>settings.json</c> carrying <c>2147483647</c> reached
+    /// <see cref="TimeSpan.FromDays"/>, which throws above ~10 675 199 days. Every Download
+    /// Metadata press then died with "TimeSpan overflowed because the duration is too long", and
+    /// the tiles' startup read silently fell back to the default: an unusable button with no way
+    /// to see why. Ten years is past every meaningful horizon, so clamping degrades instead of
+    /// throwing — the same "the service owns the sane range" stance already applied to
+    /// <c>ThumbnailConcurrency</c> in <c>LibrarySyncService</c>.
+    /// </para>
+    /// </remarks>
     public static SyncRetryPolicy FromDays(int notIdentifiedDays, int errorDays) =>
-        new(TimeSpan.FromDays(Math.Max(1, notIdentifiedDays)),
-            TimeSpan.FromDays(Math.Max(1, errorDays)),
+        new(TimeSpan.FromDays(Math.Clamp(notIdentifiedDays, 1, 3650)),
+            TimeSpan.FromDays(Math.Clamp(errorDays, 1, 3650)),
             Default.MaxErrorAttempts);
 
     /// <summary>Whether an identity attempt is due given the stored outcome.</summary>

--- a/DiffusionNexus.IntegrationTests/DatasetManagementIntegrationTests.cs
+++ b/DiffusionNexus.IntegrationTests/DatasetManagementIntegrationTests.cs
@@ -159,6 +159,9 @@ public class DatasetManagementIntegrationTests : IClassFixture<TestAppHost>
         public Task<AssignCivitaiIdsDialogResult> ShowAssignCivitaiIdsDialogAsync() =>
             Task.FromResult(new AssignCivitaiIdsDialogResult(false, null, null));
 
+        public Task<SyncPlanDialogResult> ShowSyncPlanDialogAsync(SyncPlanDialogViewModel viewModel) =>
+            Task.FromResult(SyncPlanDialogResult.Cancelled());
+
         public Task<bool> ShowBackupCompareDialogAsync(BackupCompareData currentStats, BackupCompareData backupStats) =>
             Task.FromResult(false);
 

--- a/DiffusionNexus.IntegrationTests/DatasetManagementIntegrationTests.cs
+++ b/DiffusionNexus.IntegrationTests/DatasetManagementIntegrationTests.cs
@@ -162,6 +162,8 @@ public class DatasetManagementIntegrationTests : IClassFixture<TestAppHost>
         public Task<SyncPlanDialogResult> ShowSyncPlanDialogAsync(SyncPlanDialogViewModel viewModel) =>
             Task.FromResult(SyncPlanDialogResult.Cancelled());
 
+        public Task ShowSyncReportDialogAsync(SyncReportDialogViewModel viewModel) => Task.CompletedTask;
+
         public Task<bool> ShowBackupCompareDialogAsync(BackupCompareData currentStats, BackupCompareData backupStats) =>
             Task.FromResult(false);
 

--- a/DiffusionNexus.Service/Services/AppSettingsService.cs
+++ b/DiffusionNexus.Service/Services/AppSettingsService.cs
@@ -715,6 +715,21 @@ public sealed class AppSettingsService : IAppSettingsService
     }
 
     /// <inheritdoc />
+    public async Task UpdateLastLibrarySyncAtAsync(DateTimeOffset lastLibrarySyncAt, CancellationToken cancellationToken = default)
+    {
+        var settings = await _unitOfWork.AppSettings
+            .GetSettingsAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (settings is not null)
+        {
+            settings.LastLibrarySyncAt = lastLibrarySyncAt;
+            settings.UpdatedAt = DateTimeOffset.UtcNow;
+            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc />
     public async Task<string?> GetLoraViewerFilterJsonAsync(CancellationToken cancellationToken = default)
     {
         var settings = await GetSettingsAsync(cancellationToken).ConfigureAwait(false);

--- a/DiffusionNexus.Service/Services/AppSettingsService.cs
+++ b/DiffusionNexus.Service/Services/AppSettingsService.cs
@@ -305,6 +305,9 @@ public sealed class AppSettingsService : IAppSettingsService
         existingSettings.LastBackupAt = settings.LastBackupAt;
         existingSettings.ComfyUiServerUrl = settings.ComfyUiServerUrl;
         existingSettings.LoraUpdateCheckStalenessDays = settings.LoraUpdateCheckStalenessDays;
+        existingSettings.SyncNotIdentifiedRetryDays = settings.SyncNotIdentifiedRetryDays;
+        existingSettings.SyncErrorRetryDays = settings.SyncErrorRetryDays;
+        existingSettings.SyncThumbnailConcurrency = settings.SyncThumbnailConcurrency;
         existingSettings.UpdatedAt = settings.UpdatedAt;
 
         // Handle LoRA sources (remove deleted, update existing, add new)

--- a/DiffusionNexus.Service/Services/SettingsExportService.cs
+++ b/DiffusionNexus.Service/Services/SettingsExportService.cs
@@ -59,6 +59,9 @@ public sealed class SettingsExportService : ISettingsExportService
             UseForgeStylePrompts = settings.UseForgeStylePrompts,
             MergeLoraSources = settings.MergeLoraSources,
             LoraUpdateCheckStalenessDays = settings.LoraUpdateCheckStalenessDays,
+            SyncNotIdentifiedRetryDays = settings.SyncNotIdentifiedRetryDays,
+            SyncErrorRetryDays = settings.SyncErrorRetryDays,
+            SyncThumbnailConcurrency = settings.SyncThumbnailConcurrency,
 
             LoraSortSourcePath = settings.LoraSortSourcePath,
             LoraSortTargetPath = settings.LoraSortTargetPath,
@@ -160,6 +163,14 @@ public sealed class SettingsExportService : ISettingsExportService
             UseForgeStylePrompts = export.UseForgeStylePrompts,
             MergeLoraSources = export.MergeLoraSources,
             LoraUpdateCheckStalenessDays = export.LoraUpdateCheckStalenessDays,
+            SyncNotIdentifiedRetryDays = export.SyncNotIdentifiedRetryDays,
+            SyncErrorRetryDays = export.SyncErrorRetryDays,
+            SyncThumbnailConcurrency = export.SyncThumbnailConcurrency,
+            // LastLibrarySyncAt is deliberately left unset here (CLR default null):
+            // it is machine-local bookkeeping, not part of the export schema, and
+            // AppSettingsService.SaveSettingsAsync's whitelist does not touch that
+            // column — so the real, already-persisted value survives this import
+            // untouched rather than being overwritten with this snapshot's null.
 
             LoraSortSourcePath = export.LoraSortSourcePath,
             LoraSortTargetPath = export.LoraSortTargetPath,

--- a/DiffusionNexus.Service/Services/Sync/LibrarySyncService.cs
+++ b/DiffusionNexus.Service/Services/Sync/LibrarySyncService.cs
@@ -122,7 +122,11 @@ public sealed class LibrarySyncService : ILibrarySyncService
 
         // Wait(0), not WaitAsync: the caller must learn synchronously that a run is already going,
         // and a queued second run is never what the user meant by pressing Sync twice.
-        if (!_gate.Wait(0)) throw new InvalidOperationException("A library sync is already running.");
+        //
+        // Its own exception type, not a bare InvalidOperationException: a step's SelectAsync raises
+        // that too (GetRequiredService, Single() over nothing), and a caller cannot tell "not now"
+        // from "your DI graph is broken" by type. Still derives from it, so old callers are fine.
+        if (!_gate.Wait(0)) throw new SyncAlreadyRunningException();
 
         _isRunning = true;
         var stopwatch = Stopwatch.StartNew();

--- a/DiffusionNexus.Service/Services/Sync/LibrarySyncService.cs
+++ b/DiffusionNexus.Service/Services/Sync/LibrarySyncService.cs
@@ -194,32 +194,62 @@ public sealed class LibrarySyncService : ILibrarySyncService
         var succeeded = 0;
         var skipped = 0;
         var failed = 0;
+        var tallyLock = new object();
+
+        void Record(ItemOutcome outcome, SyncItem item)
+        {
+            var result = outcome.Result;
+            processed++;
+            if (result.Succeeded) succeeded++;
+            else if (result.Skipped) skipped++;
+            else
+            {
+                failed++;
+                tally.Failures.Add(new SyncFailure(step.Kind, item.ModelId, item.Name, result.FailureReason ?? "Unknown error"));
+
+                if (outcome.Unexpected)
+                {
+                    tally.UnexpectedFailures++;
+                    tally.FirstUnexpectedError ??= result.FailureReason;
+                }
+            }
+        }
+
+        var concurrency = Math.Clamp(plan.Options.ThumbnailConcurrency, 1, 8);
 
         try
         {
-            for (var i = 0; i < items.Count; i++)
+            if (step.Kind == SyncStepKind.Thumbnails && concurrency > 1 && items.Count > 1)
             {
-                ct.ThrowIfCancellationRequested();
+                // CDN fetches only — deliberately unpaced (see ThumbnailsStep remarks), and every
+                // step owns a fresh scope per ExecuteOneAsync, so items are independent. Only the
+                // tally and the progress counter are shared, and both are synchronized here.
+                var started = 0;
+                var parallelOptions = new ParallelOptions { MaxDegreeOfParallelism = concurrency, CancellationToken = ct };
 
-                var item = items[i];
-                progress?.Report(new LibrarySyncProgress(step.Kind, i + 1, items.Count, item.Name));
-
-                var outcome = await ExecuteItemAsync(step, item, apiKey, ct).ConfigureAwait(false);
-                var result = outcome.Result;
-
-                processed++;
-                if (result.Succeeded) succeeded++;
-                else if (result.Skipped) skipped++;
-                else
+                await Parallel.ForEachAsync(items, parallelOptions, async (item, itemCt) =>
                 {
-                    failed++;
-                    tally.Failures.Add(new SyncFailure(step.Kind, item.ModelId, item.Name, result.FailureReason ?? "Unknown error"));
+                    // "Items started", not a stable position: under parallelism the status line
+                    // shows churn, and a monotonic counter is the honest number to put in [i/n].
+                    var index = Interlocked.Increment(ref started);
+                    progress?.Report(new LibrarySyncProgress(step.Kind, index, items.Count, item.Name));
 
-                    if (outcome.Unexpected)
-                    {
-                        tally.UnexpectedFailures++;
-                        tally.FirstUnexpectedError ??= result.FailureReason;
-                    }
+                    var outcome = await ExecuteItemAsync(step, item, apiKey, itemCt).ConfigureAwait(false);
+
+                    lock (tallyLock) Record(outcome, item);
+                }).ConfigureAwait(false);
+            }
+            else
+            {
+                for (var i = 0; i < items.Count; i++)
+                {
+                    ct.ThrowIfCancellationRequested();
+
+                    var item = items[i];
+                    progress?.Report(new LibrarySyncProgress(step.Kind, i + 1, items.Count, item.Name));
+
+                    var outcome = await ExecuteItemAsync(step, item, apiKey, ct).ConfigureAwait(false);
+                    Record(outcome, item);
                 }
             }
         }

--- a/DiffusionNexus.Service/Services/Sync/Steps/IdentifyModelStep.cs
+++ b/DiffusionNexus.Service/Services/Sync/Steps/IdentifyModelStep.cs
@@ -81,15 +81,17 @@ public sealed class IdentifyModelStep : ISyncStep
         var settings = dbScope.ServiceProvider.GetRequiredService<IAppSettingsService>();
         var enabledRoots = await settings.GetEnabledLoraSourcesAsync(ct).ConfigureAwait(false);
 
-        // A forced run is the user asking for another look at a model they can see, so a stored
-        // Civitai id must not hide it: that is what made the per-tile button answer "no metadata
-        // found on Civitai" for every already-matched model. An explicit id scope is the same
-        // request by a different route. Due-ness is still the retry policy's call — and under
-        // force it always says yes.
-        var includeMatched = options.ForceIdentify || scope.Kind == SyncScopeKind.Models;
+        // An explicit id scope is the user asking for another look at a model they can see — the
+        // per-tile "Download Metadata" button — so a stored Civitai id must not hide it: that is
+        // what made that button answer "no metadata found on Civitai" for every already-matched
+        // model. A bulk run is a different promise: its force is the dialog's "Models not found on
+        // Civitai" checkbox, and Matched is exactly "found" — so a library- or folder-wide force
+        // neither fetches matched rows here nor (see IsDue) re-checks the ones the CivitaiId
+        // filter cannot see, and it no longer drags hand-edited models into an overwrite run.
+        var explicitScope = scope.Kind == SyncScopeKind.Models;
 
         var candidates = await uow.SyncStates
-            .SelectIdentifyCandidatesAsync(scope, enabledRoots, includeMatched, ct)
+            .SelectIdentifyCandidatesAsync(scope, enabledRoots, includeMatched: explicitScope, ct)
             .ConfigureAwait(false);
 
         var items = new List<SyncItem>(candidates.Count);
@@ -101,7 +103,7 @@ public sealed class IdentifyModelStep : ISyncStep
             // that — leave it to the verify/discover steps rather than burning an attempt on it.
             if (!File.Exists(candidate.LocalPath)) continue;
 
-            if (IsDue(candidate, options, now)) items.Add(new SyncItem(candidate.ModelId, candidate.Name, candidate));
+            if (IsDue(candidate, options, explicitScope, now)) items.Add(new SyncItem(candidate.ModelId, candidate.Name, candidate));
         }
 
         _logger?.Debug(LogCategory.General, LogSource,
@@ -127,9 +129,14 @@ public sealed class IdentifyModelStep : ISyncStep
     /// is probed only for rows that have been checked before, not for the whole library.
     /// </para>
     /// </remarks>
-    private static bool IsDue(IdentifyCandidate candidate, SyncOptions options, DateTimeOffset now)
+    private static bool IsDue(IdentifyCandidate candidate, SyncOptions options, bool explicitScope, DateTimeOffset now)
     {
-        if (options.Policy.IsIdentifyDue(candidate.Outcome, candidate.CheckedAt, candidate.Attempts, now, options.ForceIdentify))
+        // Force re-looks at a Matched model only when the user pointed at it (the explicit scope).
+        // This gate cannot live in the candidate filter alone: the duplicate copy that owns the
+        // page id but no CivitaiId passes that filter and arrives here as Matched all the same.
+        var force = options.ForceIdentify && (explicitScope || candidate.Outcome != SyncOutcome.Matched);
+
+        if (options.Policy.IsIdentifyDue(candidate.Outcome, candidate.CheckedAt, candidate.Attempts, now, force))
             return true;
 
         // A sidecar that appeared or changed since the last look is new evidence, so it beats the

--- a/DiffusionNexus.Tests/Civitai/TolerantSeedJsonConverterTests.cs
+++ b/DiffusionNexus.Tests/Civitai/TolerantSeedJsonConverterTests.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using DiffusionNexus.Civitai.Models;
+using FluentAssertions;
+
+namespace DiffusionNexus.Tests.Civitai;
+
+/// <summary>
+/// Civitai gallery images carry generation seeds that went through JavaScript
+/// float64 on their way in, so a seed can exceed <c>Int64.MaxValue</c> (a real
+/// by-hash response served <c>"seed":12859270413054550000</c> — 1.28e19 against
+/// a max of 9.22e18). The default converter throws on such a value, and one
+/// oversized seed killed identification of the whole model: "The JSON value
+/// could not be converted to System.Nullable`1[System.Int64].
+/// Path: $.images[1].meta.seed" (user-reported — two Krea LoRAs failing every
+/// sync run). The seed is display-only and already precision-mangled, so no
+/// seed shape may ever fail the surrounding payload: in-range integers pass
+/// through, everything else reads as null.
+/// </summary>
+public class TolerantSeedJsonConverterTests
+{
+    [Fact]
+    public void CivitaiModelVersion_ReadsSeedBeyondInt64AsNull()
+    {
+        // Minimal form of the crashing shape at $.images[1].meta.seed —
+        // the oversized seed value is verbatim from the live response.
+        var json = """
+            {"id":3134500,"name":"v1.0 - 5,500 Steps","images":[
+             {"url":"https://example/a.jpeg","meta":{"prompt":"a","seed":993423092662132400}},
+             {"url":"https://example/b.jpeg","meta":{"prompt":"b","seed":12859270413054550000}}]}
+            """;
+
+        var version = JsonSerializer.Deserialize<CivitaiModelVersion>(json);
+
+        version!.Images.Should().HaveCount(2);
+        version.Images![0].Meta!.Seed.Should().Be(993423092662132400);
+        version.Images[1].Meta!.Seed.Should().BeNull();
+        version.Images[1].Meta!.Prompt.Should().Be("b", "the rest of the meta must survive the bad seed");
+    }
+
+    [Theory]
+    [InlineData("null")]
+    [InlineData("-1")]
+    [InlineData("42")]
+    public void CivitaiImageMeta_ReadsOrdinarySeedShapesAsBefore(string seedJson)
+    {
+        var meta = JsonSerializer.Deserialize<CivitaiImageMeta>($$"""{"seed":{{seedJson}}}""");
+
+        long? expected = seedJson == "null" ? null : long.Parse(seedJson);
+        meta!.Seed.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(""" "1644221548111640800" """, 1644221548111640800L)] // numeric string → parsed
+    [InlineData(""" "not-a-number" """, null)]
+    [InlineData("3.7", null)] // fractional — a rounded seed is a lie
+    [InlineData("1.2859270413054550e19", null)] // scientific notation beyond Int64
+    [InlineData("""{"nested":"object"}""", null)]
+    public void CivitaiImageMeta_ReadsUnusableSeedShapesAsNull(string seedJson, long? expected)
+    {
+        var meta = JsonSerializer.Deserialize<CivitaiImageMeta>($$"""{"seed":{{seedJson.Trim()}}}""");
+
+        meta!.Seed.Should().Be(expected);
+    }
+}

--- a/DiffusionNexus.Tests/DataAccess/Recovery/DatabaseRecoveryServiceTests.cs
+++ b/DiffusionNexus.Tests/DataAccess/Recovery/DatabaseRecoveryServiceTests.cs
@@ -254,6 +254,33 @@ public sealed class DatabaseRecoveryServiceTests : IDisposable
         Assert.Empty(logger.Errors);
     }
 
+    /// <summary>
+    /// The four Plan E settings columns each have a self-heal entry (#521 WP6). Dropping them all
+    /// and repairing pins the SQL inside those entries — a typo'd column name or type would leave
+    /// the app crashing on "no such column" with the repair silently missing it.
+    /// </summary>
+    [Fact]
+    public void CheckAndRepairSchema_ReAddsMissingSyncSettingsColumns()
+    {
+        MigrateFresh();
+        Exec("ALTER TABLE AppSettings DROP COLUMN SyncNotIdentifiedRetryDays;");
+        Exec("ALTER TABLE AppSettings DROP COLUMN SyncErrorRetryDays;");
+        Exec("ALTER TABLE AppSettings DROP COLUMN SyncThumbnailConcurrency;");
+        Exec("ALTER TABLE AppSettings DROP COLUMN LastLibrarySyncAt;");
+        Assert.DoesNotContain("SyncThumbnailConcurrency", Columns("AppSettings"));
+
+        var logger = new CapturingRecoveryLogger();
+        var svc = new DatabaseRecoveryService(logger);
+        using (var ctx = NewContext()) svc.CheckAndRepairSchema(ctx);
+
+        var repaired = Columns("AppSettings");
+        Assert.Contains("SyncNotIdentifiedRetryDays", repaired);
+        Assert.Contains("SyncErrorRetryDays", repaired);
+        Assert.Contains("SyncThumbnailConcurrency", repaired);
+        Assert.Contains("LastLibrarySyncAt", repaired);
+        Assert.Empty(logger.Errors);
+    }
+
     [Fact]
     public void CheckAndRepairSchema_RecreatesDroppedModelSyncStatesTable_WithCascadeToModels()
     {

--- a/DiffusionNexus.Tests/Service/Services/AppSettingsServiceSyncSettingsTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/AppSettingsServiceSyncSettingsTests.cs
@@ -1,0 +1,130 @@
+using DiffusionNexus.DataAccess;
+using DiffusionNexus.Domain.Entities;
+using DiffusionNexus.Domain.Services;
+using DiffusionNexus.Service.Services;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace DiffusionNexus.Tests.Service.Services;
+
+/// <summary>
+/// Covers the persistence gap discovered while wiring the Settings page's "Metadata
+/// Sync" section (Task 6): <see cref="AppSettingsService.SaveSettingsAsync"/> updates
+/// an explicit whitelist of scalar columns on the tracked, freshly-loaded entity
+/// rather than attaching the caller's detached snapshot wholesale — Task 1 added the
+/// three sync columns to <see cref="AppSettings"/> but never added them to that
+/// whitelist, so a Settings-page save silently discarded any change the user made to
+/// them. This class proves the fix (the columns now round-trip) and the deliberate
+/// non-fix for <see cref="AppSettings.LastLibrarySyncAt"/>: that column is stamped
+/// only via the dedicated <see cref="IAppSettingsService.UpdateLastLibrarySyncAtAsync"/>
+/// path (Task 5), so it is intentionally left OUT of the whitelist — the freshly
+/// loaded tracked entity already carries the real value, and copying a detached
+/// snapshot's default-initialized value over it would reproduce the same silent-null
+/// bug that already affects <c>LastBackupAt</c> on this exact code path.
+/// </summary>
+public sealed class AppSettingsServiceSyncSettingsTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly ServiceProvider _serviceProvider;
+
+    public AppSettingsServiceSyncSettingsTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var secureStorageMock = new Mock<ISecureStorage>();
+        secureStorageMock.Setup(s => s.Encrypt(It.IsAny<string?>())).Returns<string?>(v => v);
+        secureStorageMock.Setup(s => s.Decrypt(It.IsAny<string?>())).Returns<string?>(v => v);
+
+        var services = new ServiceCollection();
+        services.AddDataAccessLayer(options => options.UseSqlite(_connection));
+        services.AddSingleton(secureStorageMock.Object);
+        services.AddTransient<IAppSettingsService, AppSettingsService>();
+
+        _serviceProvider = services.BuildServiceProvider();
+
+        using var scope = _serviceProvider.CreateScope();
+        var context = scope.ServiceProvider
+            .GetRequiredService<DiffusionNexus.DataAccess.Data.DiffusionNexusCoreDbContext>();
+        context.Database.EnsureCreated();
+    }
+
+    private IAppSettingsService CreateService(IServiceScope scope)
+        => scope.ServiceProvider.GetRequiredService<IAppSettingsService>();
+
+    [Fact]
+    public async Task SaveSettings_PersistsSyncRetryAndConcurrencyColumns()
+    {
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var service = CreateService(scope);
+            var settings = new AppSettings
+            {
+                Id = 1,
+                SyncNotIdentifiedRetryDays = 60,
+                SyncErrorRetryDays = 7,
+                SyncThumbnailConcurrency = 8,
+            };
+
+            await service.SaveSettingsAsync(settings);
+        }
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var service = CreateService(scope);
+            var settings = await service.GetSettingsAsync();
+
+            settings.SyncNotIdentifiedRetryDays.Should().Be(60,
+                "the Metadata Sync section's not-identified retry window must survive a settings save");
+            settings.SyncErrorRetryDays.Should().Be(7,
+                "the Metadata Sync section's error retry window must survive a settings save");
+            settings.SyncThumbnailConcurrency.Should().Be(8,
+                "the Metadata Sync section's thumbnail concurrency must survive a settings save");
+        }
+    }
+
+    [Fact]
+    public async Task SaveSettings_LeavesLastLibrarySyncAtUntouched_WhenTheDetachedSnapshotDoesNotCarryIt()
+    {
+        var stampedAt = new DateTimeOffset(2026, 8, 1, 12, 0, 0, TimeSpan.Zero);
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var service = CreateService(scope);
+            // Seeds the singleton row (GetSettingsAsync creates it on first read, same as
+            // every real startup path); UpdateLastLibrarySyncAtAsync's own read no-ops on
+            // a still-missing row, which the real app never hits — Task 5's flow always
+            // calls the full GetSettingsAsync (seeding path) before ever stamping.
+            await service.GetSettingsAsync();
+            await service.UpdateLastLibrarySyncAtAsync(stampedAt);
+        }
+
+        // Simulates the Settings page's save command: a detached AppSettings built
+        // fresh (LastLibrarySyncAt left at its default null, since the field is not
+        // user-editable there).
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var service = CreateService(scope);
+            await service.SaveSettingsAsync(new AppSettings { Id = 1, SyncErrorRetryDays = 3 });
+        }
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var service = CreateService(scope);
+            var settings = await service.GetSettingsAsync();
+
+            settings.LastLibrarySyncAt.Should().Be(stampedAt,
+                "a settings-page save must not null out the sync flow's own stamp");
+            settings.SyncErrorRetryDays.Should().Be(3);
+        }
+    }
+
+    public void Dispose()
+    {
+        _serviceProvider.Dispose();
+        _connection.Dispose();
+    }
+}

--- a/DiffusionNexus.Tests/Service/Services/AppSettingsServiceSyncSettingsTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/AppSettingsServiceSyncSettingsTests.cs
@@ -29,6 +29,7 @@ public sealed class AppSettingsServiceSyncSettingsTests : IDisposable
 {
     private readonly SqliteConnection _connection;
     private readonly ServiceProvider _serviceProvider;
+    private readonly DirectoryInfo _tempDir = Directory.CreateTempSubdirectory("dn-appsettings-sync-tests-");
 
     public AppSettingsServiceSyncSettingsTests()
     {
@@ -43,6 +44,7 @@ public sealed class AppSettingsServiceSyncSettingsTests : IDisposable
         services.AddDataAccessLayer(options => options.UseSqlite(_connection));
         services.AddSingleton(secureStorageMock.Object);
         services.AddTransient<IAppSettingsService, AppSettingsService>();
+        services.AddTransient<ISettingsExportService, SettingsExportService>();
 
         _serviceProvider = services.BuildServiceProvider();
 
@@ -54,6 +56,11 @@ public sealed class AppSettingsServiceSyncSettingsTests : IDisposable
 
     private IAppSettingsService CreateService(IServiceScope scope)
         => scope.ServiceProvider.GetRequiredService<IAppSettingsService>();
+
+    private ISettingsExportService CreateExportService(IServiceScope scope)
+        => scope.ServiceProvider.GetRequiredService<ISettingsExportService>();
+
+    private string PathFor(string fileName) => Path.Combine(_tempDir.FullName, fileName);
 
     [Fact]
     public async Task SaveSettings_PersistsSyncRetryAndConcurrencyColumns()
@@ -122,9 +129,104 @@ public sealed class AppSettingsServiceSyncSettingsTests : IDisposable
         }
     }
 
+    /// <summary>
+    /// End-to-end proof for the fix round 1 finding: <c>SettingsExportService.ImportAsync</c>
+    /// built its detached <see cref="AppSettings"/> snapshot straight from
+    /// <c>SettingsExportData</c>, which had no Sync* properties — so re-importing an export
+    /// file always reset these three columns to the DTO's CLR defaults (30/1/4), even when
+    /// the user's real values (and the export file itself) carried something else. This
+    /// exercises the real <see cref="SettingsExportService"/> against the real
+    /// <see cref="AppSettingsService"/> and a real SQLite database, not mocks.
+    /// </summary>
+    [Fact]
+    public async Task ExportImport_RoundTripsSyncRetryAndConcurrencyColumns()
+    {
+        var path = PathFor("sync-export.json");
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var service = CreateService(scope);
+            await service.SaveSettingsAsync(new AppSettings
+            {
+                Id = 1,
+                SyncNotIdentifiedRetryDays = 60,
+                SyncErrorRetryDays = 7,
+                SyncThumbnailConcurrency = 8,
+            });
+        }
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            await CreateExportService(scope).ExportAsync(path);
+        }
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            await CreateExportService(scope).ImportAsync(path);
+        }
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var settings = await CreateService(scope).GetSettingsAsync();
+
+            settings.SyncNotIdentifiedRetryDays.Should().Be(60,
+                "a real export/import round trip must not reset the retry window to the DTO default");
+            settings.SyncErrorRetryDays.Should().Be(7);
+            settings.SyncThumbnailConcurrency.Should().Be(8);
+        }
+    }
+
+    /// <summary>
+    /// The other half of the <see cref="AppSettings.LastLibrarySyncAt"/> preservation
+    /// guarantee (the ViewModel-level half lives in <c>SettingsViewModelSyncSettingsTests</c>,
+    /// and the DTO-level half — that <c>ImportAsync</c> never invents a value — lives in
+    /// <c>SettingsExportServiceTests</c>): a real settings export followed by a real import
+    /// must leave a previously stamped sync timestamp untouched, end to end.
+    /// </summary>
+    [Fact]
+    public async Task ExportImport_DoesNotDisturbLastLibrarySyncAt()
+    {
+        var stampedAt = new DateTimeOffset(2026, 8, 1, 12, 0, 0, TimeSpan.Zero);
+        var path = PathFor("sync-stamp-export.json");
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var service = CreateService(scope);
+            // Seeds the row first — see the comment in the sibling test above.
+            await service.GetSettingsAsync();
+            await service.UpdateLastLibrarySyncAtAsync(stampedAt);
+        }
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            await CreateExportService(scope).ExportAsync(path);
+        }
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            await CreateExportService(scope).ImportAsync(path);
+        }
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var settings = await CreateService(scope).GetSettingsAsync();
+
+            settings.LastLibrarySyncAt.Should().Be(stampedAt,
+                "a settings import must not disturb the sync flow's own machine-local stamp");
+        }
+    }
+
     public void Dispose()
     {
         _serviceProvider.Dispose();
         _connection.Dispose();
+        try
+        {
+            _tempDir.Delete(recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best effort — never fail a test run on temp-folder cleanup.
+        }
     }
 }

--- a/DiffusionNexus.Tests/Service/Services/SettingsExportServiceTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/SettingsExportServiceTests.cs
@@ -298,6 +298,46 @@ public class SettingsExportServiceTests : IDisposable
             .Should().Be(SettingsExportSchema.CurrentVersion);
     }
 
+    /// <summary>
+    /// The file's own rule: bump <c>CurrentVersion</c> whenever fields are added to
+    /// <c>SettingsExportData</c>. v3 is the metadata-sync retry windows and thumbnail concurrency.
+    /// Without the bump a v2 file written before that feature and one written after it are
+    /// indistinguishable, so no later migration can tell "absent because it predates the feature"
+    /// from "the user chose nothing" — which is exactly the distinction the v1→v2 backup split
+    /// needed and got.
+    /// </summary>
+    [Fact]
+    public void TheSchemaVersionIsBumpedForTheMetadataSyncFields()
+    {
+        SettingsExportSchema.CurrentVersion.Should().Be(3);
+        SettingsExportSchema.MinSupportedVersion.Should().Be(1,
+            "the bump costs nothing on the way in — v1 and v2 files still import");
+    }
+
+    /// <summary>
+    /// …and costs nothing on the way in either. A v2 file has none of the three new properties, so
+    /// the DTO defaults stand in and the file imports exactly as it did before the bump. (The
+    /// reverse — an old build reading a v3 file — is covered by the unknown-property tolerance the
+    /// deserializer already has, and by the "newer than this build" test below.)
+    /// </summary>
+    [Fact]
+    public async Task WhenAVersionTwoFileHasNoSyncFieldsThenTheDefaultsAreImported()
+    {
+        var captured = GivenSaveIsCaptured();
+        var path = await WriteJsonAsync("v2-no-sync-fields.json", """
+        { "schemaVersion": 2, "showNsfw": true }
+        """);
+        var sut = CreateSut();
+
+        await sut.ImportAsync(path);
+
+        var imported = captured()!;
+        imported.ShowNsfw.Should().BeTrue("the file's own fields still apply");
+        imported.SyncNotIdentifiedRetryDays.Should().Be(30);
+        imported.SyncErrorRetryDays.Should().Be(1);
+        imported.SyncThumbnailConcurrency.Should().Be(4);
+    }
+
     [Fact]
     public async Task WhenExportingThenTheLegacyV1BackupFlagIsNeverWritten()
     {

--- a/DiffusionNexus.Tests/Service/Services/SettingsExportServiceTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/SettingsExportServiceTests.cs
@@ -92,6 +92,9 @@ public class SettingsExportServiceTests : IDisposable
         UseForgeStylePrompts = false,
         MergeLoraSources = true,
         LoraUpdateCheckStalenessDays = 17,
+        SyncNotIdentifiedRetryDays = 60,
+        SyncErrorRetryDays = 7,
+        SyncThumbnailConcurrency = 8,
 
         LoraSortSourcePath = @"D:\Sort\In",
         LoraSortTargetPath = @"D:\Sort\Out",
@@ -130,6 +133,9 @@ public class SettingsExportServiceTests : IDisposable
         imported.UseForgeStylePrompts.Should().BeFalse();
         imported.MergeLoraSources.Should().BeTrue();
         imported.LoraUpdateCheckStalenessDays.Should().Be(17);
+        imported.SyncNotIdentifiedRetryDays.Should().Be(60);
+        imported.SyncErrorRetryDays.Should().Be(7);
+        imported.SyncThumbnailConcurrency.Should().Be(8);
         imported.LoraSortSourcePath.Should().Be(@"D:\Sort\In");
         imported.LoraSortTargetPath.Should().Be(@"D:\Sort\Out");
         imported.DeleteEmptySourceFolders.Should().BeTrue();
@@ -575,6 +581,93 @@ public class SettingsExportServiceTests : IDisposable
         await sut.ImportAsync(path);
 
         captured()!.BackupDatasetImagesEnabled.Should().BeFalse();
+    }
+
+    // Metadata Sync (Task 6 fix round 1).
+    // AppSettingsService.SaveSettingsAsync's whitelist copies these three
+    // columns from whatever detached AppSettings snapshot it is handed.
+    // ImportAsync built that snapshot straight from SettingsExportData without
+    // loading current DB state, and the DTO had no Sync* properties — so every
+    // import silently reset the user's retry windows and concurrency back to
+    // the CLR defaults (30/1/4), even when the export file the user just
+    // produced carried different values.
+
+    [Fact]
+    public async Task WhenSyncSettingsAreExportedAndReimportedThenTheyRoundTrip()
+    {
+        var original = FullyPopulatedSettings();
+        original.SyncNotIdentifiedRetryDays = 60;
+        original.SyncErrorRetryDays = 7;
+        original.SyncThumbnailConcurrency = 8;
+        GivenCurrentSettings(original);
+        var captured = GivenSaveIsCaptured();
+        var sut = CreateSut();
+        var path = PathFor("sync-settings.json");
+
+        await sut.ExportAsync(path);
+        await sut.ImportAsync(path);
+
+        var imported = captured()!;
+        imported.SyncNotIdentifiedRetryDays.Should().Be(60,
+            "the exported retry window must survive re-import, not silently reset to the CLR default");
+        imported.SyncErrorRetryDays.Should().Be(7);
+        imported.SyncThumbnailConcurrency.Should().Be(8);
+    }
+
+    [Fact]
+    public async Task WhenAnOldExportWithoutSyncSettingsIsImportedThenTheSyncDefaultsApply()
+    {
+        // Unavoidable without the fields: an export file written before this fix
+        // (or by an older app version) carries no sync data at all, so import
+        // lands on the DTO's declared defaults — same as any other newly added
+        // setting under this schema's backward-compatibility contract.
+        var captured = GivenSaveIsCaptured();
+        var path = await WriteJsonAsync("old-export-no-sync.json", """
+        { "schemaVersion": 2, "showNsfw": true }
+        """);
+        var sut = CreateSut();
+
+        await sut.ImportAsync(path);
+
+        var imported = captured()!;
+        imported.SyncNotIdentifiedRetryDays.Should().Be(30);
+        imported.SyncErrorRetryDays.Should().Be(1);
+        imported.SyncThumbnailConcurrency.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task WhenExportingThenLastLibrarySyncAtIsNeverWritten()
+    {
+        // Machine-local bookkeeping (Task 5's own sync flow stamps it directly
+        // via UpdateLastLibrarySyncAtAsync), not a portable user setting — it
+        // must never appear in an export file.
+        GivenCurrentSettings(FullyPopulatedSettings());
+        var sut = CreateSut();
+        var path = PathFor("no-last-sync-stamp.json");
+
+        await sut.ExportAsync(path);
+
+        (await File.ReadAllTextAsync(path)).Should().NotContain("lastLibrarySyncAt");
+    }
+
+    [Fact]
+    public async Task WhenImportingThenTheDetachedSnapshotNeverSetsLastLibrarySyncAt()
+    {
+        // ImportAsync's own contribution to the preservation guarantee: it must
+        // never invent a LastLibrarySyncAt value on the snapshot it hands to
+        // SaveSettingsAsync. The other half of the guarantee — that
+        // AppSettingsService.SaveSettingsAsync's whitelist leaves the column
+        // alone so the real (already persisted) value survives untouched — is
+        // proven against a real database in AppSettingsServiceSyncSettingsTests.
+        var captured = GivenSaveIsCaptured();
+        var path = await WriteJsonAsync("last-sync-not-set.json", """
+        { "schemaVersion": 2, "showNsfw": true }
+        """);
+        var sut = CreateSut();
+
+        await sut.ImportAsync(path);
+
+        captured()!.LastLibrarySyncAt.Should().BeNull();
     }
 
     [Fact]

--- a/DiffusionNexus.Tests/Services/CivitaiModelDownloaderTests.cs
+++ b/DiffusionNexus.Tests/Services/CivitaiModelDownloaderTests.cs
@@ -138,8 +138,15 @@ public sealed class CivitaiModelDownloaderTests : IDisposable
         return sync;
     }
 
-    /// <summary>Scope factory whose scoped IUnitOfWork resolves any local path to <paramref name="modelId"/>.</summary>
-    private static IServiceScopeFactory ScopeFactory(int? modelId)
+    /// <summary>
+    /// Scope factory whose scoped IUnitOfWork resolves any local path to <paramref name="modelId"/>.
+    /// </summary>
+    /// <param name="settings">
+    /// The saved settings the completion sync reads for its retry windows and thumbnail fan-out.
+    /// Left null, no <c>IAppSettingsService</c> is registered at all — which is exactly the
+    /// fail-open case: the read throws and the completion sync runs on the defaults.
+    /// </param>
+    private static IServiceScopeFactory ScopeFactory(int? modelId, AppSettings? settings = null)
     {
         var repository = new Mock<IModelRepository>();
         repository
@@ -149,6 +156,14 @@ public sealed class CivitaiModelDownloaderTests : IDisposable
         unitOfWork.SetupGet(u => u.Models).Returns(repository.Object);
         var services = new ServiceCollection();
         services.AddScoped(_ => unitOfWork.Object);
+
+        if (settings is not null)
+        {
+            var settingsService = new Mock<IAppSettingsService>();
+            settingsService.Setup(s => s.GetSettingsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(settings);
+            services.AddScoped(_ => settingsService.Object);
+        }
+
         return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
     }
 
@@ -559,6 +574,81 @@ public sealed class CivitaiModelDownloaderTests : IDisposable
 
         bad.Status.Should().Be(DownloadStatus.HashMismatch);
         bad.VerifiedSha256.Should().BeNull("verification ran and FAILED — nothing was proven");
+    }
+
+    /// <summary>
+    /// The completion sync was the one thumbnail path that honoured neither the user's retry
+    /// windows nor their fan-out: it judged due-ness by the built-in default and fetched four wide,
+    /// while the documentation said all three paths were bounded by the setting. A model can finish
+    /// with a dozen due images, so a user on a metered connection who asked for one parallel
+    /// download got four concurrent CDN GETs after every download.
+    /// </summary>
+    [Fact]
+    public async Task CompletionSync_CarriesTheUsersRetryWindowsAndThumbnailFanOut()
+    {
+        var dir = NewTempDir();
+        var sync = Sync();
+        SyncOptions? plannedOptions = null;
+        sync.Setup(s => s.PlanAsync(It.IsAny<SyncScope>(), It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SyncScope scope, SyncOptions options, CancellationToken _) =>
+            {
+                plannedOptions = options;
+                return new SyncPlan(scope, options, [], DateTimeOffset.UtcNow);
+            });
+
+        // None of them the defaults, so a default value cannot be mistaken for one that travelled.
+        var settings = new AppSettings
+        {
+            SyncNotIdentifiedRetryDays = 14,
+            SyncErrorRetryDays = 3,
+            SyncThumbnailConcurrency = 1,
+        };
+
+        var downloader = new CivitaiModelDownloader(
+            Transport().Object, Coordinator().Object, sync.Object, new LibraryChangeNotifier(),
+            ScopeFactory(77, settings));
+
+        await downloader.DownloadAsync(new DownloadRequest(Version(), dir, DownloadTrigger.BrowseQueue));
+        await Settle(downloader);
+
+        plannedOptions.Should().NotBeNull();
+        plannedOptions!.ThumbnailConcurrency.Should().Be(1, "SyncThumbnailConcurrency");
+        plannedOptions.Policy.NotIdentifiedRetryAfter.Should().Be(TimeSpan.FromDays(14));
+        plannedOptions.Policy.ErrorRetryAfter.Should().Be(TimeSpan.FromDays(3));
+    }
+
+    /// <summary>
+    /// …and a settings read that fails costs the settings, not the completion sync. A download that
+    /// reached disk has succeeded whatever the follow-up does.
+    /// </summary>
+    [Fact]
+    public async Task CompletionSync_FallsBackToTheDefaultsWhenTheSettingsCannotBeRead()
+    {
+        var dir = NewTempDir();
+        var sync = Sync();
+        SyncOptions? plannedOptions = null;
+        sync.Setup(s => s.PlanAsync(It.IsAny<SyncScope>(), It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SyncScope scope, SyncOptions options, CancellationToken _) =>
+            {
+                plannedOptions = options;
+                return new SyncPlan(scope, options, [], DateTimeOffset.UtcNow);
+            });
+
+        // No IAppSettingsService registered: GetRequiredService throws inside the read.
+        var downloader = new CivitaiModelDownloader(
+            Transport().Object, Coordinator().Object, sync.Object, new LibraryChangeNotifier(), ScopeFactory(77));
+
+        var outcome = await downloader.DownloadAsync(new DownloadRequest(Version(), dir, DownloadTrigger.BrowseQueue));
+        await Settle(downloader);
+
+        outcome.Status.Should().Be(DownloadStatus.Completed);
+        plannedOptions!.Steps.Should().BeEquivalentTo(new[] { SyncStepKind.FetchTags, SyncStepKind.Thumbnails },
+            "the sync still ran");
+        plannedOptions.ThumbnailConcurrency.Should().Be(4, "the record default");
+        plannedOptions.Policy.Should().BeSameAs(SyncRetryPolicy.Default);
+        sync.Verify(
+            s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]

--- a/DiffusionNexus.Tests/Sync/Domain/SyncRetryPolicyTests.cs
+++ b/DiffusionNexus.Tests/Sync/Domain/SyncRetryPolicyTests.cs
@@ -98,4 +98,25 @@ public class SyncRetryPolicyTests
         plan.HasWork.Should().BeTrue();
         plan.EstimatedDuration.Should().Be(TimeSpan.FromSeconds(6));
     }
+
+    [Fact]
+    public void FromDays_BuildsWindowsFromSettingsValues()
+    {
+        var policy = SyncRetryPolicy.FromDays(notIdentifiedDays: 14, errorDays: 3);
+
+        policy.NotIdentifiedRetryAfter.Should().Be(TimeSpan.FromDays(14));
+        policy.ErrorRetryAfter.Should().Be(TimeSpan.FromDays(3));
+        policy.MaxErrorAttempts.Should().Be(SyncRetryPolicy.Default.MaxErrorAttempts);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void FromDays_FloorsAtOneDay_BecauseZeroWouldMeanAlwaysDue(int days)
+    {
+        var policy = SyncRetryPolicy.FromDays(days, days);
+
+        policy.NotIdentifiedRetryAfter.Should().Be(TimeSpan.FromDays(1));
+        policy.ErrorRetryAfter.Should().Be(TimeSpan.FromDays(1));
+    }
 }

--- a/DiffusionNexus.Tests/Sync/Domain/SyncRetryPolicyTests.cs
+++ b/DiffusionNexus.Tests/Sync/Domain/SyncRetryPolicyTests.cs
@@ -145,4 +145,39 @@ public class SyncRetryPolicyTests
         policy.NotIdentifiedRetryAfter.Should().Be(TimeSpan.FromDays(1));
         policy.ErrorRetryAfter.Should().Be(TimeSpan.FromDays(1));
     }
+
+    /// <summary>
+    /// These values are not guaranteed to come from the settings combo boxes: the settings importer
+    /// copies them straight out of a JSON file with no range check, and the repository persists them
+    /// unvalidated. <c>TimeSpan.FromDays</c> throws above ~10 675 199 days, so a corrupted
+    /// <c>settings.json</c> carrying <c>2147483647</c> made every Download Metadata press die with
+    /// "TimeSpan overflowed because the duration is too long" — an unusable button, no way to see
+    /// why. Ten years is past every meaningful horizon, so it degrades instead.
+    /// </summary>
+    [Theory]
+    [InlineData(int.MaxValue)]
+    [InlineData(3651)]
+    public void FromDays_CapsAtTenYears_BecauseTheValuesAreNotValidatedOnTheWayIn(int days)
+    {
+        var policy = SyncRetryPolicy.FromDays(days, days);
+
+        policy.NotIdentifiedRetryAfter.Should().Be(TimeSpan.FromDays(3650));
+        policy.ErrorRetryAfter.Should().Be(TimeSpan.FromDays(3650));
+    }
+
+    /// <summary>
+    /// "Everything but discovery" is derived, not listed. A sixth step kind therefore reaches the
+    /// bulk button's plan and the plan dialog's rows on its own — the hand-written copies this
+    /// replaced would have left it silently absent from both, with no compile error to say so.
+    /// </summary>
+    [Fact]
+    public void AllStepsExcept_IsEveryEnumMemberMinusTheExcludedOne()
+    {
+        var all = Enum.GetValues<SyncStepKind>();
+
+        SyncOptions.AllStepsExcept(SyncStepKind.DiscoverFiles).Should()
+            .BeEquivalentTo(all.Where(k => k != SyncStepKind.DiscoverFiles));
+        SyncOptions.AllStepsExcept(SyncStepKind.Thumbnails).Should()
+            .BeEquivalentTo(all.Where(k => k != SyncStepKind.Thumbnails));
+    }
 }

--- a/DiffusionNexus.Tests/Sync/Domain/SyncRetryPolicyTests.cs
+++ b/DiffusionNexus.Tests/Sync/Domain/SyncRetryPolicyTests.cs
@@ -99,6 +99,32 @@ public class SyncRetryPolicyTests
         plan.EstimatedDuration.Should().Be(TimeSpan.FromSeconds(6));
     }
 
+    /// <summary>
+    /// Discovery is not work in the sense this property answers. It used to be special-cased as
+    /// always-work, which made <c>HasWork</c> constant-true for every full plan and every
+    /// "nothing to do" branch behind it dead code — including the viewer's up-to-date early-out.
+    /// A scan whose result nobody can count in advance is executed on its own terms instead.
+    /// </summary>
+    [Fact]
+    public void PlanHasWorkIgnoresTheUncountableDiscoveryStep()
+    {
+        var discoveryOnly = new SyncPlan(SyncScope.Library, SyncOptions.All, new[]
+        {
+            new SyncPlanStep(SyncStepKind.DiscoverFiles, 0, TimeSpan.FromSeconds(2), "Discover new files"),
+        }, Now);
+
+        discoveryOnly.HasWork.Should().BeFalse("a scan that has counted nothing is not counted work");
+
+        var withIdentify = discoveryOnly with
+        {
+            Steps = discoveryOnly.Steps
+                .Append(new SyncPlanStep(SyncStepKind.IdentifyModel, 1, TimeSpan.FromSeconds(3), "Identify"))
+                .ToList(),
+        };
+
+        withIdentify.HasWork.Should().BeTrue("one counted item in any step is work");
+    }
+
     [Fact]
     public void FromDays_BuildsWindowsFromSettingsValues()
     {

--- a/DiffusionNexus.Tests/Sync/Service/LibrarySyncServiceTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/LibrarySyncServiceTests.cs
@@ -481,6 +481,53 @@ public sealed class LibrarySyncServiceTests : IDisposable
         report.Steps.Single().Succeeded.Should().Be(1);
     }
 
+    // ------------------------------------------------------ Thumbnail parallelism
+
+    [Fact]
+    public async Task Thumbnails_RunInParallel_UpToTheConfiguredConcurrency()
+    {
+        var probe = new ConcurrencyProbeStep(itemCount: 12);
+        var service = NewService([probe]);
+        var options = new SyncOptions(new HashSet<SyncStepKind> { SyncStepKind.Thumbnails }, ThumbnailConcurrency: 4);
+
+        var plan = await service.PlanAsync(SyncScope.Library, options);
+        var report = await service.ExecuteAsync(plan);
+
+        probe.Executed.Should().Be(12);
+        probe.MaxObservedConcurrency.Should().BeGreaterThan(1).And.BeLessThanOrEqualTo(4);
+        report.Steps.Single().Succeeded.Should().Be(12);
+    }
+
+    [Fact]
+    public async Task Thumbnails_ConcurrencyOne_StaysStrictlySequential()
+    {
+        var probe = new ConcurrencyProbeStep(itemCount: 6);
+        var service = NewService([probe]);
+        var options = new SyncOptions(new HashSet<SyncStepKind> { SyncStepKind.Thumbnails }, ThumbnailConcurrency: 1);
+
+        var plan = await service.PlanAsync(SyncScope.Library, options);
+        await service.ExecuteAsync(plan);
+
+        probe.MaxObservedConcurrency.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ParallelThumbnails_RecordEveryFailure_WithoutLosingAny()
+    {
+        var probe = new ConcurrencyProbeStep(itemCount: 10, failOddItems: true);
+        var service = NewService([probe]);
+        var options = new SyncOptions(new HashSet<SyncStepKind> { SyncStepKind.Thumbnails }, ThumbnailConcurrency: 4);
+
+        var plan = await service.PlanAsync(SyncScope.Library, options);
+        var report = await service.ExecuteAsync(plan);
+
+        var step = report.Steps.Single();
+        step.Processed.Should().Be(10);
+        step.Failed.Should().Be(5);
+        report.Failures.Should().HaveCount(5);
+        report.Failures.Select(f => f.Reason).Should().AllBe("probe-failure");
+    }
+
     // ------------------------------------------------------------------ DI
 
     [Fact]
@@ -606,6 +653,56 @@ public sealed class LibrarySyncServiceTests : IDisposable
             if (OnExecute is not null) await OnExecute(item);
 
             return _result(item);
+        }
+    }
+
+    /// <summary>
+    /// A self-contained <c>Thumbnails</c> step that records the highest number of concurrently
+    /// in-flight <see cref="ExecuteOneAsync"/> calls it observed, to prove (or disprove) that the
+    /// service actually parallelizes this step's items.
+    /// </summary>
+    private sealed class ConcurrencyProbeStep : ISyncStep
+    {
+        private readonly IReadOnlyList<SyncItem> _items;
+        private readonly bool _failOddItems;
+        private int _inFlight;
+
+        public int MaxObservedConcurrency;
+        public int Executed;
+
+        public ConcurrencyProbeStep(int itemCount, bool failOddItems = false)
+        {
+            _items = Enumerable.Range(1, itemCount)
+                .Select(i => new SyncItem(i, $"model-{i}", i))
+                .ToList();
+            _failOddItems = failOddItems;
+        }
+
+        public SyncStepKind Kind => SyncStepKind.Thumbnails;
+        public string Description => "probe";
+        public TimeSpan EstimatedPerItem => TimeSpan.Zero;
+
+        public Task<IReadOnlyList<SyncItem>> SelectAsync(SyncScope scope, SyncOptions options, DateTimeOffset now, CancellationToken ct)
+            => Task.FromResult(_items);
+
+        public async Task<SyncItemResult> ExecuteOneAsync(SyncItem item, string? apiKey, CancellationToken ct)
+        {
+            var now = Interlocked.Increment(ref _inFlight);
+            int seen;
+            do
+            {
+                seen = MaxObservedConcurrency;
+                if (now <= seen) break;
+            } while (Interlocked.CompareExchange(ref MaxObservedConcurrency, now, seen) != seen);
+
+            await Task.Delay(25, ct);
+
+            Interlocked.Decrement(ref _inFlight);
+            Interlocked.Increment(ref Executed);
+
+            return _failOddItems && (int)item.Payload % 2 == 1
+                ? SyncItemResult.Failure("probe-failure")
+                : SyncItemResult.Success;
         }
     }
 

--- a/DiffusionNexus.Tests/Sync/Service/LibrarySyncServiceTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/LibrarySyncServiceTests.cs
@@ -351,9 +351,14 @@ public sealed class LibrarySyncServiceTests : IDisposable
 
         service.IsRunning.Should().BeTrue();
 
+        // Its own type, not a bare InvalidOperationException: a step's SelectAsync raises that too
+        // (GetRequiredService, Single() over nothing), and the viewer used to report every one of
+        // them as "already running" at Info level. Still an InvalidOperationException underneath,
+        // so any caller that predates the type keeps catching it.
         var second = () => service.ExecuteAsync(plan);
-        await second.Should().ThrowAsync<InvalidOperationException>()
+        await second.Should().ThrowAsync<SyncAlreadyRunningException>()
             .WithMessage("*already running*");
+        (await Record.ExceptionAsync(second)).Should().BeAssignableTo<InvalidOperationException>();
 
         gate.SetResult();
         await first;

--- a/DiffusionNexus.Tests/Sync/Service/LibrarySyncServiceTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/LibrarySyncServiceTests.cs
@@ -528,6 +528,44 @@ public sealed class LibrarySyncServiceTests : IDisposable
         report.Failures.Select(f => f.Reason).Should().AllBe("probe-failure");
     }
 
+    /// <summary>
+    /// The load-bearing half of the branch condition: a PACED API step must never parallelize,
+    /// whatever the configured thumbnail concurrency says. Losing this silently turns the 1.5 s
+    /// Civitai courtesy pacing into a burst and gets users rate-limited.
+    /// </summary>
+    [Fact]
+    public async Task ANonThumbnailsStep_NeverParallelizes_RegardlessOfTheConcurrencySetting()
+    {
+        var probe = new ConcurrencyProbeStep(itemCount: 8, kind: SyncStepKind.FetchTags);
+        var service = NewService([probe]);
+        var options = new SyncOptions(new HashSet<SyncStepKind> { SyncStepKind.FetchTags }, ThumbnailConcurrency: 4);
+
+        var plan = await service.PlanAsync(SyncScope.Library, options);
+        await service.ExecuteAsync(plan);
+
+        probe.Executed.Should().Be(8);
+        probe.MaxObservedConcurrency.Should().Be(1);
+    }
+
+    /// <summary>The service, not the caller, owns the sane range: junk settings degrade, never throw.</summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-3)]
+    [InlineData(100)]
+    public async Task ThumbnailConcurrency_OutOfRangeValues_AreClampedNotThrown(int configured)
+    {
+        var probe = new ConcurrencyProbeStep(itemCount: 10);
+        var service = NewService([probe]);
+        var options = new SyncOptions(new HashSet<SyncStepKind> { SyncStepKind.Thumbnails }, ThumbnailConcurrency: configured);
+
+        var plan = await service.PlanAsync(SyncScope.Library, options);
+        var report = await service.ExecuteAsync(plan);
+
+        report.Steps.Single().Succeeded.Should().Be(10);
+        probe.MaxObservedConcurrency.Should().BeLessThanOrEqualTo(8);
+        if (configured < 1) probe.MaxObservedConcurrency.Should().Be(1, "a clamped-to-1 value must stay sequential");
+    }
+
     // ------------------------------------------------------------------ DI
 
     [Fact]
@@ -670,15 +708,16 @@ public sealed class LibrarySyncServiceTests : IDisposable
         public int MaxObservedConcurrency;
         public int Executed;
 
-        public ConcurrencyProbeStep(int itemCount, bool failOddItems = false)
+        public ConcurrencyProbeStep(int itemCount, bool failOddItems = false, SyncStepKind kind = SyncStepKind.Thumbnails)
         {
             _items = Enumerable.Range(1, itemCount)
                 .Select(i => new SyncItem(i, $"model-{i}", i))
                 .ToList();
             _failOddItems = failOddItems;
+            Kind = kind;
         }
 
-        public SyncStepKind Kind => SyncStepKind.Thumbnails;
+        public SyncStepKind Kind { get; }
         public string Description => "probe";
         public TimeSpan EstimatedPerItem => TimeSpan.Zero;
 

--- a/DiffusionNexus.Tests/Sync/Service/Steps/IdentifyModelStepTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/Steps/IdentifyModelStepTests.cs
@@ -90,7 +90,8 @@ public sealed class IdentifyModelStepTests : IDisposable
         int attempts = 0,
         string? sidecarSignature = null,
         bool withState = false,
-        int? civitaiId = null)
+        int? civitaiId = null,
+        bool isUserEdited = false)
     {
         using var scope = NewScope();
         var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
@@ -101,6 +102,7 @@ public sealed class IdentifyModelStepTests : IDisposable
             Type = ModelType.LORA,
             Source = civitaiId is null ? DataSource.LocalFile : DataSource.CivitaiApi,
             CivitaiId = civitaiId,
+            IsUserEdited = isUserEdited,
         };
         var version = new ModelVersion { Name = "v1", BaseModelRaw = "???" };
         version.Files.Add(new ModelFile
@@ -216,13 +218,14 @@ public sealed class IdentifyModelStepTests : IDisposable
     [Fact]
     public async Task Select_ForceIdentifyOverridesTheWindowButNotAMissingFile()
     {
-        var matched = await SeedAsync("matched", NewModelFile("f-matched.safetensors"),
-            outcome: SyncOutcome.Matched, checkedAt: Now.AddDays(-1), withState: true);
+        // Checked yesterday — inside the 30-day window, so only the force makes it due.
+        var recent = await SeedAsync("recent", NewModelFile("f-recent.safetensors"),
+            outcome: SyncOutcome.NotIdentified, checkedAt: Now.AddDays(-1), withState: true);
         var gone = await SeedAsync("gone", MissingModelFile("f-gone.safetensors"));
 
         var items = await NewNotFoundStep().SelectAsync(SyncScope.Library, Options(force: true), Now, CancellationToken.None);
 
-        items.Select(i => i.ModelId).Should().Contain(matched.ModelId);
+        items.Select(i => i.ModelId).Should().Contain(recent.ModelId);
         items.Select(i => i.ModelId).Should().NotContain(gone.ModelId);
     }
 
@@ -246,6 +249,35 @@ public sealed class IdentifyModelStepTests : IDisposable
         // The bulk run still leaves it alone: there is nothing to identify about a matched model.
         var bulk = await NewNotFoundStep().SelectAsync(SyncScope.Library, Options(), Now, CancellationToken.None);
         bulk.Select(i => i.ModelId).Should().NotContain(matched.ModelId);
+    }
+
+    /// <summary>
+    /// The library-wide force is the plan dialog's "Models not found on Civitai" checkbox, and it
+    /// must mean what it says: a Matched model is left alone — whether it carries the CivitaiId
+    /// itself or is the duplicate copy that only carries the page id (null CivitaiId, outcome
+    /// Matched) — and a hand-edited model is not dragged into a bulk overwrite run. Only the
+    /// per-tile scope (the user pointing at one model) re-looks at a Matched row; that path is
+    /// pinned by <see cref="Select_ForceIdentifyIncludesMatchedModel"/>. The not-found ones are
+    /// still forced past their retry window, which is the checkbox's whole purpose.
+    /// </summary>
+    [Fact]
+    public async Task Select_LibraryForceIdentifyLeavesMatchedAndHandEditedAlone()
+    {
+        var matched = await SeedAsync("lf-matched", NewModelFile("lf-matched.safetensors"), civitaiId: 77,
+            outcome: SyncOutcome.Matched, checkedAt: Now.AddDays(-1), withState: true);
+        var duplicate = await SeedAsync("lf-duplicate", NewModelFile("lf-duplicate.safetensors"),
+            outcome: SyncOutcome.Matched, checkedAt: Now.AddDays(-1), withState: true);
+        var edited = await SeedAsync("lf-edited", NewModelFile("lf-edited.safetensors"), isUserEdited: true,
+            outcome: SyncOutcome.NotIdentified, checkedAt: Now.AddDays(-1), withState: true);
+        var notFound = await SeedAsync("lf-notfound", NewModelFile("lf-notfound.safetensors"),
+            outcome: SyncOutcome.NotIdentified, checkedAt: Now.AddDays(-1), withState: true);
+
+        var items = await NewNotFoundStep().SelectAsync(SyncScope.Library, Options(force: true), Now, CancellationToken.None);
+
+        items.Select(i => i.ModelId).Should().BeEquivalentTo([notFound.ModelId]);
+        items.Should().NotContain(i => i.ModelId == matched.ModelId);
+        items.Should().NotContain(i => i.ModelId == duplicate.ModelId);
+        items.Should().NotContain(i => i.ModelId == edited.ModelId);
     }
 
     /// <summary>

--- a/DiffusionNexus.Tests/ViewModels/SettingsViewModelSyncSettingsTests.cs
+++ b/DiffusionNexus.Tests/ViewModels/SettingsViewModelSyncSettingsTests.cs
@@ -1,0 +1,107 @@
+using DiffusionNexus.Domain.Entities;
+using DiffusionNexus.Domain.Services;
+using DiffusionNexus.UI.ViewModels;
+using FluentAssertions;
+using Moq;
+
+namespace DiffusionNexus.Tests.ViewModels;
+
+/// <summary>
+/// Covers the "Metadata Sync" section of the Settings page: load mapping of the
+/// three Task 1 sync columns (<see cref="AppSettings.SyncNotIdentifiedRetryDays"/>,
+/// <see cref="AppSettings.SyncErrorRetryDays"/>, <see cref="AppSettings.SyncThumbnailConcurrency"/>),
+/// their <c>HasChanges</c> wiring, and — critically — that saving settings does not
+/// clobber <see cref="AppSettings.LastLibrarySyncAt"/>. That timestamp is not itself
+/// user-editable on this page (Task 5's flow stamps it separately via
+/// <c>UpdateLastLibrarySyncAtAsync</c>) but the save command still builds a detached
+/// <c>new AppSettings { ... }</c> snapshot, and a field the snapshot forgets is silently
+/// defaulted — so it must be carried through explicitly.
+/// </summary>
+public sealed class SettingsViewModelSyncSettingsTests
+{
+    private readonly Mock<IAppSettingsService> _settingsService = new();
+    private AppSettings _stored = new() { Id = 1 };
+
+    private SettingsViewModel CreateSut()
+    {
+        _settingsService
+            .Setup(s => s.GetSettingsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _stored);
+
+        return new SettingsViewModel(
+            _settingsService.Object,
+            new Mock<ISecureStorage>().Object);
+    }
+
+    [Fact]
+    public async Task Load_MapsSyncSettingsColumnsOntoTheViewModel()
+    {
+        _stored = new AppSettings
+        {
+            Id = 1,
+            SyncNotIdentifiedRetryDays = 60,
+            SyncErrorRetryDays = 7,
+            SyncThumbnailConcurrency = 8,
+        };
+
+        var sut = CreateSut();
+        await sut.LoadCommand.ExecuteAsync(null);
+
+        sut.SyncNotIdentifiedRetryDays.Should().Be(60);
+        sut.SyncErrorRetryDays.Should().Be(7);
+        sut.SyncThumbnailConcurrency.Should().Be(8);
+    }
+
+    [Fact]
+    public async Task ChangingEachSyncSetting_FlagsHasChanges()
+    {
+        var sut = CreateSut();
+        await sut.LoadCommand.ExecuteAsync(null);
+        sut.HasChanges = false;
+
+        sut.SyncNotIdentifiedRetryDays = 60;
+        sut.HasChanges.Should().BeTrue("changing the not-identified retry window is a pending edit");
+        sut.HasChanges = false;
+
+        sut.SyncErrorRetryDays = 7;
+        sut.HasChanges.Should().BeTrue("changing the error retry window is a pending edit");
+        sut.HasChanges = false;
+
+        sut.SyncThumbnailConcurrency = 8;
+        sut.HasChanges.Should().BeTrue("changing the thumbnail concurrency is a pending edit");
+    }
+
+    [Fact]
+    public async Task SavingSettings_PreservesLastLibrarySyncAt()
+    {
+        var knownSyncStamp = new DateTimeOffset(2026, 8, 1, 12, 0, 0, TimeSpan.Zero);
+        _stored = new AppSettings
+        {
+            Id = 1,
+            // Disable backups so SaveAsync's backup validation doesn't veto the save.
+            BackupDatabaseEnabled = false,
+            BackupDatasetImagesEnabled = false,
+            LastLibrarySyncAt = knownSyncStamp,
+            SyncErrorRetryDays = 1,
+        };
+
+        AppSettings? saved = null;
+        _settingsService
+            .Setup(s => s.SaveSettingsAsync(It.IsAny<AppSettings>(), It.IsAny<CancellationToken>()))
+            .Callback<AppSettings, CancellationToken>((s, _) => saved = s)
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateSut();
+        await sut.LoadCommand.ExecuteAsync(null);
+
+        // An unrelated edit — proves the stamp survives even when a sync setting changes.
+        sut.SyncErrorRetryDays = 3;
+
+        await sut.SaveCommand.ExecuteAsync(null);
+
+        saved.Should().NotBeNull();
+        saved!.LastLibrarySyncAt.Should().Be(knownSyncStamp,
+            "LastLibrarySyncAt is stamped by the sync flow, not this page, and a settings save must not null it out");
+        saved.SyncErrorRetryDays.Should().Be(3, "the changed sync setting must still reach the save snapshot");
+    }
+}

--- a/DiffusionNexus.Tests/ViewModels/SyncCopyTests.cs
+++ b/DiffusionNexus.Tests/ViewModels/SyncCopyTests.cs
@@ -1,0 +1,68 @@
+using DiffusionNexus.UI.ViewModels;
+using FluentAssertions;
+using Xunit;
+
+namespace DiffusionNexus.Tests.ViewModels;
+
+/// <summary>
+/// The shared sync wording and the two duration formats. Both dialogs and the viewer's status bar
+/// read from here, so these are the assertions that keep the three surfaces saying one thing.
+/// </summary>
+public class SyncCopyTests
+{
+    /// <summary>
+    /// The measured-duration format. No tilde — this is what a run cost, not what one was expected
+    /// to cost — and a zero minor unit is dropped rather than padded.
+    /// </summary>
+    [Theory]
+    [InlineData(0, "0 s")]
+    [InlineData(-5, "0 s")]
+    [InlineData(42, "42 s")]
+    [InlineData(59, "59 s")]
+    [InlineData(60, "1 min")]
+    [InlineData(222, "3 min 42 s")]
+    [InlineData(180, "3 min")]
+    [InlineData(3600, "1 h")]
+    [InlineData(3780, "1 h 3 min")]
+    public void FormatElapsed_RendersTwoUnitsAtMostAndNoTilde(double seconds, string expected)
+    {
+        SyncCopy.FormatElapsed(TimeSpan.FromSeconds(seconds)).Should().Be(expected);
+    }
+
+    /// <summary>Past the hour mark the seconds are noise, not precision — they are dropped, not shown as 0.</summary>
+    [Fact]
+    public void FormatElapsed_DropsTheSecondsOnceThereAreHours()
+    {
+        SyncCopy.FormatElapsed(TimeSpan.FromSeconds(3642)).Should().Be("1 h");
+    }
+
+    /// <summary>Rounded to the whole second first, so a fraction cannot produce "0 min 60 s".</summary>
+    [Fact]
+    public void FormatElapsed_RoundsToTheNearestSecond()
+    {
+        SyncCopy.FormatElapsed(TimeSpan.FromSeconds(59.7)).Should().Be("1 min");
+        SyncCopy.FormatElapsed(TimeSpan.FromSeconds(41.6)).Should().Be("42 s");
+    }
+
+    [Theory]
+    [InlineData(0, "")]
+    [InlineData(-1, "")]
+    [InlineData(1, "1 new file discovered")]
+    [InlineData(12, "12 new files discovered")]
+    public void DescribeDiscovered_IsOnePhrasingForBothDialogs(int count, string expected)
+    {
+        SyncCopy.DescribeDiscovered(count).Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The verdict exists exactly once. The dialog and the status bar are on screen together, so
+    /// two copies that merely happen to match today are a rewording away from contradicting.
+    /// </summary>
+    [Fact]
+    public void UpToDate_IsTheOneVerdictBothSurfacesShow()
+    {
+        SyncCopy.UpToDate.Should().Be("Library is up to date — nothing to do");
+        SyncPlanDialogViewModel.UpToDateMessage.Should().Be(SyncCopy.UpToDate,
+            "the plan dialog reads the shared const rather than carrying its own copy");
+    }
+}

--- a/DiffusionNexus.Tests/ViewModels/SyncPlanDialogViewModelTests.cs
+++ b/DiffusionNexus.Tests/ViewModels/SyncPlanDialogViewModelTests.cs
@@ -137,6 +137,124 @@ public class SyncPlanDialogViewModelTests
         SyncCopy.FormatEstimate(TimeSpan.FromSeconds(seconds)).Should().Be(expected);
     }
 
+    /// <summary>
+    /// F4. Two quick toggles queue two re-plans. The flag used to be raised inside the queued work,
+    /// so the first link's finally lowered it and the second link's continuation raised it again a
+    /// dispatcher turn later — and in that turn the UI was live with the first plan's counts. Tick
+    /// Force tags, tick Force image records, press Start in the gap: <c>BuildResult</c> filters by
+    /// <c>Count &gt; 0</c>, the Images row was still 0, and FetchImages was silently dropped from
+    /// the run the user had just asked for.
+    /// </summary>
+    [Fact]
+    public async Task StartStaysDisabledAcrossAWholeChainOfQueuedReplans()
+    {
+        var gateA = new TaskCompletionSource();
+        var gateB = new TaskCompletionSource();
+        var secondEntered = new TaskCompletionSource();
+        var calls = 0;
+
+        var vm = Vm(PlanWith(identify: 3, tags: 0, images: 0, thumbs: 0), async o =>
+        {
+            var call = Interlocked.Increment(ref calls);
+            if (call == 2) secondEntered.TrySetResult();
+            await (call == 1 ? gateA.Task : gateB.Task);
+            return PlanWith(3, 0, 0, thumbs: call == 1 ? 0 : 40, options: o);
+        });
+
+        var flag = new List<bool>();
+        var thumbsWhenStartCameBack = -1;
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName != nameof(vm.IsReplanning)) return;
+
+            flag.Add(vm.IsReplanning);
+            if (!vm.IsReplanning && thumbsWhenStartCameBack < 0)
+                thumbsWhenStartCameBack = vm.Rows.Single(r => r.Kind == SyncStepKind.Thumbnails).Count;
+        };
+
+        vm.ForceTags = true;         // queues the first re-plan
+        vm.ForceThumbnails = true;   // queues the second behind it
+
+        vm.IsReplanning.Should().BeTrue("the flag goes up at toggle time, not when the work is pumped");
+        vm.CanStart.Should().BeFalse();
+
+        gateA.SetResult();
+        await secondEntered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        gateB.SetResult();
+        await vm.WhenReplanSettles();
+
+        flag.Should().Equal(new[] { true, false },
+            "one rise and one fall for the whole chain — a fall in between is the dispatcher turn " +
+            "in which Start was live over counts the user had already superseded");
+        thumbsWhenStartCameBack.Should().Be(40,
+            "Start came back only once the LAST queued plan's counts were the ones on screen");
+        vm.CanStart.Should().BeTrue("the chain settled and the plan that landed has work");
+    }
+
+    /// <summary>
+    /// F13. Every toggle already re-planned with the exact options <c>BuildResult</c> returns, so
+    /// the caller need not pay for a third full selection pass over the library. The plan comes
+    /// back filtered to the ticked kinds and re-labelled with the chosen options.
+    /// </summary>
+    [Fact]
+    public void BuildResult_HandsBackThePlanTheDialogWasShowing()
+    {
+        var vm = Vm(PlanWith(identify: 3, tags: 68, images: 2, thumbs: 12));
+        vm.Rows.Single(r => r.Kind == SyncStepKind.FetchTags).IsSelected = false;
+
+        var result = vm.BuildResult();
+
+        result.Plan.Should().NotBeNull("nothing was forced, so the counts on screen are still the plan's");
+        result.Plan!.Options.Should().BeSameAs(result.Options,
+            "the plan is re-labelled with the chosen options so ExecuteAsync runs the ticked steps with the right forces");
+        result.Plan.Steps.Select(s => s.Kind).Should().BeEquivalentTo(new[]
+        {
+            SyncStepKind.IdentifyModel, SyncStepKind.FetchImages, SyncStepKind.Thumbnails,
+        }, "the unticked row's step is not part of this run");
+        result.Plan.Steps.Single(s => s.Kind == SyncStepKind.IdentifyModel).Count.Should().Be(3,
+            "the counts are the ones the dialog was showing");
+    }
+
+    /// <summary>
+    /// A failed re-plan deliberately keeps the previous counts — which now describe a different
+    /// item set than the toggles do. The dialog says so by withholding its plan, and the caller
+    /// plans again rather than running the wrong selection.
+    /// </summary>
+    [Fact]
+    public async Task BuildResult_WithholdsThePlanWhenAReplanFailedAndLeftTheCountsStale()
+    {
+        var vm = Vm(PlanWith(identify: 3, tags: 0, images: 0, thumbs: 0),
+            _ => Task.FromException<SyncPlan>(new InvalidOperationException("database is locked")));
+
+        vm.ForceThumbnails = true;
+        await vm.WhenReplanSettles();
+
+        vm.Rows.Single(r => r.Kind == SyncStepKind.IdentifyModel).Count.Should().Be(3,
+            "the dialog keeps what it had rather than blanking itself");
+
+        var result = vm.BuildResult();
+
+        result.Options!.ForceThumbnails.Should().BeTrue("the toggle is still the user's choice");
+        result.Plan.Should().BeNull("these counts were never computed with that force");
+    }
+
+    /// <summary>A successful re-plan brings the two back into step, so the plan travels again.</summary>
+    [Fact]
+    public async Task BuildResult_HandsBackTheReplannedPlanAfterAForce()
+    {
+        var vm = Vm(PlanWith(identify: 3, tags: 0, images: 0, thumbs: 0),
+            o => Task.FromResult(PlanWith(3, 0, 0, thumbs: 40, options: o)));
+
+        vm.ForceThumbnails = true;
+        await vm.WhenReplanSettles();
+
+        var result = vm.BuildResult();
+
+        result.Plan.Should().NotBeNull();
+        result.Plan!.Steps.Single(s => s.Kind == SyncStepKind.Thumbnails).Count.Should().Be(40);
+        result.Plan.Options.ForceThumbnails.Should().BeTrue();
+    }
+
     [Fact]
     public void AZeroCountRow_ShowsNoEstimate()
     {

--- a/DiffusionNexus.Tests/ViewModels/SyncPlanDialogViewModelTests.cs
+++ b/DiffusionNexus.Tests/ViewModels/SyncPlanDialogViewModelTests.cs
@@ -116,4 +116,33 @@ public class SyncPlanDialogViewModelTests
         result.Options.ForceIdentify.Should().BeTrue();
         result.Options.ForceTags.Should().BeFalse();
     }
+
+    /// <summary>
+    /// Pins the three unit branches and their boundaries — this string feeds the row estimates,
+    /// the footer total, and the report's elapsed line. 89.5 s reading "~90 s" while still in the
+    /// seconds branch is the documented quirk, not a bug.
+    /// </summary>
+    [Theory]
+    [InlineData(0, "~0 s")]
+    [InlineData(-5, "~0 s")]
+    [InlineData(89, "~89 s")]
+    [InlineData(89.5, "~90 s")]
+    [InlineData(90, "~2 min")]
+    [InlineData(60 * 89, "~89 min")]
+    [InlineData(60 * 90, "~1.5 h")]
+    [InlineData(60 * 60 * 3, "~3 h")]
+    public void FormatDuration_RendersEachUnitBranch(double seconds, string expected)
+    {
+        SyncPlanDialogViewModel.FormatDuration(TimeSpan.FromSeconds(seconds)).Should().Be(expected);
+    }
+
+    [Fact]
+    public void AZeroCountRow_ShowsNoEstimate()
+    {
+        var vm = Vm(PlanWith(identify: 3, tags: 0, images: 0, thumbs: 12));
+
+        vm.Rows.Single(r => r.Kind == SyncStepKind.FetchTags).EstimateText.Should().BeEmpty(
+            "a disabled '0 Tags ~0 s' row reads like pending work — an empty cell does not");
+        vm.Rows.Single(r => r.Kind == SyncStepKind.IdentifyModel).EstimateText.Should().NotBeEmpty();
+    }
 }

--- a/DiffusionNexus.Tests/ViewModels/SyncPlanDialogViewModelTests.cs
+++ b/DiffusionNexus.Tests/ViewModels/SyncPlanDialogViewModelTests.cs
@@ -118,9 +118,10 @@ public class SyncPlanDialogViewModelTests
     }
 
     /// <summary>
-    /// Pins the three unit branches and their boundaries — this string feeds the row estimates,
-    /// the footer total, and the report's elapsed line. 89.5 s reading "~90 s" while still in the
-    /// seconds branch is the documented quirk, not a bug.
+    /// Pins the three unit branches and their boundaries — this string feeds the row estimates and
+    /// the footer total. 89.5 s reading "~90 s" while still in the seconds branch is the documented
+    /// quirk, not a bug. The report's elapsed line no longer comes through here: a measurement gets
+    /// <see cref="SyncCopy.FormatElapsed"/>, which wears no tilde.
     /// </summary>
     [Theory]
     [InlineData(0, "~0 s")]
@@ -133,7 +134,7 @@ public class SyncPlanDialogViewModelTests
     [InlineData(60 * 60 * 3, "~3 h")]
     public void FormatDuration_RendersEachUnitBranch(double seconds, string expected)
     {
-        SyncPlanDialogViewModel.FormatDuration(TimeSpan.FromSeconds(seconds)).Should().Be(expected);
+        SyncCopy.FormatEstimate(TimeSpan.FromSeconds(seconds)).Should().Be(expected);
     }
 
     [Fact]

--- a/DiffusionNexus.Tests/ViewModels/SyncPlanDialogViewModelTests.cs
+++ b/DiffusionNexus.Tests/ViewModels/SyncPlanDialogViewModelTests.cs
@@ -1,0 +1,119 @@
+using DiffusionNexus.Domain.Services.Sync;
+using DiffusionNexus.UI.ViewModels;
+using FluentAssertions;
+using Xunit;
+
+namespace DiffusionNexus.Tests.ViewModels;
+
+public class SyncPlanDialogViewModelTests
+{
+    private static readonly IReadOnlySet<SyncStepKind> FourKinds = new HashSet<SyncStepKind>
+    {
+        SyncStepKind.IdentifyModel, SyncStepKind.FetchTags, SyncStepKind.FetchImages, SyncStepKind.Thumbnails,
+    };
+
+    private static SyncPlan PlanWith(int identify, int tags, int images, int thumbs, SyncOptions? options = null)
+    {
+        options ??= new SyncOptions(FourKinds);
+        return new SyncPlan(SyncScope.Library, options, new[]
+        {
+            new SyncPlanStep(SyncStepKind.IdentifyModel, identify, TimeSpan.FromSeconds(3 * identify), "identify"),
+            new SyncPlanStep(SyncStepKind.FetchTags, tags, TimeSpan.FromSeconds(1.6 * tags), "tags"),
+            new SyncPlanStep(SyncStepKind.FetchImages, images, TimeSpan.FromSeconds(1.6 * images), "images"),
+            new SyncPlanStep(SyncStepKind.Thumbnails, thumbs, TimeSpan.FromSeconds(0.4 * thumbs), "thumbs"),
+        }, DateTimeOffset.UtcNow);
+    }
+
+    private static SyncPlanDialogViewModel Vm(
+        SyncPlan plan,
+        Func<SyncOptions, Task<SyncPlan>>? replan = null,
+        DateTimeOffset? lastSync = null,
+        int discovered = 0)
+        => new(plan, new SyncOptions(FourKinds), replan ?? (_ => Task.FromResult(plan)), lastSync, discovered);
+
+    [Fact]
+    public void RowsWithWork_ArePreChecked_AndEmptyRowsAreDisabled()
+    {
+        var vm = Vm(PlanWith(identify: 3, tags: 68, images: 0, thumbs: 12));
+
+        vm.Rows.Should().HaveCount(4);
+        vm.Rows.Single(r => r.Kind == SyncStepKind.IdentifyModel).IsSelected.Should().BeTrue();
+        vm.Rows.Single(r => r.Kind == SyncStepKind.FetchImages).IsSelected.Should().BeFalse();
+        vm.Rows.Single(r => r.Kind == SyncStepKind.FetchImages).IsEnabled.Should().BeFalse();
+        vm.IsUpToDate.Should().BeFalse();
+        vm.CanStart.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AllZeroPlan_IsUpToDate_WithNoStart_AndShowsTheLastRun()
+    {
+        var last = new DateTimeOffset(2026, 8, 25, 14, 3, 0, TimeSpan.Zero);
+        var vm = Vm(PlanWith(0, 0, 0, 0), lastSync: last);
+
+        vm.IsUpToDate.Should().BeTrue();
+        vm.CanStart.Should().BeFalse();
+        vm.UpToDateText.Should().Be("Library is up to date — nothing to do");
+        vm.LastRunText.Should().Contain("Last full sync:").And.NotContain("never");
+    }
+
+    [Fact]
+    public void NoRecordedRun_SaysNever()
+    {
+        var vm = Vm(PlanWith(0, 0, 0, 0), lastSync: null);
+        vm.LastRunText.Should().Be("Last full sync: never");
+    }
+
+    [Fact]
+    public async Task TogglingAForce_Replans_AndAppliesTheNewCounts()
+    {
+        SyncOptions? seen = null;
+        Task<SyncPlan> Replan(SyncOptions o)
+        {
+            seen = o;
+            return Task.FromResult(PlanWith(0, 0, 0, thumbs: 40, options: o));
+        }
+
+        var vm = Vm(PlanWith(0, 0, 0, 0), Replan);
+        vm.ForceThumbnails = true;
+        await vm.WhenReplanSettles();
+
+        seen.Should().NotBeNull();
+        seen!.ForceThumbnails.Should().BeTrue();
+        seen.Steps.Should().BeEquivalentTo(FourKinds);
+        vm.Rows.Single(r => r.Kind == SyncStepKind.Thumbnails).Count.Should().Be(40);
+        vm.Rows.Single(r => r.Kind == SyncStepKind.Thumbnails).IsSelected.Should().BeTrue();
+        vm.IsUpToDate.Should().BeFalse();
+        vm.CanStart.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AUserUntick_SurvivesAReplan()
+    {
+        var vm = Vm(PlanWith(identify: 3, tags: 68, images: 0, thumbs: 12),
+            o => Task.FromResult(PlanWith(3, 68, 0, 40, o)));
+
+        vm.Rows.Single(r => r.Kind == SyncStepKind.FetchTags).IsSelected = false;
+        vm.ForceThumbnails = true;
+        await vm.WhenReplanSettles();
+
+        vm.Rows.Single(r => r.Kind == SyncStepKind.FetchTags).IsSelected.Should().BeFalse();
+    }
+
+    [Fact]
+    public void BuildResult_CarriesTheCheckedKindsAndForces()
+    {
+        var vm = Vm(PlanWith(identify: 3, tags: 68, images: 2, thumbs: 12));
+        vm.Rows.Single(r => r.Kind == SyncStepKind.FetchTags).IsSelected = false;
+        vm.ForceIdentify = true;
+
+        var result = vm.BuildResult();
+
+        result.Confirmed.Should().BeTrue();
+        result.Options!.Steps.Should().BeEquivalentTo(new[]
+        {
+            SyncStepKind.IdentifyModel, SyncStepKind.FetchImages, SyncStepKind.Thumbnails,
+        });
+        result.Options.ForceIdentify.Should().BeTrue();
+        result.Options.ForceTags.Should().BeFalse();
+    }
+}

--- a/DiffusionNexus.Tests/ViewModels/SyncReportDialogViewModelTests.cs
+++ b/DiffusionNexus.Tests/ViewModels/SyncReportDialogViewModelTests.cs
@@ -1,0 +1,79 @@
+using DiffusionNexus.Domain.Services.Sync;
+using DiffusionNexus.UI.ViewModels;
+using FluentAssertions;
+using Xunit;
+
+namespace DiffusionNexus.Tests.ViewModels;
+
+public class SyncReportDialogViewModelTests
+{
+    private static SyncReport Report(
+        IReadOnlyList<SyncStepReport> steps,
+        IReadOnlyList<SyncFailure>? failures = null,
+        bool cancelled = false,
+        int unexpected = 0)
+    {
+        var options = new SyncOptions(new HashSet<SyncStepKind> { SyncStepKind.IdentifyModel });
+        var plan = new SyncPlan(SyncScope.Library, options, Array.Empty<SyncPlanStep>(), DateTimeOffset.UtcNow);
+        return new SyncReport(plan, steps, failures ?? Array.Empty<SyncFailure>(), cancelled,
+            TimeSpan.FromSeconds(90), NewFilesDiscovered: 0, UnexpectedFailures: unexpected);
+    }
+
+    [Fact]
+    public void FailuresAreGroupedByStep_WithNameAndReasonPerRow()
+    {
+        var report = Report(
+            new[] { new SyncStepReport(SyncStepKind.FetchTags, 10, 10, 7, 0, 3),
+                    new SyncStepReport(SyncStepKind.Thumbnails, 5, 5, 4, 0, 1) },
+            new[]
+            {
+                new SyncFailure(SyncStepKind.FetchTags, 1, "ModelA", "Timeout"),
+                new SyncFailure(SyncStepKind.FetchTags, 2, "ModelB", "Timeout"),
+                new SyncFailure(SyncStepKind.FetchTags, 3, "ModelC", "Http500"),
+                new SyncFailure(SyncStepKind.Thumbnails, 4, "ModelD", "Http404"),
+            });
+
+        var vm = new SyncReportDialogViewModel(report, newFilesDiscovered: 0);
+
+        vm.FailureGroups.Should().HaveCount(2);
+        var tags = vm.FailureGroups.Single(g => g.Kind == SyncStepKind.FetchTags);
+        tags.Header.Should().Be("Tags — 3 failed");
+        tags.Items.Should().HaveCount(3);
+        tags.Items[0].Name.Should().Be("ModelA");
+        tags.Items[0].Reason.Should().Be("Timeout");
+        vm.HasFailures.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ACleanRun_ShowsNoFailureGroups()
+    {
+        var vm = new SyncReportDialogViewModel(
+            Report(new[] { new SyncStepReport(SyncStepKind.FetchTags, 10, 10, 10, 0, 0) }),
+            newFilesDiscovered: 3);
+
+        vm.HasFailures.Should().BeFalse();
+        vm.FailureGroups.Should().BeEmpty();
+        vm.DiscoveredText.Should().Contain("3");
+    }
+
+    [Fact]
+    public void ACancelledRun_SaysPartial()
+    {
+        var vm = new SyncReportDialogViewModel(
+            Report(new[] { new SyncStepReport(SyncStepKind.FetchTags, 10, 4, 4, 0, 0) }, cancelled: true),
+            newFilesDiscovered: 0);
+
+        vm.IsPartial.Should().BeTrue();
+        vm.PartialText.Should().Contain("Cancelled");
+    }
+
+    [Fact]
+    public void UnexpectedFailures_AreCalledOut()
+    {
+        var vm = new SyncReportDialogViewModel(
+            Report(new[] { new SyncStepReport(SyncStepKind.FetchTags, 10, 10, 9, 0, 1) }, unexpected: 1),
+            newFilesDiscovered: 0);
+
+        vm.UnexpectedText.Should().Contain("1").And.ContainEquivalentOf("log");
+    }
+}

--- a/DiffusionNexus.Tests/ViewModels/SyncReportDialogViewModelTests.cs
+++ b/DiffusionNexus.Tests/ViewModels/SyncReportDialogViewModelTests.cs
@@ -67,6 +67,22 @@ public class SyncReportDialogViewModelTests
         vm.PartialText.Should().Contain("Cancelled");
     }
 
+    /// <summary>
+    /// The report shows a measurement, so it is rendered by the exact formatter and not the plan
+    /// dialog's estimate one. A "~40 s" under a table of finished work claims the stopwatch was
+    /// guessing — and the estimate formatter is also where the missing scan time used to hide.
+    /// </summary>
+    [Fact]
+    public void ElapsedText_IsTheExactDuration_WithNoEstimateTilde()
+    {
+        var vm = new SyncReportDialogViewModel(
+            Report(new[] { new SyncStepReport(SyncStepKind.FetchTags, 10, 10, 10, 0, 0) }),
+            newFilesDiscovered: 0);
+
+        vm.ElapsedText.Should().Be("1 min 30 s", "the report's stopwatch read 90 seconds");
+        vm.ElapsedText.Should().NotContain("~");
+    }
+
     [Fact]
     public void UnexpectedFailures_AreCalledOut()
     {

--- a/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
+++ b/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
@@ -68,13 +68,25 @@ public class LoraViewerViewModelSyncTests
     /// <summary>True once the plan dialog has been shown — the stale-plan case re-plans behind it.</summary>
     private bool _dialogShown;
 
-    /// <summary>What the user does at the plan dialog. Default: start exactly what the dialog offers.</summary>
-    private Func<SyncPlanDialogViewModel, SyncPlanDialogResult> _planDialogAnswer = vm => vm.BuildResult();
+    /// <summary>
+    /// What the user does at the plan dialog. Default: start exactly what the dialog offers.
+    /// Asynchronous because some answers involve the dialog first — ticking a Force and waiting for
+    /// the re-plan it queues, which is the state the cancel wording has to be read from.
+    /// </summary>
+    private Func<SyncPlanDialogViewModel, Task<SyncPlanDialogResult>> _planDialogAnswer =
+        vm => Task.FromResult(vm.BuildResult());
 
     private int _identifyCount = 3;
 
     /// <summary>Identify count for plans made after the dialog closed, or -1 to keep <see cref="_identifyCount"/>.</summary>
     private int _identifyCountAfterDialog = -1;
+
+    /// <summary>
+    /// Count given to every step other than identify. Zero by default — one step with work is all
+    /// most of these tests need — but a run that has to cover all four kinds (the only kind of run
+    /// allowed to stamp "last full sync") needs every row to have something in it.
+    /// </summary>
+    private int _otherStepCount;
 
     private int _executeCalls;
 
@@ -95,7 +107,7 @@ public class LoraViewerViewModelSyncTests
                 _calls.Add("plan-dialog");
                 _planDialogVm = dialogVm;
                 _dialogShown = true;
-                return Task.FromResult(_planDialogAnswer(dialogVm));
+                return _planDialogAnswer(dialogVm);
             });
         _dialogs.Setup(d => d.ShowSyncReportDialogAsync(It.IsAny<SyncReportDialogViewModel>()))
             .Returns((SyncReportDialogViewModel dialogVm) =>
@@ -150,7 +162,18 @@ public class LoraViewerViewModelSyncTests
     /// (and runs) the scan alone, every other request plans exactly the steps its options asked
     /// for, and a run succeeds at all of them minus the failures handed in.
     /// </summary>
-    private void SetupSyncService(int discovered = 0, bool cancelled = false, params SyncFailure[] failures)
+    /// <param name="discoverFailures">
+    /// What the scan could not read — an unreachable source folder, a row it could not write. The
+    /// scan is its own run now, so these have to travel into the run's report or they vanish.
+    /// </param>
+    private void SetupSyncService(
+        int discovered = 0,
+        bool cancelled = false,
+        SyncFailure[]? discoverFailures = null,
+        int discoverUnexpected = 0,
+        TimeSpan? discoverElapsed = null,
+        TimeSpan? runElapsed = null,
+        params SyncFailure[] failures)
     {
         _sync.Setup(s => s.PlanAsync(It.IsAny<SyncScope>(), It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((SyncScope scope, SyncOptions options, CancellationToken _) =>
@@ -165,13 +188,21 @@ public class LoraViewerViewModelSyncTests
             {
                 _executeCalls++;
                 if (_executeCalls == _throwOnExecuteCall)
-                    throw new InvalidOperationException("A library sync is already running.");
+                    throw NotNowException();
 
                 _executed.Add(plan);
-                _calls.Add(IsDiscovery(plan.Options) ? "execute:discover" : "execute:run");
-                return ReportFor(plan, discovered, cancelled, failures);
+                var isDiscovery = IsDiscovery(plan.Options);
+                _calls.Add(isDiscovery ? "execute:discover" : "execute:run");
+
+                return isDiscovery
+                    ? ReportFor(plan, discovered, cancelled: false, discoverFailures ?? [], discoverElapsed,
+                        discoverUnexpected, discoverUnexpected > 0 ? "scan: NullReferenceException" : null)
+                    : ReportFor(plan, discovered: 0, cancelled, failures, runElapsed);
             });
     }
+
+    /// <summary>The refusal the single-flight gate raises when a run is already holding the service.</summary>
+    private static Exception NotNowException() => new InvalidOperationException("A library sync is already running.");
 
     /// <summary>The steps a plan for <paramref name="options"/> carries, with the counts the test asked for.</summary>
     private SyncPlanStep[] StepsFor(SyncOptions options)
@@ -186,12 +217,19 @@ public class LoraViewerViewModelSyncTests
             .OrderBy(k => (int)k)
             .Select(k => k == SyncStepKind.IdentifyModel
                 ? IdentifyStep(identify)
-                : new SyncPlanStep(k, 0, TimeSpan.Zero, SyncReport.Label(k)))
+                : new SyncPlanStep(k, _otherStepCount, TimeSpan.Zero, SyncReport.Label(k)))
             .ToArray();
     }
 
     /// <summary>A report for a plan: everything planned was processed, minus the failures on that step.</summary>
-    private static SyncReport ReportFor(SyncPlan plan, int discovered, bool cancelled, IReadOnlyList<SyncFailure> failures)
+    private static SyncReport ReportFor(
+        SyncPlan plan,
+        int discovered,
+        bool cancelled,
+        IReadOnlyList<SyncFailure> failures,
+        TimeSpan? elapsed = null,
+        int unexpected = 0,
+        string? firstUnexpectedError = null)
         => new(
             plan,
             plan.Steps.Select(s =>
@@ -201,8 +239,10 @@ public class LoraViewerViewModelSyncTests
             }).ToList(),
             failures,
             Cancelled: cancelled,
-            Elapsed: TimeSpan.FromSeconds(12),
-            NewFilesDiscovered: IsDiscovery(plan.Options) ? discovered : 0);
+            Elapsed: elapsed ?? TimeSpan.FromSeconds(12),
+            NewFilesDiscovered: IsDiscovery(plan.Options) ? discovered : 0,
+            UnexpectedFailures: unexpected,
+            FirstUnexpectedError: firstUnexpectedError);
 
     /// <summary>The report the run (not the discovery pre-run) produced, as the ViewModel saw it.</summary>
     private SyncReport RunReport() => ReportFor(_executed[^1], discovered: 0, cancelled: false, []);
@@ -259,7 +299,7 @@ public class LoraViewerViewModelSyncTests
         {
             busyDuringDialog = vm.IsBusy;
             cancellableDuringDialog = vm.IsCancellable;
-            return dialogVm.BuildResult();
+            return Task.FromResult(dialogVm.BuildResult());
         };
 
         await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
@@ -274,7 +314,7 @@ public class LoraViewerViewModelSyncTests
     {
         var vm = CreateViewModel();
         SetupSyncService();
-        _planDialogAnswer = _ => SyncPlanDialogResult.Cancelled();
+        _planDialogAnswer = _ => Task.FromResult(SyncPlanDialogResult.Cancelled());
 
         await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
 
@@ -295,12 +335,110 @@ public class LoraViewerViewModelSyncTests
         var vm = CreateViewModel();
         _identifyCount = 0;
         SetupSyncService();
-        _planDialogAnswer = _ => SyncPlanDialogResult.Cancelled();
+        _planDialogAnswer = _ => Task.FromResult(SyncPlanDialogResult.Cancelled());
 
         await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
 
         vm.SyncStatus.Should().Be("Library is up to date — nothing to do");
         _planDialogVm!.IsUpToDate.Should().BeTrue("the dialog said so too — this is the same verdict, not a second one");
+    }
+
+    /// <summary>
+    /// F3. The scan runs before the dialog and commits its new <c>Model</c> rows straight to the
+    /// database, and nothing else refreshes the grid — <c>ILibraryChangeNotifier.ModelDownloaded</c>
+    /// is raised only by the downloader, never by the discovery step. Only the run path rebuilt, so
+    /// a user who dropped twelve LoRAs into a source folder, pressed the button, read
+    /// "12 new files discovered" and then pressed Cancel got twelve rows in the database, none of
+    /// them on screen until a manual Refresh — under a status line claiming nothing had happened.
+    /// </summary>
+    [Theory]
+    [InlineData(12, "Sync cancelled — the scan added 12 new files.")]
+    [InlineData(1, "Sync cancelled — the scan added 1 new file.")]
+    public async Task DownloadMissingMetadata_CancellingTheDialogStillRebuildsAndSaysWhatTheScanAdded(
+        int discovered, string expectedStatus)
+    {
+        var vm = CreateViewModel();
+        SetupSyncService(discovered: discovered);
+        _planDialogAnswer = _ => Task.FromResult(SyncPlanDialogResult.Cancelled());
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        _modelSync.Verify(s => s.LoadCachedFilesAsync(It.IsAny<CancellationToken>()), Times.Once,
+            "the discovered rows are committed and stay invisible until the grid is re-projected from the database");
+        vm.SyncStatus.Should().Be(expectedStatus,
+            "\"nothing was run\" is false once the scan has added files — it is what the button just did");
+    }
+
+    /// <summary>The same rebuild is owed when the flow leaves through a refusal rather than a cancel.</summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_RebuildsAfterTheScanEvenWhenTheRunIsRefused()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService(discovered: 5);
+        _throwOnExecuteCall = 2;   // the run meets the single-flight gate; the scan already happened
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        _modelSync.Verify(s => s.LoadCachedFilesAsync(It.IsAny<CancellationToken>()), Times.Once,
+            "the refusal is about the run, not about the five files the scan already committed");
+    }
+
+    /// <summary>And exactly once when the run path already did it — the finally is a backstop, not a second pass.</summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_DoesNotRebuildTwiceWhenTheRunAlreadyDid()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService(discovered: 9);
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        _modelSync.Verify(s => s.LoadCachedFilesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>
+    /// F7. The plan behind the dialog is built before it opens; the Force expander re-plans live.
+    /// An all-zero plan can therefore sit behind a dialog showing 40 thumbnails, and the cancel
+    /// wording used to be read off the stale plan — telling the user the library was up to date
+    /// one second after the dialog showed them work to do. The dialog's own current verdict wins.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_CancellingAfterAForceReplanDoesNotClaimUpToDate()
+    {
+        var vm = CreateViewModel();
+        _identifyCount = 0;                 // the plan the dialog opened on: nothing to do
+        _identifyCountAfterDialog = 40;     // what ticking a Force re-plans into
+        SetupSyncService();
+        _planDialogAnswer = async dialogVm =>
+        {
+            dialogVm.ForceThumbnails = true;
+            await dialogVm.WhenReplanSettles();
+            return SyncPlanDialogResult.Cancelled();
+        };
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        _planDialogVm!.IsUpToDate.Should().BeFalse("the re-plan found work and the dialog was showing it");
+        vm.SyncStatus.Should().Be("Sync cancelled — nothing was run.",
+            "the status may not contradict the numbers the user was looking at a second earlier");
+    }
+
+    /// <summary>
+    /// F4. A source folder on a disconnected share makes <c>DiscoverNewFilesAsync</c> throw; the
+    /// step records it as a failure precisely so a report can show it. Cancelling at the dialog
+    /// used to leave that in the log alone, with a status line that said nothing went wrong.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_CancellingAfterAFailedScanSaysTheScanFailed()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService(discoverFailures:
+            [new SyncFailure(SyncStepKind.DiscoverFiles, 0, @"\\nas\loras", "network path not found")]);
+        _planDialogAnswer = _ => Task.FromResult(SyncPlanDialogResult.Cancelled());
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        vm.SyncStatus.Should().Be("Sync cancelled — the scan reported 1 failure(s), see the log.",
+            "the user concluded the library was fully scanned; only the log knew otherwise");
     }
 
     // ---------------------------------------------------------------------------- the run itself
@@ -314,11 +452,11 @@ public class LoraViewerViewModelSyncTests
     {
         var vm = CreateViewModel();
         SetupSyncService();
-        _planDialogAnswer = _ => new SyncPlanDialogResult(true, _planned[^1] with
+        _planDialogAnswer = _ => Task.FromResult(new SyncPlanDialogResult(true, _planned[^1] with
         {
             Steps = new HashSet<SyncStepKind> { SyncStepKind.FetchTags },
             ForceTags = true,
-        });
+        }));
 
         await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
 
@@ -359,6 +497,7 @@ public class LoraViewerViewModelSyncTests
     public async Task DownloadMissingMetadata_StampsTheRunOnlyWhenItWasNotCancelled(bool cancelled, int stamps)
     {
         var vm = CreateViewModel();
+        _otherStepCount = 2;   // every kind has work, so the dialog's default ticks cover all four
         SetupSyncService(cancelled: cancelled);
 
         await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
@@ -366,6 +505,26 @@ public class LoraViewerViewModelSyncTests
         _settings.Verify(s => s.UpdateLastLibrarySyncAtAsync(It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
             Times.Exactly(stamps),
             "\"last full sync\" is a claim about a run that finished — a cancelled one covered only part of the library");
+    }
+
+    /// <summary>
+    /// F6. The dialog exists so the user can run a subset — and "Last full sync: …" is the only
+    /// staleness signal the next dialog shows. A 20-second thumbnails-only top-up that stamped it
+    /// made the viewer announce a full sync for metadata that had never been fetched at all.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_DoesNotStampAFullSyncForASubsetRun()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService();   // only the identify row has work, so only it is ticked and run
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        _executed[^1].Options.Steps.Should().BeEquivalentTo(new[] { SyncStepKind.IdentifyModel },
+            "this run covered one of the four offered kinds");
+        _settings.Verify(s => s.UpdateLastLibrarySyncAtAsync(It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "a run that skipped tags, images and thumbnails may not present itself as a full sync next week");
     }
 
     [Fact]
@@ -397,6 +556,7 @@ public class LoraViewerViewModelSyncTests
     public async Task DownloadMissingMetadata_AFailedStampStillRebuildsAndReports()
     {
         var vm = CreateViewModel();
+        _otherStepCount = 2;   // all four kinds run, so the stamp is actually attempted
         SetupSyncService();
         _settings.Setup(s => s.UpdateLastLibrarySyncAtAsync(It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("database is locked"));
@@ -428,6 +588,77 @@ public class LoraViewerViewModelSyncTests
             "the status bar is DescribeOutcome's view of the very same report");
         _reportDialogVm!.SummaryText.Should().StartWith("Discovered 9 ");
         _reportDialogVm.DiscoveredText.Should().Be("9 new files discovered");
+    }
+
+    /// <summary>
+    /// F4. …and so does everything else the scan produced. Its <c>Failures</c> were dropped on the
+    /// floor with only the count surviving, so an unreadable source folder produced a report dialog
+    /// that never mentioned the scan and a status line with no failure count on it.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_FoldsTheScansFailuresIntoTheRunsReport()
+    {
+        var vm = CreateViewModel();
+        var scanFailure = new SyncFailure(SyncStepKind.DiscoverFiles, 0, @"\\nas\loras", "network path not found");
+        SetupSyncService(
+            discoverFailures: [scanFailure],
+            failures: new SyncFailure(SyncStepKind.IdentifyModel, 1, "a.safetensors", "timeout"));
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        var scanGroup = _reportDialogVm!.FailureGroups.Should()
+            .ContainSingle(g => g.Kind == SyncStepKind.DiscoverFiles).Subject;
+        scanGroup.Items.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new { Name = @"\\nas\loras", Reason = "network path not found" });
+
+        _reportDialogVm.FailureGroups.Should().HaveCount(2, "the run's own failure is still there too");
+        vm.SyncStatus.Should().EndWith("· 2 failed",
+            "the scan's failure counts towards the tally the user is asked to act on");
+    }
+
+    /// <summary>A clean scan adds no group — the fold must not invent one.</summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_ACleanScanAddsNoFailureGroup()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService(discovered: 4);
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        _reportDialogVm!.HasFailures.Should().BeFalse();
+        _reportDialogVm.FailureGroups.Should().BeEmpty();
+    }
+
+    /// <summary>An item the scan lost to a bug no step claimed is still a bug when the scan is its own run.</summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_FoldsTheScansUnexpectedFailuresIn()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService(discoverUnexpected: 1);
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        _reportDialogVm!.HasUnexpected.Should().BeTrue();
+        vm.SyncStatus.Should().Contain("1 item failed unexpectedly (see log)");
+    }
+
+    /// <summary>
+    /// F5. The scan is often the slowest part of the whole button press, and it is a separate run
+    /// with its own stopwatch. Reporting only the second one told a user who waited four minutes
+    /// that the work took 40 seconds.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_TheReportedElapsedCoversTheScanToo()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService(
+            discoverElapsed: TimeSpan.FromMinutes(3),
+            runElapsed: TimeSpan.FromSeconds(40));
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        _reportDialogVm!.ElapsedText.Should().Be("3 min 40 s",
+            "the press cost the scan plus the run, and the report says what it cost rather than estimating it");
     }
 
     /// <summary>

--- a/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
+++ b/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
@@ -492,7 +492,44 @@ public class LoraViewerViewModelSyncTests
         }
 
         _planned[1].ThumbnailConcurrency.Should().Be(6, "SyncThumbnailConcurrency, on the options the dialog builds from");
-        _planned[^1].ThumbnailConcurrency.Should().Be(6, "and therefore on the ones the run executes");
+        _executed[^1].Options.ThumbnailConcurrency.Should().Be(6, "and therefore on the ones the run executes");
+        _executed[^1].Options.Policy.NotIdentifiedRetryAfter.Should().Be(TimeSpan.FromDays(14));
+        _executed[^1].Options.Policy.ErrorRetryAfter.Should().Be(TimeSpan.FromDays(3));
+    }
+
+    /// <summary>
+    /// F13. Every Force toggle already re-planned with the exact options the dialog hands back, and
+    /// PlanAsync is a repository query over the whole library per requested step. Pressing Start
+    /// without changing anything — the common case, since every row with work is pre-ticked — used
+    /// to pay for that pass a second time on the button's critical path.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_RunsTheDialogsOwnPlanInsteadOfPlanningAThirdTime()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService();
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        _planned.Should().HaveCount(2, "the discovery plan and the one behind the dialog — and no third pass");
+        _calls.Should().ContainInOrder("plan-dialog", "execute:run")
+            .And.NotContainInOrder("plan-dialog", "plan:run");
+        _executed[^1].Steps.Select(s => s.Kind).Should().BeEquivalentTo(new[] { SyncStepKind.IdentifyModel },
+            "the dialog's plan comes back filtered to the ticked kinds");
+    }
+
+    /// <summary>…and plans again when the dialog cannot vouch for its counts (a failed re-plan).</summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_PlansAgainWhenTheDialogHandsBackNoPlan()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService();
+        _planDialogAnswer = dialogVm => Task.FromResult(dialogVm.BuildResult() with { Plan = null });
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        _planned.Should().HaveCount(3, "without a plan to run, the flow has to make one");
+        _calls.Should().ContainInOrder("plan-dialog", "plan:run", "execute:run");
     }
 
     [Theory]
@@ -788,6 +825,9 @@ public class LoraViewerViewModelSyncTests
         var vm = CreateViewModel();
         _identifyCountAfterDialog = 0;
         SetupSyncService();
+        // The dialog withholds its plan whenever a re-plan failed and left its counts stale, and
+        // the flow then plans again — which is the pass that finds the work already done.
+        _planDialogAnswer = dialogVm => Task.FromResult(dialogVm.BuildResult() with { Plan = null });
 
         await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
 

--- a/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
+++ b/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
@@ -976,6 +976,9 @@ public class LoraViewerViewModelSyncTests
 
         options!.Policy.NotIdentifiedRetryAfter.Should().Be(TimeSpan.FromDays(14));
         options.Policy.ErrorRetryAfter.Should().Be(TimeSpan.FromDays(3));
+        options.ThumbnailConcurrency.Should().Be(6,
+            "one model can have a dozen due images, and someone who set 'thumbnail downloads in parallel = 1' " +
+            "on a metered connection meant it for this button too — not only for the bulk run");
     }
 
     [Fact]

--- a/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
+++ b/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
@@ -99,13 +99,20 @@ public class LoraViewerViewModelSyncTests
     /// </summary>
     private Exception _executeThrow = new SyncAlreadyRunningException();
 
+    /// <summary>
+    /// How the mocked settings read behaves. Null means "hand back <see cref="_savedSettings"/>
+    /// immediately"; a test that cares about <i>when</i> the read happens supplies its own.
+    /// </summary>
+    private Func<Task<AppSettings>>? _settingsRead;
+
     private LoraViewerViewModel CreateViewModel(bool withSyncService = true)
     {
         _modelSync.Setup(s => s.LoadCachedFilesAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<InstalledModelFile>());
         _unitOfWork.SetupGet(u => u.Models).Returns(_models.Object);
         _unitOfWork.SetupGet(u => u.SyncStates).Returns(_syncStates.Object);
-        _settings.Setup(s => s.GetSettingsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(_savedSettings);
+        _settings.Setup(s => s.GetSettingsAsync(It.IsAny<CancellationToken>()))
+            .Returns(() => _settingsRead is null ? Task.FromResult(_savedSettings) : _settingsRead());
 
         _dialogs.Setup(d => d.ShowSyncPlanDialogAsync(It.IsAny<SyncPlanDialogViewModel>()))
             .Returns((SyncPlanDialogViewModel dialogVm) =>
@@ -1202,6 +1209,46 @@ public class LoraViewerViewModelSyncTests
 
         canExecuteDuringRun.Should().BeFalse("one tile's fetch owns the single-flight service for its duration");
         vm.IsSyncRunning.Should().BeFalse("and gives it back when it is done");
+    }
+
+    // ------------------------------------------------------------------------------- startup cost
+
+    /// <summary>
+    /// F14. The startup read wants two ints, but <c>AppSettingsService.GetSettingsAsync</c> clears
+    /// the change tracker, loads the whole settings graph and performs up to three writes — and
+    /// SQLite has no true async, so awaited bare from the constructor all of that ran inline on the
+    /// UI thread before the first real yield. A startup hitch, and a database <i>write</i>, during
+    /// viewer construction.
+    /// </summary>
+    /// <remarks>
+    /// The gate blocks synchronously, the way a SQLite call does, and is self-bounding: a
+    /// regression makes this test take five seconds and fail on <c>readReleased</c>, rather than
+    /// hang and say nothing.
+    /// </remarks>
+    [Fact]
+    public async Task ConstructingTheViewer_DoesNotRunTheSettingsReadInline()
+    {
+        using var release = new ManualResetEventSlim(false);
+        using var entered = new ManualResetEventSlim(false);
+        var readReleased = false;
+
+        _settingsRead = () =>
+        {
+            entered.Set();
+            release.Wait(TimeSpan.FromSeconds(5));
+            Volatile.Write(ref readReleased, true);
+            return Task.FromResult(_savedSettings);
+        };
+
+        var vm = CreateViewModel();
+
+        Volatile.Read(ref readReleased).Should().BeFalse(
+            "the constructor must return while the settings read is still going, not sit on it");
+        entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue("the read was still started, just not inline");
+
+        release.Set();
+        await vm.ScrollRetryPolicyLoad.WaitAsync(TimeSpan.FromSeconds(10));
+        vm.ScrollRetryPolicyLoad.IsCompletedSuccessfully.Should().BeTrue("and it does finish");
     }
 
     private static ModelTileViewModel CreateTile(int modelId)

--- a/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
+++ b/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
@@ -5,6 +5,7 @@ using DiffusionNexus.Domain.Enums;
 using DiffusionNexus.Domain.Services;
 using DiffusionNexus.Domain.Services.Sync;
 using DiffusionNexus.Tests.Helpers;
+using DiffusionNexus.UI.Services;
 using DiffusionNexus.UI.ViewModels;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,13 +16,15 @@ namespace DiffusionNexus.Tests.Viewer;
 /// <summary>
 /// The LoRA viewer no longer owns the metadata sync: the "Download Metadata" button and the
 /// per-tile button both plan and execute against <see cref="ILibrarySyncService"/> (#521 WP2).
-/// These tests pin the ViewModel's half of that contract — the scope and options it asks for,
-/// the status text it shows, and the single tile rebuild after a run — with the service itself
-/// mocked (its own behaviour is covered by <c>LibrarySyncServiceTests</c>).
+/// Plan E turned the bulk button into a conversation — discover, plan, ask, run, stamp, report —
+/// and these tests pin the ViewModel's half of it: the order of those calls, the options it asks
+/// for, what the dialogs are handed, the status text, and the single tile rebuild after a run.
+/// The service itself is mocked (its own behaviour is covered by <c>LibrarySyncServiceTests</c>).
 /// <para>
 /// No Avalonia platform is initialised: UI-thread marshalling goes through the injected
-/// <see cref="ImmediateUiScheduler"/>, and the fresh-scope database reads go through an
-/// injected <see cref="IServiceScopeFactory"/> instead of the <c>App.Services</c> locator.
+/// <see cref="ImmediateUiScheduler"/>, the fresh-scope database reads go through an injected
+/// <see cref="IServiceScopeFactory"/> instead of the <c>App.Services</c> locator, and both dialogs
+/// go through the <see cref="IDialogService"/> assigned to the ViewModel's inherited property.
 /// </para>
 /// </summary>
 public class LoraViewerViewModelSyncTests
@@ -29,12 +32,51 @@ public class LoraViewerViewModelSyncTests
     private readonly Mock<ILibrarySyncService> _sync = new();
     private readonly Mock<IModelSyncService> _modelSync = new();
     private readonly Mock<IAppSettingsService> _settings = new();
+    private readonly Mock<IDialogService> _dialogs = new();
     private readonly Mock<IUnitOfWork> _unitOfWork = new();
     private readonly Mock<IModelRepository> _models = new();
     private readonly Mock<ISyncStateRepository> _syncStates = new();
 
+    /// <summary>
+    /// The saved settings every run reads. Deliberately none of them the defaults, so an option
+    /// carrying a default value cannot be mistaken for one that travelled from here.
+    /// </summary>
+    private readonly AppSettings _savedSettings = new()
+    {
+        SyncNotIdentifiedRetryDays = 14,
+        SyncErrorRetryDays = 3,
+        SyncThumbnailConcurrency = 6,
+        LastLibrarySyncAt = new DateTimeOffset(2026, 8, 1, 9, 0, 0, TimeSpan.Zero),
+    };
+
     /// <summary>Every value <c>SyncStatus</c> took during the run — the final one overwrites the progress text.</summary>
     private readonly List<string?> _statusHistory = [];
+
+    /// <summary>
+    /// Ordered trace of what the flow did: <c>plan:discover</c>, <c>execute:discover</c>,
+    /// <c>plan:run</c>, <c>plan-dialog</c>, <c>execute:run</c>, <c>report-dialog</c>. The order is
+    /// the contract — discovery has to be finished before the dialog can show its counts.
+    /// </summary>
+    private readonly List<string> _calls = [];
+
+    private readonly List<SyncOptions> _planned = [];
+    private readonly List<SyncPlan> _executed = [];
+
+    private SyncPlanDialogViewModel? _planDialogVm;
+    private SyncReportDialogViewModel? _reportDialogVm;
+
+    /// <summary>What the user does at the plan dialog. Default: start exactly what the dialog offers.</summary>
+    private Func<SyncPlanDialogViewModel, SyncPlanDialogResult> _planDialogAnswer = vm => vm.BuildResult();
+
+    private int _identifyCount = 3;
+
+    /// <summary>Identify count for plans made after the dialog closed, or -1 to keep <see cref="_identifyCount"/>.</summary>
+    private int _identifyCountAfterDialog = -1;
+
+    private int _executeCalls;
+
+    /// <summary>1 = the discovery pre-run throws, 2 = the real run throws, 0 = neither.</summary>
+    private int _throwOnExecuteCall;
 
     private LoraViewerViewModel CreateViewModel(bool withSyncService = true)
     {
@@ -42,6 +84,22 @@ public class LoraViewerViewModelSyncTests
             .ReturnsAsync(Array.Empty<InstalledModelFile>());
         _unitOfWork.SetupGet(u => u.Models).Returns(_models.Object);
         _unitOfWork.SetupGet(u => u.SyncStates).Returns(_syncStates.Object);
+        _settings.Setup(s => s.GetSettingsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(_savedSettings);
+
+        _dialogs.Setup(d => d.ShowSyncPlanDialogAsync(It.IsAny<SyncPlanDialogViewModel>()))
+            .Returns((SyncPlanDialogViewModel dialogVm) =>
+            {
+                _calls.Add("plan-dialog");
+                _planDialogVm = dialogVm;
+                return Task.FromResult(_planDialogAnswer(dialogVm));
+            });
+        _dialogs.Setup(d => d.ShowSyncReportDialogAsync(It.IsAny<SyncReportDialogViewModel>()))
+            .Returns((SyncReportDialogViewModel dialogVm) =>
+            {
+                _calls.Add("report-dialog");
+                _reportDialogVm = dialogVm;
+                return Task.CompletedTask;
+            });
 
         var services = new ServiceCollection();
         services.AddSingleton(_modelSync.Object);
@@ -58,7 +116,10 @@ public class LoraViewerViewModelSyncTests
             updateChecker: null,
             librarySync: withSyncService ? _sync.Object : null,
             uiScheduler: new ImmediateUiScheduler(),
-            scopeFactory: provider.GetRequiredService<IServiceScopeFactory>());
+            scopeFactory: provider.GetRequiredService<IServiceScopeFactory>())
+        {
+            DialogService = _dialogs.Object,
+        };
 
         vm.PropertyChanged += (_, e) =>
         {
@@ -68,116 +129,307 @@ public class LoraViewerViewModelSyncTests
         return vm;
     }
 
-    private static SyncPlan PlanFor(SyncScope scope, params SyncPlanStep[] steps)
-        => new(scope, SyncOptions.All, steps, DateTimeOffset.UtcNow);
+    private static SyncPlan PlanFor(SyncScope scope, SyncOptions options, params SyncPlanStep[] steps)
+        => new(scope, options, steps, DateTimeOffset.UtcNow);
 
     private static SyncPlanStep IdentifyStep(int count = 3)
         => new(SyncStepKind.IdentifyModel, count, TimeSpan.FromSeconds(3 * count), "Identify unknown files");
 
-    private static SyncReport ReportFor(SyncPlan plan, int succeeded = 3, params SyncFailure[] failures)
-        => new(
-            plan,
-            [new SyncStepReport(SyncStepKind.IdentifyModel, 3, 3, succeeded, 0, failures.Length)],
-            failures,
-            Cancelled: false,
-            Elapsed: TimeSpan.FromSeconds(12),
-            NewFilesDiscovered: 0);
+    /// <summary>Discovery never has a count — it is a scan, and nobody can size it in advance.</summary>
+    private static SyncPlanStep DiscoverStep()
+        => new(SyncStepKind.DiscoverFiles, 0, TimeSpan.FromSeconds(2), "Discover new files in all LoRA sources");
 
-    /// <summary>Plans return a one-step plan; executions return a report for the plan they were given.</summary>
-    private SyncPlan SetupPlanAndExecute(params SyncFailure[] failures)
+    private static bool IsDiscovery(SyncOptions options) => options.Steps.Contains(SyncStepKind.DiscoverFiles);
+
+    /// <summary>
+    /// Wires the mocked service the way the real one answers this flow: a discovery request plans
+    /// (and runs) the scan alone, every other request plans exactly the steps its options asked
+    /// for, and a run succeeds at all of them minus the failures handed in.
+    /// </summary>
+    private void SetupSyncService(int discovered = 0, bool cancelled = false, params SyncFailure[] failures)
     {
-        var plan = PlanFor(SyncScope.Library, IdentifyStep());
-
         _sync.Setup(s => s.PlanAsync(It.IsAny<SyncScope>(), It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(plan);
-        _sync.Setup(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((SyncPlan p, IProgress<LibrarySyncProgress>? _, CancellationToken _) => ReportFor(p, failures: failures));
+            .ReturnsAsync((SyncScope scope, SyncOptions options, CancellationToken _) =>
+            {
+                _planned.Add(options);
+                _calls.Add(IsDiscovery(options) ? "plan:discover" : "plan:run");
+                return PlanFor(scope, options, StepsFor(options));
+            });
 
-        return plan;
+        _sync.Setup(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SyncPlan plan, IProgress<LibrarySyncProgress>? progress, CancellationToken _) =>
+            {
+                _executeCalls++;
+                if (_executeCalls == _throwOnExecuteCall)
+                    throw new InvalidOperationException("A library sync is already running.");
+
+                _executed.Add(plan);
+                _calls.Add(IsDiscovery(plan.Options) ? "execute:discover" : "execute:run");
+                return ReportFor(plan, discovered, cancelled, failures);
+            });
     }
 
+    /// <summary>The steps a plan for <paramref name="options"/> carries, with the counts the test asked for.</summary>
+    private SyncPlanStep[] StepsFor(SyncOptions options)
+    {
+        if (IsDiscovery(options)) return [DiscoverStep()];
+
+        var identify = _planDialogVm is not null && _identifyCountAfterDialog >= 0
+            ? _identifyCountAfterDialog
+            : _identifyCount;
+
+        return options.Steps
+            .OrderBy(k => (int)k)
+            .Select(k => k == SyncStepKind.IdentifyModel
+                ? IdentifyStep(identify)
+                : new SyncPlanStep(k, 0, TimeSpan.Zero, SyncReport.Label(k)))
+            .ToArray();
+    }
+
+    /// <summary>A report for a plan: everything planned was processed, minus the failures on that step.</summary>
+    private static SyncReport ReportFor(SyncPlan plan, int discovered, bool cancelled, IReadOnlyList<SyncFailure> failures)
+        => new(
+            plan,
+            plan.Steps.Select(s =>
+            {
+                var failed = failures.Count(f => f.Step == s.Kind);
+                return new SyncStepReport(s.Kind, s.Count, s.Count, Math.Max(0, s.Count - failed), 0, failed);
+            }).ToList(),
+            failures,
+            Cancelled: cancelled,
+            Elapsed: TimeSpan.FromSeconds(12),
+            NewFilesDiscovered: IsDiscovery(plan.Options) ? discovered : 0);
+
+    /// <summary>The report the run (not the discovery pre-run) produced, as the ViewModel saw it.</summary>
+    private SyncReport RunReport() => ReportFor(_executed[^1], discovered: 0, cancelled: false, []);
+
+    // ------------------------------------------------------------------ discover → plan → dialog
+
+    /// <summary>
+    /// Discovery runs to completion <i>before</i> the dialog opens, and is the only thing that pre-run
+    /// does. That ordering is the whole reason the dialog can show honest counts: a file added since
+    /// the app started is in the library — and in the identify count — by the time the user reads it,
+    /// and the dialog needs no un-countable "Discover" row of its own.
+    /// </summary>
     [Fact]
-    public async Task DownloadMissingMetadata_PlansThenExecutesLibraryScope()
+    public async Task DownloadMissingMetadata_DiscoversFirstThenAsks()
     {
         var vm = CreateViewModel();
-        var plan = SetupPlanAndExecute();
+        SetupSyncService(discovered: 7);
 
         await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
 
-        _sync.Verify(s => s.PlanAsync(SyncScope.Library, It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()), Times.Once,
-            "the bulk button syncs the whole library, not a folder or a model subset");
-        _sync.Verify(s => s.ExecuteAsync(plan, It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()), Times.Once,
-            "the run must execute the plan that was just presented, not re-plan");
+        _calls.Should().ContainInOrder("plan:discover", "execute:discover", "plan:run", "plan-dialog", "execute:run");
+        _executed[0].Options.Steps.Should().BeEquivalentTo(new[] { SyncStepKind.DiscoverFiles },
+            "the pre-run scans and does nothing else — identifying is what the user is about to be asked about");
+
+        _planned[1].Steps.Should().BeEquivalentTo(new[]
+        {
+            SyncStepKind.IdentifyModel, SyncStepKind.FetchTags, SyncStepKind.FetchImages, SyncStepKind.Thumbnails,
+        }, "the dialog offers the four decidable steps; discovery has already happened");
+
+        _planDialogVm!.Rows.Select(r => r.Kind).Should().Equal(
+            SyncStepKind.IdentifyModel, SyncStepKind.FetchTags, SyncStepKind.FetchImages, SyncStepKind.Thumbnails);
+        _planDialogVm.DiscoveredText.Should().Be("7 new files discovered",
+            "the count comes from the discovery report the dialog was built after");
+        _planDialogVm.LastRunText.Should().NotBe("Last full sync: never",
+            "the saved LastLibrarySyncAt is what tells the user how stale the library is");
+
+        _sync.Verify(s => s.PlanAsync(It.Is<SyncScope>(sc => sc.Kind != SyncScopeKind.Library), It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()),
+            Times.Never, "the bulk button syncs the whole library, not a folder or a model subset");
     }
 
     /// <summary>
-    /// The plan cannot know there is nothing to do: a plan that carries the discovery step always
-    /// reports work, because nobody knows what a folder scan will find until it has run. So the
-    /// "up to date" wording has to come from the <i>report</i> — discovered nothing, planned nothing.
+    /// The overlay is down while the dialog is up: a modal question behind a "Syncing..." spinner
+    /// with a Cancel button is two different claims about the same moment.
     /// </summary>
     [Fact]
-    public async Task DownloadMissingMetadata_UpToDateWordingWhenRunFoundNothing()
+    public async Task DownloadMissingMetadata_DropsTheBusyOverlayWhileTheDialogIsOpen()
     {
         var vm = CreateViewModel();
-        var plan = PlanFor(
-            SyncScope.Library,
-            new SyncPlanStep(SyncStepKind.DiscoverFiles, 0, TimeSpan.FromSeconds(2), "Discover new files in all LoRA sources"),
-            new SyncPlanStep(SyncStepKind.IdentifyModel, 0, TimeSpan.Zero, "Identify unknown files"));
+        SetupSyncService();
 
-        _sync.Setup(s => s.PlanAsync(It.IsAny<SyncScope>(), It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(plan);
-        _sync.Setup(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((SyncPlan p, IProgress<LibrarySyncProgress>? _, CancellationToken _) => new SyncReport(
-                p,
-                [
-                    new SyncStepReport(SyncStepKind.DiscoverFiles, 0, 1, 1, 0, 0),
-                    new SyncStepReport(SyncStepKind.IdentifyModel, 0, 0, 0, 0, 0),
-                ],
-                Failures: [],
-                Cancelled: false,
-                Elapsed: TimeSpan.FromSeconds(1),
-                NewFilesDiscovered: 0));
+        var busyDuringDialog = true;
+        var cancellableDuringDialog = true;
+        _planDialogAnswer = dialogVm =>
+        {
+            busyDuringDialog = vm.IsBusy;
+            cancellableDuringDialog = vm.IsCancellable;
+            return dialogVm.BuildResult();
+        };
 
         await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
 
-        vm.SyncStatus.Should().Be("Library is up to date — nothing to do",
-            "\"Discovered 0\" is technically true and useless to read");
-        _sync.Verify(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()), Times.Once,
-            "the run still has to happen — the scan is the only thing that can prove there is nothing new");
-        vm.IsBusy.Should().BeFalse("the busy overlay must be released on the nothing-to-do path too");
+        busyDuringDialog.Should().BeFalse("nothing is running while the user decides");
+        cancellableDuringDialog.Should().BeFalse("there is nothing to cancel yet");
+        vm.IsBusy.Should().BeFalse("and the overlay is down again when everything is finished");
     }
 
-    /// <summary>The `!plan.HasWork` early-out stays correct for an option set that excludes discovery.</summary>
     [Fact]
-    public async Task DownloadMissingMetadata_EmptyPlanShortCircuitsWithoutExecuting()
+    public async Task DownloadMissingMetadata_CancellingThePlanDialogRunsNothing()
     {
         var vm = CreateViewModel();
-        _sync.Setup(s => s.PlanAsync(It.IsAny<SyncScope>(), It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(PlanFor(SyncScope.Library)); // no steps at all → HasWork is false
+        SetupSyncService();
+        _planDialogAnswer = _ => SyncPlanDialogResult.Cancelled();
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        vm.SyncStatus.Should().Be("Sync cancelled — nothing was run.",
+            "the button did do something — it scanned — so silence would read as a dead click");
+        _sync.Verify(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()),
+            Times.Once, "only the discovery pre-run ran; the work itself was never started");
+        _settings.Verify(s => s.UpdateLastLibrarySyncAtAsync(It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
+            Times.Never, "nothing was synced, so nothing may be stamped as synced");
+        _reportDialogVm.Should().BeNull("there is no report to show for a run that never happened");
+        vm.IsBusy.Should().BeFalse("the overlay must not come back for a run the user declined");
+    }
+
+    /// <summary>Closing an up-to-date dialog is not a cancellation of anything — say what is true instead.</summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_ClosingAnUpToDateDialogSaysUpToDate()
+    {
+        var vm = CreateViewModel();
+        _identifyCount = 0;
+        SetupSyncService();
+        _planDialogAnswer = _ => SyncPlanDialogResult.Cancelled();
 
         await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
 
         vm.SyncStatus.Should().Be("Library is up to date — nothing to do");
-        _sync.Verify(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()), Times.Never,
-            "a plan with no steps at all has nothing to run");
-        vm.IsBusy.Should().BeFalse("the busy overlay must be released on the nothing-to-do path too");
+        _planDialogVm!.IsUpToDate.Should().BeTrue("the dialog said so too — this is the same verdict, not a second one");
     }
+
+    // ---------------------------------------------------------------------------- the run itself
+
+    /// <summary>
+    /// What the user ticked is what runs. The dialog may have been open for minutes, so the run
+    /// re-plans with the chosen options rather than executing the plan the dialog was built from.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_RunsTheOptionsTheDialogReturned()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService();
+        _planDialogAnswer = _ => new SyncPlanDialogResult(true, _planned[^1] with
+        {
+            Steps = new HashSet<SyncStepKind> { SyncStepKind.FetchTags },
+            ForceTags = true,
+        });
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        _planned.Should().HaveCount(3, "discovery, the plan behind the dialog, and the re-plan the run executes");
+        _planned[^1].Steps.Should().BeEquivalentTo(new[] { SyncStepKind.FetchTags });
+        _planned[^1].ForceTags.Should().BeTrue();
+
+        _executed[^1].Options.Should().BeSameAs(_planned[^1],
+            "the run executes the plan made from the user's choice, not the one behind the dialog");
+    }
+
+    /// <summary>
+    /// The retry windows and the thumbnail fan-out are settings, not constants (Plan E Task 1), and
+    /// they have to survive the round trip through the dialog — which lays the ticks and forces over
+    /// the base options it was given rather than building its own.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_CarriesTheSavedRetryWindowsAndConcurrencyIntoTheRun()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService();
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        foreach (var options in _planned)
+        {
+            options.Policy.NotIdentifiedRetryAfter.Should().Be(TimeSpan.FromDays(14), "SyncNotIdentifiedRetryDays");
+            options.Policy.ErrorRetryAfter.Should().Be(TimeSpan.FromDays(3), "SyncErrorRetryDays");
+        }
+
+        _planned[1].ThumbnailConcurrency.Should().Be(6, "SyncThumbnailConcurrency, on the options the dialog builds from");
+        _planned[^1].ThumbnailConcurrency.Should().Be(6, "and therefore on the ones the run executes");
+    }
+
+    [Theory]
+    [InlineData(false, 1)]
+    [InlineData(true, 0)]
+    public async Task DownloadMissingMetadata_StampsTheRunOnlyWhenItWasNotCancelled(bool cancelled, int stamps)
+    {
+        var vm = CreateViewModel();
+        SetupSyncService(cancelled: cancelled);
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        _settings.Verify(s => s.UpdateLastLibrarySyncAtAsync(It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(stamps),
+            "\"last full sync\" is a claim about a run that finished — a cancelled one covered only part of the library");
+    }
+
+    [Fact]
+    public async Task DownloadMissingMetadata_ShowsTheReportOfTheRunItJustFinished()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService(discovered: 4, failures: [new SyncFailure(SyncStepKind.IdentifyModel, 1, "a.safetensors", "timeout")]);
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        _calls.Should().ContainInOrder("execute:run", "report-dialog");
+        _reportDialogVm.Should().NotBeNull();
+        _reportDialogVm!.SummaryText.Should().Be("Discovered 0 · Identified 2/3",
+            "the report dialog projects the run's own report — three planned, one of them failed");
+        _reportDialogVm.DiscoveredText.Should().Be("4 new files discovered",
+            "the run's own report knows nothing about the scan that preceded it");
+        _reportDialogVm.HasFailures.Should().BeTrue("the failures are the part the user has to act on");
+        vm.IsBusy.Should().BeFalse("the overlay comes down before the report, not behind it");
+    }
+
+    /// <summary>
+    /// The service admits one run at a time and throws on the second. A post-download completion
+    /// sync can hold that slot for a moment, so both of this flow's runs can meet it — and an
+    /// unhandled InvalidOperationException would surface as "Sync error: A library sync is
+    /// already running." with a stack trace in the log for something that is not a bug.
+    /// </summary>
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public async Task DownloadMissingMetadata_ReportsARunAlreadyHoldingTheServiceInsteadOfThrowing(int throwOnCall)
+    {
+        var vm = CreateViewModel();
+        SetupSyncService();
+        _throwOnExecuteCall = throwOnCall;
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        vm.SyncStatus.Should().Be("A metadata sync is already running.");
+        _reportDialogVm.Should().BeNull("there is no report — this run never got the service");
+        vm.IsBusy.Should().BeFalse();
+        vm.IsSyncRunning.Should().BeFalse("the refused run must not leave the buttons off");
+    }
+
+    // ------------------------------------------------------------------- outcome, status, rebuild
 
     [Fact]
     public async Task DownloadMissingMetadata_ProgressUpdatesStatus()
     {
         var vm = CreateViewModel();
-        var plan = PlanFor(SyncScope.Library, IdentifyStep());
-
         IProgress<LibrarySyncProgress>? captured = null;
+
         _sync.Setup(s => s.PlanAsync(It.IsAny<SyncScope>(), It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(plan);
-        _sync.Setup(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((SyncPlan p, IProgress<LibrarySyncProgress>? progress, CancellationToken _) =>
+            .ReturnsAsync((SyncScope scope, SyncOptions options, CancellationToken _) =>
             {
-                captured = progress;
-                progress!.Report(new LibrarySyncProgress(SyncStepKind.FetchTags, 3, 68, "Foo"));
-                return ReportFor(p);
+                _planned.Add(options);
+                return PlanFor(scope, options, StepsFor(options));
+            });
+        _sync.Setup(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SyncPlan plan, IProgress<LibrarySyncProgress>? progress, CancellationToken _) =>
+            {
+                _executed.Add(plan);
+                if (progress is not null)
+                {
+                    captured = progress;
+                    progress.Report(new LibrarySyncProgress(SyncStepKind.FetchTags, 3, 68, "Foo"));
+                }
+
+                return ReportFor(plan, 0, false, []);
             });
 
         await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
@@ -191,11 +443,11 @@ public class LoraViewerViewModelSyncTests
     public async Task DownloadMissingMetadata_StatusIsReportSummary()
     {
         var vm = CreateViewModel();
-        var plan = SetupPlanAndExecute();
+        SetupSyncService();
 
         await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
 
-        vm.SyncStatus.Should().Be(ReportFor(plan).Summary,
+        vm.SyncStatus.Should().Be(RunReport().Summary,
             "the status bar shows the report's own summary rather than a second, divergent tally");
     }
 
@@ -208,12 +460,32 @@ public class LoraViewerViewModelSyncTests
             new SyncFailure(SyncStepKind.IdentifyModel, 1, "a.safetensors", "timeout"),
             new SyncFailure(SyncStepKind.IdentifyModel, 2, "b.safetensors", "timeout"),
         };
-        var plan = SetupPlanAndExecute(failures);
+        SetupSyncService(failures: failures);
 
         await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
 
-        vm.SyncStatus.Should().Be(ReportFor(plan, failures: failures).Summary + " · 2 failed",
+        vm.SyncStatus.Should().Be(
+            ReportFor(_executed[^1], discovered: 0, cancelled: false, failures).Summary + " · 2 failed",
             "failures are the part of the outcome the user has to act on, so they are never silent");
+    }
+
+    /// <summary>
+    /// The plan behind the dialog can go stale — the dialog is modal, and the user can leave it open
+    /// while a per-tile fetch or a download's completion sync does the same work. The re-plan then
+    /// finds nothing, and the honest verdict for that run is the report's, not the dialog's.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_UpToDateWordingWhenTheRunFoundNothingLeft()
+    {
+        var vm = CreateViewModel();
+        _identifyCountAfterDialog = 0;
+        SetupSyncService();
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        vm.SyncStatus.Should().Be("Library is up to date — nothing to do",
+            "\"Discovered 0\" is technically true and useless to read");
+        vm.IsBusy.Should().BeFalse("the busy overlay must be released on the nothing-to-do path too");
     }
 
     /// <summary>
@@ -225,7 +497,7 @@ public class LoraViewerViewModelSyncTests
     public async Task DownloadMissingMetadata_AnnouncesTheFirstRunStateBackfill()
     {
         var vm = CreateViewModel();
-        SetupPlanAndExecute();
+        SetupSyncService();
 
         _models.Setup(m => m.CountAsync(It.IsAny<System.Linq.Expressions.Expression<Func<Model, bool>>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(2577);
@@ -242,7 +514,7 @@ public class LoraViewerViewModelSyncTests
     public async Task DownloadMissingMetadata_SaysNothingAboutBackfillWhenEveryModelHasAState()
     {
         var vm = CreateViewModel();
-        SetupPlanAndExecute();
+        SetupSyncService();
 
         _models.Setup(m => m.CountAsync(It.IsAny<System.Linq.Expressions.Expression<Func<Model, bool>>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(2577);
@@ -258,7 +530,7 @@ public class LoraViewerViewModelSyncTests
     public async Task DownloadMissingMetadata_RebuildsTilesOnceAfterRun()
     {
         var vm = CreateViewModel();
-        SetupPlanAndExecute();
+        SetupSyncService();
 
         await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
 
@@ -277,6 +549,23 @@ public class LoraViewerViewModelSyncTests
         _sync.Verify(s => s.PlanAsync(It.IsAny<SyncScope>(), It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    /// <summary>Without a dialog service there is nobody to ask, so the run stops before it starts.</summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_WithoutADialogServiceDoesNotRunUnasked()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService();
+        vm.DialogService = null;
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        vm.SyncStatus.Should().Be("Dialog service not available.");
+        _sync.Verify(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()),
+            Times.Once, "the discovery pre-run had already happened; nothing beyond it may run unasked");
+    }
+
+    // ------------------------------------------------------------------------------ the per-tile button
+
     [Fact]
     public async Task DownloadMetadataForTile_UsesForModelsScopeWithForceIdentify()
     {
@@ -290,10 +579,11 @@ public class LoraViewerViewModelSyncTests
             {
                 scope = s;
                 options = o;
-                return PlanFor(s, IdentifyStep(1));
+                return PlanFor(s, o, IdentifyStep(1));
             });
         _sync.Setup(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((SyncPlan p, IProgress<LibrarySyncProgress>? _, CancellationToken _) => ReportFor(p, succeeded: 1));
+            .ReturnsAsync((SyncPlan p, IProgress<LibrarySyncProgress>? _, CancellationToken _) =>
+                new SyncReport(p, [new SyncStepReport(SyncStepKind.IdentifyModel, 3, 3, 1, 0, 0)], [], false, TimeSpan.FromSeconds(2), 0));
         _models.Setup(m => m.GetByIdWithIncludesAsync(42, It.IsAny<CancellationToken>())).ReturnsAsync((Model?)null);
 
         var outcome = await vm.DownloadMetadataForTileAsync(tile);
@@ -313,6 +603,33 @@ public class LoraViewerViewModelSyncTests
         }, "one tile never triggers a library-wide discovery pass, but the thumbnail is half of what the user pressed the button for");
     }
 
+    /// <summary>
+    /// The forces cover identify and thumbnails, not the un-forced tags/images fetches — those are
+    /// still judged against a retry window, and that window is the user's, not the built-in default.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMetadataForTile_UsesTheSavedRetryWindows()
+    {
+        var vm = CreateViewModel();
+        await vm.ScrollRetryPolicyLoad; // the startup read the per-tile fetch shares with the tiles
+
+        SyncOptions? options = null;
+        _sync.Setup(s => s.PlanAsync(It.IsAny<SyncScope>(), It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SyncScope s, SyncOptions o, CancellationToken _) =>
+            {
+                options = o;
+                return PlanFor(s, o, IdentifyStep(1));
+            });
+        _sync.Setup(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SyncPlan p, IProgress<LibrarySyncProgress>? _, CancellationToken _) =>
+                new SyncReport(p, [new SyncStepReport(SyncStepKind.IdentifyModel, 1, 1, 0, 0, 0)], [], false, TimeSpan.Zero, 0));
+
+        await vm.DownloadMetadataForTileAsync(CreateTile(modelId: 42));
+
+        options!.Policy.NotIdentifiedRetryAfter.Should().Be(TimeSpan.FromDays(14));
+        options.Policy.ErrorRetryAfter.Should().Be(TimeSpan.FromDays(3));
+    }
+
     [Fact]
     public async Task DownloadMetadataForTile_WithNothingAppliedReturnsFalse()
     {
@@ -320,9 +637,10 @@ public class LoraViewerViewModelSyncTests
         var tile = CreateTile(modelId: 42);
 
         _sync.Setup(s => s.PlanAsync(It.IsAny<SyncScope>(), It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((SyncScope s, SyncOptions _, CancellationToken _) => PlanFor(s, IdentifyStep(1)));
+            .ReturnsAsync((SyncScope s, SyncOptions o, CancellationToken _) => PlanFor(s, o, IdentifyStep(1)));
         _sync.Setup(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((SyncPlan p, IProgress<LibrarySyncProgress>? _, CancellationToken _) => ReportFor(p, succeeded: 0));
+            .ReturnsAsync((SyncPlan p, IProgress<LibrarySyncProgress>? _, CancellationToken _) =>
+                new SyncReport(p, [new SyncStepReport(SyncStepKind.IdentifyModel, 3, 3, 0, 0, 0)], [], false, TimeSpan.FromSeconds(2), 0));
 
         var outcome = await vm.DownloadMetadataForTileAsync(tile);
 
@@ -343,7 +661,7 @@ public class LoraViewerViewModelSyncTests
         var tile = CreateTile(modelId: 42);
 
         _sync.Setup(s => s.PlanAsync(It.IsAny<SyncScope>(), It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((SyncScope s, SyncOptions _, CancellationToken _) => PlanFor(s, IdentifyStep(0)));
+            .ReturnsAsync((SyncScope s, SyncOptions o, CancellationToken _) => PlanFor(s, o, IdentifyStep(0)));
         _sync.Setup(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((SyncPlan p, IProgress<LibrarySyncProgress>? _, CancellationToken _) => new SyncReport(
                 p,
@@ -359,6 +677,8 @@ public class LoraViewerViewModelSyncTests
         outcome.IdentifyPlanned.Should().Be(0, "nothing was asked, so nothing may be claimed about Civitai");
     }
 
+    // -------------------------------------------------------------------------------- single flight
+
     /// <summary>
     /// R10. The sync service admits one run at a time and throws on the second. The old code
     /// assigned <c>_metadataSyncCts</c> before it looked at anything, so a second press both
@@ -369,21 +689,20 @@ public class LoraViewerViewModelSyncTests
     public async Task DownloadMissingMetadata_SecondCallWhileRunningIsRefusedAndCancelStillReachesTheFirstRun()
     {
         var vm = CreateViewModel();
-        var plan = PlanFor(SyncScope.Library, IdentifyStep());
 
         var entered = new TaskCompletionSource();
         var release = new TaskCompletionSource();
         CancellationToken firstRunToken = default;
 
         _sync.Setup(s => s.PlanAsync(It.IsAny<SyncScope>(), It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(plan);
+            .ReturnsAsync((SyncScope scope, SyncOptions options, CancellationToken _) => PlanFor(scope, options, StepsFor(options)));
         _sync.Setup(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()))
             .Returns(async (SyncPlan p, IProgress<LibrarySyncProgress>? _, CancellationToken ct) =>
             {
                 firstRunToken = ct;
                 entered.TrySetResult();
                 await release.Task;
-                return ReportFor(p);
+                return ReportFor(p, 0, false, []);
             });
 
         var first = vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
@@ -404,7 +723,7 @@ public class LoraViewerViewModelSyncTests
 
         vm.CancelMetadataDownloadCommand.Execute(null);
         firstRunToken.IsCancellationRequested.Should().BeTrue(
-            "Cancel must reach the token the run in flight is actually observing");
+            "Cancel must reach the token the run in flight is actually observing — the discovery pre-run included");
 
         release.TrySetResult();
         await first;
@@ -424,15 +743,17 @@ public class LoraViewerViewModelSyncTests
     public async Task DownloadMissingMetadata_CancelledRunStillRebuildsTheGridAndShowsItsTally()
     {
         var vm = CreateViewModel();
-        var plan = PlanFor(SyncScope.Library, IdentifyStep());
         SyncReport? report = null;
 
         _sync.Setup(s => s.PlanAsync(It.IsAny<SyncScope>(), It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(plan);
+            .ReturnsAsync((SyncScope scope, SyncOptions options, CancellationToken _) => PlanFor(scope, options, StepsFor(options)));
         _sync.Setup(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((SyncPlan p, IProgress<LibrarySyncProgress>? _, CancellationToken _) =>
             {
-                // The user presses Cancel while the run is going; two of the three items are done.
+                // The discovery pre-run finishes normally; the user presses Cancel during the run
+                // that follows, with two of the three items done.
+                if (IsDiscovery(p.Options)) return ReportFor(p, 0, false, []);
+
                 vm.CancelMetadataDownloadCommand.Execute(null);
                 report = new SyncReport(
                     p,
@@ -451,6 +772,8 @@ public class LoraViewerViewModelSyncTests
         vm.SyncStatus.Should().Be(report!.Summary,
             "a cancelled run still has a tally, and the report is the only thing that knows it");
         vm.SyncStatus.Should().Contain("(cancelled)", "the report's own summary says so");
+        _settings.Verify(s => s.UpdateLastLibrarySyncAtAsync(It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()), Times.Never,
+            "a cancelled run is not a full sync, whatever it managed to finish");
     }
 
     /// <summary>
@@ -466,14 +789,15 @@ public class LoraViewerViewModelSyncTests
         var release = new TaskCompletionSource();
 
         _sync.Setup(s => s.PlanAsync(It.IsAny<SyncScope>(), It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()))
-            .Returns(async (SyncScope s, SyncOptions _, CancellationToken _) =>
+            .Returns(async (SyncScope s, SyncOptions o, CancellationToken _) =>
             {
                 planning.TrySetResult();
                 await release.Task;
-                return PlanFor(s, IdentifyStep(1));
+                return PlanFor(s, o, IdentifyStep(1));
             });
         _sync.Setup(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((SyncPlan p, IProgress<LibrarySyncProgress>? _, CancellationToken _) => ReportFor(p, succeeded: 0));
+            .ReturnsAsync((SyncPlan p, IProgress<LibrarySyncProgress>? _, CancellationToken _) =>
+                new SyncReport(p, [new SyncStepReport(SyncStepKind.IdentifyModel, 1, 1, 0, 0, 0)], [], false, TimeSpan.Zero, 0));
 
         var tileRun = vm.DownloadMetadataForTileAsync(CreateTile(modelId: 42));
         await planning.Task.WaitAsync(TimeSpan.FromSeconds(10));
@@ -515,12 +839,12 @@ public class LoraViewerViewModelSyncTests
         var canExecuteDuringRun = true;
 
         _sync.Setup(s => s.PlanAsync(It.IsAny<SyncScope>(), It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((SyncScope s, SyncOptions _, CancellationToken _) => PlanFor(s, IdentifyStep(1)));
+            .ReturnsAsync((SyncScope s, SyncOptions o, CancellationToken _) => PlanFor(s, o, IdentifyStep(1)));
         _sync.Setup(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((SyncPlan p, IProgress<LibrarySyncProgress>? _, CancellationToken _) =>
             {
                 canExecuteDuringRun = vm.DownloadMissingMetadataCommand.CanExecute(null);
-                return ReportFor(p, succeeded: 0);
+                return new SyncReport(p, [new SyncStepReport(SyncStepKind.IdentifyModel, 1, 1, 0, 0, 0)], [], false, TimeSpan.Zero, 0);
             });
 
         await vm.DownloadMetadataForTileAsync(CreateTile(modelId: 42));

--- a/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
+++ b/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
@@ -93,6 +93,12 @@ public class LoraViewerViewModelSyncTests
     /// <summary>1 = the discovery pre-run throws, 2 = the real run throws, 0 = neither.</summary>
     private int _throwOnExecuteCall;
 
+    /// <summary>
+    /// What that call throws. The gate's own refusal by default; a test that wants to prove a real
+    /// bug is not laundered into "not now" swaps in a plain <see cref="InvalidOperationException"/>.
+    /// </summary>
+    private Exception _executeThrow = new SyncAlreadyRunningException();
+
     private LoraViewerViewModel CreateViewModel(bool withSyncService = true)
     {
         _modelSync.Setup(s => s.LoadCachedFilesAsync(It.IsAny<CancellationToken>()))
@@ -188,7 +194,7 @@ public class LoraViewerViewModelSyncTests
             {
                 _executeCalls++;
                 if (_executeCalls == _throwOnExecuteCall)
-                    throw NotNowException();
+                    throw _executeThrow;
 
                 _executed.Add(plan);
                 var isDiscovery = IsDiscovery(plan.Options);
@@ -201,8 +207,6 @@ public class LoraViewerViewModelSyncTests
             });
     }
 
-    /// <summary>The refusal the single-flight gate raises when a run is already holding the service.</summary>
-    private static Exception NotNowException() => new InvalidOperationException("A library sync is already running.");
 
     /// <summary>The steps a plan for <paramref name="options"/> carries, with the counts the test asked for.</summary>
     private SyncPlanStep[] StepsFor(SyncOptions options)
@@ -682,6 +686,31 @@ public class LoraViewerViewModelSyncTests
         _reportDialogVm.Should().BeNull("there is no report — this run never got the service");
         vm.IsBusy.Should().BeFalse();
         vm.IsSyncRunning.Should().BeFalse("the refused run must not leave the buttons off");
+    }
+
+    /// <summary>
+    /// F8. …and only that refusal. <c>InvalidOperationException</c> is what every step's
+    /// <c>GetRequiredService&lt;IUnitOfWork&gt;()</c> and every <c>Single()</c> over an empty
+    /// sequence raises too. Catching the base type told the user a DI regression was a busy
+    /// service, logged it at Info without the exception, and re-enabled the button so the same
+    /// wrong answer came back on every press. A genuine bug has to stay loud.
+    /// </summary>
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public async Task DownloadMissingMetadata_AnUnrelatedInvalidOperationIsReportedAsAnError(int throwOnCall)
+    {
+        var vm = CreateViewModel();
+        SetupSyncService();
+        _throwOnExecuteCall = throwOnCall;
+        _executeThrow = new InvalidOperationException("No service for type 'IUnitOfWork' has been registered.");
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        vm.SyncStatus.Should().Be("Sync error: No service for type 'IUnitOfWork' has been registered.",
+            "the generic catch logs at Error with the exception; the already-running path logs at Info without it");
+        vm.IsBusy.Should().BeFalse();
+        vm.IsSyncRunning.Should().BeFalse();
     }
 
     // ------------------------------------------------------------------- outcome, status, rebuild

--- a/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
+++ b/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
@@ -65,6 +65,9 @@ public class LoraViewerViewModelSyncTests
     private SyncPlanDialogViewModel? _planDialogVm;
     private SyncReportDialogViewModel? _reportDialogVm;
 
+    /// <summary>True once the plan dialog has been shown — the stale-plan case re-plans behind it.</summary>
+    private bool _dialogShown;
+
     /// <summary>What the user does at the plan dialog. Default: start exactly what the dialog offers.</summary>
     private Func<SyncPlanDialogViewModel, SyncPlanDialogResult> _planDialogAnswer = vm => vm.BuildResult();
 
@@ -91,6 +94,7 @@ public class LoraViewerViewModelSyncTests
             {
                 _calls.Add("plan-dialog");
                 _planDialogVm = dialogVm;
+                _dialogShown = true;
                 return Task.FromResult(_planDialogAnswer(dialogVm));
             });
         _dialogs.Setup(d => d.ShowSyncReportDialogAsync(It.IsAny<SyncReportDialogViewModel>()))
@@ -174,7 +178,7 @@ public class LoraViewerViewModelSyncTests
     {
         if (IsDiscovery(options)) return [DiscoverStep()];
 
-        var identify = _planDialogVm is not null && _identifyCountAfterDialog >= 0
+        var identify = _dialogShown && _identifyCountAfterDialog >= 0
             ? _identifyCountAfterDialog
             : _identifyCount;
 
@@ -374,12 +378,56 @@ public class LoraViewerViewModelSyncTests
 
         _calls.Should().ContainInOrder("execute:run", "report-dialog");
         _reportDialogVm.Should().NotBeNull();
-        _reportDialogVm!.SummaryText.Should().Be("Discovered 0 · Identified 2/3",
-            "the report dialog projects the run's own report — three planned, one of them failed");
+        _reportDialogVm!.SummaryText.Should().Be("Discovered 4 · Identified 2/3",
+            "the report dialog projects the run's own report — three planned, one of them failed — " +
+            "with the scan's count folded back in");
         _reportDialogVm.DiscoveredText.Should().Be("4 new files discovered",
-            "the run's own report knows nothing about the scan that preceded it");
+            "the dialog's own discovered line says the same thing as its table");
         _reportDialogVm.HasFailures.Should().BeTrue("the failures are the part the user has to act on");
         vm.IsBusy.Should().BeFalse("the overlay comes down before the report, not behind it");
+    }
+
+    /// <summary>
+    /// The stamp is a SQLite write at the peak of WAL contention — the run that just ended has been
+    /// writing for minutes. Unguarded, its exception reached the outer catch and took the grid
+    /// rebuild and the report dialog with it: everything the run achieved, lost to save a
+    /// timestamp. A failed stamp may cost the timestamp and nothing else.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_AFailedStampStillRebuildsAndReports()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService();
+        _settings.Setup(s => s.UpdateLastLibrarySyncAtAsync(It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("database is locked"));
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        _modelSync.Verify(s => s.LoadCachedFilesAsync(It.IsAny<CancellationToken>()), Times.Once,
+            "the models the run identified are already committed and stay invisible until the grid is rebuilt");
+        _reportDialogVm.Should().NotBeNull("the user still gets the report of the run that did happen");
+        vm.SyncStatus.Should().Be(RunReport().Summary,
+            "and the status line is the run's tally, not an error message about a timestamp");
+    }
+
+    /// <summary>
+    /// The scan is a separate run, so the run's own report counts none of it — and a report dialog
+    /// whose table says "Discovered 0" a few lines above "9 new files discovered" is arguing with
+    /// itself, as is a status bar that says the same. The scan's count is folded back into the
+    /// report the moment the run returns, so every projection of it agrees.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_FoldsTheScanCountIntoTheRunsOwnReport()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService(discovered: 9);
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        vm.SyncStatus.Should().StartWith("Discovered 9 ",
+            "the status bar is DescribeOutcome's view of the very same report");
+        _reportDialogVm!.SummaryText.Should().StartWith("Discovered 9 ");
+        _reportDialogVm.DiscoveredText.Should().Be("9 new files discovered");
     }
 
     /// <summary>

--- a/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
+++ b/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
@@ -394,6 +394,45 @@ public class LoraViewerViewModelSyncTests
             "the refusal is about the run, not about the five files the scan already committed");
     }
 
+    /// <summary>
+    /// The same rebuild is owed when the RUN dies midway, not only when the scan added rows. Each
+    /// item commits in its own scope, and a step's SelectAsync sits outside the loop's try in
+    /// LibrarySyncService — so a DbException there escapes ExecuteAsync with, say, 200 freshly
+    /// identified models already durable. Gating the backstop on "the scan discovered something"
+    /// left all of that invisible whenever the scan itself came up empty.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_RebuildsWhenTheRunDiesMidway()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService();   // discovered: 0 — only the run wrote anything
+        _throwOnExecuteCall = 2;
+        _executeThrow = new InvalidOperationException("database is locked");
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        _modelSync.Verify(s => s.LoadCachedFilesAsync(It.IsAny<CancellationToken>()), Times.Once,
+            "whatever the run finished before dying is committed, and the grid has to show it");
+        vm.SyncStatus.Should().StartWith("Sync error:", "the rebuild must not soften the error verdict");
+    }
+
+    /// <summary>
+    /// …but a run the single-flight gate refused never got the service at all, so this press wrote
+    /// nothing beyond the scan — with an empty scan there is nothing new to re-project.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_DoesNotRebuildWhenARefusedRunFollowedAnEmptyScan()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService();   // discovered: 0
+        _throwOnExecuteCall = 2;   // _executeThrow defaults to SyncAlreadyRunningException
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        _modelSync.Verify(s => s.LoadCachedFilesAsync(It.IsAny<CancellationToken>()), Times.Never,
+            "the refusal happened at the gate, before any work — a full grid re-projection would be pure cost");
+    }
+
     /// <summary>And exactly once when the run path already did it — the finally is a backstop, not a second pass.</summary>
     [Fact]
     public async Task DownloadMissingMetadata_DoesNotRebuildTwiceWhenTheRunAlreadyDid()

--- a/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
+++ b/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
@@ -558,21 +558,49 @@ public class LoraViewerViewModelSyncTests
     /// <summary>
     /// F6. The dialog exists so the user can run a subset — and "Last full sync: …" is the only
     /// staleness signal the next dialog shows. A 20-second thumbnails-only top-up that stamped it
-    /// made the viewer announce a full sync for metadata that had never been fetched at all.
+    /// made the viewer announce a full sync for metadata that had never been fetched at all. The
+    /// yardstick is the dialog's rows: a kind the user UNTICKED while it had work makes the run
+    /// partial, and partial runs leave the timestamp alone.
     /// </summary>
     [Fact]
-    public async Task DownloadMissingMetadata_DoesNotStampAFullSyncForASubsetRun()
+    public async Task DownloadMissingMetadata_DoesNotStampAFullSyncWhenAKindWithWorkWasUnticked()
     {
         var vm = CreateViewModel();
-        SetupSyncService();   // only the identify row has work, so only it is ticked and run
+        _otherStepCount = 2;   // every kind has work…
+        _planDialogAnswer = dialogVm =>
+        {
+            // …but the user opts tags out of the run.
+            dialogVm.Rows.Single(r => r.Kind == SyncStepKind.FetchTags).IsSelected = false;
+            return Task.FromResult(dialogVm.BuildResult());
+        };
+        SetupSyncService();
 
         await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
 
-        _executed[^1].Options.Steps.Should().BeEquivalentTo(new[] { SyncStepKind.IdentifyModel },
-            "this run covered one of the four offered kinds");
+        _executed[^1].Options.Steps.Should().NotContain(SyncStepKind.FetchTags,
+            "the untick must actually have excluded the step for this test to mean anything");
         _settings.Verify(s => s.UpdateLastLibrarySyncAtAsync(It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
             Times.Never,
-            "a run that skipped tags, images and thumbnails may not present itself as a full sync next week");
+            "a run that skipped tags the library still needed may not present itself as a full sync next week");
+    }
+
+    /// <summary>
+    /// The counterpart: a kind with NOTHING to do is covered by doing nothing. BuildResult drops
+    /// zero-count kinds from the chosen set, so demanding all four kinds would mean a library
+    /// where tags/images/thumbnails are already complete could never refresh its stamp again.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_StampsWhenEveryKindWithWorkRan()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService();   // only the identify row has work; the other three have nothing to do
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        _executed[^1].Options.Steps.Should().BeEquivalentTo(new[] { SyncStepKind.IdentifyModel });
+        _settings.Verify(s => s.UpdateLastLibrarySyncAtAsync(It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
+            Times.Once,
+            "after this run the library is as synced as four ticked boxes would have left it");
     }
 
     [Fact]

--- a/DiffusionNexus.Tests/Viewer/ModelTileThumbnailTests.cs
+++ b/DiffusionNexus.Tests/Viewer/ModelTileThumbnailTests.cs
@@ -235,7 +235,7 @@ public class ModelTileThumbnailTests
     [Fact]
     public void ScrollFetch_IsDueForARowNothingHasEverTried()
     {
-        ModelTileViewModel.IsScrollFetchDue(new ModelImage(), Now).Should().BeTrue();
+        ModelTileViewModel.IsScrollFetchDue(new ModelImage(), Now, SyncRetryPolicy.Default).Should().BeTrue();
     }
 
     /// <summary>
@@ -252,7 +252,7 @@ public class ModelTileThumbnailTests
             ThumbnailFailure = ThumbnailFailureReason.Http404,
         };
 
-        ModelTileViewModel.IsScrollFetchDue(image, Now).Should().BeFalse(
+        ModelTileViewModel.IsScrollFetchDue(image, Now, SyncRetryPolicy.Default).Should().BeFalse(
             "the asset is gone; asking again a year later costs a request to learn nothing");
     }
 
@@ -265,11 +265,11 @@ public class ModelTileThumbnailTests
             ThumbnailFailure = ThumbnailFailureReason.HttpError,
         };
 
-        ModelTileViewModel.IsScrollFetchDue(image, Now).Should().BeFalse("still inside the retry window");
+        ModelTileViewModel.IsScrollFetchDue(image, Now, SyncRetryPolicy.Default).Should().BeFalse("still inside the retry window");
 
         image.ThumbnailAttemptedAt = Now - SyncRetryPolicy.Default.ErrorRetryAfter;
 
-        ModelTileViewModel.IsScrollFetchDue(image, Now).Should().BeTrue("the CDN coming back is exactly the case to catch");
+        ModelTileViewModel.IsScrollFetchDue(image, Now, SyncRetryPolicy.Default).Should().BeTrue("the CDN coming back is exactly the case to catch");
     }
 
     [Fact]
@@ -277,8 +277,29 @@ public class ModelTileThumbnailTests
     {
         var image = new ModelImage { ThumbnailAttemptedAt = Now, ThumbnailFailure = ThumbnailFailureReason.Corrupt };
 
-        ModelTileViewModel.IsScrollFetchDue(image, Now).Should().BeTrue(
+        ModelTileViewModel.IsScrollFetchDue(image, Now, SyncRetryPolicy.Default).Should().BeTrue(
             "nothing failed at the source — the row simply has no bytes any more");
+    }
+
+    /// <summary>
+    /// The window is the user's (Plan E): the same row is due or not depending on the policy the
+    /// tile is handed, so a widened error window in settings really does stop the scroll path
+    /// re-fetching on the default one-day cadence.
+    /// </summary>
+    [Fact]
+    public void ScrollFetch_HonoursTheSettingsDerivedWindowRatherThanTheDefaultOne()
+    {
+        var image = new ModelImage
+        {
+            ThumbnailAttemptedAt = Now - TimeSpan.FromDays(7),
+            ThumbnailFailure = ThumbnailFailureReason.HttpError,
+        };
+
+        ModelTileViewModel.IsScrollFetchDue(image, Now, SyncRetryPolicy.Default).Should().BeTrue(
+            "a week is well past the default one-day error window");
+
+        ModelTileViewModel.IsScrollFetchDue(image, Now, SyncRetryPolicy.FromDays(30, 30)).Should().BeFalse(
+            "the user asked for a 30-day error window, and the scroll gate is not exempt from it");
     }
 
     // ------------------------------------------- the user-initiated static-sibling pick (Task 8)

--- a/DiffusionNexus.UI/Doc/LoraViewer.md
+++ b/DiffusionNexus.UI/Doc/LoraViewer.md
@@ -470,12 +470,18 @@ is safe by escaping, not by absence: EF renders a captured-variable `StartsWith`
 `LIKE @p ESCAPE '\'` with `%`, `_` and `\` escaped into the parameter at runtime, so those in a
 source folder's name are ordinary characters here, not wildcards.
 
-Forcing also widens *selection*, not just due-ness: `SelectIdentifyCandidatesAsync` takes an
-`includeMatched` flag (`ForceIdentify || scope.Kind == Models`) that drops the
-"no `CivitaiId` yet" predicate, and an explicit id scope additionally drops the LoRA-family
-type filter. Without that, a forced run over an already-matched model planned zero items and
-the detail panel reported "No metadata found on Civitai for this file." about a model Civitai
-knows — for most of the library.
+Force means two different things by scope, and only the explicit one touches Matched models.
+The per-tile scope widens *selection* as well as due-ness: `SelectIdentifyCandidatesAsync` takes
+an `includeMatched` flag (`scope.Kind == Models`) that drops the "no `CivitaiId` yet" predicate,
+and an explicit id scope additionally drops the LoRA-family type filter. Without that, a forced
+run over an already-matched model planned zero items and the detail panel reported "No metadata
+found on Civitai for this file." about a model Civitai knows — for most of the library. The
+library- and folder-wide force is the plan dialog's "Models not found on Civitai" checkbox, and
+it keeps that promise: Matched models are left alone — `IdentifyModelStep.IsDue` also drops the
+force for a Matched candidate the `CivitaiId` filter cannot see (the duplicate copy that owns
+only the page id) — and hand-edited models are not dragged into a bulk overwrite run. The
+not-found outcomes (`NotIdentified`, `Sidecar`, `Header`, `Heuristic`, `Error`) are forced past
+their retry windows, which is the checkbox's purpose.
 
 The method returns `TileMetadataSyncResult(Applied, Report)`: `Applied` (any step succeeded)
 tells the detail view to reload; `IdentifyPlanned` is what separates the two failure

--- a/DiffusionNexus.UI/Doc/LoraViewer.md
+++ b/DiffusionNexus.UI/Doc/LoraViewer.md
@@ -443,8 +443,10 @@ sync, so every model queued behind the bad one went unchecked.
 `SyncOptions` carries `ForceIdentify`, `ForceTags`, `ForceImages`, `ForceThumbnails`.
 A forced step ignores the stored verdict and the retry window. The per-LoRA button in the
 detail panel is exactly this: `DownloadMetadataForTileAsync` plans
-`SyncScope.ForModels(modelId)` with `IdentifyModel + FetchTags + FetchImages` and
-`ForceIdentify: true` — same service, same steps, one model — then re-reads that model and
+`SyncScope.ForModels(modelId)` with `IdentifyModel + FetchTags + FetchImages + Thumbnails` and
+`ForceIdentify: true, ForceThumbnails: true` — the thumbnail is force-refreshed too, because
+"download metadata for this model" is, to the person pressing it, a request for the picture as
+well — same service, same steps, one model — then re-reads that model and
 refreshes the tile.
 
 **The scope predicate is the viewer's predicate.** "In the library" means "owns a local file

--- a/DiffusionNexus.UI/Doc/LoraViewer.md
+++ b/DiffusionNexus.UI/Doc/LoraViewer.md
@@ -173,37 +173,61 @@ RefreshAsync
 The viewer owns none of this logic. The toolbar button and the detail panel's per-LoRA
 button both drive `ILibrarySyncService` (`DiffusionNexus.Service/Services/Sync/`), which
 plans a run, executes it step by step and records **per-model state** so a second run only
-does what is genuinely outstanding. `LoraViewerViewModel` just starts the run, shows
-progress, and rebuilds its grid once at the end.
+does what is genuinely outstanding. `LoraViewerViewModel` scans, asks the user what to do
+about what the scan found, shows progress, rebuilds its grid once at the end, and reports.
 
 ```
-DownloadMissingMetadataAsync                      (both service calls run on Task.Run —
+DownloadMissingMetadataAsync                      (every service call runs on Task.Run —
 │                                                  SQLite is synchronous, and the planning
-├── PlanAsync(SyncScope.Library, SyncOptions.All)   pass + the folder scan would otherwise
-│     → SyncPlan: one SyncPlanStep per step         freeze the overlay and the Cancel button)
-│       (Kind, Count, EstimatedDuration, Description)
-│     → plan.HasWork == false ⇒ "Library is up to date — nothing to do", no run.
-│       Only reachable for an option set WITHOUT DiscoverFiles: a plan carrying the
-│       discovery step always reports work, because nobody knows what a scan will
-│       find until it has run.
-│     (Plan B puts a confirmation dialog here; for now the plan is logged and started)
+├── 1. Discovery pre-run                            pass + the folder scan would otherwise
+│      Plan+Execute with steps {DiscoverFiles}      freeze the overlay and the Cancel button)
+│      → report.NewFilesDiscovered
+│      Runs BEFORE the question, and is the one step nobody is asked about: a scan cannot be
+│      counted in advance, and running it first is what lets every count below include the
+│      files it just found.
 │
-├── ExecuteAsync(plan, progress, ct)
-│     progress → status bar: "{Label} [{index}/{total}] {currentItem}"
-│     steps run in registration order — a file must be discovered before it can be
-│     identified, and only an identified model has the ids tags/images need
+├── 2. PlanAsync(SyncScope.Library, base options)
+│      steps {IdentifyModel, FetchTags, FetchImages, Thumbnails}; RetryPolicy and
+│      ThumbnailConcurrency come from the saved sync settings, not from constants
+│      → SyncPlan: one SyncPlanStep per step (Kind, Count, EstimatedDuration, Description)
 │
-├── RebuildTilesFromDatabaseAsync()   ← exactly once, after the run — including after a
+├── 3. SyncPlanDialog   ← the busy overlay comes DOWN: nothing is running while the user reads
+│      per-step counts + estimates with tick boxes, four Force toggles that re-plan live,
+│      "Last full sync: …" from AppSettings.LastLibrarySyncAt, and the discovered count
+│      cancelled / closed ⇒ "Sync cancelled — nothing was run.", or
+│        "Library is up to date — nothing to do" when the plan had no counted work
+│
+├── 4. PlanAsync(SyncScope.Library, the options the dialog returned)
+│      re-planned rather than executing the dialog's plan: it is cheap, the ticks and forces
+│      select a different set of items, and the dialog may have been open for minutes
+│
+├── 5. ExecuteAsync(plan, progress, ct)
+│      progress → status bar: "{Label} [{index}/{total}] {currentItem}"
+│      steps run in registration order — a file must be discovered before it can be
+│      identified, and only an identified model has the ids tags/images need
+│      InvalidOperationException from the service's single-flight gate (a download's
+│      completion sync can hold it) ⇒ "A metadata sync is already running." — a "not now",
+│      not a fault: no stack trace, no retry loop. Both runs above are guarded.
+│
+├── 6. UpdateLastLibrarySyncAtAsync(UtcNow)   ← only when the run was NOT cancelled, and with
+│                                        CancellationToken.None: it records what already
+│                                        happened, so a just-pressed Cancel must not lose it
+│
+├── 7. RebuildTilesFromDatabaseAsync()   ← exactly once, after the run — including after a
 │                                       CANCELLED one: those models are already committed,
 │                                       and the run's (signalled) token is deliberately not
 │                                       passed here, or the rebuild would be skipped and the
 │                                       report thrown away with it
 │
-└── SyncStatus:
-      report.NewFilesDiscovered == 0 && every step Planned == 0
-        ⇒ "Library is up to date — nothing to do"   ← the honest verdict, from the report
-      otherwise report.Summary (+ " · N failed" when report.Failures is non-empty)
-        (+ " · N items failed unexpectedly (see log)" when report.UnexpectedFailures > 0)
+├── 8. SyncStatus:
+│      report.NewFilesDiscovered == 0 && every step Planned == 0
+│        ⇒ "Library is up to date — nothing to do"   ← the honest verdict, from the report
+│      otherwise report.Summary (+ " · N failed" when report.Failures is non-empty)
+│        (+ " · N items failed unexpectedly (see log)" when report.UnexpectedFailures > 0)
+│      (the run's own report always says "Discovered 0" — the scan was step 1's run, and its
+│       count is shown by the two dialogs instead)
+│
+└── 9. SyncReportDialog — per-step counts, failures grouped by step, the discovered count
 ```
 
 ### The steps
@@ -378,7 +402,11 @@ the network.
 **Checked-and-empty is final.** A model whose tags were fetched and came back empty is
 never re-fetched; only an explicit Force re-asks.
 
-### Retry windows (`SyncRetryPolicy.Default`)
+### Retry windows (`SyncRetryPolicy`)
+
+The windows below are the defaults; the two that are user-facing come from settings
+(`SyncNotIdentifiedRetryDays`, `SyncErrorRetryDays`, floored at one day) and the viewer
+builds the policy from them for the bulk run, the per-LoRA button and the tiles alike.
 
 | Stored outcome | Re-checked |
 |----------------|-----------|
@@ -716,7 +744,10 @@ explain why.
 3. **No BLOB, fetchable URL** → gated by `IsScrollFetchDue`, which is `SyncRetryPolicy.IsThumbnailDue`
    called with `force: false` — **the scroll path honors exactly the same retry windows as the sync
    step.** A row stamped `Http404` yesterday is not re-asked on every pass through the viewport; a
-   soft failure waits out its 1-day window like it would in a bulk run. `AllowVideoDownload` is
+   soft failure waits out the user's error window (`SyncErrorRetryDays`, 1 day by default) like it
+   would in a bulk run — the tile is handed that policy through
+   `ModelTileDependencies.RetryPolicyProvider`, so scroll and sync never disagree about it.
+   `AllowVideoDownload` is
    `false` here too. Without this gate, flinging through a video-heavy library would cost one GET,
    one DI scope and one `SaveChanges` per tile per scroll, forever.
 4. **Everything else** (no URL, a `file://` row, or a `user-thumbnail://` row that lost its BLOB) →

--- a/DiffusionNexus.UI/Doc/LoraViewer.md
+++ b/DiffusionNexus.UI/Doc/LoraViewer.md
@@ -409,10 +409,13 @@ never re-fetched; only an explicit Force re-asks.
 The windows below are the defaults; the two that are user-facing come from
 **Settings → LoRA Viewer → Metadata Sync** (`SyncNotIdentifiedRetryDays` — 7/14/30/60/90,
 default 30; `SyncErrorRetryDays` — 1/3/7, default 1) and reach the policy through
-`SyncRetryPolicy.FromDays`, which floors either value at one day so a settings row of `0`
-cannot turn the retry window into a busy-loop. `MaxErrorAttempts` (3) is not user-facing —
-it is a fixed ceiling on the `Error` row below. The viewer builds one policy from these
-settings and hands it to the bulk run, the per-LoRA button and the tiles alike, so a scroll
+`SyncRetryPolicy.FromDays`, which clamps either value to 1–3650 days: `0` would turn the
+retry window into a busy-loop, and a value big enough to overflow `TimeSpan.FromDays` would
+otherwise throw on every press — neither number is validated on the way in, because the
+settings importer copies them straight out of a JSON file. `MaxErrorAttempts` (3) is not
+user-facing — it is a fixed ceiling on the `Error` row below. The viewer builds one policy
+from these settings and hands it to the bulk run, the per-LoRA button and the tiles alike,
+and the downloader builds the same one for its post-download completion sync, so a scroll
 past a thumbnail and a bulk sync of the same row never disagree about whether it is due
 (§9, "The tile — three on-demand paths, one gate").
 

--- a/DiffusionNexus.UI/Doc/LoraViewer.md
+++ b/DiffusionNexus.UI/Doc/LoraViewer.md
@@ -406,15 +406,21 @@ never re-fetched; only an explicit Force re-asks.
 
 ### Retry windows (`SyncRetryPolicy`)
 
-The windows below are the defaults; the two that are user-facing come from settings
-(`SyncNotIdentifiedRetryDays`, `SyncErrorRetryDays`, floored at one day) and the viewer
-builds the policy from them for the bulk run, the per-LoRA button and the tiles alike.
+The windows below are the defaults; the two that are user-facing come from
+**Settings → LoRA Viewer → Metadata Sync** (`SyncNotIdentifiedRetryDays` — 7/14/30/60/90,
+default 30; `SyncErrorRetryDays` — 1/3/7, default 1) and reach the policy through
+`SyncRetryPolicy.FromDays`, which floors either value at one day so a settings row of `0`
+cannot turn the retry window into a busy-loop. `MaxErrorAttempts` (3) is not user-facing —
+it is a fixed ceiling on the `Error` row below. The viewer builds one policy from these
+settings and hands it to the bulk run, the per-LoRA button and the tiles alike, so a scroll
+past a thumbnail and a bulk sync of the same row never disagree about whether it is due
+(§9, "The tile — three on-demand paths, one gate").
 
 | Stored outcome | Re-checked |
 |----------------|-----------|
 | `Matched` | Never (only Force) |
-| `NotIdentified`, `Sidecar`, `Header`, `Heuristic` | After 30 days — a better source may have appeared |
-| `Error` | After 1 day, at most 3 consecutive attempts |
+| `NotIdentified`, `Sidecar`, `Header`, `Heuristic` | After `SyncNotIdentifiedRetryDays` (default 30) — a better source may have appeared |
+| `Error` | After `SyncErrorRetryDays` (default 1), at most `MaxErrorAttempts` (3) consecutive attempts |
 | `None` / no row | Immediately |
 | Tags / images already stamped | Never (only Force) |
 
@@ -604,6 +610,12 @@ Grid (3 rows: Auto, *, Auto)
 └── Row 2: Status Bar (SyncStatus text, auto-hides when empty)
 ```
 
+**Bulk sync windows.** `SyncPlanDialog` and `SyncReportDialog` (`Views/Dialogs/`) are not rows in
+this Grid — they are separate windows the Download Metadata flow shows through `IDialogService`,
+one before the run and one after (§4 steps 3 and 9). The plan dialog's appearance is deliberate
+about the Loading Overlay above: it comes down while the dialog is open, because nothing is
+running yet — the user is still choosing what to start.
+
 ---
 
 ## 8. Filtering Pipeline
@@ -678,11 +690,19 @@ every producer — a thumbnail from the sync step, the tile, and the sidecar app
   already carries bytes contributes nothing at all, and the loop never reaches the runner-up. Rows
   with a blank URL or a `user-thumbnail://` one are dropped from the ranking itself, not merely from
   the result — left in, either could win its version and hide the real image behind it.
-- **One item per due image, no pacer.** Unlike the other four steps this one never awaits
-  `ICivitaiRequestPacer` — the CDN is a static-asset host, not the rate-limited API, and pacing a
-  library's worth of ~65 KB GETs at API speed would turn a minute into an hour. The record of an
-  attempt lives on `ModelImage` itself, not on `ModelSyncStates`, because the unit of work is the
-  image: two versions of one model are two independent thumbnails, two requests, two outcomes.
+- **One item per due image, no pacer — and the unpaced thumbnails step runs N at a time.** Unlike
+  the other four steps this one never awaits `ICivitaiRequestPacer` — the CDN is a static-asset
+  host, not the rate-limited API, and pacing a library's worth of ~65 KB GETs at API speed would
+  turn a minute into an hour. The record of an attempt lives on `ModelImage` itself, not on
+  `ModelSyncStates`, because the unit of work is the image: two versions of one model are two
+  independent thumbnails, two requests, two outcomes. `ThumbnailsStep` is the one step that runs
+  its due images with bounded parallelism instead of one at a time: `SyncOptions.ThumbnailConcurrency`
+  (from **Settings → LoRA Viewer → Metadata Sync**, clamped to 1–8, default 4) sets how many CDN GETs
+  `LibrarySyncService` has in flight at once. The other four steps stay sequential and paced — this
+  is the one place in the pipeline where "sequential" and "paced" pull apart, because the CDN needs
+  neither. The same clamp applies wherever a model has more than one due image at once: the
+  downloader's post-download completion sync and a per-tile sync both fetch that model's outstanding
+  thumbnails through the same bounded path, not one request each in series.
 - **`AllowVideoDownload` is always `false`.** A video-primary row costs exactly one small poster GET
   in bulk; if the CDN has no poster for it yet, the row fails soft (`VideoNoPoster`) and tries again
   tomorrow — it never falls back to pulling the clip. That is the **0-video-bytes-in-bulk guarantee**:

--- a/DiffusionNexus.UI/Doc/LoraViewer.md
+++ b/DiffusionNexus.UI/Doc/LoraViewer.md
@@ -224,8 +224,10 @@ DownloadMissingMetadataAsync                      (every service call runs on Ta
 │        ⇒ "Library is up to date — nothing to do"   ← the honest verdict, from the report
 │      otherwise report.Summary (+ " · N failed" when report.Failures is non-empty)
 │        (+ " · N items failed unexpectedly (see log)" when report.UnexpectedFailures > 0)
-│      (the run's own report always says "Discovered 0" — the scan was step 1's run, and its
-│       count is shown by the two dialogs instead)
+│      (step 1's count is folded back into the run's report the moment it returns — rebuilt
+│       explicitly, never with `with`: Summary is a get-only auto-property and the record
+│       copy constructor would carry the stale one — so the status line, the report table
+│       and the dialog's discovered line all say the same number)
 │
 └── 9. SyncReportDialog — per-step counts, failures grouped by step, the discovered count
 ```

--- a/DiffusionNexus.UI/Services/DialogService.cs
+++ b/DiffusionNexus.UI/Services/DialogService.cs
@@ -733,4 +733,17 @@ public class DialogService : IDialogService
         await dialog.ShowDialog(_window);
         return new AssignCivitaiIdsDialogResult(dialog.IsConfirmed, dialog.ResolvedModel, dialog.ResolvedVersion);
     }
+
+    public async Task<SyncPlanDialogResult> ShowSyncPlanDialogAsync(SyncPlanDialogViewModel viewModel)
+    {
+        if (!Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
+        {
+            return await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
+                () => ShowSyncPlanDialogAsync(viewModel));
+        }
+
+        var dialog = new SyncPlanDialog().WithViewModel(viewModel);
+        await dialog.ShowDialog(_window);
+        return dialog.Result ?? SyncPlanDialogResult.Cancelled();
+    }
     }

--- a/DiffusionNexus.UI/Services/DialogService.cs
+++ b/DiffusionNexus.UI/Services/DialogService.cs
@@ -746,4 +746,17 @@ public class DialogService : IDialogService
         await dialog.ShowDialog(_window);
         return dialog.Result ?? SyncPlanDialogResult.Cancelled();
     }
+
+    public async Task ShowSyncReportDialogAsync(SyncReportDialogViewModel viewModel)
+    {
+        if (!Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
+        {
+            await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
+                () => ShowSyncReportDialogAsync(viewModel));
+            return;
+        }
+
+        var dialog = new SyncReportDialog().WithViewModel(viewModel);
+        await dialog.ShowDialog(_window);
+    }
     }

--- a/DiffusionNexus.UI/Services/Download/CivitaiModelDownloader.cs
+++ b/DiffusionNexus.UI/Services/Download/CivitaiModelDownloader.cs
@@ -431,7 +431,7 @@ public sealed class CivitaiModelDownloader : ICivitaiModelDownloader
             }
 
             _logger?.Debug(LogCategory.Download, LogSource, $"Step 9: completing metadata for model {modelId}");
-            var options = new SyncOptions(new HashSet<SyncStepKind> { SyncStepKind.FetchTags, SyncStepKind.Thumbnails });
+            var options = await BuildCompletionOptionsAsync(ct).ConfigureAwait(false);
             var plan = await _librarySync.PlanAsync(SyncScope.ForModels(modelId), options, ct).ConfigureAwait(false);
             await _librarySync.ExecuteAsync(plan, progress: null, ct).ConfigureAwait(false);
         }
@@ -442,6 +442,53 @@ public sealed class CivitaiModelDownloader : ICivitaiModelDownloader
         finally
         {
             if (acquired) CompletionGate.Release();
+        }
+    }
+
+    /// <summary>
+    /// The completion sync's options, carrying the user's retry windows and thumbnail fan-out.
+    /// </summary>
+    /// <remarks>
+    /// Before this, the completion sync was the one thumbnail path that honoured neither: it judged
+    /// due-ness by <see cref="SyncRetryPolicy.Default"/> rather than the user's error window, and
+    /// fetched at the record's default width of four. A model can finish with a dozen due images,
+    /// so someone on a metered connection who set "Thumbnail downloads in parallel = 1" still got
+    /// four concurrent CDN GETs after every download — while the documentation said all three paths
+    /// were bounded by that number.
+    /// <para>
+    /// Read per completion rather than cached: this service is scoped, a download takes minutes,
+    /// and the setting may have changed since the last one. Its own scope, because this runs on the
+    /// detached completion tail alongside whatever else holds the shared <c>DbContext</c>.
+    /// </para>
+    /// <para>
+    /// Never fatal: a completion sync that cannot read settings still runs, on the defaults. A
+    /// download that reached disk has succeeded whatever the follow-up does.
+    /// </para>
+    /// </remarks>
+    private async Task<SyncOptions> BuildCompletionOptionsAsync(CancellationToken ct)
+    {
+        var steps = new HashSet<SyncStepKind> { SyncStepKind.FetchTags, SyncStepKind.Thumbnails };
+
+        if (_scopeFactory is null) return new SyncOptions(steps);
+
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var settingsService = scope.ServiceProvider.GetRequiredService<IAppSettingsService>();
+            var settings = await settingsService.GetSettingsAsync(ct).ConfigureAwait(false);
+            if (settings is null) return new SyncOptions(steps);
+
+            return new SyncOptions(
+                steps,
+                RetryPolicy: SyncRetryPolicy.FromDays(
+                    settings.SyncNotIdentifiedRetryDays, settings.SyncErrorRetryDays),
+                ThumbnailConcurrency: settings.SyncThumbnailConcurrency);
+        }
+        catch (Exception ex)
+        {
+            _logger?.Debug(LogCategory.Download, LogSource,
+                $"Step 9: could not read the sync settings; using the defaults: {ex.Message}");
+            return new SyncOptions(steps);
         }
     }
 

--- a/DiffusionNexus.UI/Services/IDialogService.cs
+++ b/DiffusionNexus.UI/Services/IDialogService.cs
@@ -433,6 +433,9 @@ public interface IDialogService
 
     /// <summary>Shows the metadata-sync plan dialog. Never null: closing the window is a cancel.</summary>
     Task<SyncPlanDialogResult> ShowSyncPlanDialogAsync(SyncPlanDialogViewModel viewModel);
+
+    /// <summary>Shows the post-run sync report.</summary>
+    Task ShowSyncReportDialogAsync(SyncReportDialogViewModel viewModel);
 }
 
 /// <summary>

--- a/DiffusionNexus.UI/Services/IDialogService.cs
+++ b/DiffusionNexus.UI/Services/IDialogService.cs
@@ -430,6 +430,9 @@ public interface IDialogService
     /// </summary>
     /// <returns>Whether the user confirmed, plus the resolved Civitai model/version.</returns>
     Task<AssignCivitaiIdsDialogResult> ShowAssignCivitaiIdsDialogAsync();
+
+    /// <summary>Shows the metadata-sync plan dialog. Never null: closing the window is a cancel.</summary>
+    Task<SyncPlanDialogResult> ShowSyncPlanDialogAsync(SyncPlanDialogViewModel viewModel);
 }
 
 /// <summary>

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -1018,10 +1018,18 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
                 $"User started sync: steps [{string.Join(", ", chosen.Steps)}] forces " +
                 $"[I:{chosen.ForceIdentify} T:{chosen.ForceTags} Im:{chosen.ForceImages} Th:{chosen.ForceThumbnails}]");
 
-            // Re-planned, not the dialog's plan: it is cheap, the dialog may have been open for
-            // minutes, and the ticks and forces the user came back with select a different set of
-            // items than the one the dialog was built from.
-            var runPlan = await Task.Run(() => _librarySync.PlanAsync(SyncScope.Library, chosen, ct), ct);
+            // The dialog's own plan when it can vouch for it, and only otherwise a third pass
+            // (F13). PlanAsync runs SelectAsync on every requested step, and each of those is a
+            // repository query over the whole library plus per-item retry filtering — this button
+            // was paying for it at least twice, and once more for every Force the user toggled,
+            // even though each toggle had already re-planned with the exact options BuildResult
+            // then returned. The dialog withholds its plan whenever its counts no longer match its
+            // toggles (a failed re-plan), and then this plans again.
+            //
+            // A minutes-old plan is safe: RunStepAsync re-selects per step at execution time, so
+            // the plan's counts reach nothing but the report's Planned column.
+            var runPlan = choice.Plan
+                          ?? await Task.Run(() => _librarySync.PlanAsync(SyncScope.Library, chosen, ct), ct);
 
             var progress = new UiProgress<LibrarySyncProgress>(this, p =>
                 SyncStatus = $"{SyncReport.Label(p.Step)} [{p.Index}/{p.Total}] {p.CurrentItem}");

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -120,6 +120,20 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
     private CancellationTokenSource? _metadataSyncCts;
 
     /// <summary>
+    /// The user's retry windows, read from settings at startup and again at the top of every bulk
+    /// sync. Cached because the tiles' scroll-fetch gate asks per activation — a settings read per
+    /// tile passing the viewport is not a thing to do — and because the per-tile fetch has to judge
+    /// its un-forced steps by the same windows the sync run does.
+    /// </summary>
+    private SyncRetryPolicy _scrollRetryPolicy = SyncRetryPolicy.Default;
+
+    /// <summary>
+    /// The startup read that fills <see cref="_scrollRetryPolicy"/>. Test seam: tests await it
+    /// instead of relying on it having finished.
+    /// </summary>
+    internal Task ScrollRetryPolicyLoad { get; private set; } = Task.CompletedTask;
+
+    /// <summary>
     /// True from the moment this ViewModel starts a run — bulk or per-tile — until it finishes.
     /// </summary>
     /// <remarks>
@@ -494,6 +508,10 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
 
         _ = InitializeBaseModelFilterAsync();
         _ = LoadDestinationFoldersAsync(destination);
+
+        // Once, at startup: the tiles' scroll-fetch gate needs the user's retry windows before the
+        // first bulk sync of the session ever happens, and it must not read settings per tile.
+        ScrollRetryPolicyLoad = LoadScrollRetryPolicyAsync();
     }
 
     /// <summary>
@@ -790,7 +808,36 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             ScopeFactory: sp?.GetService<IServiceScopeFactory>(),
             DialogService: TryResolveDialogService(sp),
             Clipboard: sp?.GetService<DiffusionNexus.Installer.SDK.Shared.Services.IClipboardService>(),
-            UiScheduler: sp?.GetService<IUiScheduler>());
+            UiScheduler: sp?.GetService<IUiScheduler>(),
+            // A delegate, not the value: tiles built now must see a policy re-read later (the
+            // startup load landing, or a bulk sync picking up changed settings) without a rebuild.
+            RetryPolicyProvider: () => _scrollRetryPolicy);
+    }
+
+    /// <summary>
+    /// Reads the saved sync settings once at startup so the tiles' scroll-fetch gate judges by the
+    /// user's retry windows from the first scroll, not only after the first bulk sync.
+    /// </summary>
+    /// <remarks>
+    /// Through <see cref="UseSettingsServiceAsync"/> for a fresh scope: this runs concurrently with
+    /// the other two startup tasks, which share the constructor-injected service's single
+    /// non-thread-safe DbContext. Failure is silent and harmless — the built-in default stands in.
+    /// </remarks>
+    private async Task LoadScrollRetryPolicyAsync()
+    {
+        try
+        {
+            var settings = await UseSettingsServiceAsync(s => s.GetSettingsAsync()).ConfigureAwait(false);
+            if (settings is null) return;
+
+            _scrollRetryPolicy = SyncRetryPolicy.FromDays(
+                settings.SyncNotIdentifiedRetryDays, settings.SyncErrorRetryDays);
+        }
+        catch (Exception ex)
+        {
+            _logger?.Debug(LogCategory.General, "LoraViewer",
+                $"Could not read the sync retry settings; using the defaults: {ex.Message}");
+        }
     }
 
     /// <summary>
@@ -806,16 +853,20 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
     }
 
     /// <summary>
-    /// Runs a full library metadata sync through <see cref="ILibrarySyncService"/>: plans the
-    /// work (discover new files, identify unknown ones, fetch tags and images), executes the
-    /// plan, then rebuilds the grid once from the database.
+    /// Runs a full library metadata sync through <see cref="ILibrarySyncService"/> as a
+    /// conversation: scan for new files, plan the rest, ask the user what to run, run it, record
+    /// that it happened, rebuild the grid once, and show what came of it.
     /// </summary>
     /// <remarks>
     /// The viewer owns none of the sync logic any more (#521 WP2) — no hashing, no Civitai
     /// calls, no per-tile persistence. Everything the old phases did is a step in the service,
     /// which records per-model state so a second run skips what has already been checked
-    /// instead of re-asking Civitai about the whole library. Thumbnails are not a step yet
-    /// (Plan B); on-screen tiles keep pulling their own preview on activation.
+    /// instead of re-asking Civitai about the whole library.
+    /// <para>
+    /// Discovery is a separate, un-negotiable pre-run (Plan E): a scan cannot be counted before it
+    /// has run, so it is the one step nobody can be asked about — and running it first is what lets
+    /// every count in the dialog include the files it just found.
+    /// </para>
     /// </remarks>
     [RelayCommand(CanExecute = nameof(CanStartMetadataSync))]
     private async Task DownloadMissingMetadataAsync()
@@ -847,7 +898,7 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
         {
             IsBusy = true;
             IsCancellable = true;
-            BusyMessage = "Syncing with Civitai...";
+            BusyMessage = "Scanning source folders…";
             SyncStatus = "Planning sync...";
 
             // The first plan after the upgrade also backfills a state row for every model that
@@ -857,32 +908,123 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             if (await Task.Run(() => HasPendingSyncStateBackfillAsync(ct), ct))
                 SyncStatus = "Preparing sync state — first run after update may take a moment…";
 
+            // The retry windows and the thumbnail fan-out are the user's, not constants. Read once
+            // per run and cached, because the tiles' scroll gate reads the same field.
+            //
+            // Through UseSettingsServiceAsync (a fresh scope), not the injected instance: this runs
+            // while the browser sub-VM and the passive update check may be reading settings over
+            // that shared, non-thread-safe DbContext — and GetSettingsAsync is no mere read, it
+            // clears the change tracker and saves. On Task.Run for the usual R7 reason.
+            var settings = await Task.Run(() => UseSettingsServiceAsync(s => s.GetSettingsAsync(ct)), ct)
+                           ?? new AppSettings();
+            var policy = SyncRetryPolicy.FromDays(settings.SyncNotIdentifiedRetryDays, settings.SyncErrorRetryDays);
+            _scrollRetryPolicy = policy;
+
+            // Discovery runs BEFORE the dialog, on its own, for two reasons: the counts the user is
+            // about to approve must include files added since the app started, and a scan cannot be
+            // counted in advance — so a "Discover" row in the dialog could only ever show a blank.
+            //
             // Task.Run, not a bare await: SQLite has no true async, so the planning pass (the
             // first-run state backfill plus every step's selection query) and the discovery scan
             // both run to completion inline before anything yields — on the UI thread that means a
             // frozen overlay and a dead Cancel button, which is exactly what the old phase code
             // used a background thread to avoid. Every UI touch below the await hops back through
             // PostToUi / InvokeOnUiAsync.
-            var plan = await Task.Run(() => _librarySync.PlanAsync(SyncScope.Library, SyncOptions.All, ct), ct);
+            var discoverOptions = new SyncOptions(DiscoverOnly, RetryPolicy: policy);
+            var discoverPlan = await Task.Run(() => _librarySync.PlanAsync(SyncScope.Library, discoverOptions, ct), ct);
 
-            // Correct only when the caller excluded discovery: a plan that still carries the
-            // Discover step always reports work, because nobody knows what a scan will find until
-            // it has run. The honest "nothing to do" verdict is the report's, below.
-            if (!plan.HasWork)
+            SyncReport discoverReport;
+            try
             {
-                SyncStatus = UpToDateStatus;
-                _logger?.Info(LogCategory.Network, "CivitaiSync", "Sync plan is empty — nothing to do");
+                discoverReport = await Task.Run(() => _librarySync.ExecuteAsync(discoverPlan, null, ct), ct);
+            }
+            catch (InvalidOperationException ex)
+            {
+                ReportServiceAlreadyRunning(ex);
                 return;
             }
 
-            // Plan B replaces this with a confirmation dialog showing the same numbers.
+            var discovered = discoverReport.NewFilesDiscovered;
+
+            var baseOptions = new SyncOptions(
+                PlannedStepKinds, RetryPolicy: policy, ThumbnailConcurrency: settings.SyncThumbnailConcurrency);
+            var plan = await Task.Run(() => _librarySync.PlanAsync(SyncScope.Library, baseOptions, ct), ct);
+
             _logger?.Info(LogCategory.Network, "CivitaiSync",
-                $"Starting sync: {string.Join(" · ", plan.Steps.Select(s => $"{SyncReport.Label(s.Kind)} {s.Count}"))}");
+                $"Plan dialog: {string.Join(" · ", plan.Steps.Select(s => $"{SyncReport.Label(s.Kind)} {s.Count}"))} · {discovered} discovered");
+
+            // The overlay comes down for the question: nothing is running while the user reads it,
+            // and a Cancel button over a modal dialog would be cancelling a run that has not started.
+            IsBusy = false;
+            IsCancellable = false;
+            BusyMessage = null;
+
+            var dialogService = DialogService ?? App.Services?.GetService<IDialogService>();
+            if (dialogService is null)
+            {
+                SyncStatus = "Dialog service not available.";
+                return;
+            }
+
+            var dialogVm = new SyncPlanDialogViewModel(
+                plan,
+                baseOptions,
+                replanAsync: o => Task.Run(() => _librarySync.PlanAsync(SyncScope.Library, o, ct), ct),
+                settings.LastLibrarySyncAt,
+                discovered,
+                _logger);
+
+            var choice = await dialogService.ShowSyncPlanDialogAsync(dialogVm);
+            if (!choice.Confirmed || choice.Options is null)
+            {
+                // The button did do something — it scanned — so it owes an answer either way. Which
+                // answer depends on whether there was anything to decline in the first place.
+                SyncStatus = plan.HasWork ? "Sync cancelled — nothing was run." : UpToDateStatus;
+                _logger?.Info(LogCategory.Network, "CivitaiSync", "User cancelled at the plan dialog");
+                return;
+            }
+
+            IsBusy = true;
+            IsCancellable = true;
+            BusyMessage = "Syncing with Civitai...";
+
+            var chosen = choice.Options;
+            _logger?.Info(LogCategory.Network, "CivitaiSync",
+                $"User started sync: steps [{string.Join(", ", chosen.Steps)}] forces " +
+                $"[I:{chosen.ForceIdentify} T:{chosen.ForceTags} Im:{chosen.ForceImages} Th:{chosen.ForceThumbnails}]");
+
+            // Re-planned, not the dialog's plan: it is cheap, the dialog may have been open for
+            // minutes, and the ticks and forces the user came back with select a different set of
+            // items than the one the dialog was built from.
+            var runPlan = await Task.Run(() => _librarySync.PlanAsync(SyncScope.Library, chosen, ct), ct);
 
             var progress = new UiProgress<LibrarySyncProgress>(this, p =>
                 SyncStatus = $"{SyncReport.Label(p.Step)} [{p.Index}/{p.Total}] {p.CurrentItem}");
 
-            var report = await Task.Run(() => _librarySync.ExecuteAsync(plan, progress, ct), ct);
+            SyncReport report;
+            try
+            {
+                report = await Task.Run(() => _librarySync.ExecuteAsync(runPlan, progress, ct), ct);
+            }
+            catch (InvalidOperationException ex)
+            {
+                ReportServiceAlreadyRunning(ex);
+                return;
+            }
+
+            // "Last full sync" is what the next plan dialog tells the user about staleness, so it
+            // records a run that actually finished. Deliberately CancellationToken.None: this
+            // records what already happened, and a just-pressed Cancel must not lose it. Same fresh
+            // scope as the read above, for the same reason — and a write has more to lose.
+            if (!report.Cancelled)
+            {
+                await UseSettingsServiceAsync(async s =>
+                {
+                    await s.UpdateLastLibrarySyncAtAsync(DateTimeOffset.UtcNow, CancellationToken.None)
+                        .ConfigureAwait(false);
+                    return true;
+                });
+            }
 
             // One rebuild, at the end: the service wrote straight to the database, so the
             // in-memory tiles are stale until they are re-projected from it.
@@ -903,6 +1045,14 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             var statusText = DescribeOutcome(report);
             _logger?.Info(LogCategory.Network, "CivitaiSync", statusText);
             SyncStatus = statusText;
+
+            // Down before the report, not behind it: the finally repeats this harmlessly, but a
+            // modal report over a live "Syncing..." overlay claims the run is still going.
+            IsBusy = false;
+            IsCancellable = false;
+            BusyMessage = null;
+
+            await dialogService.ShowSyncReportDialogAsync(new SyncReportDialogViewModel(report, discovered));
         }
         catch (OperationCanceledException)
         {
@@ -928,6 +1078,34 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             _localSyncActive = false;
             RefreshSyncRunning();
         }
+    }
+
+    /// <summary>
+    /// The discovery pre-run: the folder scan and nothing else. Run before the plan dialog opens so
+    /// the counts it shows include files added since the app started.
+    /// </summary>
+    private static readonly IReadOnlySet<SyncStepKind> DiscoverOnly =
+        new HashSet<SyncStepKind> { SyncStepKind.DiscoverFiles };
+
+    /// <summary>
+    /// The four steps the plan dialog offers. Discovery is not among them: by the time the dialog
+    /// opens it has already happened, and its count could never have been shown in advance anyway.
+    /// </summary>
+    private static readonly IReadOnlySet<SyncStepKind> PlannedStepKinds = new HashSet<SyncStepKind>
+    {
+        SyncStepKind.IdentifyModel, SyncStepKind.FetchTags, SyncStepKind.FetchImages, SyncStepKind.Thumbnails,
+    };
+
+    /// <summary>
+    /// The service admits one run at a time and throws on the second (its <c>Wait(0)</c> gate).
+    /// Both of this flow's runs can meet it — a download's completion sync holds the slot for a
+    /// moment — and that is a "not now", not a fault: no stack trace, no retry loop.
+    /// </summary>
+    private void ReportServiceAlreadyRunning(InvalidOperationException ex)
+    {
+        SyncStatus = AlreadyRunningStatus;
+        _logger?.Info(LogCategory.Network, "CivitaiSync",
+            $"Sync not started — the service is already running: {ex.Message}");
     }
 
     /// <summary>Both buttons that can start a run are off while one is running — the service takes one at a time.</summary>
@@ -1582,6 +1760,9 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
         // an explicit re-fetch, so a stored "already checked" or "already failed" verdict must not
         // make the button do nothing. Forcing thumbnails only retries failures, because selection
         // still skips any image that already has bytes.
+        // The retry policy is the user's here too (Plan E). The forces make most windows moot, but
+        // the tags and images fetches are not forced and are judged by it. ThumbnailConcurrency
+        // stays at its default: one model's handful of images gains nothing from a wider fan-out.
         var options = new SyncOptions(
             new HashSet<SyncStepKind>
             {
@@ -1589,7 +1770,8 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
                 SyncStepKind.Thumbnails,
             },
             ForceIdentify: true,
-            ForceThumbnails: true);
+            ForceThumbnails: true,
+            RetryPolicy: _scrollRetryPolicy);
 
         SyncPlan plan;
         SyncReport report;

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -1101,12 +1101,16 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             // failure documented under the rebuild, re-entered through a new door. A timestamp is
             // not worth everything the run achieved, so a failed stamp costs only the timestamp.
             //
-            // And only a run that covered every offered kind may claim it (F6). The dialog exists
+            // And only a run that covered every kind WITH WORK may claim it (F6). The dialog exists
             // so the user can run a subset; a 20-second thumbnails-only top-up that stamps this
             // makes next week's dialog announce "Last full sync: <today>" for metadata that was
             // never fetched at all. A subset run therefore leaves the timestamp where it was —
             // stale in the safe direction, understating freshness rather than inventing it.
-            if (!report.Cancelled && chosen.Steps.SetEquals(PlannedStepKinds))
+            // Judged against the dialog's rows, not the four kinds: BuildResult drops zero-count
+            // kinds from the chosen set, so demanding all four would mean a library where one step
+            // legitimately has nothing to do could never stamp again. A kind with nothing to do is
+            // covered by doing nothing.
+            if (!report.Cancelled && dialogVm.Rows.All(r => r.Count == 0 || chosen.Steps.Contains(r.Kind)))
             {
                 try
                 {

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -520,7 +520,15 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
 
         // Once, at startup: the tiles' scroll-fetch gate needs the user's retry windows before the
         // first bulk sync of the session ever happens, and it must not read settings per tile.
-        ScrollRetryPolicyLoad = LoadScrollRetryPolicyAsync();
+        //
+        // On Task.Run for the usual R7 reason, and this one needs it more than most: it wants two
+        // ints, but AppSettingsService.GetSettingsAsync clears the change tracker, loads the whole
+        // settings graph (LoRA sources, image galleries, base-model folders, dataset categories),
+        // saves, and de-duplicates categories and folder rows. SQLite has no true async, so awaited
+        // bare it ran that full graph load AND up to three writes inline on the UI thread before
+        // the constructor's first real yield — a startup hitch on exactly the view the
+        // UI-performance work targeted.
+        ScrollRetryPolicyLoad = Task.Run(LoadScrollRetryPolicyAsync);
     }
 
     /// <summary>

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -1333,8 +1333,12 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
     private IServiceScopeFactory RequireScopeFactory()
         => _scopeFactory ?? App.Services!.GetRequiredService<IServiceScopeFactory>();
 
-    /// <summary>Status shown when a run had genuinely nothing left to do.</summary>
-    private const string UpToDateStatus = "Library is up to date — nothing to do";
+    /// <summary>
+    /// Status shown when a run had genuinely nothing left to do. The same const the plan dialog
+    /// shows (<see cref="SyncCopy.UpToDate"/>): the two are on screen together, so they must be
+    /// one string, not two that happen to match.
+    /// </summary>
+    private const string UpToDateStatus = SyncCopy.UpToDate;
 
     /// <summary>
     /// Status shown when a second run is asked for while one is going. The service refuses it, so

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -128,8 +128,17 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
     private SyncRetryPolicy _scrollRetryPolicy = SyncRetryPolicy.Default;
 
     /// <summary>
-    /// The startup read that fills <see cref="_scrollRetryPolicy"/>. Test seam: tests await it
-    /// instead of relying on it having finished.
+    /// The user's thumbnail fan-out, read alongside <see cref="_scrollRetryPolicy"/> and cached for
+    /// the same reason. A model with several due images fetches them through this width on the
+    /// per-tile path too — someone who set "Thumbnail downloads in parallel = 1" on a metered
+    /// connection meant it for every path, not only the bulk button.
+    /// </summary>
+    private int _thumbnailConcurrency = 4;
+
+    /// <summary>
+    /// The startup read that fills <see cref="_scrollRetryPolicy"/> and
+    /// <see cref="_thumbnailConcurrency"/>. Test seam: tests await it instead of relying on it
+    /// having finished.
     /// </summary>
     internal Task ScrollRetryPolicyLoad { get; private set; } = Task.CompletedTask;
 
@@ -832,6 +841,7 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
 
             _scrollRetryPolicy = SyncRetryPolicy.FromDays(
                 settings.SyncNotIdentifiedRetryDays, settings.SyncErrorRetryDays);
+            _thumbnailConcurrency = settings.SyncThumbnailConcurrency;
         }
         catch (Exception ex)
         {
@@ -927,6 +937,7 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
                            ?? new AppSettings();
             var policy = SyncRetryPolicy.FromDays(settings.SyncNotIdentifiedRetryDays, settings.SyncErrorRetryDays);
             _scrollRetryPolicy = policy;
+            _thumbnailConcurrency = settings.SyncThumbnailConcurrency;
 
             // Discovery runs BEFORE the dialog, on its own, for two reasons: the counts the user is
             // about to approve must include files added since the app started, and a scan cannot be
@@ -1187,13 +1198,13 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
         new HashSet<SyncStepKind> { SyncStepKind.DiscoverFiles };
 
     /// <summary>
-    /// The four steps the plan dialog offers. Discovery is not among them: by the time the dialog
-    /// opens it has already happened, and its count could never have been shown in advance anyway.
+    /// The steps the plan dialog offers. Discovery is not among them: by the time the dialog opens
+    /// it has already happened, and its count could never have been shown in advance anyway.
+    /// Derived from the enum — a fifth step joins the button's plan and the dialog's rows together
+    /// or not at all, rather than being silently absent from both.
     /// </summary>
-    private static readonly IReadOnlySet<SyncStepKind> PlannedStepKinds = new HashSet<SyncStepKind>
-    {
-        SyncStepKind.IdentifyModel, SyncStepKind.FetchTags, SyncStepKind.FetchImages, SyncStepKind.Thumbnails,
-    };
+    private static readonly IReadOnlySet<SyncStepKind> PlannedStepKinds =
+        SyncOptions.AllStepsExcept(SyncStepKind.DiscoverFiles);
 
     /// <summary>
     /// The service admits one run at a time and throws on the second (its <c>Wait(0)</c> gate).
@@ -1871,9 +1882,11 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
         // an explicit re-fetch, so a stored "already checked" or "already failed" verdict must not
         // make the button do nothing. Forcing thumbnails only retries failures, because selection
         // still skips any image that already has bytes.
-        // The retry policy is the user's here too (Plan E). The forces make most windows moot, but
-        // the tags and images fetches are not forced and are judged by it. ThumbnailConcurrency
-        // stays at its default: one model's handful of images gains nothing from a wider fan-out.
+        // The retry policy AND the thumbnail fan-out are the user's here too (Plan E). The forces
+        // make most windows moot, but the tags and images fetches are not forced and are judged by
+        // the windows — and one model can easily have a dozen due images, which this path fetches
+        // through exactly the bounded gate the bulk run uses. Leaving the concurrency at the record
+        // default meant a user who asked for one parallel download still got four.
         var options = new SyncOptions(
             new HashSet<SyncStepKind>
             {
@@ -1882,7 +1895,8 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             },
             ForceIdentify: true,
             ForceThumbnails: true,
-            RetryPolicy: _scrollRetryPolicy);
+            RetryPolicy: _scrollRetryPolicy,
+            ThumbnailConcurrency: _thumbnailConcurrency);
 
         SyncPlan plan;
         SyncReport report;

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -920,6 +920,7 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
         // cancellation catch, the generic catch) left those rows invisible until a manual Refresh.
         var discovered = 0;
         var rebuilt = false;
+        var rebuildOwed = false;
         try
         {
             IsBusy = true;
@@ -1053,6 +1054,13 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             var progress = new UiProgress<LibrarySyncProgress>(this, p =>
                 SyncStatus = $"{SyncReport.Label(p.Step)} [{p.Index}/{p.Total}] {p.CurrentItem}");
 
+            // From here the run may commit work — each item in its own scope — and a step's
+            // SelectAsync sits outside the loop's try in LibrarySyncService, so a non-cancellation
+            // throw there escapes ExecuteAsync with everything already durable. The finally's
+            // backstop owes a rebuild for that door too, not only for the scan's rows; the cost is
+            // one wasted rebuild when the run dies before writing anything.
+            rebuildOwed = true;
+
             SyncReport report;
             try
             {
@@ -1060,6 +1068,8 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             }
             catch (SyncAlreadyRunningException ex)
             {
+                // The gate refused it at Wait(0), before any work — this press wrote nothing.
+                rebuildOwed = false;
                 ReportServiceAlreadyRunning(ex);
                 return;
             }
@@ -1182,11 +1192,13 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             // (F3). Nothing else refreshes it — ILibraryChangeNotifier.ModelDownloaded is raised
             // only by CivitaiModelDownloader, never by DiscoverFilesStep — so without this a
             // cancelled dialog leaves twelve new LoRAs in the database and none of them on screen.
+            // rebuildOwed covers the other door: a run that died midway has committed per-item
+            // work too, and gating on the scan alone left it just as invisible.
             // Guarded so a failed rebuild costs only the rebuild: the status line above already
             // says what happened, and an exception here would replace it with a lie.
             // BEFORE the sync-running flag drops: re-enabling the per-tile button while the tile
             // collection is mid-swap would let a fetch update a tile the rebuild is discarding.
-            if (discovered > 0 && !rebuilt)
+            if ((discovered > 0 || rebuildOwed) && !rebuilt)
             {
                 try
                 {

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -1012,18 +1012,39 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
                 return;
             }
 
+            // The scan was its own run; fold its count back in so every projection of this run
+            // agrees. Not `with`: Summary is a get-only auto-property, and the copy constructor
+            // keeps the stale one — the dialog would print "Discovered 0" above "40 new files
+            // discovered" and the status bar would carry the same contradiction.
+            report = new SyncReport(report.Plan, report.Steps, report.Failures, report.Cancelled,
+                report.Elapsed, discovered, report.UnexpectedFailures, report.FirstUnexpectedError);
+
             // "Last full sync" is what the next plan dialog tells the user about staleness, so it
             // records a run that actually finished. Deliberately CancellationToken.None: this
             // records what already happened, and a just-pressed Cancel must not lose it. Same fresh
             // scope as the read above, for the same reason — and a write has more to lose.
+            //
+            // Guarded, and on the pool like the read: this is a SQLite write at the peak of WAL
+            // contention — the run that just ended has been writing for minutes. Letting it escape
+            // to the catch below would skip the rebuild AND the report dialog, which is the F1
+            // failure documented under the rebuild, re-entered through a new door. A timestamp is
+            // not worth everything the run achieved, so a failed stamp costs only the timestamp.
             if (!report.Cancelled)
             {
-                await UseSettingsServiceAsync(async s =>
+                try
                 {
-                    await s.UpdateLastLibrarySyncAtAsync(DateTimeOffset.UtcNow, CancellationToken.None)
-                        .ConfigureAwait(false);
-                    return true;
-                });
+                    await Task.Run(() => UseSettingsServiceAsync(async s =>
+                    {
+                        await s.UpdateLastLibrarySyncAtAsync(DateTimeOffset.UtcNow, CancellationToken.None)
+                            .ConfigureAwait(false);
+                        return true;
+                    }));
+                }
+                catch (Exception ex)
+                {
+                    _logger?.Warn(LogCategory.Network, "CivitaiSync",
+                        $"Could not record the last-sync timestamp: {ex.Message}");
+                }
             }
 
             // One rebuild, at the end: the service wrote straight to the database, so the

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -1178,15 +1178,14 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             cts.Dispose();
             if (ReferenceEquals(_metadataSyncCts, cts)) _metadataSyncCts = null;
 
-            _localSyncActive = false;
-            RefreshSyncRunning();
-
             // The scan's rows are committed; the grid has to show them however this press ended
             // (F3). Nothing else refreshes it — ILibraryChangeNotifier.ModelDownloaded is raised
             // only by CivitaiModelDownloader, never by DiscoverFilesStep — so without this a
             // cancelled dialog leaves twelve new LoRAs in the database and none of them on screen.
             // Guarded so a failed rebuild costs only the rebuild: the status line above already
             // says what happened, and an exception here would replace it with a lie.
+            // BEFORE the sync-running flag drops: re-enabling the per-tile button while the tile
+            // collection is mid-swap would let a fetch update a tile the rebuild is discarding.
             if (discovered > 0 && !rebuilt)
             {
                 try
@@ -1199,6 +1198,9 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
                         $"Grid refresh after the scan failed: {ex.Message}");
                 }
             }
+
+            _localSyncActive = false;
+            RefreshSyncRunning();
         }
     }
 

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -946,7 +946,7 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             {
                 discoverReport = await Task.Run(() => _librarySync.ExecuteAsync(discoverPlan, null, ct), ct);
             }
-            catch (InvalidOperationException ex)
+            catch (SyncAlreadyRunningException ex)
             {
                 ReportServiceAlreadyRunning(ex);
                 return;
@@ -1031,7 +1031,7 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             {
                 report = await Task.Run(() => _librarySync.ExecuteAsync(runPlan, progress, ct), ct);
             }
-            catch (InvalidOperationException ex)
+            catch (SyncAlreadyRunningException ex)
             {
                 ReportServiceAlreadyRunning(ex);
                 return;
@@ -1192,7 +1192,15 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
     /// Both of this flow's runs can meet it — a download's completion sync holds the slot for a
     /// moment — and that is a "not now", not a fault: no stack trace, no retry loop.
     /// </summary>
-    private void ReportServiceAlreadyRunning(InvalidOperationException ex)
+    /// <remarks>
+    /// The parameter type is the gate's own exception, deliberately. Catching plain
+    /// <see cref="InvalidOperationException"/> here caught every step's
+    /// <c>GetRequiredService&lt;IUnitOfWork&gt;()</c> and every <c>Single()</c> over an empty
+    /// sequence as well, so a DI regression was announced as "a metadata sync is already running",
+    /// logged at Info without the exception, and reproduced forever on every press. Anything else
+    /// now falls to the generic catch, which logs at Error with the exception attached.
+    /// </remarks>
+    private void ReportServiceAlreadyRunning(SyncAlreadyRunningException ex)
     {
         SyncStatus = AlreadyRunningStatus;
         _logger?.Info(LogCategory.Network, "CivitaiSync",

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -894,6 +894,14 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
         RefreshSyncRunning();
 
         var ct = cts.Token;
+
+        // Both live out here because the finally needs them (F3). The scan runs before the dialog
+        // and commits new Model rows straight to the database, so the grid is stale from that
+        // moment on — and only the run path used to rebuild it. Every other exit (the user
+        // cancelling at the dialog, a missing dialog service, either single-flight refusal, the
+        // cancellation catch, the generic catch) left those rows invisible until a manual Refresh.
+        var discovered = 0;
+        var rebuilt = false;
         try
         {
             IsBusy = true;
@@ -944,7 +952,7 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
                 return;
             }
 
-            var discovered = discoverReport.NewFilesDiscovered;
+            discovered = discoverReport.NewFilesDiscovered;
 
             var baseOptions = new SyncOptions(
                 PlannedStepKinds, RetryPolicy: policy, ThumbnailConcurrency: settings.SyncThumbnailConcurrency);
@@ -977,9 +985,26 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             var choice = await dialogService.ShowSyncPlanDialogAsync(dialogVm);
             if (!choice.Confirmed || choice.Options is null)
             {
-                // The button did do something — it scanned — so it owes an answer either way. Which
-                // answer depends on whether there was anything to decline in the first place.
-                SyncStatus = plan.HasWork ? "Sync cancelled — nothing was run." : UpToDateStatus;
+                // The button did do something — it scanned — so it owes an answer either way, and
+                // the answer is about the scan, in that order of importance: what it added, what it
+                // could not read, and only then the verdict. The verdict comes from the dialog's
+                // CURRENT state, never from `plan`: that plan was built before the dialog opened,
+                // and a Force toggle re-plans live, so an all-zero `plan` can sit behind a dialog
+                // showing 40 thumbnails. Saying "up to date" over that is a flat contradiction of
+                // the number the user was looking at a second earlier.
+                if (discovered > 0)
+                {
+                    SyncStatus = $"Sync cancelled — the scan added {discovered} new file{(discovered == 1 ? "" : "s")}.";
+                }
+                else if (discoverReport.Failures.Count > 0)
+                {
+                    SyncStatus = $"Sync cancelled — the scan reported {discoverReport.Failures.Count} failure(s), see the log.";
+                }
+                else
+                {
+                    SyncStatus = dialogVm.IsUpToDate ? UpToDateStatus : "Sync cancelled — nothing was run.";
+                }
+
                 _logger?.Info(LogCategory.Network, "CivitaiSync", "User cancelled at the plan dialog");
                 return;
             }
@@ -1012,12 +1037,31 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
                 return;
             }
 
-            // The scan was its own run; fold its count back in so every projection of this run
-            // agrees. Not `with`: Summary is a get-only auto-property, and the copy constructor
-            // keeps the stale one — the dialog would print "Discovered 0" above "40 new files
-            // discovered" and the status bar would carry the same contradiction.
-            report = new SyncReport(report.Plan, report.Steps, report.Failures, report.Cancelled,
-                report.Elapsed, discovered, report.UnexpectedFailures, report.FirstUnexpectedError);
+            // The scan was its own run; fold ALL of it back in so every projection of this button
+            // press agrees. Not `with`: Summary is a get-only auto-property, and the copy
+            // constructor keeps the stale one — the dialog would print "Discovered 0" above "40 new
+            // files discovered" and the status bar would carry the same contradiction.
+            //
+            // Four things travel, not just the count (F4, F5):
+            //  · Failures — DiscoverFilesStep deliberately records IOException /
+            //    UnauthorizedAccessException / DbUpdateException as SyncItemResult.Failure so a
+            //    report can show them. Dropped, a disconnected source folder produced a dialog with
+            //    no discovered line, no failure row and a clean report. Scan failures go FIRST so
+            //    the report dialog's orphan-group rule (a group for a kind absent from Steps sorts
+            //    last) still surfaces them — DiscoverFiles is not among this run's steps, so they
+            //    form exactly such a group, which is intended.
+            //  · UnexpectedFailures / FirstUnexpectedError — same reasoning, summed, scan first.
+            //  · Elapsed — on a real library the scan is often the slowest part of the press, and
+            //    the run's own stopwatch never saw it. "~40 s" for four minutes of waiting.
+            report = new SyncReport(
+                report.Plan,
+                report.Steps,
+                discoverReport.Failures.Concat(report.Failures).ToList(),
+                report.Cancelled,
+                discoverReport.Elapsed + report.Elapsed,
+                discovered,
+                discoverReport.UnexpectedFailures + report.UnexpectedFailures,
+                discoverReport.FirstUnexpectedError ?? report.FirstUnexpectedError);
 
             // "Last full sync" is what the next plan dialog tells the user about staleness, so it
             // records a run that actually finished. Deliberately CancellationToken.None: this
@@ -1029,7 +1073,13 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             // to the catch below would skip the rebuild AND the report dialog, which is the F1
             // failure documented under the rebuild, re-entered through a new door. A timestamp is
             // not worth everything the run achieved, so a failed stamp costs only the timestamp.
-            if (!report.Cancelled)
+            //
+            // And only a run that covered every offered kind may claim it (F6). The dialog exists
+            // so the user can run a subset; a 20-second thumbnails-only top-up that stamps this
+            // makes next week's dialog announce "Last full sync: <today>" for metadata that was
+            // never fetched at all. A subset run therefore leaves the timestamp where it was —
+            // stale in the safe direction, understating freshness rather than inventing it.
+            if (!report.Cancelled && chosen.Steps.SetEquals(PlannedStepKinds))
             {
                 try
                 {
@@ -1062,6 +1112,7 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             // before the rebuild, so the work landed in the database and stayed invisible in the
             // grid, and the report was swallowed by the cancellation catch below.
             await Task.Run(RebuildTilesFromDatabaseAsync);
+            rebuilt = true;
 
             var statusText = DescribeOutcome(report);
             _logger?.Info(LogCategory.Network, "CivitaiSync", statusText);
@@ -1098,6 +1149,25 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
 
             _localSyncActive = false;
             RefreshSyncRunning();
+
+            // The scan's rows are committed; the grid has to show them however this press ended
+            // (F3). Nothing else refreshes it — ILibraryChangeNotifier.ModelDownloaded is raised
+            // only by CivitaiModelDownloader, never by DiscoverFilesStep — so without this a
+            // cancelled dialog leaves twelve new LoRAs in the database and none of them on screen.
+            // Guarded so a failed rebuild costs only the rebuild: the status line above already
+            // says what happened, and an exception here would replace it with a lie.
+            if (discovered > 0 && !rebuilt)
+            {
+                try
+                {
+                    await Task.Run(RebuildTilesFromDatabaseAsync);
+                }
+                catch (Exception ex)
+                {
+                    _logger?.Warn(LogCategory.Network, "CivitaiSync",
+                        $"Grid refresh after the scan failed: {ex.Message}");
+                }
+            }
         }
     }
 

--- a/DiffusionNexus.UI/ViewModels/ModelDetailViewModel.Editing.cs
+++ b/DiffusionNexus.UI/ViewModels/ModelDetailViewModel.Editing.cs
@@ -10,6 +10,7 @@ using DiffusionNexus.DataAccess.UnitOfWork;
 using DiffusionNexus.Domain.Entities;
 using DiffusionNexus.Domain.Enums;
 using DiffusionNexus.Domain.Services.UnifiedLogging;
+using DiffusionNexus.Service.Services.Sync.Thumbnails;
 using DiffusionNexus.UI.Services;
 using DiffusionNexus.UI.Views.Dialogs;
 using Microsoft.Extensions.DependencyInjection;
@@ -747,10 +748,10 @@ public partial class ModelDetailViewModel
                 dbVersion.Images.Add(image);
             }
 
-            image.ThumbnailData = data;
-            image.ThumbnailMimeType = mime;
-            image.ThumbnailWidth = width;
-            image.ThumbnailHeight = height;
+            // Plan B made ThumbnailWriter the one writer of the six thumbnail columns; this was the
+            // last path around it. Routing through it also stamps the attempt and clears any prior
+            // failure verdict — a user-uploaded image must not sit next to yesterday's "Corrupt".
+            ThumbnailWriter.ApplySuccess(image, new ThumbnailPayload(data, mime, width, height), DateTimeOffset.UtcNow);
             image.IsLocalCacheValid = false;
             image.LocalCachePath = null;
             image.CachedAt = DateTimeOffset.UtcNow;

--- a/DiffusionNexus.UI/ViewModels/ModelTileDependencies.cs
+++ b/DiffusionNexus.UI/ViewModels/ModelTileDependencies.cs
@@ -1,4 +1,5 @@
 using DiffusionNexus.Domain.Services;
+using DiffusionNexus.Domain.Services.Sync;
 using DiffusionNexus.Domain.Services.UnifiedLogging;
 using DiffusionNexus.Installer.SDK.Shared.Services;
 using DiffusionNexus.UI.Services;
@@ -28,9 +29,16 @@ namespace DiffusionNexus.UI.ViewModels;
 /// which owns the FFmpeg fallback internally and is resolved from <see cref="ScopeFactory"/> at
 /// the point of use. The tile stopped extracting video frames itself in #521 Plan B.
 /// </remarks>
+/// <param name="RetryPolicyProvider">
+/// Supplies the user's current retry windows to the tile's scroll-fetch gate. A delegate rather
+/// than a value because the settings behind it can change while the tile is alive — the parent
+/// view model re-reads them on every bulk sync — and tiles outlive that read. Null (design time,
+/// grouping tests) falls back to <see cref="SyncRetryPolicy.Default"/>.
+/// </param>
 public sealed record ModelTileDependencies(
     IUnifiedLogger? Logger = null,
     IServiceScopeFactory? ScopeFactory = null,
     IDialogService? DialogService = null,
     IClipboardService? Clipboard = null,
-    IUiScheduler? UiScheduler = null);
+    IUiScheduler? UiScheduler = null,
+    Func<SyncRetryPolicy>? RetryPolicyProvider = null);

--- a/DiffusionNexus.UI/ViewModels/ModelTileViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/ModelTileViewModel.cs
@@ -42,6 +42,12 @@ public partial class ModelTileViewModel : ViewModelBase
     private readonly IUiScheduler _uiScheduler = AvaloniaUiScheduler.Instance;
 
     /// <summary>
+    /// The user's retry windows, read at the moment the scroll gate asks. Null outside DI, where
+    /// <see cref="SyncRetryPolicy.Default"/> stands in — the same policy the tile used to hardcode.
+    /// </summary>
+    private readonly Func<SyncRetryPolicy>? _retryPolicyProvider;
+
+    /// <summary>
     /// Design-time / demo constructor. Produces a tile with no backing services —
     /// commands that need the database or dialogs no-op, and the clipboard/scheduler
     /// use their shared production defaults.
@@ -62,6 +68,7 @@ public partial class ModelTileViewModel : ViewModelBase
             _dialogService = d.DialogService;
             _clipboard = d.Clipboard ?? AvaloniaClipboardService.Instance;
             _uiScheduler = d.UiScheduler ?? AvaloniaUiScheduler.Instance;
+            _retryPolicyProvider = d.RetryPolicyProvider;
         }
     }
     /// <summary>
@@ -1337,7 +1344,8 @@ public partial class ModelTileViewModel : ViewModelBase
             // to retry: without this gate a poster that 404s costs a GET, a DI scope and a
             // SaveChanges every single time the tile passes the viewport, forever.
             ThumbnailImage = null;
-            if (IsScrollFetchDue(primaryImage, DateTimeOffset.UtcNow))
+            var policy = _retryPolicyProvider?.Invoke() ?? SyncRetryPolicy.Default;
+            if (IsScrollFetchDue(primaryImage, DateTimeOffset.UtcNow, policy))
                 _ = DownloadThumbnailAsync(primaryImage, allowVideoDownload: false, ct);
         }
         else
@@ -1396,9 +1404,15 @@ public partial class ModelTileViewModel : ViewModelBase
     /// asking. <see cref="TryDownloadMissingThumbnailAsync"/> — the one path a person initiates —
     /// does not come through here at all, because a user who clicks "download the missing
     /// thumbnail" has overruled every window by asking.
+    /// <para>
+    /// <paramref name="policy"/> is the user's, not a constant: it comes from the saved sync
+    /// settings through <see cref="ModelTileDependencies.RetryPolicyProvider"/>, so a library
+    /// whose owner widened the error window does not keep re-fetching on scroll on a schedule
+    /// the sync run no longer agrees with.
+    /// </para>
     /// </remarks>
-    internal static bool IsScrollFetchDue(ModelImage image, DateTimeOffset now) =>
-        SyncRetryPolicy.Default.IsThumbnailDue(image.ThumbnailAttemptedAt, image.ThumbnailFailure, now, force: false);
+    internal static bool IsScrollFetchDue(ModelImage image, DateTimeOffset now, SyncRetryPolicy policy) =>
+        policy.IsThumbnailDue(image.ThumbnailAttemptedAt, image.ThumbnailFailure, now, force: false);
 
     /// <summary>
     /// Whether a decode attempt means the stored BLOB is corrupt.

--- a/DiffusionNexus.UI/ViewModels/SettingsViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/SettingsViewModel.cs
@@ -89,6 +89,45 @@ public partial class SettingsViewModel : BusyViewModelBase
         new[] { 0, 1, 3, 7, 14, 30 };
 
     /// <summary>
+    /// Days before the bulk metadata sync re-checks a model whose identity attempt
+    /// found nothing. Mirrors <see cref="AppSettings.SyncNotIdentifiedRetryDays"/>.
+    /// </summary>
+    [ObservableProperty]
+    private int _syncNotIdentifiedRetryDays = 30;
+
+    /// <summary>
+    /// Days before the bulk metadata sync retries a model whose last attempt errored.
+    /// Mirrors <see cref="AppSettings.SyncErrorRetryDays"/>.
+    /// </summary>
+    [ObservableProperty]
+    private int _syncErrorRetryDays = 1;
+
+    /// <summary>
+    /// How many thumbnail CDN downloads the bulk metadata sync runs in parallel.
+    /// Mirrors <see cref="AppSettings.SyncThumbnailConcurrency"/>.
+    /// </summary>
+    [ObservableProperty]
+    private int _syncThumbnailConcurrency = 4;
+
+    /// <summary>Selectable windows (days) before a not-identified model is re-checked.</summary>
+    public IReadOnlyList<int> AvailableSyncNotIdentifiedRetryDays { get; } = new[] { 7, 14, 30, 60, 90 };
+
+    /// <summary>Selectable windows (days) before an errored attempt is retried.</summary>
+    public IReadOnlyList<int> AvailableSyncErrorRetryDays { get; } = new[] { 1, 3, 7 };
+
+    /// <summary>Parallel thumbnail downloads during a bulk sync.</summary>
+    public IReadOnlyList<int> AvailableSyncThumbnailConcurrency { get; } = new[] { 1, 2, 4, 6, 8 };
+
+    /// <summary>
+    /// The <see cref="AppSettings.LastLibrarySyncAt"/> value read at load time. Not
+    /// user-editable on this page (Task 5's flow stamps it directly via
+    /// <c>UpdateLastLibrarySyncAtAsync</c>), but the save command still builds a
+    /// detached <c>AppSettings</c> snapshot — without carrying this through, every
+    /// settings save would silently null the stamp back out.
+    /// </summary>
+    private DateTimeOffset? _loadedLastLibrarySyncAt;
+
+    /// <summary>
     /// Default source folder for LoRA Sort.
     /// </summary>
     [ObservableProperty]
@@ -326,6 +365,10 @@ public partial class SettingsViewModel : BusyViewModelBase
             UseForgeStylePrompts = settings.UseForgeStylePrompts;
             MergeLoraSources = settings.MergeLoraSources;
             LoraUpdateCheckStalenessDays = settings.LoraUpdateCheckStalenessDays;
+            SyncNotIdentifiedRetryDays = settings.SyncNotIdentifiedRetryDays;
+            SyncErrorRetryDays = settings.SyncErrorRetryDays;
+            SyncThumbnailConcurrency = settings.SyncThumbnailConcurrency;
+            _loadedLastLibrarySyncAt = settings.LastLibrarySyncAt;
             LoraSortSourcePath = settings.LoraSortSourcePath;
             LoraSortTargetPath = settings.LoraSortTargetPath;
             DatasetStoragePath = settings.DatasetStoragePath;
@@ -639,6 +682,10 @@ public partial class SettingsViewModel : BusyViewModelBase
                 UseForgeStylePrompts = UseForgeStylePrompts,
                 MergeLoraSources = MergeLoraSources,
                 LoraUpdateCheckStalenessDays = LoraUpdateCheckStalenessDays,
+                SyncNotIdentifiedRetryDays = SyncNotIdentifiedRetryDays,
+                SyncErrorRetryDays = SyncErrorRetryDays,
+                SyncThumbnailConcurrency = SyncThumbnailConcurrency,
+                LastLibrarySyncAt = _loadedLastLibrarySyncAt,
                 LoraSortSourcePath = LoraSortSourcePath,
                 LoraSortTargetPath = LoraSortTargetPath,
                 DatasetStoragePath = DatasetStoragePath,
@@ -1444,6 +1491,9 @@ public partial class SettingsViewModel : BusyViewModelBase
     partial void OnUseForgeStylePromptsChanged(bool value) => HasChanges = true;
     partial void OnMergeLoraSourcesChanged(bool value) => HasChanges = true;
     partial void OnLoraUpdateCheckStalenessDaysChanged(int value) => HasChanges = true;
+    partial void OnSyncNotIdentifiedRetryDaysChanged(int value) => HasChanges = true;
+    partial void OnSyncErrorRetryDaysChanged(int value) => HasChanges = true;
+    partial void OnSyncThumbnailConcurrencyChanged(int value) => HasChanges = true;
     partial void OnLoraSortSourcePathChanged(string? value) => HasChanges = true;
     partial void OnLoraSortTargetPathChanged(string? value) => HasChanges = true;
     partial void OnDatasetStoragePathChanged(string? value)

--- a/DiffusionNexus.UI/ViewModels/SyncCopy.cs
+++ b/DiffusionNexus.UI/ViewModels/SyncCopy.cs
@@ -1,0 +1,79 @@
+using System.Globalization;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+/// <summary>
+/// The wording and the duration formats the sync surfaces share. The plan dialog, the report
+/// dialog and the viewer's status bar are all reachable from the same screen in the same second —
+/// the dialog states a verdict and the status bar behind it restates it — so a phrasing that lives
+/// in three files is a phrasing that will eventually disagree with itself while every test stays
+/// green. One home, referenced from all three.
+/// </summary>
+internal static class SyncCopy
+{
+    /// <summary>The verdict for a library with nothing left to do. Shown by the dialog and the status bar.</summary>
+    public const string UpToDate = "Library is up to date — nothing to do";
+
+    /// <summary>
+    /// The scan's headline. Both dialogs show the same number in the same flow, seconds apart,
+    /// so they say it with the same words. An empty string when nothing was found: the surfaces
+    /// hide the line rather than printing "0 new files discovered".
+    /// </summary>
+    public static string DescribeDiscovered(int count) => count switch
+    {
+        <= 0 => "",
+        1 => "1 new file discovered",
+        _ => $"{count} new files discovered",
+    };
+
+    /// <summary>
+    /// A predicted duration: "~45 s" under 90 s, "~4 min" under 90 min, else "~1.5 h". The tilde
+    /// is load-bearing — this is what a run is expected to take, not what one took.
+    /// </summary>
+    /// <remarks>89.5 s reading "~90 s" while still in the seconds branch is the documented quirk, not a bug.</remarks>
+    public static string FormatEstimate(TimeSpan t)
+    {
+        if (t < TimeSpan.Zero) t = TimeSpan.Zero;
+
+        if (t.TotalSeconds < 90)
+        {
+            return $"~{Math.Round(t.TotalSeconds).ToString("0", CultureInfo.InvariantCulture)} s";
+        }
+
+        if (t.TotalMinutes < 90)
+        {
+            return $"~{Math.Round(t.TotalMinutes).ToString("0", CultureInfo.InvariantCulture)} min";
+        }
+
+        return $"~{t.TotalHours.ToString("0.#", CultureInfo.InvariantCulture)} h";
+    }
+
+    /// <summary>
+    /// A measured duration: "42 s", "3 min 42 s", "1 h 3 min". No tilde — the run is over and this
+    /// is what it cost. Two units at most, and a zero minor unit is dropped ("3 min", "1 h"):
+    /// beyond the hour mark a stray "0 s" is noise, not precision.
+    /// </summary>
+    public static string FormatElapsed(TimeSpan t)
+    {
+        if (t < TimeSpan.Zero) t = TimeSpan.Zero;
+
+        // Rounded to the second first, so 59.7 s reads "1 min" rather than "0 min 60 s".
+        var total = (long)Math.Round(t.TotalSeconds);
+
+        var hours = total / 3600;
+        var minutes = total % 3600 / 60;
+        var seconds = total % 60;
+
+        if (hours > 0)
+        {
+            return minutes > 0 ? $"{hours} h {minutes} min" : $"{hours} h";
+        }
+
+        if (minutes > 0)
+        {
+            return seconds > 0 ? $"{minutes} min {seconds} s" : $"{minutes} min";
+        }
+
+        return $"{seconds} s";
+    }
+}

--- a/DiffusionNexus.UI/ViewModels/SyncPlanDialogViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/SyncPlanDialogViewModel.cs
@@ -47,7 +47,8 @@ public sealed partial class SyncPlanStepRowViewModel : ObservableObject
 /// </summary>
 public sealed partial class SyncPlanDialogViewModel : ObservableObject
 {
-    internal const string UpToDateMessage = "Library is up to date — nothing to do";
+    /// <summary>The status bar behind this dialog says the same thing — from the same const (<see cref="SyncCopy.UpToDate"/>).</summary>
+    internal const string UpToDateMessage = SyncCopy.UpToDate;
 
     /// <summary>
     /// The rows, in fixed display order. DiscoverFiles is deliberately absent: discovery has
@@ -93,12 +94,7 @@ public sealed partial class SyncPlanDialogViewModel : ObservableObject
             : "Last full sync: never";
 
         HasDiscoveredFiles = newFilesDiscovered > 0;
-        DiscoveredText = newFilesDiscovered switch
-        {
-            <= 0 => "",
-            1 => "1 new file discovered",
-            _ => $"{newFilesDiscovered} new files discovered",
-        };
+        DiscoveredText = SyncCopy.DescribeDiscovered(newFilesDiscovered);
 
         ApplyPlan(initialPlan);
     }
@@ -194,7 +190,7 @@ public sealed partial class SyncPlanDialogViewModel : ObservableObject
             row.Estimate = step?.EstimatedDuration ?? TimeSpan.Zero;
             row.Count = step?.Count ?? 0;
             // A row with nothing to do shows no estimate — "~0 s" reads like pending work.
-            row.EstimateText = row.Count > 0 ? FormatDuration(row.Estimate) : "";
+            row.EstimateText = row.Count > 0 ? SyncCopy.FormatEstimate(row.Estimate) : "";
 
             // A row that had nothing to do could not have been ticked, so a force that gives it
             // work ticks it. A row that was live keeps whatever the user decided about it.
@@ -215,7 +211,7 @@ public sealed partial class SyncPlanDialogViewModel : ObservableObject
         CanStart = !IsReplanning && Rows.Any(r => r.IsSelected && r.Count > 0);
         // Same predicate as CanStart and BuildResult: a ticked-but-empty row is not part of the run,
         // so its (stale) estimate must not be part of the total either.
-        TotalEstimateText = FormatDuration(TimeSpan.FromTicks(
+        TotalEstimateText = SyncCopy.FormatEstimate(TimeSpan.FromTicks(
             Rows.Where(r => r.IsSelected && r.Count > 0).Sum(r => r.Estimate.Ticks)));
 
         OnPropertyChanged(nameof(IsUpToDate));
@@ -246,23 +242,5 @@ public sealed partial class SyncPlanDialogViewModel : ObservableObject
     {
         var description = plan.Steps.FirstOrDefault(s => s.Kind == kind)?.Description;
         return string.IsNullOrWhiteSpace(description) ? SyncReport.Label(kind) : description;
-    }
-
-    /// <summary>"~45 s" under 90 s, "~4 min" under 90 min, else "~1.5 h".</summary>
-    internal static string FormatDuration(TimeSpan t)
-    {
-        if (t < TimeSpan.Zero) t = TimeSpan.Zero;
-
-        if (t.TotalSeconds < 90)
-        {
-            return $"~{Math.Round(t.TotalSeconds).ToString("0", CultureInfo.InvariantCulture)} s";
-        }
-
-        if (t.TotalMinutes < 90)
-        {
-            return $"~{Math.Round(t.TotalMinutes).ToString("0", CultureInfo.InvariantCulture)} min";
-        }
-
-        return $"~{t.TotalHours.ToString("0.#", CultureInfo.InvariantCulture)} h";
     }
 }

--- a/DiffusionNexus.UI/ViewModels/SyncPlanDialogViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/SyncPlanDialogViewModel.cs
@@ -193,7 +193,8 @@ public sealed partial class SyncPlanDialogViewModel : ObservableObject
 
             row.Estimate = step?.EstimatedDuration ?? TimeSpan.Zero;
             row.Count = step?.Count ?? 0;
-            row.EstimateText = FormatDuration(row.Estimate);
+            // A row with nothing to do shows no estimate — "~0 s" reads like pending work.
+            row.EstimateText = row.Count > 0 ? FormatDuration(row.Estimate) : "";
 
             // A row that had nothing to do could not have been ticked, so a force that gives it
             // work ticks it. A row that was live keeps whatever the user decided about it.

--- a/DiffusionNexus.UI/ViewModels/SyncPlanDialogViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/SyncPlanDialogViewModel.cs
@@ -133,8 +133,11 @@ public sealed partial class SyncPlanDialogViewModel : ObservableObject
     /// Queues a re-plan behind whatever is already running. Serialized, not coalesced: the
     /// forces are snapshotted here, at toggle time, so each queued plan is the one that toggle
     /// asked for and the last one to land is the one the user last chose. Swapping
-    /// <see cref="_replanTask"/> for the new tail before anything awaits is what makes
-    /// <see cref="WhenReplanSettles"/> cover re-plans queued while another is running.
+    /// <see cref="_replanTask"/> for the new tail before this method returns is what makes
+    /// <see cref="WhenReplanSettles"/> cover re-plans queued while another is running — which
+    /// means the prologue of <see cref="ReplanAfterAsync"/> before its first await must stay
+    /// free of anything that can re-enter this method, or the inner queue link is silently
+    /// dropped from the chain.
     /// </summary>
     private void QueueReplan()
     {
@@ -194,6 +197,8 @@ public sealed partial class SyncPlanDialogViewModel : ObservableObject
 
             // A row that had nothing to do could not have been ticked, so a force that gives it
             // work ticks it. A row that was live keeps whatever the user decided about it.
+            // Known dip: an enabled row the user unticked that transiently drops to 0 and comes
+            // back re-ticks itself — once it hit 0 the untick stopped being a live choice.
             if (!wasEnabled)
             {
                 row.IsSelected = row.Count > 0;
@@ -207,7 +212,10 @@ public sealed partial class SyncPlanDialogViewModel : ObservableObject
     {
         IsUpToDate = Rows.All(r => r.Count == 0);
         CanStart = !IsReplanning && Rows.Any(r => r.IsSelected && r.Count > 0);
-        TotalEstimateText = FormatDuration(TimeSpan.FromTicks(Rows.Where(r => r.IsSelected).Sum(r => r.Estimate.Ticks)));
+        // Same predicate as CanStart and BuildResult: a ticked-but-empty row is not part of the run,
+        // so its (stale) estimate must not be part of the total either.
+        TotalEstimateText = FormatDuration(TimeSpan.FromTicks(
+            Rows.Where(r => r.IsSelected && r.Count > 0).Sum(r => r.Estimate.Ticks)));
 
         OnPropertyChanged(nameof(IsUpToDate));
         OnPropertyChanged(nameof(CanStart));

--- a/DiffusionNexus.UI/ViewModels/SyncPlanDialogViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/SyncPlanDialogViewModel.cs
@@ -1,0 +1,259 @@
+using System.Globalization;
+using CommunityToolkit.Mvvm.ComponentModel;
+using DiffusionNexus.Domain.Services.Sync;
+using DiffusionNexus.Domain.Services.UnifiedLogging;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+/// <summary>The plan dialog's outcome. A cancelled dialog carries no options.</summary>
+public sealed record SyncPlanDialogResult(bool Confirmed, SyncOptions? Options)
+{
+    public static SyncPlanDialogResult Cancelled() => new(false, null);
+}
+
+/// <summary>One step row: what it would do, how many items, whether it runs.</summary>
+public sealed partial class SyncPlanStepRowViewModel : ObservableObject
+{
+    public SyncPlanStepRowViewModel(SyncStepKind kind, string description)
+    {
+        Kind = kind;
+        Description = description;
+    }
+
+    public SyncStepKind Kind { get; }
+    public string Label => SyncReport.Label(Kind);
+    public string Description { get; }
+
+    [ObservableProperty] private int _count;
+    [ObservableProperty] private string _estimateText = "";
+    [ObservableProperty] private bool _isSelected;
+
+    /// <summary>
+    /// The planned duration behind <see cref="EstimateText"/>, kept so the dialog can total the
+    /// selected rows without re-parsing the text it just formatted.
+    /// </summary>
+    internal TimeSpan Estimate { get; set; }
+
+    /// <summary>A row with nothing to do cannot be ticked.</summary>
+    public bool IsEnabled => Count > 0;
+    partial void OnCountChanged(int value) => OnPropertyChanged(nameof(IsEnabled));
+    partial void OnIsSelectedChanged(bool value) => SelectionChanged?.Invoke();
+    internal Action? SelectionChanged { get; set; }
+}
+
+/// <summary>
+/// Confirmation dialog for a metadata sync run: the four candidate steps with their counts,
+/// the force toggles that re-plan on the spot, and the options the run is started with.
+/// </summary>
+public sealed partial class SyncPlanDialogViewModel : ObservableObject
+{
+    internal const string UpToDateMessage = "Library is up to date — nothing to do";
+
+    /// <summary>
+    /// The rows, in fixed display order. DiscoverFiles is deliberately absent: discovery has
+    /// already run by the time this dialog opens, so there is nothing left to decide about it.
+    /// Re-plans always ask for all four — the ticks filter at Start, not at plan time.
+    /// </summary>
+    private static readonly SyncStepKind[] RowOrder =
+    [
+        SyncStepKind.IdentifyModel, SyncStepKind.FetchTags, SyncStepKind.FetchImages, SyncStepKind.Thumbnails,
+    ];
+
+    private static readonly IReadOnlySet<SyncStepKind> AllRowKinds = new HashSet<SyncStepKind>(RowOrder);
+
+    private readonly SyncOptions _baseOptions;
+    private readonly Func<SyncOptions, Task<SyncPlan>> _replanAsync;
+    private readonly IUnifiedLogger? _logger;
+    private Task _replanTask = Task.CompletedTask;
+
+    public SyncPlanDialogViewModel(
+        SyncPlan initialPlan,
+        SyncOptions baseOptions,
+        Func<SyncOptions, Task<SyncPlan>> replanAsync,
+        DateTimeOffset? lastLibrarySyncAt,
+        int newFilesDiscovered,
+        IUnifiedLogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(initialPlan);
+        ArgumentNullException.ThrowIfNull(baseOptions);
+        ArgumentNullException.ThrowIfNull(replanAsync);
+
+        _baseOptions = baseOptions;
+        _replanAsync = replanAsync;
+        _logger = logger;
+
+        Rows = RowOrder.Select(kind => new SyncPlanStepRowViewModel(kind, DescribeStep(initialPlan, kind))).ToList();
+        foreach (var row in Rows)
+        {
+            row.SelectionChanged = RefreshDerived;
+        }
+
+        LastRunText = lastLibrarySyncAt is { } last
+            ? $"Last full sync: {last.ToLocalTime().ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture)}"
+            : "Last full sync: never";
+
+        HasDiscoveredFiles = newFilesDiscovered > 0;
+        DiscoveredText = newFilesDiscovered switch
+        {
+            <= 0 => "",
+            1 => "1 new file discovered",
+            _ => $"{newFilesDiscovered} new files discovered",
+        };
+
+        ApplyPlan(initialPlan);
+    }
+
+    public IReadOnlyList<SyncPlanStepRowViewModel> Rows { get; }
+
+    [ObservableProperty] private bool _forceIdentify;      // "Re-check models not found on Civitai"
+    [ObservableProperty] private bool _forceTags;
+    [ObservableProperty] private bool _forceImages;
+    [ObservableProperty] private bool _forceThumbnails;
+    [ObservableProperty] private bool _isReplanning;
+
+    /// <summary>True when no row has any work — the "nothing to do" state.</summary>
+    public bool IsUpToDate { get; private set; }
+
+    /// <summary>True when at least one ticked row has work and no re-plan is in flight.</summary>
+    public bool CanStart { get; private set; }
+
+    public string UpToDateText => UpToDateMessage;
+    public string LastRunText { get; }
+    public string DiscoveredText { get; }
+    public bool HasDiscoveredFiles { get; }
+    public string TotalEstimateText { get; private set; } = "";
+
+    partial void OnForceIdentifyChanged(bool value) => QueueReplan();
+    partial void OnForceTagsChanged(bool value) => QueueReplan();
+    partial void OnForceImagesChanged(bool value) => QueueReplan();
+    partial void OnForceThumbnailsChanged(bool value) => QueueReplan();
+    partial void OnIsReplanningChanged(bool value) => RefreshDerived();
+
+    /// <summary>
+    /// Queues a re-plan behind whatever is already running. Serialized, not coalesced: the
+    /// forces are snapshotted here, at toggle time, so each queued plan is the one that toggle
+    /// asked for and the last one to land is the one the user last chose. Swapping
+    /// <see cref="_replanTask"/> for the new tail before anything awaits is what makes
+    /// <see cref="WhenReplanSettles"/> cover re-plans queued while another is running.
+    /// </summary>
+    private void QueueReplan()
+    {
+        var options = OptionsWith(AllRowKinds);
+        var previous = _replanTask;
+        _replanTask = ReplanAfterAsync(previous, options);
+    }
+
+    /// <summary>
+    /// A task that completes when every queued re-plan has been applied. Test seam: tests await
+    /// it instead of polling for the new counts.
+    /// </summary>
+    internal Task WhenReplanSettles() => _replanTask;
+
+    private async Task ReplanAfterAsync(Task previous, SyncOptions options)
+    {
+        // This method never faults — everything below is caught — so awaiting the predecessor
+        // needs no guard of its own, and one failed re-plan can never strand the queue.
+        await previous;
+
+        try
+        {
+            IsReplanning = true;
+            _logger?.Info(LogCategory.Network, "CivitaiSync",
+                $"Plan dialog: re-planning with forces identify={options.ForceIdentify} tags={options.ForceTags} " +
+                $"images={options.ForceImages} thumbnails={options.ForceThumbnails}");
+
+            var plan = await _replanAsync(options);
+            ApplyPlan(plan);
+        }
+        catch (Exception ex)
+        {
+            // Keep the counts we already have: a dialog that blanks itself because a query
+            // hiccuped is worse than one showing a slightly stale plan.
+            _logger?.Warn(LogCategory.Network, "CivitaiSync",
+                $"Plan dialog: re-plan failed, keeping the previous counts: {ex.Message}");
+        }
+        finally
+        {
+            IsReplanning = false;
+        }
+    }
+
+    private void ApplyPlan(SyncPlan plan)
+    {
+        foreach (var row in Rows)
+        {
+            var step = plan.Steps.FirstOrDefault(s => s.Kind == row.Kind);
+
+            // Read before the count changes: it is the pre-plan enabled state that decides
+            // whether this row's tick is the user's choice or ours to make.
+            var wasEnabled = row.IsEnabled;
+
+            row.Estimate = step?.EstimatedDuration ?? TimeSpan.Zero;
+            row.Count = step?.Count ?? 0;
+            row.EstimateText = FormatDuration(row.Estimate);
+
+            // A row that had nothing to do could not have been ticked, so a force that gives it
+            // work ticks it. A row that was live keeps whatever the user decided about it.
+            if (!wasEnabled)
+            {
+                row.IsSelected = row.Count > 0;
+            }
+        }
+
+        RefreshDerived();
+    }
+
+    private void RefreshDerived()
+    {
+        IsUpToDate = Rows.All(r => r.Count == 0);
+        CanStart = !IsReplanning && Rows.Any(r => r.IsSelected && r.Count > 0);
+        TotalEstimateText = FormatDuration(TimeSpan.FromTicks(Rows.Where(r => r.IsSelected).Sum(r => r.Estimate.Ticks)));
+
+        OnPropertyChanged(nameof(IsUpToDate));
+        OnPropertyChanged(nameof(CanStart));
+        OnPropertyChanged(nameof(TotalEstimateText));
+    }
+
+    public SyncPlanDialogResult BuildResult()
+    {
+        var steps = Rows.Where(r => r.IsSelected && r.Count > 0).Select(r => r.Kind).ToHashSet();
+        return new SyncPlanDialogResult(true, OptionsWith(steps));
+    }
+
+    /// <summary>
+    /// The base options — which carry the retry policy and thumbnail concurrency the caller
+    /// configured — with this dialog's steps and force toggles laid over them.
+    /// </summary>
+    private SyncOptions OptionsWith(IReadOnlySet<SyncStepKind> steps) => _baseOptions with
+    {
+        Steps = steps,
+        ForceIdentify = ForceIdentify,
+        ForceTags = ForceTags,
+        ForceImages = ForceImages,
+        ForceThumbnails = ForceThumbnails,
+    };
+
+    private static string DescribeStep(SyncPlan plan, SyncStepKind kind)
+    {
+        var description = plan.Steps.FirstOrDefault(s => s.Kind == kind)?.Description;
+        return string.IsNullOrWhiteSpace(description) ? SyncReport.Label(kind) : description;
+    }
+
+    /// <summary>"~45 s" under 90 s, "~4 min" under 90 min, else "~1.5 h".</summary>
+    internal static string FormatDuration(TimeSpan t)
+    {
+        if (t < TimeSpan.Zero) t = TimeSpan.Zero;
+
+        if (t.TotalSeconds < 90)
+        {
+            return $"~{Math.Round(t.TotalSeconds).ToString("0", CultureInfo.InvariantCulture)} s";
+        }
+
+        if (t.TotalMinutes < 90)
+        {
+            return $"~{Math.Round(t.TotalMinutes).ToString("0", CultureInfo.InvariantCulture)} min";
+        }
+
+        return $"~{t.TotalHours.ToString("0.#", CultureInfo.InvariantCulture)} h";
+    }
+}

--- a/DiffusionNexus.UI/ViewModels/SyncPlanDialogViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/SyncPlanDialogViewModel.cs
@@ -57,14 +57,18 @@ public sealed partial class SyncPlanDialogViewModel : ObservableObject
     internal const string UpToDateMessage = SyncCopy.UpToDate;
 
     /// <summary>
-    /// The rows, in fixed display order. DiscoverFiles is deliberately absent: discovery has
-    /// already run by the time this dialog opens, so there is nothing left to decide about it.
-    /// Re-plans always ask for all four — the ticks filter at Start, not at plan time.
+    /// The rows, in display order. DiscoverFiles is deliberately absent: discovery has already run
+    /// by the time this dialog opens, so there is nothing left to decide about it. Re-plans always
+    /// ask for every row kind — the ticks filter at Start, not at plan time.
     /// </summary>
+    /// <remarks>
+    /// Derived from the enum rather than listed: the enum's declaration order IS the display order
+    /// (identify, then tags, then images, then thumbnails — the order the pipeline runs them in),
+    /// so a fifth step appears here on its own. The hand-written list this replaces had to be kept
+    /// in step with the enum and with the viewer's own copy, and nothing would have said otherwise.
+    /// </remarks>
     private static readonly SyncStepKind[] RowOrder =
-    [
-        SyncStepKind.IdentifyModel, SyncStepKind.FetchTags, SyncStepKind.FetchImages, SyncStepKind.Thumbnails,
-    ];
+        Enum.GetValues<SyncStepKind>().Where(k => k != SyncStepKind.DiscoverFiles).ToArray();
 
     private static readonly IReadOnlySet<SyncStepKind> AllRowKinds = new HashSet<SyncStepKind>(RowOrder);
 

--- a/DiffusionNexus.UI/ViewModels/SyncPlanDialogViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/SyncPlanDialogViewModel.cs
@@ -6,7 +6,13 @@ using DiffusionNexus.Domain.Services.UnifiedLogging;
 namespace DiffusionNexus.UI.ViewModels;
 
 /// <summary>The plan dialog's outcome. A cancelled dialog carries no options.</summary>
-public sealed record SyncPlanDialogResult(bool Confirmed, SyncOptions? Options)
+/// <param name="Plan">
+/// The plan the dialog was showing when Start was pressed, filtered to the ticked kinds — the
+/// caller may execute it instead of paying for a third full selection pass over the library. Null
+/// when the dialog cannot vouch for its own counts (a re-plan failed and left them stale relative
+/// to the force toggles), in which case the caller must plan again.
+/// </param>
+public sealed record SyncPlanDialogResult(bool Confirmed, SyncOptions? Options, SyncPlan? Plan = null)
 {
     public static SyncPlanDialogResult Cancelled() => new(false, null);
 }
@@ -67,6 +73,28 @@ public sealed partial class SyncPlanDialogViewModel : ObservableObject
     private readonly IUnifiedLogger? _logger;
     private Task _replanTask = Task.CompletedTask;
 
+    /// <summary>
+    /// How many re-plans are queued or in flight. Raised in <see cref="QueueReplan"/> at toggle
+    /// time and lowered in <see cref="ReplanAfterAsync"/>'s finally; only the last one out lowers
+    /// <see cref="IsReplanning"/>, so the flag covers the whole chain and not just one link of it.
+    /// </summary>
+    /// <remarks>
+    /// No <c>Interlocked</c>: every touch is on the UI context. The toggles arrive through property
+    /// setters raised by the dispatcher, and the continuations that decrement resume on the same
+    /// context. It reads like a race and is not one.
+    /// </remarks>
+    private int _pendingReplans;
+
+    /// <summary>The last plan that was actually applied to the rows — what the user is looking at.</summary>
+    private SyncPlan _lastPlan;
+
+    /// <summary>
+    /// The force toggles <see cref="_lastPlan"/> was computed with. A failed re-plan updates
+    /// neither: the counts on screen are then the previous plan's, and saying otherwise would hand
+    /// the caller a plan for a different item set than the toggles now describe.
+    /// </summary>
+    private (bool Identify, bool Tags, bool Images, bool Thumbnails) _lastPlanForces;
+
     public SyncPlanDialogViewModel(
         SyncPlan initialPlan,
         SyncOptions baseOptions,
@@ -82,6 +110,7 @@ public sealed partial class SyncPlanDialogViewModel : ObservableObject
         _baseOptions = baseOptions;
         _replanAsync = replanAsync;
         _logger = logger;
+        _lastPlan = initialPlan;
 
         Rows = RowOrder.Select(kind => new SyncPlanStepRowViewModel(kind, DescribeStep(initialPlan, kind))).ToList();
         foreach (var row in Rows)
@@ -96,7 +125,10 @@ public sealed partial class SyncPlanDialogViewModel : ObservableObject
         HasDiscoveredFiles = newFilesDiscovered > 0;
         DiscoveredText = SyncCopy.DescribeDiscovered(newFilesDiscovered);
 
-        ApplyPlan(initialPlan);
+        // The initial plan counts as applied: its forces are all false — which is exactly the state
+        // the toggles start in — and it was built over all four kinds, so it can be filtered down
+        // to whatever the user ends up ticking.
+        ApplyPlan(initialPlan, baseOptions);
     }
 
     public IReadOnlyList<SyncPlanStepRowViewModel> Rows { get; }
@@ -134,10 +166,22 @@ public sealed partial class SyncPlanDialogViewModel : ObservableObject
     /// means the prologue of <see cref="ReplanAfterAsync"/> before its first await must stay
     /// free of anything that can re-enter this method, or the inner queue link is silently
     /// dropped from the chain.
+    /// <para>
+    /// The flag goes up here, synchronously, at toggle time — not inside the queued work. Raised
+    /// there, it came down when the first link finished and only went back up when the second
+    /// link's continuation was pumped, leaving a dispatcher turn in which Start was live over the
+    /// superseded counts: tick Force tags, tick Force image records, press Start in the gap, and
+    /// the Images row was still 0 from the first plan, so FetchImages was silently dropped from
+    /// the run the user had just asked for.
+    /// </para>
     /// </summary>
     private void QueueReplan()
     {
         var options = OptionsWith(AllRowKinds);
+
+        _pendingReplans++;
+        IsReplanning = true;
+
         var previous = _replanTask;
         _replanTask = ReplanAfterAsync(previous, options);
     }
@@ -156,28 +200,31 @@ public sealed partial class SyncPlanDialogViewModel : ObservableObject
 
         try
         {
-            IsReplanning = true;
             _logger?.Info(LogCategory.Network, "CivitaiSync",
                 $"Plan dialog: re-planning with forces identify={options.ForceIdentify} tags={options.ForceTags} " +
                 $"images={options.ForceImages} thumbnails={options.ForceThumbnails}");
 
             var plan = await _replanAsync(options);
-            ApplyPlan(plan);
+            ApplyPlan(plan, options);
         }
         catch (Exception ex)
         {
             // Keep the counts we already have: a dialog that blanks itself because a query
-            // hiccuped is worse than one showing a slightly stale plan.
+            // hiccuped is worse than one showing a slightly stale plan. Deliberately without
+            // touching _lastPlan / _lastPlanForces — the counts are now the PREVIOUS plan's, and
+            // BuildResult uses that mismatch to withhold a plan the caller must not run.
             _logger?.Warn(LogCategory.Network, "CivitaiSync",
                 $"Plan dialog: re-plan failed, keeping the previous counts: {ex.Message}");
         }
         finally
         {
-            IsReplanning = false;
+            // Only the last link out lowers it: with two toggles queued, the first one finishing
+            // must not re-enable Start over counts the second is about to replace.
+            if (--_pendingReplans == 0) IsReplanning = false;
         }
     }
 
-    private void ApplyPlan(SyncPlan plan)
+    private void ApplyPlan(SyncPlan plan, SyncOptions builtWith)
     {
         foreach (var row in Rows)
         {
@@ -202,6 +249,12 @@ public sealed partial class SyncPlanDialogViewModel : ObservableObject
             }
         }
 
+        // Recorded together: the rows now show this plan's counts, and these are the forces that
+        // produced them. BuildResult hands the plan on only while the two still agree.
+        _lastPlan = plan;
+        _lastPlanForces =
+            (builtWith.ForceIdentify, builtWith.ForceTags, builtWith.ForceImages, builtWith.ForceThumbnails);
+
         RefreshDerived();
     }
 
@@ -219,10 +272,39 @@ public sealed partial class SyncPlanDialogViewModel : ObservableObject
         OnPropertyChanged(nameof(TotalEstimateText));
     }
 
+    /// <summary>
+    /// What the user chose, and — when the dialog can still vouch for its own numbers — the plan
+    /// behind them, so the caller need not run a third full selection pass over the library.
+    /// </summary>
+    /// <remarks>
+    /// The plan travels only while the current force toggles are the ones it was computed with.
+    /// Every toggle re-plans, so that is the common case; the exception is a re-plan that failed
+    /// and deliberately kept the previous counts, where the numbers now describe a different item
+    /// set than the toggles do. It is filtered to the ticked kinds and re-labelled with the chosen
+    /// options so <c>ExecuteAsync</c> runs exactly what was ticked, with the right forces.
+    /// <para>
+    /// Staleness is safe here: <c>RunStepAsync</c> re-selects per step at execution time, so the
+    /// plan's counts only ever reach the report's Planned column. A dialog left open for minutes
+    /// therefore costs a cosmetic number, not a wrong run.
+    /// </para>
+    /// </remarks>
     public SyncPlanDialogResult BuildResult()
     {
         var steps = Rows.Where(r => r.IsSelected && r.Count > 0).Select(r => r.Kind).ToHashSet();
-        return new SyncPlanDialogResult(true, OptionsWith(steps));
+        var options = OptionsWith(steps);
+
+        var countsMatchTheToggles =
+            _lastPlanForces == (ForceIdentify, ForceTags, ForceImages, ForceThumbnails);
+
+        var plan = countsMatchTheToggles
+            ? new SyncPlan(
+                _lastPlan.Scope,
+                options,
+                _lastPlan.Steps.Where(s => steps.Contains(s.Kind)).ToList(),
+                _lastPlan.PlannedAt)
+            : null;
+
+        return new SyncPlanDialogResult(true, options, plan);
     }
 
     /// <summary>

--- a/DiffusionNexus.UI/ViewModels/SyncReportDialogViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/SyncReportDialogViewModel.cs
@@ -1,0 +1,112 @@
+using DiffusionNexus.Domain.Services.Sync;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+/// <summary>One step's outcome counts, ready to display in the report table.</summary>
+public sealed class SyncReportStepRowViewModel
+{
+    public SyncReportStepRowViewModel(SyncStepReport step)
+    {
+        Label = SyncReport.Label(step.Kind);
+        Planned = step.Planned;
+        Processed = step.Processed;
+        Succeeded = step.Succeeded;
+        Skipped = step.Skipped;
+        Failed = step.Failed;
+        HasFailed = step.Failed > 0;
+    }
+
+    public string Label { get; }
+    public int Planned { get; }
+    public int Processed { get; }
+    public int Succeeded { get; }
+    public int Skipped { get; }
+    public int Failed { get; }
+    public bool HasFailed { get; }
+}
+
+/// <summary>One failed item within a <see cref="SyncReportFailureGroup"/>.</summary>
+public sealed record SyncReportFailureItem(string Name, string Reason);
+
+/// <summary>All failures for one step, with a header summarizing the count.</summary>
+public sealed class SyncReportFailureGroup
+{
+    public SyncReportFailureGroup(SyncStepKind kind, IReadOnlyList<SyncReportFailureItem> items)
+    {
+        Kind = kind;
+        Items = items;
+        Header = $"{SyncReport.Label(kind)} — {items.Count} failed";
+    }
+
+    public SyncStepKind Kind { get; }
+    public string Header { get; }
+    public IReadOnlyList<SyncReportFailureItem> Items { get; }
+}
+
+/// <summary>
+/// Read-only projection of a completed <see cref="SyncReport"/> for the post-run report dialog.
+/// No observable state: the run is already finished by the time this is constructed.
+/// </summary>
+public sealed class SyncReportDialogViewModel
+{
+    public SyncReportDialogViewModel(SyncReport report, int newFilesDiscovered)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+
+        StepRows = report.Steps.Select(s => new SyncReportStepRowViewModel(s)).ToList();
+
+        FailureGroups = report.Failures
+            .GroupBy(f => f.Step)
+            .OrderBy(g => IndexOf(report.Steps, g.Key))
+            .Select(g => new SyncReportFailureGroup(
+                g.Key,
+                g.Select(f => new SyncReportFailureItem(f.Name, f.Reason)).ToList()))
+            .ToList();
+        HasFailures = FailureGroups.Count > 0;
+
+        IsPartial = report.Cancelled;
+        PartialText = "Cancelled — partial run. Completed items are recorded and will not be redone.";
+
+        SummaryText = report.Summary;
+        ElapsedText = SyncPlanDialogViewModel.FormatDuration(report.Elapsed);
+
+        HasDiscoveredFiles = newFilesDiscovered > 0;
+        DiscoveredText = newFilesDiscovered switch
+        {
+            <= 0 => "",
+            1 => "1 new file discovered",
+            _ => $"{newFilesDiscovered} new files discovered",
+        };
+
+        HasUnexpected = report.UnexpectedFailures > 0;
+        UnexpectedText = report.UnexpectedFailures switch
+        {
+            <= 0 => "",
+            1 => "1 item failed unexpectedly — see the log.",
+            _ => $"{report.UnexpectedFailures} items failed unexpectedly — see the log.",
+        };
+    }
+
+    public IReadOnlyList<SyncReportStepRowViewModel> StepRows { get; }
+    public IReadOnlyList<SyncReportFailureGroup> FailureGroups { get; }
+    public bool HasFailures { get; }
+    public bool IsPartial { get; }
+    public string PartialText { get; }
+    public string SummaryText { get; }
+    public string ElapsedText { get; }
+    public string DiscoveredText { get; }
+    public bool HasDiscoveredFiles { get; }
+    public string UnexpectedText { get; }
+    public bool HasUnexpected { get; }
+
+    /// <summary>Report order for a step kind, so failure groups follow the same order as the step table.</summary>
+    private static int IndexOf(IReadOnlyList<SyncStepReport> steps, SyncStepKind kind)
+    {
+        for (var i = 0; i < steps.Count; i++)
+        {
+            if (steps[i].Kind == kind) return i;
+        }
+
+        return steps.Count;
+    }
+}

--- a/DiffusionNexus.UI/ViewModels/SyncReportDialogViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/SyncReportDialogViewModel.cs
@@ -68,15 +68,12 @@ public sealed class SyncReportDialogViewModel
         PartialText = "Cancelled — partial run. Completed items are recorded and will not be redone.";
 
         SummaryText = report.Summary;
-        ElapsedText = SyncPlanDialogViewModel.FormatDuration(report.Elapsed);
+        // The exact formatter, not the plan dialog's estimate one: this is a measurement, and a
+        // tilde in front of it claims the run's own stopwatch was guessing.
+        ElapsedText = SyncCopy.FormatElapsed(report.Elapsed);
 
         HasDiscoveredFiles = newFilesDiscovered > 0;
-        DiscoveredText = newFilesDiscovered switch
-        {
-            <= 0 => "",
-            1 => "1 new file discovered",
-            _ => $"{newFilesDiscovered} new files discovered",
-        };
+        DiscoveredText = SyncCopy.DescribeDiscovered(newFilesDiscovered);
 
         HasUnexpected = report.UnexpectedFailures > 0;
         UnexpectedText = report.UnexpectedFailures switch

--- a/DiffusionNexus.UI/Views/Dialogs/SyncPlanDialog.axaml
+++ b/DiffusionNexus.UI/Views/Dialogs/SyncPlanDialog.axaml
@@ -1,0 +1,127 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:DiffusionNexus.UI.ViewModels"
+        x:Class="DiffusionNexus.UI.Views.Dialogs.SyncPlanDialog"
+        x:DataType="vm:SyncPlanDialogViewModel"
+        Title="Metadata Sync"
+        Width="560"
+        SizeToContent="Height"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        Background="#2D2D30">
+
+  <StackPanel Margin="20" Spacing="14">
+
+    <!-- What the discovery pass just found (Task 5 runs it before opening this dialog) -->
+    <TextBlock Text="{Binding DiscoveredText}"
+               IsVisible="{Binding HasDiscoveredFiles}"
+               Foreground="#CCCCCC"
+               FontSize="12"
+               TextWrapping="Wrap"/>
+
+    <!-- Nothing to do: no steps, no Start button - but the force expander below stays -->
+    <StackPanel Spacing="4" IsVisible="{Binding IsUpToDate}">
+      <TextBlock Text="{Binding UpToDateText}"
+                 FontSize="14"
+                 FontWeight="Bold"
+                 Foreground="White"
+                 TextWrapping="Wrap"/>
+      <TextBlock Text="{Binding LastRunText}"
+                 FontSize="12"
+                 Foreground="#888888"/>
+    </StackPanel>
+
+    <!-- The four steps, in fixed order -->
+    <ItemsControl ItemsSource="{Binding Rows}" IsVisible="{Binding !IsUpToDate}">
+      <ItemsControl.ItemTemplate>
+        <DataTemplate x:DataType="vm:SyncPlanStepRowViewModel">
+          <Border Background="#1E1E1E"
+                  BorderBrush="#444444"
+                  BorderThickness="1"
+                  CornerRadius="6"
+                  Padding="12,10"
+                  Margin="0,0,0,6">
+            <Grid ColumnDefinitions="Auto,Auto,*,Auto">
+              <CheckBox Grid.Column="0"
+                        IsChecked="{Binding IsSelected, Mode=TwoWay}"
+                        IsEnabled="{Binding IsEnabled}"
+                        VerticalAlignment="Center"
+                        Margin="0,0,4,0"/>
+
+              <TextBlock Grid.Column="1"
+                         Text="{Binding Count}"
+                         MinWidth="40"
+                         TextAlignment="Right"
+                         FontSize="14"
+                         FontWeight="SemiBold"
+                         Foreground="#FFCC00"
+                         VerticalAlignment="Center"
+                         Margin="0,0,12,0"/>
+
+              <StackPanel Grid.Column="2" Spacing="2" VerticalAlignment="Center">
+                <TextBlock Text="{Binding Label}" FontSize="13" FontWeight="SemiBold"/>
+                <TextBlock Text="{Binding Description}"
+                           FontSize="12"
+                           Foreground="#999999"
+                           TextWrapping="Wrap"/>
+              </StackPanel>
+
+              <TextBlock Grid.Column="3"
+                         Text="{Binding EstimateText}"
+                         FontSize="12"
+                         Foreground="#999999"
+                         TextAlignment="Right"
+                         VerticalAlignment="Center"
+                         Margin="12,0,0,0"/>
+            </Grid>
+          </Border>
+        </DataTemplate>
+      </ItemsControl.ItemTemplate>
+    </ItemsControl>
+
+    <!-- Forcing from the up-to-date state is exactly this expander's purpose, so it is
+         always visible; each toggle re-plans against the database and refreshes the counts. -->
+    <Expander Header="Force re-check…" IsExpanded="False">
+      <StackPanel Spacing="8" Margin="0,6,0,0">
+        <CheckBox Content="Models not found on Civitai"
+                  IsChecked="{Binding ForceIdentify, Mode=TwoWay}"
+                  FontSize="13"/>
+        <CheckBox Content="Tags (even when already checked)"
+                  IsChecked="{Binding ForceTags, Mode=TwoWay}"
+                  FontSize="13"/>
+        <CheckBox Content="Image records (even when already checked)"
+                  IsChecked="{Binding ForceImages, Mode=TwoWay}"
+                  FontSize="13"/>
+        <CheckBox Content="Thumbnails (re-fetch existing attempts)"
+                  IsChecked="{Binding ForceThumbnails, Mode=TwoWay}"
+                  FontSize="13"/>
+        <TextBlock Text="Re-planning…"
+                   IsVisible="{Binding IsReplanning}"
+                   FontSize="12"
+                   Foreground="#66CCFF"/>
+      </StackPanel>
+    </Expander>
+
+    <Grid ColumnDefinitions="*,Auto">
+      <TextBlock Grid.Column="0"
+                 Text="{Binding TotalEstimateText}"
+                 IsVisible="{Binding !IsUpToDate}"
+                 FontSize="12"
+                 Foreground="#CCCCCC"
+                 VerticalAlignment="Center"/>
+
+      <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8">
+        <Button Content="Cancel" Width="90" Click="OnCancelClick"/>
+        <Button Content="Start"
+                MinWidth="120"
+                Background="#FFCC00"
+                Foreground="#1E1E1E"
+                FontWeight="SemiBold"
+                IsVisible="{Binding !IsUpToDate}"
+                IsEnabled="{Binding CanStart}"
+                Click="OnStartClick"/>
+      </StackPanel>
+    </Grid>
+
+  </StackPanel>
+</Window>

--- a/DiffusionNexus.UI/Views/Dialogs/SyncPlanDialog.axaml
+++ b/DiffusionNexus.UI/Views/Dialogs/SyncPlanDialog.axaml
@@ -111,7 +111,7 @@
                  VerticalAlignment="Center"/>
 
       <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8">
-        <Button Content="Cancel" Width="90" Click="OnCancelClick"/>
+        <Button Content="Cancel" Width="90" Click="OnCancelClick" IsCancel="True"/>
         <Button Content="Start"
                 MinWidth="120"
                 Background="#FFCC00"

--- a/DiffusionNexus.UI/Views/Dialogs/SyncPlanDialog.axaml.cs
+++ b/DiffusionNexus.UI/Views/Dialogs/SyncPlanDialog.axaml.cs
@@ -1,0 +1,46 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using DiffusionNexus.UI.ViewModels;
+
+namespace DiffusionNexus.UI.Views.Dialogs;
+
+/// <summary>
+/// Confirmation dialog for a metadata sync run: shows what the plan would do per step and
+/// returns the options to run with. Closing the window without pressing Start is a cancel.
+/// </summary>
+public partial class SyncPlanDialog : Window
+{
+    private SyncPlanDialogViewModel? _viewModel;
+
+    public SyncPlanDialog()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    /// <summary>The confirmed options, or null when the user backed out.</summary>
+    public SyncPlanDialogResult? Result { get; private set; }
+
+    public SyncPlanDialog WithViewModel(SyncPlanDialogViewModel viewModel)
+    {
+        _viewModel = viewModel;
+        DataContext = _viewModel;
+        return this;
+    }
+
+    private void OnStartClick(object? sender, RoutedEventArgs e)
+    {
+        Result = _viewModel?.BuildResult();
+        Close();
+    }
+
+    private void OnCancelClick(object? sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+}

--- a/DiffusionNexus.UI/Views/Dialogs/SyncReportDialog.axaml
+++ b/DiffusionNexus.UI/Views/Dialogs/SyncReportDialog.axaml
@@ -48,7 +48,9 @@
 
     <!-- Per-step counts table -->
     <StackPanel Spacing="0">
-      <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto" Margin="0,0,0,4">
+      <!-- Horizontal margin mirrors the rows' Border Padding="12,8" (+1 border) so header
+           columns sit exactly above their data columns. -->
+      <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto" Margin="13,0,13,4">
         <TextBlock Grid.Column="0" Text="Step" FontSize="12" FontWeight="SemiBold" Foreground="#999999"/>
         <TextBlock Grid.Column="1" Text="Planned" MinWidth="60" TextAlignment="Right" FontSize="12" FontWeight="SemiBold" Foreground="#999999"/>
         <TextBlock Grid.Column="2" Text="Processed" MinWidth="70" TextAlignment="Right" FontSize="12" FontWeight="SemiBold" Foreground="#999999"/>

--- a/DiffusionNexus.UI/Views/Dialogs/SyncReportDialog.axaml
+++ b/DiffusionNexus.UI/Views/Dialogs/SyncReportDialog.axaml
@@ -1,0 +1,118 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:DiffusionNexus.UI.ViewModels"
+        x:Class="DiffusionNexus.UI.Views.Dialogs.SyncReportDialog"
+        x:DataType="vm:SyncReportDialogViewModel"
+        Title="Sync Report"
+        Width="560"
+        SizeToContent="Height"
+        MaxHeight="700"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        Background="#2D2D30">
+
+  <Window.Styles>
+    <Style Selector="TextBlock.failed"><Setter Property="Foreground" Value="#E2B14C"/></Style>
+  </Window.Styles>
+
+  <StackPanel Margin="20" Spacing="14">
+
+    <!-- Summary header -->
+    <TextBlock Text="{Binding SummaryText}"
+               FontSize="14"
+               FontWeight="SemiBold"
+               Foreground="White"
+               TextWrapping="Wrap"/>
+
+    <TextBlock Text="{Binding PartialText}"
+               IsVisible="{Binding IsPartial}"
+               FontSize="12"
+               Foreground="#E2B14C"
+               TextWrapping="Wrap"/>
+
+    <TextBlock Text="{Binding DiscoveredText}"
+               IsVisible="{Binding HasDiscoveredFiles}"
+               FontSize="12"
+               Foreground="#CCCCCC"
+               TextWrapping="Wrap"/>
+
+    <TextBlock Text="{Binding UnexpectedText}"
+               IsVisible="{Binding HasUnexpected}"
+               FontSize="12"
+               Foreground="#E2B14C"
+               TextWrapping="Wrap"/>
+
+    <TextBlock Text="{Binding ElapsedText}"
+               FontSize="12"
+               Foreground="#888888"/>
+
+    <!-- Per-step counts table -->
+    <StackPanel Spacing="0">
+      <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto" Margin="0,0,0,4">
+        <TextBlock Grid.Column="0" Text="Step" FontSize="12" FontWeight="SemiBold" Foreground="#999999"/>
+        <TextBlock Grid.Column="1" Text="Planned" MinWidth="60" TextAlignment="Right" FontSize="12" FontWeight="SemiBold" Foreground="#999999"/>
+        <TextBlock Grid.Column="2" Text="Processed" MinWidth="70" TextAlignment="Right" FontSize="12" FontWeight="SemiBold" Foreground="#999999"/>
+        <TextBlock Grid.Column="3" Text="Succeeded" MinWidth="70" TextAlignment="Right" FontSize="12" FontWeight="SemiBold" Foreground="#999999"/>
+        <TextBlock Grid.Column="4" Text="Skipped" MinWidth="60" TextAlignment="Right" FontSize="12" FontWeight="SemiBold" Foreground="#999999"/>
+        <TextBlock Grid.Column="5" Text="Failed" MinWidth="50" TextAlignment="Right" FontSize="12" FontWeight="SemiBold" Foreground="#999999"/>
+      </Grid>
+
+      <ItemsControl ItemsSource="{Binding StepRows}">
+        <ItemsControl.ItemTemplate>
+          <DataTemplate x:DataType="vm:SyncReportStepRowViewModel">
+            <Border Background="#1E1E1E"
+                    BorderBrush="#444444"
+                    BorderThickness="1"
+                    CornerRadius="6"
+                    Padding="12,8"
+                    Margin="0,0,0,6">
+              <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto">
+                <TextBlock Grid.Column="0" Text="{Binding Label}" FontSize="13" VerticalAlignment="Center"/>
+                <TextBlock Grid.Column="1" Text="{Binding Planned}" MinWidth="60" TextAlignment="Right" FontSize="13" Foreground="#CCCCCC" VerticalAlignment="Center"/>
+                <TextBlock Grid.Column="2" Text="{Binding Processed}" MinWidth="70" TextAlignment="Right" FontSize="13" Foreground="#CCCCCC" VerticalAlignment="Center"/>
+                <TextBlock Grid.Column="3" Text="{Binding Succeeded}" MinWidth="70" TextAlignment="Right" FontSize="13" Foreground="#CCCCCC" VerticalAlignment="Center"/>
+                <TextBlock Grid.Column="4" Text="{Binding Skipped}" MinWidth="60" TextAlignment="Right" FontSize="13" Foreground="#CCCCCC" VerticalAlignment="Center"/>
+                <TextBlock Grid.Column="5" Text="{Binding Failed}" MinWidth="50" TextAlignment="Right" FontSize="13"
+                           Foreground="#CCCCCC" FontWeight="SemiBold" VerticalAlignment="Center"
+                           Classes.failed="{Binding HasFailed}"/>
+              </Grid>
+            </Border>
+          </DataTemplate>
+        </ItemsControl.ItemTemplate>
+      </ItemsControl>
+    </StackPanel>
+
+    <!-- Grouped, expandable failures -->
+    <StackPanel Spacing="6" IsVisible="{Binding HasFailures}">
+      <TextBlock Text="Failures" FontSize="13" FontWeight="SemiBold" Foreground="White"/>
+      <ScrollViewer MaxHeight="360">
+        <ItemsControl ItemsSource="{Binding FailureGroups}">
+          <ItemsControl.ItemTemplate>
+            <DataTemplate x:DataType="vm:SyncReportFailureGroup">
+              <Expander Header="{Binding Header}" IsExpanded="False" Margin="0,0,0,6">
+                <ItemsControl ItemsSource="{Binding Items}">
+                  <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="vm:SyncReportFailureItem">
+                      <StackPanel Orientation="Horizontal" Spacing="6" Margin="0,4,0,4">
+                        <TextBlock Text="{Binding Name}" FontSize="12" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                        <TextBlock Text="—" FontSize="12" Foreground="#888888"/>
+                        <TextBlock Text="{Binding Reason}" FontSize="12" Foreground="#999999" TextWrapping="Wrap"/>
+                      </StackPanel>
+                    </DataTemplate>
+                  </ItemsControl.ItemTemplate>
+                </ItemsControl>
+              </Expander>
+            </DataTemplate>
+          </ItemsControl.ItemTemplate>
+        </ItemsControl>
+      </ScrollViewer>
+    </StackPanel>
+
+    <Grid ColumnDefinitions="*,Auto">
+      <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8">
+        <Button Content="Close" Width="90" Click="OnCloseClick" IsCancel="True"/>
+      </StackPanel>
+    </Grid>
+
+  </StackPanel>
+</Window>

--- a/DiffusionNexus.UI/Views/Dialogs/SyncReportDialog.axaml
+++ b/DiffusionNexus.UI/Views/Dialogs/SyncReportDialog.axaml
@@ -95,11 +95,15 @@
                 <ItemsControl ItemsSource="{Binding Items}">
                   <ItemsControl.ItemTemplate>
                     <DataTemplate x:DataType="vm:SyncReportFailureItem">
-                      <StackPanel Orientation="Horizontal" Spacing="6" Margin="0,4,0,4">
-                        <TextBlock Text="{Binding Name}" FontSize="12" FontWeight="SemiBold" TextWrapping="Wrap"/>
-                        <TextBlock Text="—" FontSize="12" Foreground="#888888"/>
-                        <TextBlock Text="{Binding Reason}" FontSize="12" Foreground="#999999" TextWrapping="Wrap"/>
-                      </StackPanel>
+                      <!-- A Grid, not a horizontal StackPanel: a horizontal StackPanel measures
+                           children with unbounded width, so TextWrapping never engages and long
+                           reasons (deserialize errors carry a raw-response snippet) clip at the
+                           window edge. The star column bounds the reason so it wraps. -->
+                      <Grid ColumnDefinitions="Auto,Auto,*" Margin="0,4,0,4">
+                        <TextBlock Grid.Column="0" Text="{Binding Name}" FontSize="12" FontWeight="SemiBold" TextWrapping="Wrap" MaxWidth="180" Margin="0,0,6,0"/>
+                        <TextBlock Grid.Column="1" Text="—" FontSize="12" Foreground="#888888" Margin="0,0,6,0"/>
+                        <TextBlock Grid.Column="2" Text="{Binding Reason}" FontSize="12" Foreground="#999999" TextWrapping="Wrap"/>
+                      </Grid>
                     </DataTemplate>
                   </ItemsControl.ItemTemplate>
                 </ItemsControl>

--- a/DiffusionNexus.UI/Views/Dialogs/SyncReportDialog.axaml.cs
+++ b/DiffusionNexus.UI/Views/Dialogs/SyncReportDialog.axaml.cs
@@ -1,0 +1,34 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using DiffusionNexus.UI.ViewModels;
+
+namespace DiffusionNexus.UI.Views.Dialogs;
+
+/// <summary>
+/// Read-only post-run sync report: per-step counts and grouped, expandable failures.
+/// No result — Close is the only way out.
+/// </summary>
+public partial class SyncReportDialog : Window
+{
+    public SyncReportDialog()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    public SyncReportDialog WithViewModel(SyncReportDialogViewModel viewModel)
+    {
+        DataContext = viewModel;
+        return this;
+    }
+
+    private void OnCloseClick(object? sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+}

--- a/DiffusionNexus.UI/Views/SettingsView.axaml
+++ b/DiffusionNexus.UI/Views/SettingsView.axaml
@@ -317,6 +317,32 @@
                       </StackPanel>
                       <Border Height="1" Background="#40FFFFFF" Margin="0,8"/>
                       <StackPanel Spacing="8">
+                        <TextBlock Text="Metadata Sync" FontWeight="SemiBold" FontSize="14"/>
+                        <TextBlock Text="How the bulk metadata sync retries models it could not resolve, and how many thumbnails it downloads at once. Applies from the next sync run."
+                                   FontSize="12"
+                                   Opacity="0.7"
+                                   TextWrapping="Wrap"/>
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                          <ComboBox ItemsSource="{Binding AvailableSyncNotIdentifiedRetryDays}"
+                                    SelectedItem="{Binding SyncNotIdentifiedRetryDays, Mode=TwoWay}"
+                                    Width="80"/>
+                          <TextBlock Text="Days before re-checking models Civitai did not identify" VerticalAlignment="Center"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                          <ComboBox ItemsSource="{Binding AvailableSyncErrorRetryDays}"
+                                    SelectedItem="{Binding SyncErrorRetryDays, Mode=TwoWay}"
+                                    Width="80"/>
+                          <TextBlock Text="Days before retrying failed lookups" VerticalAlignment="Center"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                          <ComboBox ItemsSource="{Binding AvailableSyncThumbnailConcurrency}"
+                                    SelectedItem="{Binding SyncThumbnailConcurrency, Mode=TwoWay}"
+                                    Width="80"/>
+                          <TextBlock Text="Thumbnail downloads in parallel" VerticalAlignment="Center"/>
+                        </StackPanel>
+                      </StackPanel>
+                      <Border Height="1" Background="#40FFFFFF" Margin="0,8"/>
+                      <StackPanel Spacing="8">
                         <TextBlock Text="Base Model Filter" FontWeight="SemiBold" FontSize="14"/>
                         <TextBlock Text="Force-updates the base-model filter list shared by the Installed and Browse Civitai tabs. Fetches the latest base-model definition from Civitai and rebuilds the filter immediately, without an app restart. Status is reported in the Unified Console."
                                    FontSize="12"

--- a/docs/superpowers/plans/2026-08-25-metadata-sync-overhaul-E-sync-ui.md
+++ b/docs/superpowers/plans/2026-08-25-metadata-sync-overhaul-E-sync-ui.md
@@ -1,0 +1,1137 @@
+# Metadata Sync Overhaul — Plan E: Sync Plan Dialog, Report, Settings (WP6) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The user sees a truthful plan (counts + estimate + per-step checkboxes + Force options) *before* a library sync runs, a faithful per-step report with an expandable failure list *after* it, and can tune retry windows and thumbnail download parallelism in Settings.
+
+**Architecture:** Everything the dialog and report need already exists in the Domain records (`SyncPlanStep` carries Count/EstimatedDuration/Description; `SyncReport` carries `SyncStepReport` counts and per-item `SyncFailure`s). This plan adds no sync logic — it adds two dialogs (following the `DownloadLoraDialog` VM + `WithViewModel` pattern), four `AppSettings` columns feeding `SyncRetryPolicy`/`SyncOptions`, bounded parallelism for the Thumbnails step only (deferred here from Plan B), and rewires `LoraViewerViewModel.DownloadMissingMetadataAsync` to: discover → plan → dialog → execute → stamp → report.
+
+**Tech Stack:** .NET 10, Avalonia 11, CommunityToolkit.Mvvm, EF Core 10 SQLite, xUnit + FluentAssertions + Moq.
+
+**Spec:** `docs/superpowers/specs/2026-08-21-metadata-sync-overhaul-design.md` — this is WP6 (§4.6, §5). Decision D4 (dialog, not auto-start) is accepted and binding.
+
+**Branch:** `feature/metadata-sync-overhaul-e-sync-ui` (already created off the merged develop at `2d66c385`).
+
+## Global Constraints
+
+- **S1 — Additive schema only.** New nullable/defaulted columns on `AppSettings` only. No column drops, renames, type changes, or rewrites of existing columns.
+- **S2 — Pre-migration backup is automatic.** `DatabaseRecoveryService` already VACUUMs a backup before applying any pending migration; do not add another mechanism, do not bypass it.
+- **S7 — Nothing new runs at startup.** Startup stays: load tiles → discover new files → background file verify. The dialog, report, and settings reads change nothing about startup work.
+- **D4 (spec §7):** "Download Metadata" opens the plan dialog. The expensive (network) run starts only after the user presses Start.
+- **Spec §4.6 copy is binding, verbatim:** the all-zero plan shows **"Library is up to date — nothing to do"** with the last-run timestamp and no Start button. The report is per-step counts plus an expandable failure list with reasons — never a bare "N failed".
+- **API pacing is untouchable.** The 1.5 s `ICivitaiRequestPacer` on Identify/Tags/Images stays exactly as is. Parallelism applies to the Thumbnails step ONLY (CDN, deliberately unpaced — see the remarks block at the top of `ThumbnailsStep.cs`).
+- **Standing rule (log-feature-steps):** every new component logs its working steps to the Unified Console (`IUnifiedLogger`): dialog shown (with counts), the user's choice, report shown. Failures one `Warn` line each, stack traces only at `Debug` — the sync steps already comply; keep it that way.
+- **Tests:** `dotnet test DiffusionNexus.Tests/DiffusionNexus.Tests.csproj -c Release` — never solution-level. If `bin\Release` is file-locked (user runs the app from it), build/test `-c Debug` instead of killing their process.
+- **Line endings:** never flip an existing file's line endings — verify the diff has no EOL-only churn (byte-level check via `git diff` — a full-file diff on a file you edited 3 lines of means you flipped it). New `.cs`/`.axaml` files: LF.
+- **Branch discipline:** commit per task on this branch; never merge into develop (PR only, user merges).
+- **Ctor convention:** new optional collaborators go at the END of constructor parameter lists with `= null` defaults, resolved via `App.Services?.GetService<T>()` fallback where the class already does that.
+
+---
+
+## File Structure
+
+| File | Role |
+|---|---|
+| `DiffusionNexus.Domain/Entities/AppSettings.cs` | +4 columns (2 retry-day ints, thumbnail concurrency int, `LastLibrarySyncAt`) |
+| `DiffusionNexus.Domain/Services/Sync/SyncRetryPolicy.cs` | +`FromDays` factory |
+| `DiffusionNexus.Domain/Services/Sync/SyncOptions.cs` | +`ThumbnailConcurrency` |
+| `DiffusionNexus.Domain/Services/Sync/SyncPlan.cs` | `HasWork` fixed to mean "any counted work" |
+| `DiffusionNexus.Domain/Services/IAppSettingsService.cs` + `DiffusionNexus.Service/Services/AppSettingsService.cs` | +`UpdateLastLibrarySyncAtAsync` |
+| `DiffusionNexus.DataAccess/Migrations/Core/*_AddSyncSettings.cs` (generated) + `DiffusionNexus.DataAccess/Recovery/DatabaseRecoveryService.cs` | migration + self-heal entries |
+| `DiffusionNexus.Service/Services/Sync/LibrarySyncService.cs` | bounded-parallel branch for the Thumbnails step |
+| `DiffusionNexus.UI/ViewModels/SyncPlanDialogViewModel.cs` (new) | plan dialog VM: rows, forces, live re-plan, up-to-date state |
+| `DiffusionNexus.UI/Views/Dialogs/SyncPlanDialog.axaml(.cs)` (new) | plan dialog window |
+| `DiffusionNexus.UI/ViewModels/SyncReportDialogViewModel.cs` (new) | report VM: step table + grouped failures |
+| `DiffusionNexus.UI/Views/Dialogs/SyncReportDialog.axaml(.cs)` (new) | report window |
+| `DiffusionNexus.UI/Services/IDialogService.cs` + `DialogService.cs` | +2 show methods |
+| `DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs` | new flow: discover → plan → dialog → execute → stamp → report |
+| `DiffusionNexus.UI/ViewModels/ModelTileViewModel.cs` | scroll gate takes the settings-derived policy |
+| `DiffusionNexus.UI/ViewModels/SettingsViewModel.cs` + `Views/SettingsView.axaml` | "Metadata Sync" settings block |
+| `DiffusionNexus.UI/ViewModels/ModelDetailViewModel.Editing.cs` | rider: `UploadThumbnailAsync` via `ThumbnailWriter` |
+| `DiffusionNexus.UI/Doc/LoraViewer.md` + spec §5 | docs |
+
+Task order: 1 (settings backbone) → 2 (parallelism) → 3 (plan dialog) → 4 (report dialog) → 5 (wire the flow) → 6 (settings UI) → 7 (rider + docs). Tasks 2, 3, 4 are mutually independent; 5 needs 1–4; 6 needs 1; 7 is last.
+
+---
+
+### Task 1: Settings backbone — columns, migration, policy factory
+
+**Files:**
+- Modify: `DiffusionNexus.Domain/Entities/AppSettings.cs`
+- Modify: `DiffusionNexus.Domain/Services/Sync/SyncRetryPolicy.cs`
+- Modify: `DiffusionNexus.Domain/Services/IAppSettingsService.cs`
+- Modify: `DiffusionNexus.Service/Services/AppSettingsService.cs`
+- Modify: `DiffusionNexus.DataAccess/Recovery/DatabaseRecoveryService.cs` (self-heal dictionary, ~line 284)
+- Create (generated): `DiffusionNexus.DataAccess/Migrations/Core/<ts>_AddSyncSettings.cs` + Designer + snapshot update
+- Test: `DiffusionNexus.Tests/Sync/Domain/SyncRetryPolicyTests.cs` (extend)
+
+**Interfaces:**
+- Produces: `AppSettings.SyncNotIdentifiedRetryDays` (int, 30), `AppSettings.SyncErrorRetryDays` (int, 1), `AppSettings.SyncThumbnailConcurrency` (int, 4), `AppSettings.LastLibrarySyncAt` (DateTimeOffset?); `SyncRetryPolicy.FromDays(int notIdentifiedDays, int errorDays)`; `Task IAppSettingsService.UpdateLastLibrarySyncAtAsync(DateTimeOffset lastLibrarySyncAt, CancellationToken cancellationToken = default)`. Tasks 5 and 6 consume all of these.
+
+- [ ] **Step 1: Write the failing test for the policy factory**
+
+Append to `DiffusionNexus.Tests/Sync/Domain/SyncRetryPolicyTests.cs` (match the file's existing test naming style):
+
+```csharp
+    [Fact]
+    public void FromDays_BuildsWindowsFromSettingsValues()
+    {
+        var policy = SyncRetryPolicy.FromDays(notIdentifiedDays: 14, errorDays: 3);
+
+        policy.NotIdentifiedRetryAfter.Should().Be(TimeSpan.FromDays(14));
+        policy.ErrorRetryAfter.Should().Be(TimeSpan.FromDays(3));
+        policy.MaxErrorAttempts.Should().Be(SyncRetryPolicy.Default.MaxErrorAttempts);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void FromDays_FloorsAtOneDay_BecauseZeroWouldMeanAlwaysDue(int days)
+    {
+        var policy = SyncRetryPolicy.FromDays(days, days);
+
+        policy.NotIdentifiedRetryAfter.Should().Be(TimeSpan.FromDays(1));
+        policy.ErrorRetryAfter.Should().Be(TimeSpan.FromDays(1));
+    }
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `dotnet test DiffusionNexus.Tests/DiffusionNexus.Tests.csproj -c Release --filter "FullyQualifiedName~SyncRetryPolicyTests"`
+Expected: compile error — `FromDays` does not exist.
+
+- [ ] **Step 3: Implement `SyncRetryPolicy.FromDays`**
+
+Add to `DiffusionNexus.Domain/Services/Sync/SyncRetryPolicy.cs`, after the `Default` property:
+
+```csharp
+    /// <summary>
+    /// Builds a policy from the user's saved settings. Floors both windows at one day: zero would
+    /// mean "always due", which turns every plan into a full re-run — when that is wanted it is a
+    /// Force checkbox on the plan dialog, not a saved setting. <see cref="MaxErrorAttempts"/> stays
+    /// at the default: it caps API hammering inside one run window and is not a user-facing knob.
+    /// </summary>
+    public static SyncRetryPolicy FromDays(int notIdentifiedDays, int errorDays) =>
+        new(TimeSpan.FromDays(Math.Max(1, notIdentifiedDays)),
+            TimeSpan.FromDays(Math.Max(1, errorDays)),
+            Default.MaxErrorAttempts);
+```
+
+- [ ] **Step 4: Run the tests and make sure they pass**
+
+Same filter as Step 2. Expected: PASS.
+
+- [ ] **Step 5: Add the four entity columns**
+
+In `DiffusionNexus.Domain/Entities/AppSettings.cs`, add a new region after the existing LoRA-Helper/Viewer-related settings (place it next to `LoraUpdateCheckStalenessDays` so related knobs read together):
+
+```csharp
+    // --- Metadata Sync Settings (issue #521 Plan E) ---
+
+    /// <summary>
+    /// Days before the bulk sync re-checks a model whose identity attempt found nothing
+    /// (NotIdentified/Sidecar/Header/Heuristic outcomes). Default 30 (spec §4.1 retry policy).
+    /// </summary>
+    public int SyncNotIdentifiedRetryDays { get; set; } = 30;
+
+    /// <summary>Days before the bulk sync retries a model whose last attempt errored. Default 1.</summary>
+    public int SyncErrorRetryDays { get; set; } = 1;
+
+    /// <summary>
+    /// How many thumbnail CDN downloads the bulk sync runs in parallel (1–8, default 4).
+    /// Applies to the Thumbnails step only; API steps are paced, never parallel.
+    /// </summary>
+    public int SyncThumbnailConcurrency { get; set; } = 4;
+
+    /// <summary>When the last user-started library-wide metadata sync completed uncancelled, if ever.</summary>
+    public DateTimeOffset? LastLibrarySyncAt { get; set; }
+```
+
+No `AppSettingsConfiguration` change is needed — precedent: `LoraUpdateCheckStalenessDays` has no fluent config; its CLR initializer flowed into the migration as `defaultValue: 3` (see `Migrations/Core/20260510202951_AddLoraUpdateCheckStalenessDays.cs`).
+
+- [ ] **Step 6: Add the timestamp setter to the settings service**
+
+`DiffusionNexus.Domain/Services/IAppSettingsService.cs` — add next to `UpdateLastBackupAtAsync`:
+
+```csharp
+    /// <summary>
+    /// Stamps when the last user-started library sync completed, without touching any other setting.
+    /// </summary>
+    Task UpdateLastLibrarySyncAtAsync(DateTimeOffset lastLibrarySyncAt, CancellationToken cancellationToken = default);
+```
+
+`DiffusionNexus.Service/Services/AppSettingsService.cs` — implement by copying the `UpdateLastBackupAtAsync` body shape exactly (read settings via `_unitOfWork.AppSettings.GetSettingsAsync`, set `LastLibrarySyncAt` and `UpdatedAt`, save). Read `UpdateLastBackupAtAsync` at line ~703 first and mirror it.
+
+Check for other implementers: `Grep " : IAppSettingsService" across the repo` — if a test fake implements the interface (rather than Moq), add the method there too.
+
+- [ ] **Step 7: Generate the migration and verify it is additive-only**
+
+```powershell
+cd e:\Repos\DiffusionNexus\DiffusionNexus.DataAccess
+dotnet ef migrations add AddSyncSettings --context DiffusionNexusCoreDbContext --output-dir Migrations/Core
+```
+
+Open the generated `<ts>_AddSyncSettings.cs` and verify `Up` contains exactly four `AddColumn` calls on `AppSettings`: `SyncNotIdentifiedRetryDays` (INTEGER, not null, defaultValue 30), `SyncErrorRetryDays` (INTEGER, not null, defaultValue 1), `SyncThumbnailConcurrency` (INTEGER, not null, defaultValue 4), `LastLibrarySyncAt` (TEXT, nullable) — and NOTHING touching any other table. If anything else appears, the snapshot was stale: stop and report.
+
+- [ ] **Step 8: Add the self-heal entries**
+
+In `DiffusionNexus.DataAccess/Recovery/DatabaseRecoveryService.cs`, extend the AppSettings column-repair dictionary (the one at ~line 284 holding `MaxBackups`, `LastBackupAt`, `LoraUpdateCheckStalenessDays`, …) with:
+
+```csharp
+                { "SyncNotIdentifiedRetryDays", "ALTER TABLE AppSettings ADD COLUMN SyncNotIdentifiedRetryDays INTEGER NOT NULL DEFAULT 30" },
+                { "SyncErrorRetryDays", "ALTER TABLE AppSettings ADD COLUMN SyncErrorRetryDays INTEGER NOT NULL DEFAULT 1" },
+                { "SyncThumbnailConcurrency", "ALTER TABLE AppSettings ADD COLUMN SyncThumbnailConcurrency INTEGER NOT NULL DEFAULT 4" },
+                { "LastLibrarySyncAt", "ALTER TABLE AppSettings ADD COLUMN LastLibrarySyncAt TEXT" },
+```
+
+- [ ] **Step 9: Full suite green, commit**
+
+Run: `dotnet test DiffusionNexus.Tests/DiffusionNexus.Tests.csproj -c Release`
+Expected: PASS (existing DataAccess migration/round-trip tests pick up the new columns automatically; if a settings round-trip test enumerates properties explicitly, extend it).
+
+```bash
+git add -A
+git commit -m "feat(sync): sync retry/concurrency settings columns + last-library-sync stamp"
+```
+
+---
+
+### Task 2: Bounded parallelism for the Thumbnails step
+
+**Files:**
+- Modify: `DiffusionNexus.Domain/Services/Sync/SyncOptions.cs`
+- Modify: `DiffusionNexus.Service/Services/Sync/LibrarySyncService.cs` (`RunStepAsync`, ~line 179)
+- Test: `DiffusionNexus.Tests/Sync/Service/LibrarySyncServiceTests.cs` (extend)
+
+**Interfaces:**
+- Consumes: nothing from Task 1 (independent).
+- Produces: `SyncOptions.ThumbnailConcurrency` (int, default 4, trailing optional ctor param). Task 5 sets it from settings.
+
+**Why this is safe:** `ThumbnailsStep.ExecuteOneAsync` creates a fresh `IServiceScope` + `IUnitOfWork` per item (read `ThumbnailsStep.cs:90-156` to confirm this is still true), the `IThumbnailProvider` is a typed-`HttpClient` singleton (thread-safe), and the step deliberately has no `ICivitaiRequestPacer` (its own remarks block says so). The `LibrarySyncService` remarks at ~line 276 state the invariant: "every step owns its own scope inside `ExecuteOneAsync`". Only the run tally and progress reporting are shared — those are what this task synchronizes.
+
+- [ ] **Step 1: Add the option**
+
+`SyncOptions.cs` — add a trailing parameter to the record (source-compatible with every existing construction site):
+
+```csharp
+public sealed record SyncOptions(
+    IReadOnlySet<SyncStepKind> Steps,
+    bool ForceIdentify = false,
+    bool ForceTags = false,
+    bool ForceImages = false,
+    bool ForceThumbnails = false,
+    SyncRetryPolicy? RetryPolicy = null,
+    int ThumbnailConcurrency = 4)
+```
+
+Keep the existing `All` static and `Policy` member untouched. Add an XML doc line on the new parameter position (`/// <param>` style if the record uses it, else a `<remarks>` sentence): "Thumbnails-step download parallelism, clamped to 1–8 by the service. API steps ignore it."
+
+- [ ] **Step 2: Write the failing concurrency tests**
+
+Append to `DiffusionNexus.Tests/Sync/Service/LibrarySyncServiceTests.cs`. Read the file's existing fixture first (how it constructs `LibrarySyncService` with a step list and builds plans) and reuse that; the probe step is self-contained:
+
+```csharp
+    private sealed class ConcurrencyProbeStep : ISyncStep
+    {
+        private readonly IReadOnlyList<SyncItem> _items;
+        private readonly bool _failOddItems;
+        private int _inFlight;
+
+        public int MaxObservedConcurrency;
+        public int Executed;
+
+        public ConcurrencyProbeStep(int itemCount, bool failOddItems = false)
+        {
+            _items = Enumerable.Range(1, itemCount)
+                .Select(i => new SyncItem(i, $"model-{i}", i))
+                .ToList();
+            _failOddItems = failOddItems;
+        }
+
+        public SyncStepKind Kind => SyncStepKind.Thumbnails;
+        public string Description => "probe";
+        public TimeSpan EstimatedPerItem => TimeSpan.Zero;
+
+        public Task<IReadOnlyList<SyncItem>> SelectAsync(SyncScope scope, SyncOptions options, DateTimeOffset now, CancellationToken ct)
+            => Task.FromResult(_items);
+
+        public async Task<SyncItemResult> ExecuteOneAsync(SyncItem item, string? apiKey, CancellationToken ct)
+        {
+            var now = Interlocked.Increment(ref _inFlight);
+            int seen;
+            do
+            {
+                seen = MaxObservedConcurrency;
+                if (now <= seen) break;
+            } while (Interlocked.CompareExchange(ref MaxObservedConcurrency, now, seen) != seen);
+
+            await Task.Delay(25, ct);
+
+            Interlocked.Decrement(ref _inFlight);
+            Interlocked.Increment(ref Executed);
+
+            return _failOddItems && (int)item.Payload % 2 == 1
+                ? SyncItemResult.Failure("probe-failure")
+                : SyncItemResult.Success;
+        }
+    }
+
+    [Fact]
+    public async Task Thumbnails_RunInParallel_UpToTheConfiguredConcurrency()
+    {
+        var probe = new ConcurrencyProbeStep(itemCount: 12);
+        var service = /* build LibrarySyncService with [probe] exactly as the file's other tests do */;
+        var options = new SyncOptions(new HashSet<SyncStepKind> { SyncStepKind.Thumbnails }, ThumbnailConcurrency: 4);
+
+        var plan = await service.PlanAsync(SyncScope.Library, options);
+        var report = await service.ExecuteAsync(plan);
+
+        probe.Executed.Should().Be(12);
+        probe.MaxObservedConcurrency.Should().BeGreaterThan(1).And.BeLessThanOrEqualTo(4);
+        report.Steps.Single().Succeeded.Should().Be(12);
+    }
+
+    [Fact]
+    public async Task Thumbnails_ConcurrencyOne_StaysStrictlySequential()
+    {
+        var probe = new ConcurrencyProbeStep(itemCount: 6);
+        var service = /* same fixture */;
+        var options = new SyncOptions(new HashSet<SyncStepKind> { SyncStepKind.Thumbnails }, ThumbnailConcurrency: 1);
+
+        var plan = await service.PlanAsync(SyncScope.Library, options);
+        await service.ExecuteAsync(plan);
+
+        probe.MaxObservedConcurrency.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ParallelThumbnails_RecordEveryFailure_WithoutLosingAny()
+    {
+        var probe = new ConcurrencyProbeStep(itemCount: 10, failOddItems: true);
+        var service = /* same fixture */;
+        var options = new SyncOptions(new HashSet<SyncStepKind> { SyncStepKind.Thumbnails }, ThumbnailConcurrency: 4);
+
+        var plan = await service.PlanAsync(SyncScope.Library, options);
+        var report = await service.ExecuteAsync(plan);
+
+        var step = report.Steps.Single();
+        step.Processed.Should().Be(10);
+        step.Failed.Should().Be(5);
+        report.Failures.Should().HaveCount(5);
+        report.Failures.Select(f => f.Reason).Should().AllBe("probe-failure");
+    }
+```
+
+The `/* build LibrarySyncService ... */` comments are for you, the implementer: replace them with the file's real construction helper — do not invent a new fixture. If the fixture's step registration is keyed by kind, register the probe as the Thumbnails step.
+
+- [ ] **Step 3: Run to verify they fail**
+
+Run: `dotnet test DiffusionNexus.Tests/DiffusionNexus.Tests.csproj -c Release --filter "FullyQualifiedName~LibrarySyncServiceTests"`
+Expected: the two parallel tests FAIL (`MaxObservedConcurrency` is 1 — today's loop is sequential); the sequential test passes.
+
+- [ ] **Step 4: Implement the parallel branch in `RunStepAsync`**
+
+In `LibrarySyncService.RunStepAsync` (read it fully first — the current sequential loop is at ~lines 198-224), restructure the body so both paths share one result-recording local function:
+
+```csharp
+        var processed = 0;
+        var succeeded = 0;
+        var skipped = 0;
+        var failed = 0;
+        var tallyLock = new object();
+
+        void Record(ItemOutcome outcome, SyncItem item)
+        {
+            var result = outcome.Result;
+            processed++;
+            if (result.Succeeded) succeeded++;
+            else if (result.Skipped) skipped++;
+            else
+            {
+                failed++;
+                tally.Failures.Add(new SyncFailure(step.Kind, item.ModelId, item.Name, result.FailureReason ?? "Unknown error"));
+
+                if (outcome.Unexpected)
+                {
+                    tally.UnexpectedFailures++;
+                    tally.FirstUnexpectedError ??= result.FailureReason;
+                }
+            }
+        }
+
+        var concurrency = Math.Clamp(plan.Options.ThumbnailConcurrency, 1, 8);
+
+        try
+        {
+            if (step.Kind == SyncStepKind.Thumbnails && concurrency > 1 && items.Count > 1)
+            {
+                // CDN fetches only — deliberately unpaced (see ThumbnailsStep remarks), and every
+                // step owns a fresh scope per ExecuteOneAsync, so items are independent. Only the
+                // tally and the progress counter are shared, and both are synchronized here.
+                var started = 0;
+                var parallelOptions = new ParallelOptions { MaxDegreeOfParallelism = concurrency, CancellationToken = ct };
+
+                await Parallel.ForEachAsync(items, parallelOptions, async (item, itemCt) =>
+                {
+                    // "Items started", not a stable position: under parallelism the status line
+                    // shows churn, and a monotonic counter is the honest number to put in [i/n].
+                    var index = Interlocked.Increment(ref started);
+                    progress?.Report(new LibrarySyncProgress(step.Kind, index, items.Count, item.Name));
+
+                    var outcome = await ExecuteItemAsync(step, item, apiKey, itemCt).ConfigureAwait(false);
+
+                    lock (tallyLock) Record(outcome, item);
+                }).ConfigureAwait(false);
+            }
+            else
+            {
+                for (var i = 0; i < items.Count; i++)
+                {
+                    ct.ThrowIfCancellationRequested();
+
+                    var item = items[i];
+                    progress?.Report(new LibrarySyncProgress(step.Kind, i + 1, items.Count, item.Name));
+
+                    var outcome = await ExecuteItemAsync(step, item, apiKey, ct).ConfigureAwait(false);
+                    Record(outcome, item);
+                }
+            }
+        }
+        finally
+        {
+            // (existing finally block — unchanged)
+```
+
+Notes that are part of the requirement, not suggestions:
+- The sequential path must remain byte-for-byte the current behavior for all non-Thumbnails steps (the pacing tests depend on it).
+- `ExecuteItemAsync` already swallows everything except genuine cancellation, so the only exception a parallel body can throw is `OperationCanceledException` — `Parallel.ForEachAsync` then cancels the remaining work and the existing `catch (OperationCanceledException)` in `ExecuteAsync` plus the `finally` tally handling produce a correct partial report. Do not add a second cancellation handler.
+- The `finally` block and the `RunTally` class are untouched.
+
+- [ ] **Step 5: Run the step tests, then the full suite**
+
+Run the filter from Step 3 → all PASS. Then the full suite → PASS (watch `CivitaiRequestPacerTests` and the step tests for any accidental behavior change).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "feat(sync): bounded parallelism for the thumbnails step (SyncOptions.ThumbnailConcurrency)"
+```
+
+---
+
+### Task 3: SyncPlanDialog — ViewModel, window, DialogService method
+
+**Files:**
+- Create: `DiffusionNexus.UI/ViewModels/SyncPlanDialogViewModel.cs`
+- Create: `DiffusionNexus.UI/Views/Dialogs/SyncPlanDialog.axaml`
+- Create: `DiffusionNexus.UI/Views/Dialogs/SyncPlanDialog.axaml.cs`
+- Modify: `DiffusionNexus.UI/Services/IDialogService.cs`, `DiffusionNexus.UI/Services/DialogService.cs`
+- Test: Create `DiffusionNexus.Tests/ViewModels/SyncPlanDialogViewModelTests.cs`
+
+**Interfaces:**
+- Consumes: `SyncPlan`/`SyncPlanStep`/`SyncOptions`/`SyncStepKind`/`SyncReport.Label` from `DiffusionNexus.Domain.Services.Sync` (existing).
+- Produces: `SyncPlanDialogResult(bool Confirmed, SyncOptions? Options)` with `static Cancelled()`; `SyncPlanDialogViewModel(SyncPlan initialPlan, SyncOptions baseOptions, Func<SyncOptions, Task<SyncPlan>> replanAsync, DateTimeOffset? lastLibrarySyncAt, int newFilesDiscovered, IUnifiedLogger? logger = null)`; `Task<SyncPlanDialogResult> IDialogService.ShowSyncPlanDialogAsync(SyncPlanDialogViewModel viewModel)`. Task 5 consumes all three.
+
+Design rules (binding):
+- The dialog shows **four rows** in fixed order — IdentifyModel, FetchTags, FetchImages, Thumbnails — never a DiscoverFiles row (discovery has already run by the time the dialog opens; Task 5). Row labels come from `SyncReport.Label`.
+- A row with `Count == 0` is unchecked and disabled ("there is nothing to start"). A row going `0 → N` after a Force re-plan becomes checked; a row the user explicitly unchecked while it was enabled STAYS unchecked across re-plans.
+- Toggling any Force checkbox re-plans immediately via the injected delegate (DB-only, sub-second) and updates the row counts. Re-plans always request **all four kinds** — selection filters at Start, not at plan time.
+- All-zero plan (every row `Count == 0`): show verbatim **"Library is up to date — nothing to do"** plus "Last full sync: `yyyy-MM-dd HH:mm`" (or "Last full sync: never"), and the Start button is hidden. The Force expander stays visible — forcing from the up-to-date state is exactly its purpose, and a force that produces counts un-hides Start.
+- The result's `SyncOptions` = `baseOptions` (which carries `RetryPolicy` and `ThumbnailConcurrency` from Task 5) with `Steps` = the checked kinds and the four Force flags as toggled.
+
+- [ ] **Step 1: Write the failing VM tests**
+
+`DiffusionNexus.Tests/ViewModels/SyncPlanDialogViewModelTests.cs` (new file, LF):
+
+```csharp
+using DiffusionNexus.Domain.Services.Sync;
+using DiffusionNexus.UI.ViewModels;
+using FluentAssertions;
+using Xunit;
+
+namespace DiffusionNexus.Tests.ViewModels;
+
+public class SyncPlanDialogViewModelTests
+{
+    private static readonly IReadOnlySet<SyncStepKind> FourKinds = new HashSet<SyncStepKind>
+    {
+        SyncStepKind.IdentifyModel, SyncStepKind.FetchTags, SyncStepKind.FetchImages, SyncStepKind.Thumbnails,
+    };
+
+    private static SyncPlan PlanWith(int identify, int tags, int images, int thumbs, SyncOptions? options = null)
+    {
+        options ??= new SyncOptions(FourKinds);
+        return new SyncPlan(SyncScope.Library, options, new[]
+        {
+            new SyncPlanStep(SyncStepKind.IdentifyModel, identify, TimeSpan.FromSeconds(3 * identify), "identify"),
+            new SyncPlanStep(SyncStepKind.FetchTags, tags, TimeSpan.FromSeconds(1.6 * tags), "tags"),
+            new SyncPlanStep(SyncStepKind.FetchImages, images, TimeSpan.FromSeconds(1.6 * images), "images"),
+            new SyncPlanStep(SyncStepKind.Thumbnails, thumbs, TimeSpan.FromSeconds(0.4 * thumbs), "thumbs"),
+        }, DateTimeOffset.UtcNow);
+    }
+
+    private static SyncPlanDialogViewModel Vm(
+        SyncPlan plan,
+        Func<SyncOptions, Task<SyncPlan>>? replan = null,
+        DateTimeOffset? lastSync = null,
+        int discovered = 0)
+        => new(plan, new SyncOptions(FourKinds), replan ?? (_ => Task.FromResult(plan)), lastSync, discovered);
+
+    [Fact]
+    public void RowsWithWork_ArePreChecked_AndEmptyRowsAreDisabled()
+    {
+        var vm = Vm(PlanWith(identify: 3, tags: 68, images: 0, thumbs: 12));
+
+        vm.Rows.Should().HaveCount(4);
+        vm.Rows.Single(r => r.Kind == SyncStepKind.IdentifyModel).IsSelected.Should().BeTrue();
+        vm.Rows.Single(r => r.Kind == SyncStepKind.FetchImages).IsSelected.Should().BeFalse();
+        vm.Rows.Single(r => r.Kind == SyncStepKind.FetchImages).IsEnabled.Should().BeFalse();
+        vm.IsUpToDate.Should().BeFalse();
+        vm.CanStart.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AllZeroPlan_IsUpToDate_WithNoStart_AndShowsTheLastRun()
+    {
+        var last = new DateTimeOffset(2026, 8, 25, 14, 3, 0, TimeSpan.Zero);
+        var vm = Vm(PlanWith(0, 0, 0, 0), lastSync: last);
+
+        vm.IsUpToDate.Should().BeTrue();
+        vm.CanStart.Should().BeFalse();
+        vm.UpToDateText.Should().Be("Library is up to date — nothing to do");
+        vm.LastRunText.Should().Contain("Last full sync:").And.NotContain("never");
+    }
+
+    [Fact]
+    public void NoRecordedRun_SaysNever()
+    {
+        var vm = Vm(PlanWith(0, 0, 0, 0), lastSync: null);
+        vm.LastRunText.Should().Be("Last full sync: never");
+    }
+
+    [Fact]
+    public async Task TogglingAForce_Replans_AndAppliesTheNewCounts()
+    {
+        SyncOptions? seen = null;
+        Task<SyncPlan> Replan(SyncOptions o)
+        {
+            seen = o;
+            return Task.FromResult(PlanWith(0, 0, 0, thumbs: 40, options: o));
+        }
+
+        var vm = Vm(PlanWith(0, 0, 0, 0), Replan);
+        vm.ForceThumbnails = true;
+        await vm.WhenReplanSettles();
+
+        seen.Should().NotBeNull();
+        seen!.ForceThumbnails.Should().BeTrue();
+        seen.Steps.Should().BeEquivalentTo(FourKinds);
+        vm.Rows.Single(r => r.Kind == SyncStepKind.Thumbnails).Count.Should().Be(40);
+        vm.Rows.Single(r => r.Kind == SyncStepKind.Thumbnails).IsSelected.Should().BeTrue();
+        vm.IsUpToDate.Should().BeFalse();
+        vm.CanStart.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AUserUntick_SurvivesAReplan()
+    {
+        var vm = Vm(PlanWith(identify: 3, tags: 68, images: 0, thumbs: 12),
+            o => Task.FromResult(PlanWith(3, 68, 0, 40, o)));
+
+        vm.Rows.Single(r => r.Kind == SyncStepKind.FetchTags).IsSelected = false;
+        vm.ForceThumbnails = true;
+        await vm.WhenReplanSettles();
+
+        vm.Rows.Single(r => r.Kind == SyncStepKind.FetchTags).IsSelected.Should().BeFalse();
+    }
+
+    [Fact]
+    public void BuildResult_CarriesTheCheckedKindsAndForces()
+    {
+        var vm = Vm(PlanWith(identify: 3, tags: 68, images: 2, thumbs: 12));
+        vm.Rows.Single(r => r.Kind == SyncStepKind.FetchTags).IsSelected = false;
+        vm.ForceIdentify = true;
+
+        var result = vm.BuildResult();
+
+        result.Confirmed.Should().BeTrue();
+        result.Options!.Steps.Should().BeEquivalentTo(new[]
+        {
+            SyncStepKind.IdentifyModel, SyncStepKind.FetchImages, SyncStepKind.Thumbnails,
+        });
+        result.Options.ForceIdentify.Should().BeTrue();
+        result.Options.ForceTags.Should().BeFalse();
+    }
+}
+```
+
+Note the test seam `WhenReplanSettles()` — the VM exposes `internal Task WhenReplanSettles()` returning the in-flight re-plan task (or `Task.CompletedTask`), so tests never poll. `ForceThumbnails` etc. are the `[ObservableProperty]`-generated setters (property change triggers the re-plan).
+
+- [ ] **Step 2: Run to verify they fail to compile** (types don't exist yet).
+
+- [ ] **Step 3: Implement the ViewModel**
+
+`DiffusionNexus.UI/ViewModels/SyncPlanDialogViewModel.cs` (new). Full shape — implement exactly this contract, filling in the obvious bodies:
+
+```csharp
+using CommunityToolkit.Mvvm.ComponentModel;
+using DiffusionNexus.Domain.Services.Sync;
+using DiffusionNexus.Domain.Services.UnifiedLogging;
+
+namespace DiffusionNexus.UI.ViewModels;
+
+/// <summary>The plan dialog's outcome. A cancelled dialog carries no options.</summary>
+public sealed record SyncPlanDialogResult(bool Confirmed, SyncOptions? Options)
+{
+    public static SyncPlanDialogResult Cancelled() => new(false, null);
+}
+
+/// <summary>One step row: what it would do, how many items, whether it runs.</summary>
+public sealed partial class SyncPlanStepRowViewModel : ObservableObject
+{
+    public SyncPlanStepRowViewModel(SyncStepKind kind, string description) { ... }
+
+    public SyncStepKind Kind { get; }
+    public string Label => SyncReport.Label(Kind);
+    public string Description { get; }
+
+    [ObservableProperty] private int _count;
+    [ObservableProperty] private string _estimateText = "";
+    [ObservableProperty] private bool _isSelected;
+
+    /// <summary>A row with nothing to do cannot be ticked.</summary>
+    public bool IsEnabled => Count > 0;
+    partial void OnCountChanged(int value) => OnPropertyChanged(nameof(IsEnabled));
+    partial void OnIsSelectedChanged(bool value) => SelectionChanged?.Invoke();
+    internal Action? SelectionChanged { get; set; }
+}
+
+public sealed partial class SyncPlanDialogViewModel : ObservableObject
+{
+    internal const string UpToDateMessage = "Library is up to date — nothing to do";
+
+    private readonly SyncOptions _baseOptions;
+    private readonly Func<SyncOptions, Task<SyncPlan>> _replanAsync;
+    private readonly IUnifiedLogger? _logger;
+    private Task _replanTask = Task.CompletedTask;
+
+    public SyncPlanDialogViewModel(
+        SyncPlan initialPlan,
+        SyncOptions baseOptions,
+        Func<SyncOptions, Task<SyncPlan>> replanAsync,
+        DateTimeOffset? lastLibrarySyncAt,
+        int newFilesDiscovered,
+        IUnifiedLogger? logger = null)
+    {
+        // Rows in fixed order; descriptions come from the plan's steps (fall back to the label).
+        // Apply the initial plan, wire row.SelectionChanged -> RefreshDerived().
+    }
+
+    public IReadOnlyList<SyncPlanStepRowViewModel> Rows { get; }
+
+    [ObservableProperty] private bool _forceIdentify;      // "Re-check models not found on Civitai"
+    [ObservableProperty] private bool _forceTags;
+    [ObservableProperty] private bool _forceImages;
+    [ObservableProperty] private bool _forceThumbnails;
+    [ObservableProperty] private bool _isReplanning;
+
+    public bool IsUpToDate { get; private set; }           // all rows Count == 0
+    public bool CanStart { get; private set; }             // any selected row with Count > 0, and not replanning
+    public string UpToDateText => UpToDateMessage;
+    public string LastRunText { get; }                     // "Last full sync: yyyy-MM-dd HH:mm" local time, or "Last full sync: never"
+    public string DiscoveredText { get; }                  // "N new file(s) discovered" — "" when 0
+    public bool HasDiscoveredFiles { get; }
+    public string TotalEstimateText { get; private set; } = "";  // sum of SELECTED rows' plan durations, via FormatDuration
+
+    partial void OnForceIdentifyChanged(bool value) => QueueReplan();
+    partial void OnForceTagsChanged(bool value) => QueueReplan();
+    partial void OnForceImagesChanged(bool value) => QueueReplan();
+    partial void OnForceThumbnailsChanged(bool value) => QueueReplan();
+
+    private void QueueReplan()
+    {
+        // Chain onto _replanTask so toggles serialize; set IsReplanning around the await;
+        // log Info(LogCategory.Network, "CivitaiSync", "Plan dialog: re-planning with forces ...").
+        // On the replan's plan: ApplyPlan(plan). Exceptions: log one Warn, keep the old counts.
+    }
+
+    internal Task WhenReplanSettles() => _replanTask;
+
+    private void ApplyPlan(SyncPlan plan)
+    {
+        // Per row: Count/EstimateText ("~2 min" via FormatDuration of the step's EstimatedDuration).
+        // Selection rule: a row that was DISABLED before (Count==0) and now has work becomes checked;
+        // a row that was enabled keeps whatever the user chose. Then RefreshDerived().
+    }
+
+    private void RefreshDerived()
+    {
+        // IsUpToDate, CanStart, TotalEstimateText (+ OnPropertyChanged for each).
+    }
+
+    public SyncPlanDialogResult BuildResult()
+    {
+        var steps = Rows.Where(r => r.IsSelected && r.Count > 0).Select(r => r.Kind).ToHashSet();
+        var options = _baseOptions with
+        {
+            Steps = steps,
+            ForceIdentify = ForceIdentify,
+            ForceTags = ForceTags,
+            ForceImages = ForceImages,
+            ForceThumbnails = ForceThumbnails,
+        };
+        return new SyncPlanDialogResult(true, options);
+    }
+
+    /// <summary>"~45 s" under 90 s, "~4 min" under 90 min, else "~1.5 h".</summary>
+    internal static string FormatDuration(TimeSpan t) { ... }
+}
+```
+
+(`SyncOptions.Steps` is an `IReadOnlySet<SyncStepKind>` positional record property, so `with { Steps = steps }` works.)
+
+- [ ] **Step 4: Run the VM tests** — filter `SyncPlanDialogViewModelTests`. Expected: PASS.
+
+- [ ] **Step 5: The window**
+
+`SyncPlanDialog.axaml` — follow `DownloadLoraDialog.axaml`'s conventions (theme, spacing, `x:DataType="vm:SyncPlanDialogViewModel"`). Layout, top to bottom:
+- Title bar text "Metadata Sync". `Width="560" SizeToContent="Height" CanResize="False" WindowStartupLocation="CenterOwner"`.
+- Header block: `DiscoveredText` (visible via `HasDiscoveredFiles`); the up-to-date block (`IsVisible="{Binding IsUpToDate}"`): `UpToDateText` bold + `LastRunText` dimmed.
+- Rows (`IsVisible="{Binding !IsUpToDate}"`): `ItemsControl ItemsSource="{Binding Rows}"`; each row a Grid: `CheckBox IsChecked="{Binding IsSelected}" IsEnabled="{Binding IsEnabled}"`, count (`TextBlock Text="{Binding Count}"` right-aligned, min-width 40), `Label` semibold + `Description` dimmed `FontSize="12"` `TextWrapping="Wrap"`, `EstimateText` dimmed right-aligned.
+- `Expander Header="Force re-check…"` (collapsed by default, always visible): four CheckBoxes bound to the Force properties, contents: "Models not found on Civitai", "Tags (even when already checked)", "Image records (even when already checked)", "Thumbnails (re-fetch existing attempts)". A small "Re-planning…" `TextBlock IsVisible="{Binding IsReplanning}"`.
+- Footer: `TotalEstimateText` left; right-aligned buttons **Start** (`Classes="accent"` if the app's dialogs use an accent class — copy whatever `DownloadLoraDialog`'s primary button does, `IsVisible="{Binding !IsUpToDate}" IsEnabled="{Binding CanStart}"`) and **Cancel**.
+
+`SyncPlanDialog.axaml.cs` — the `DownloadLoraDialog` code-behind pattern verbatim (`InitializeComponent` via `AvaloniaXamlLoader.Load(this)`; `WithViewModel(SyncPlanDialogViewModel)` fluent; `public SyncPlanDialogResult? Result { get; private set; }`). Start click: `Result = _viewModel!.BuildResult(); Close();`. Cancel click and window close: leave `Result` null.
+
+- [ ] **Step 6: DialogService**
+
+`IDialogService.cs`:
+
+```csharp
+    /// <summary>Shows the metadata-sync plan dialog. Never null: closing the window is a cancel.</summary>
+    Task<SyncPlanDialogResult> ShowSyncPlanDialogAsync(SyncPlanDialogViewModel viewModel);
+```
+
+`DialogService.cs` — copy the UI-thread-marshalling shape of `ShowSelectLoraVersionsToDeleteDialogAsync` (re-invoke on `Dispatcher.UIThread` when off-thread), then:
+
+```csharp
+        var dialog = new SyncPlanDialog().WithViewModel(viewModel);
+        await dialog.ShowDialog(_window);
+        return dialog.Result ?? SyncPlanDialogResult.Cancelled();
+```
+
+- [ ] **Step 7: Build the UI project, run the full suite, commit**
+
+`dotnet build DiffusionNexus.UI/DiffusionNexus.UI.csproj -c Release` → 0 warnings. Full suite → PASS.
+
+```bash
+git add -A
+git commit -m "feat(sync): SyncPlanDialog — per-step counts, checkboxes, force re-plan, up-to-date state"
+```
+
+---
+
+### Task 4: SyncReportDialog — faithful post-run report
+
+**Files:**
+- Create: `DiffusionNexus.UI/ViewModels/SyncReportDialogViewModel.cs`
+- Create: `DiffusionNexus.UI/Views/Dialogs/SyncReportDialog.axaml` + `.axaml.cs`
+- Modify: `DiffusionNexus.UI/Services/IDialogService.cs`, `DialogService.cs`
+- Test: Create `DiffusionNexus.Tests/ViewModels/SyncReportDialogViewModelTests.cs`
+
+**Interfaces:**
+- Consumes: `SyncReport`/`SyncStepReport`/`SyncFailure` (existing).
+- Produces: `SyncReportDialogViewModel(SyncReport report, int newFilesDiscovered)`; `Task IDialogService.ShowSyncReportDialogAsync(SyncReportDialogViewModel viewModel)`. Task 5 consumes both.
+
+- [ ] **Step 1: Write the failing VM tests**
+
+`DiffusionNexus.Tests/ViewModels/SyncReportDialogViewModelTests.cs` (new, LF):
+
+```csharp
+using DiffusionNexus.Domain.Services.Sync;
+using DiffusionNexus.UI.ViewModels;
+using FluentAssertions;
+using Xunit;
+
+namespace DiffusionNexus.Tests.ViewModels;
+
+public class SyncReportDialogViewModelTests
+{
+    private static SyncReport Report(
+        IReadOnlyList<SyncStepReport> steps,
+        IReadOnlyList<SyncFailure>? failures = null,
+        bool cancelled = false,
+        int unexpected = 0)
+    {
+        var options = new SyncOptions(new HashSet<SyncStepKind> { SyncStepKind.IdentifyModel });
+        var plan = new SyncPlan(SyncScope.Library, options, Array.Empty<SyncPlanStep>(), DateTimeOffset.UtcNow);
+        return new SyncReport(plan, steps, failures ?? Array.Empty<SyncFailure>(), cancelled,
+            TimeSpan.FromSeconds(90), NewFilesDiscovered: 0, UnexpectedFailures: unexpected);
+    }
+
+    [Fact]
+    public void FailuresAreGroupedByStep_WithNameAndReasonPerRow()
+    {
+        var report = Report(
+            new[] { new SyncStepReport(SyncStepKind.FetchTags, 10, 10, 7, 0, 3),
+                    new SyncStepReport(SyncStepKind.Thumbnails, 5, 5, 4, 0, 1) },
+            new[]
+            {
+                new SyncFailure(SyncStepKind.FetchTags, 1, "ModelA", "Timeout"),
+                new SyncFailure(SyncStepKind.FetchTags, 2, "ModelB", "Timeout"),
+                new SyncFailure(SyncStepKind.FetchTags, 3, "ModelC", "Http500"),
+                new SyncFailure(SyncStepKind.Thumbnails, 4, "ModelD", "Http404"),
+            });
+
+        var vm = new SyncReportDialogViewModel(report, newFilesDiscovered: 0);
+
+        vm.FailureGroups.Should().HaveCount(2);
+        var tags = vm.FailureGroups.Single(g => g.Kind == SyncStepKind.FetchTags);
+        tags.Header.Should().Be("Tags — 3 failed");
+        tags.Items.Should().HaveCount(3);
+        tags.Items[0].Name.Should().Be("ModelA");
+        tags.Items[0].Reason.Should().Be("Timeout");
+        vm.HasFailures.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ACleanRun_ShowsNoFailureGroups()
+    {
+        var vm = new SyncReportDialogViewModel(
+            Report(new[] { new SyncStepReport(SyncStepKind.FetchTags, 10, 10, 10, 0, 0) }),
+            newFilesDiscovered: 3);
+
+        vm.HasFailures.Should().BeFalse();
+        vm.FailureGroups.Should().BeEmpty();
+        vm.DiscoveredText.Should().Contain("3");
+    }
+
+    [Fact]
+    public void ACancelledRun_SaysPartial()
+    {
+        var vm = new SyncReportDialogViewModel(
+            Report(new[] { new SyncStepReport(SyncStepKind.FetchTags, 10, 4, 4, 0, 0) }, cancelled: true),
+            newFilesDiscovered: 0);
+
+        vm.IsPartial.Should().BeTrue();
+        vm.PartialText.Should().Contain("Cancelled");
+    }
+
+    [Fact]
+    public void UnexpectedFailures_AreCalledOut()
+    {
+        var vm = new SyncReportDialogViewModel(
+            Report(new[] { new SyncStepReport(SyncStepKind.FetchTags, 10, 10, 9, 0, 1) }, unexpected: 1),
+            newFilesDiscovered: 0);
+
+        vm.UnexpectedText.Should().Contain("1").And.ContainEquivalentOf("log");
+    }
+}
+```
+
+- [ ] **Step 2: Run — fails to compile.**
+
+- [ ] **Step 3: Implement the VM**
+
+`SyncReportDialogViewModel.cs` — plain read-only projection, no observable state:
+
+```csharp
+public sealed class SyncReportStepRowViewModel   // Label, Planned, Processed, Succeeded, Skipped, Failed, bool HasFailed
+public sealed record SyncReportFailureItem(string Name, string Reason);
+public sealed class SyncReportFailureGroup       // SyncStepKind Kind, string Header ("Tags — 3 failed"), IReadOnlyList<SyncReportFailureItem> Items
+
+public sealed class SyncReportDialogViewModel
+{
+    public SyncReportDialogViewModel(SyncReport report, int newFilesDiscovered) { ... }
+
+    public IReadOnlyList<SyncReportStepRowViewModel> StepRows { get; }   // one per report.Steps, in report order
+    public IReadOnlyList<SyncReportFailureGroup> FailureGroups { get; }  // grouped by Step, report order, only steps with failures
+    public bool HasFailures { get; }
+    public bool IsPartial { get; }            // report.Cancelled
+    public string PartialText { get; }        // "Cancelled — partial run. Completed items are recorded and will not be redone."
+    public string SummaryText { get; }        // report.Summary
+    public string ElapsedText { get; }        // reuse SyncPlanDialogViewModel.FormatDuration
+    public string DiscoveredText { get; }     // "N new file(s) discovered" or ""
+    public bool HasDiscoveredFiles { get; }
+    public string UnexpectedText { get; }     // "N item(s) failed unexpectedly — see the log." or ""
+    public bool HasUnexpected { get; }
+}
+```
+
+Group headers use `SyncReport.Label(kind)`.
+
+- [ ] **Step 4: Run the VM tests** — PASS.
+
+- [ ] **Step 5: The window + DialogService**
+
+`SyncReportDialog.axaml`: Title "Sync Report", `Width="560" SizeToContent="Height"` (cap with `MaxHeight="700"`, failures list inside a `ScrollViewer`). Top: `SummaryText` semibold; `PartialText` in the app's warning color (`IsVisible="{Binding IsPartial}"`); `DiscoveredText`; `UnexpectedText` warning-colored (`IsVisible="{Binding HasUnexpected}"`); `ElapsedText` dimmed. Middle: step table — `ItemsControl` over `StepRows` with a header row: Step | Planned | Processed | Succeeded | Skipped | Failed (Failed cell colored when `HasFailed`). Below (`IsVisible="{Binding HasFailures}"`): one collapsed `Expander` per `FailureGroups` entry (`Header="{Binding Header}"`), content an `ItemsControl` of `Name — Reason` rows (`FontSize="12"`, name semibold, reason dimmed, `TextWrapping="Wrap"`). Footer: a single **Close** button.
+
+Code-behind: same pattern; no result (`Close()` only). `IDialogService`:
+
+```csharp
+    /// <summary>Shows the post-run sync report.</summary>
+    Task ShowSyncReportDialogAsync(SyncReportDialogViewModel viewModel);
+```
+
+`DialogService` implementation mirrors Task 3's (marshal, construct, `await dialog.ShowDialog(_window)`).
+
+- [ ] **Step 6: Build UI (0 warnings), full suite, commit**
+
+```bash
+git add -A
+git commit -m "feat(sync): SyncReportDialog — per-step counts and grouped, expandable failures"
+```
+
+---
+
+### Task 5: Wire the flow — discover → plan → dialog → execute → stamp → report
+
+**Files:**
+- Modify: `DiffusionNexus.Domain/Services/Sync/SyncPlan.cs` (`HasWork`)
+- Modify: `DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs` (`DownloadMissingMetadataAsync` ~line 820, `DownloadMetadataForTileAsync` ~line 1555, tile-dependency construction)
+- Modify: `DiffusionNexus.UI/ViewModels/ModelTileViewModel.cs` (`IsScrollFetchDue` ~line 1400, its call site ~line 1340, `ModelTileDependencies`)
+- Test: `DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs` (rework), `DiffusionNexus.Tests/Viewer/ModelTileThumbnailTests.cs` (signature updates), `DiffusionNexus.Tests/Sync/Domain/SyncRetryPolicyTests.cs:98` area (HasWork assertion)
+
+**Interfaces:**
+- Consumes: everything Tasks 1–4 produced.
+- Produces: the final user-facing flow. Also `internal static bool ModelTileViewModel.IsScrollFetchDue(ModelImage image, DateTimeOffset now, SyncRetryPolicy policy)` (3-arg) and `ModelTileDependencies.RetryPolicyProvider` (`Func<SyncRetryPolicy>?`).
+
+The new flow, replacing the body between the guards and the catch blocks of `DownloadMissingMetadataAsync` (the guards, CTS bookkeeping, catch/finally stay as they are):
+
+1. Busy on: `BusyMessage = "Scanning source folders…"`, `SyncStatus = "Planning sync..."`; keep the existing backfill check + message.
+2. Read settings once: `var settings = await _settingsService.GetSettingsAsync(ct)`; derive `var policy = SyncRetryPolicy.FromDays(settings.SyncNotIdentifiedRetryDays, settings.SyncErrorRetryDays)`; cache it in a new field `private SyncRetryPolicy _scrollRetryPolicy = SyncRetryPolicy.Default;` (`_scrollRetryPolicy = policy;`) — the tiles' scroll gate reads this via the dependency provider.
+3. **Discovery pre-run** (so the dialog's counts include files added since startup, and the dialog needs no un-countable Discover row):
+   ```csharp
+   var discoverOptions = new SyncOptions(DiscoverOnly, RetryPolicy: policy);
+   var discoverPlan = await Task.Run(() => _librarySync.PlanAsync(SyncScope.Library, discoverOptions, ct), ct);
+   var discoverReport = await Task.Run(() => _librarySync.ExecuteAsync(discoverPlan, null, ct), ct);
+   var discovered = discoverReport.NewFilesDiscovered;
+   ```
+   with `private static readonly IReadOnlySet<SyncStepKind> DiscoverOnly = new HashSet<SyncStepKind> { SyncStepKind.DiscoverFiles };` and `private static readonly IReadOnlySet<SyncStepKind> PlannedStepKinds = new HashSet<SyncStepKind> { SyncStepKind.IdentifyModel, SyncStepKind.FetchTags, SyncStepKind.FetchImages, SyncStepKind.Thumbnails };`
+4. Plan: `var baseOptions = new SyncOptions(PlannedStepKinds, RetryPolicy: policy, ThumbnailConcurrency: settings.SyncThumbnailConcurrency);` then `PlanAsync(SyncScope.Library, baseOptions, ct)`. Log Info (`"CivitaiSync"`): `$"Plan dialog: {string.Join(" · ", plan.Steps.Select(s => $"{SyncReport.Label(s.Kind)} {s.Count}"))} · {discovered} discovered"`.
+5. Drop the overlay for the dialog (`IsBusy = false; IsCancellable = false; BusyMessage = null;`) and show it:
+   ```csharp
+   var dialogService = DialogService ?? App.Services?.GetService<IDialogService>();
+   if (dialogService is null) { SyncStatus = "Dialog service not available."; return; }
+
+   var dialogVm = new SyncPlanDialogViewModel(plan, baseOptions,
+       replanAsync: o => Task.Run(() => _librarySync.PlanAsync(SyncScope.Library, o, ct), ct),
+       settings.LastLibrarySyncAt, discovered, _logger);
+   var choice = await dialogService.ShowSyncPlanDialogAsync(dialogVm);
+   if (!choice.Confirmed || choice.Options is null)
+   {
+       SyncStatus = plan.HasWork ? "Sync cancelled — nothing was run." : UpToDateStatus;
+       _logger?.Info(LogCategory.Network, "CivitaiSync", "User cancelled at the plan dialog");
+       return;
+   }
+   ```
+6. Re-arm the overlay (`IsBusy = true; IsCancellable = true; BusyMessage = "Syncing with Civitai...";`), **re-plan with the chosen options** (`PlanAsync(SyncScope.Library, choice.Options, ct)` — cheap, and `RunStepAsync` re-selects anyway; the dialog may have been open for minutes), log the choice (`$"User started sync: steps [{string.Join(", ", choice.Options.Steps)}] forces [I:{...} T:{...} Im:{...} Th:{...}]"`), then execute with the existing `UiProgress` wiring, unchanged.
+7. After execute: if `!report.Cancelled`, `await _settingsService.UpdateLastLibrarySyncAtAsync(DateTimeOffset.UtcNow, CancellationToken.None);` (NOT `ct` — the stamp records what already happened and must survive a just-pressed Cancel).
+8. `await Task.Run(RebuildTilesFromDatabaseAsync);` once (existing), set `SyncStatus = DescribeOutcome(report)` and log it (existing), then drop the overlay explicitly (`IsBusy = false; BusyMessage = null;` — the finally re-does this harmlessly) and show the report: `await dialogService.ShowSyncReportDialogAsync(new SyncReportDialogViewModel(report, discovered));`
+9. Wrap BOTH `ExecuteAsync` calls' `InvalidOperationException` ("A library sync is already running" — thrown by the service's `Wait(0)` gate; a post-download completion sync can briefly hold the slot): catch it, set `SyncStatus = AlreadyRunningStatus`, log Info, return. Do not retry in a loop.
+10. Delete the now-satisfied comment `// Plan B replaces this with a confirmation dialog showing the same numbers.` and the old pre-run `!plan.HasWork` early return (the dialog's up-to-date state replaces it).
+
+- [ ] **Step 1: Fix `HasWork`**
+
+`SyncPlan.cs`: change to
+
+```csharp
+    /// <summary>
+    /// Whether any step has counted work. DiscoverFiles is deliberately not special-cased: its
+    /// count is always 0 (it scans, it cannot be counted in advance), so a discovery-bearing plan
+    /// must be executed on its own terms, not smuggled in as "work" here — that special case made
+    /// this property constant-true for every SyncOptions.All plan and the up-to-date branch dead.
+    /// </summary>
+    public bool HasWork => Steps.Any(s => s.Count > 0);
+```
+
+Then `Grep HasWork` across Tests + UI and fix the assertions: `DiffusionNexus.Tests/Sync/Domain/SyncRetryPolicyTests.cs:98` (read the surrounding test — if it asserts the old always-true behavior for a discovery plan, invert it into a test that a DiscoverFiles-only zero-count plan has NO counted work) and `LoraViewerViewModelSyncTests` (reworked below anyway).
+
+- [ ] **Step 2: Scroll gate takes the policy**
+
+`ModelTileViewModel.cs`:
+- `IsScrollFetchDue` (~line 1400) becomes `internal static bool IsScrollFetchDue(ModelImage image, DateTimeOffset now, SyncRetryPolicy policy) => policy.IsThumbnailDue(image.ThumbnailAttemptedAt, image.ThumbnailFailure, now, force: false);` — update its `<remarks>` to say the policy now comes from the user's settings via the tile dependencies.
+- `ModelTileDependencies` (find its declaration — grep `ModelTileDependencies`): add `public Func<SyncRetryPolicy>? RetryPolicyProvider { get; init; }` (match the type's existing property style).
+- Call site (~line 1340): `var policy = _dependencies?.RetryPolicyProvider?.Invoke() ?? SyncRetryPolicy.Default;` then pass it. (Adapt the field name to whatever the class stores its dependencies in.)
+- `LoraViewerViewModel`: where it builds `ModelTileDependencies` (grep `new ModelTileDependencies`), add `RetryPolicyProvider = () => _scrollRetryPolicy,`. Initialize `_scrollRetryPolicy` from settings in the existing startup settings-read path (the same method that first reads `IAppSettingsService` when the viewer loads — find it; if none reads full settings, add the read to the initial `RebuildTilesFromDatabaseAsync` entry path, once, not per tile).
+- Update the four `IsScrollFetchDue` call sites in `DiffusionNexus.Tests/Viewer/ModelTileThumbnailTests.cs` (lines ~238–280) to pass `SyncRetryPolicy.Default` explicitly, and add one new test: a policy with a 7-day error window makes an image due at day 8 that `Default` (1-day window would also pass — so instead use the inverse: a 7-day-old `HttpError` attempt is due under Default's 1-day window but NOT due under `SyncRetryPolicy.FromDays(30, 30)`). Assert both directions.
+
+- [ ] **Step 3: Rework the VM flow tests RED-first**
+
+`DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs` — read the whole file first; it already mocks `ILibrarySyncService`, uses `ImmediateUiScheduler`, and injects `IServiceScopeFactory`. Extend the fixture: a `Mock<IDialogService>` assigned to the VM's inherited `DialogService` property, with `ShowSyncPlanDialogAsync` returning a canned `SyncPlanDialogResult` and `ShowSyncReportDialogAsync` returning `Task.CompletedTask`. The `IAppSettingsService` mock's `GetSettingsAsync` returns an `AppSettings` with the four new defaults. New/updated tests (adapt names to the file's style):
+
+1. `BulkSync_RunsDiscoveryFirst_ThenShowsThePlanDialog` — `ExecuteAsync` is called with a DiscoverFiles-only plan BEFORE `ShowSyncPlanDialogAsync`; the dialog VM handed over carries the discovered count from that report and rows for the four kinds only.
+2. `CancellingThePlanDialog_RunsNothing` — dialog returns `Cancelled()`; `ExecuteAsync` was called exactly once (discovery); `UpdateLastLibrarySyncAtAsync` never; status is "Sync cancelled — nothing was run." (or `UpToDateStatus` for an all-zero plan — cover both).
+3. `ConfirmedOptions_AreForwardedToTheRun` — dialog returns options with `Steps = {FetchTags}` + `ForceTags = true`; the second `PlanAsync` and the executed plan carry exactly those options; `ThumbnailConcurrency` and `RetryPolicy` came from the settings mock (assert `NotIdentifiedRetryAfter == TimeSpan.FromDays(settings value)`).
+4. `ACompletedRun_StampsLastLibrarySyncAt_ACancelledRunDoesNot` — two cases via the mocked report's `Cancelled` flag; verify `UpdateLastLibrarySyncAtAsync` accordingly.
+5. `TheReportDialog_IsShownAfterTheRun` — with the report the sync mock returned, `ShowSyncReportDialogAsync` received a VM built from it.
+6. `ASecondRunningSync_IsReportedNotThrown` — `ExecuteAsync` throws `InvalidOperationException`; status becomes `AlreadyRunningStatus`, no crash, no report dialog.
+
+Run the filter → the new tests FAIL against the current flow.
+
+- [ ] **Step 4: Implement the flow** as specified in the numbered list above. Keep the catch/finally structure, `UiProgress`, `DescribeOutcome`, and the per-tile path's own status strings untouched except where named.
+
+- [ ] **Step 5: Per-tile options through settings**
+
+`DownloadMetadataForTileAsync` (~line 1575): the `new SyncOptions(...)` gains `RetryPolicy: _scrollRetryPolicy` (the cached settings-derived policy; forces already make most windows moot — this matters for the un-forced tags/images fetches). Leave `ThumbnailConcurrency` at its default (a single model's handful of images gains nothing).
+
+- [ ] **Step 6: Run the reworked tests, then the full suite** — PASS. Build UI `-c Release` → 0 warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "feat(sync): plan dialog gates the bulk sync; report dialog after; settings-driven retry windows"
+```
+
+---
+
+### Task 6: Settings UI — the "Metadata Sync" block
+
+**Files:**
+- Modify: `DiffusionNexus.UI/ViewModels/SettingsViewModel.cs`
+- Modify: `DiffusionNexus.UI/Views/SettingsView.axaml` (LoRA Viewer expander, between "Civitai Update Check" ~line 317 and "Base Model Filter" ~line 320)
+- Test: extend whichever `DiffusionNexus.Tests/ViewModels/SettingsViewModel*Tests.cs` file covers load/save round-trips (read `SettingsViewModelValidationTests.cs` and `SettingsViewModelSchedulerTests.cs` first to pick the right home; create `SettingsViewModelSyncSettingsTests.cs` if neither fits)
+
+**Interfaces:**
+- Consumes: the four `AppSettings` columns from Task 1.
+- Produces: user-editable values that Task 5's flow reads on every press of Download Metadata (no restart needed — the flow reads settings per run).
+
+- [ ] **Step 1: Failing test**
+
+Test that loading maps the three values onto the VM, that changing each sets `HasChanges`, and — **critical** — that the save path preserves `LastLibrarySyncAt`: the save command builds a `new AppSettings { ... }` object (see ~line 626), and a field it forgets is silently nulled on every settings save. Read how the save block preserves `LastBackupAt` (or whether it re-reads and mutates) and assert `LastLibrarySyncAt` survives a save the same way. If the existing test harness can drive `SaveSettingsAsync` (the scheduler/validation tests show how), write:
+
+```csharp
+    [Fact]
+    public async Task SavingSettings_PreservesLastLibrarySyncAt()
+    {
+        // arrange: settings service mock returns AppSettings { LastLibrarySyncAt = <known value>, ... };
+        // act: load VM, change SyncErrorRetryDays, invoke the save command;
+        // assert: the AppSettings instance passed to SaveSettingsAsync carries the known LastLibrarySyncAt.
+    }
+```
+
+(Replace the comment skeleton with real arrange/act/assert against the file's existing mock fixture — the fixture already exists in those test files; this is adaptation, not invention.)
+
+- [ ] **Step 2: Run — RED.**
+
+- [ ] **Step 3: ViewModel**
+
+`SettingsViewModel.cs`, mirroring the `LoraUpdateCheckStalenessDays` triple exactly (observable property + `Available…` list + `On…Changed → HasChanges` + load assignment + save assignment):
+
+```csharp
+    [ObservableProperty]
+    private int _syncNotIdentifiedRetryDays = 30;
+
+    [ObservableProperty]
+    private int _syncErrorRetryDays = 1;
+
+    [ObservableProperty]
+    private int _syncThumbnailConcurrency = 4;
+
+    /// <summary>Selectable windows (days) before a not-identified model is re-checked.</summary>
+    public IReadOnlyList<int> AvailableSyncNotIdentifiedRetryDays { get; } = new[] { 7, 14, 30, 60, 90 };
+
+    /// <summary>Selectable windows (days) before an errored attempt is retried.</summary>
+    public IReadOnlyList<int> AvailableSyncErrorRetryDays { get; } = new[] { 1, 3, 7 };
+
+    /// <summary>Parallel thumbnail downloads during a bulk sync.</summary>
+    public IReadOnlyList<int> AvailableSyncThumbnailConcurrency { get; } = new[] { 1, 2, 4, 6, 8 };
+```
+
+plus the three `partial void On…Changed(int value) => HasChanges = true;` next to the existing ones, the three load assignments in `LoadSettingsAsync`, and the three save assignments in the `new AppSettings { ... }` — **and** `LastLibrarySyncAt = <however LastBackupAt is preserved there>` (copy the existing mechanism; if `LastBackupAt` is itself dropped by that block, that is a pre-existing bug — preserve `LastLibrarySyncAt` correctly anyway and note the `LastBackupAt` finding in your report rather than fixing it unasked).
+
+- [ ] **Step 4: XAML block**
+
+Insert into the LoRA Viewer expander between the "Civitai Update Check" StackPanel and the "Base Model Filter" block, separated by the section divider used there (`<Border Height="1" Background="#40FFFFFF" Margin="0,8"/>` — copy the neighbors' exact divider markup):
+
+```xml
+                      <StackPanel Spacing="8">
+                        <TextBlock Text="Metadata Sync" FontWeight="SemiBold" FontSize="14"/>
+                        <TextBlock Text="How the bulk metadata sync retries models it could not resolve, and how many thumbnails it downloads at once. Applies from the next sync run."
+                                   FontSize="12"
+                                   Opacity="0.7"
+                                   TextWrapping="Wrap"/>
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                          <ComboBox ItemsSource="{Binding AvailableSyncNotIdentifiedRetryDays}"
+                                    SelectedItem="{Binding SyncNotIdentifiedRetryDays, Mode=TwoWay}"
+                                    Width="80"/>
+                          <TextBlock Text="Days before re-checking models Civitai did not identify" VerticalAlignment="Center"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                          <ComboBox ItemsSource="{Binding AvailableSyncErrorRetryDays}"
+                                    SelectedItem="{Binding SyncErrorRetryDays, Mode=TwoWay}"
+                                    Width="80"/>
+                          <TextBlock Text="Days before retrying failed lookups" VerticalAlignment="Center"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                          <ComboBox ItemsSource="{Binding AvailableSyncThumbnailConcurrency}"
+                                    SelectedItem="{Binding SyncThumbnailConcurrency, Mode=TwoWay}"
+                                    Width="80"/>
+                          <TextBlock Text="Thumbnail downloads in parallel" VerticalAlignment="Center"/>
+                        </StackPanel>
+                      </StackPanel>
+```
+
+(Indentation: match the neighboring blocks in the file, not this snippet.)
+
+- [ ] **Step 5: Run tests + full suite, build UI 0 warnings, commit**
+
+```bash
+git add -A
+git commit -m "feat(settings): Metadata Sync section — retry windows and thumbnail parallelism"
+```
+
+---
+
+### Task 7: Rider (`UploadThumbnailAsync` → `ThumbnailWriter`) + docs
+
+**Files:**
+- Modify: `DiffusionNexus.UI/ViewModels/ModelDetailViewModel.Editing.cs` (~lines 750–756)
+- Modify: `DiffusionNexus.UI/Doc/LoraViewer.md`
+- Modify: `docs/superpowers/specs/2026-08-21-metadata-sync-overhaul-design.md` (§5: tick WP6)
+
+**Interfaces:** consumes `ThumbnailWriter.ApplySuccess(ModelImage, ThumbnailPayload, DateTimeOffset)` + `ThumbnailPayload(byte[] Data, string MimeType, int Width, int Height)` from `DiffusionNexus.Service.Services.Sync.Thumbnails` (existing since Plan B).
+
+- [ ] **Step 1: The rider**
+
+In `UploadThumbnailAsync`, replace the four direct thumbnail-column writes (`image.ThumbnailData = data;` … `image.ThumbnailHeight = height;`) with:
+
+```csharp
+            // Plan B made ThumbnailWriter the one writer of the six thumbnail columns; this was the
+            // last path around it. Routing through it also stamps the attempt and clears any prior
+            // failure verdict — a user-uploaded image must not sit next to yesterday's "Corrupt".
+            ThumbnailWriter.ApplySuccess(image, new ThumbnailPayload(data, mime, width, height), DateTimeOffset.UtcNow);
+```
+
+Keep the cache-invalidation lines that follow (`IsLocalCacheValid = false; LocalCachePath = null; CachedAt = …`) — those are local-cache columns, not ThumbnailWriter's six. Keep `dbModel.IsUserEdited = true;`. Add the `using DiffusionNexus.Service.Services.Sync.Thumbnails;` import. If an existing test harness covers `UploadThumbnailAsync`, extend it to assert `ThumbnailFailure` is cleared and `ThumbnailAttemptedAt` stamped; if none exists (it needs the file dialog), do NOT build a harness for it — state that in your report.
+
+- [ ] **Step 2: Docs — `DiffusionNexus.UI/Doc/LoraViewer.md`**
+
+Read §4 ("Data Flow — Download Metadata") and §7 ("UI Layout") first, then:
+- Replace the line `(Plan B puts a confirmation dialog here; for now the plan is logged and started)` (~line 189) and update §4's flow diagram/steps to the real flow: button → discovery run → plan → **SyncPlanDialog** (rows, Force expander, up-to-date state with last-run stamp) → execute (chosen steps only) → `LastLibrarySyncAt` stamp → one rebuild → **SyncReportDialog** (step table + grouped failures).
+- In §4's "Retry windows" subsection (~line 381): note the windows now come from Settings → LoRA Viewer → Metadata Sync (`SyncRetryPolicy.FromDays`, floors at 1 day, `MaxErrorAttempts` fixed at 3), and that the scroll-time thumbnail gate uses the same settings-derived policy.
+- In §9's "Bulk sync — ThumbnailsStep" subsection: document the bounded parallelism (Thumbnails only, `SyncOptions.ThumbnailConcurrency`, clamp 1–8, default 4, API steps stay paced and sequential).
+- §7 UI Layout: add the two dialogs where the section lists windows/overlays.
+- Keep the doc's voice and heading style; do not renumber sections.
+
+- [ ] **Step 3: Spec bookkeeping**
+
+In `docs/superpowers/specs/2026-08-21-metadata-sync-overhaul-design.md` §5, tick WP6 (`- [x] **WP6 — UI** …`) and append `(Plan E — this branch)` the way WP5's line does.
+
+- [ ] **Step 4: Full suite + UI build, commit**
+
+```bash
+git add -A
+git commit -m "refactor(detail): route thumbnail upload through ThumbnailWriter; document the Plan E sync UI"
+```
+
+---
+
+## Verification (whole branch, after Task 7)
+
+- `dotnet test DiffusionNexus.Tests/DiffusionNexus.Tests.csproj -c Release` → 0 failures.
+- `dotnet build DiffusionNexus.UI/DiffusionNexus.UI.csproj -c Release` → 0 warnings.
+- `git diff develop --stat` — no unrelated files; no EOL-only churn on any touched file.
+- Manual smokes owed by the user (record in the PR): press Download Metadata on the reference library → dialog counts match expectation, Start runs only checked steps, report groups failures; second press → up-to-date dialog with last-run stamp and no Start; a Force from the up-to-date dialog produces counts; settings changes alter the next run's plan; cancel mid-run → partial report, next plan resumes remainder (spec §6 acceptance items 1–3, 7 — WP7 will formalize them).

--- a/docs/superpowers/specs/2026-08-21-metadata-sync-overhaul-design.md
+++ b/docs/superpowers/specs/2026-08-21-metadata-sync-overhaul-design.md
@@ -185,7 +185,7 @@ Result is written to `ModelVersion.BaseModelRaw` + `ModelSyncState.MetadataOutco
 - [x] **WP3 — Thumbnails** · `IThumbnailProvider`, CDN poster rewrite (+ online canary), `file://`/sibling handling, attempt/failure recording, corrupt-on-decode marking, one BLOB writer, bounded parallelism; step 4.
 - [x] **WP4 — Identity chain** · `SafetensorsHeaderReader` + mapping table (fixture headers), filename heuristic, sidecar signature; chain folded into `IdentifyModelStep` (no separate `IModelIdentityResolver` — the Sorter will consume the DB in a follow-up); detail view shows the source.
 - [x] **WP5 — One download path** · `ICivitaiModelDownloader`, `LoraPathBuilder` + `CollisionPolicy` moved to Service, all five callers migrated, post-download completion, `ILibraryChangeNotifier`, clones deleted (§4.4 list), `IsUserEdited` in the persister, card-handler bug, `FileHasher` casing (+ D2 data migration if approved). (Plan D — this branch)
-- [ ] **WP6 — UI** · `SyncPlanDialog`, report view, settings, Unified Console polish, docs (`Doc/LoraViewer.md`).
+- [x] **WP6 — UI** · `SyncPlanDialog`, report view, settings, Unified Console polish, docs (`Doc/LoraViewer.md`). (Plan E — this branch)
 - [ ] **WP7 — Acceptance on the reference library** (§6) + PR.
 - [ ] **Follow-up (separate PR)** — rebase #520's Sorter onto this: drop its private resolver chain, consume DB identity, then the preview-UI rework.
 


### PR DESCRIPTION
## What this is

Plan E of the metadata-sync overhaul (#521) — spec WP6, the last work package before WP7 acceptance. "Download Metadata" now shows the user what a sync will do **before** it runs, reports faithfully **after** it, and the retry windows + thumbnail parallelism are user-tunable.

Design: `docs/superpowers/specs/2026-08-21-metadata-sync-overhaul-design.md` §4.6 (decision D4: dialog, not auto-start). Plan doc: `docs/superpowers/plans/2026-08-25-metadata-sync-overhaul-E-sync-ui.md`.

## What shipped

- **SyncPlanDialog** gates the bulk sync: discovery pre-run (so counts are truthful) → plan → dialog with one checkbox row per step (count, description, estimate), a *Force re-check…* expander that re-plans live, and the all-zero state showing "Library is up to date — nothing to do" with the last-run stamp and no Start.
- **SyncReportDialog** after every started run: per-step Planned/Processed/Succeeded/Skipped/Failed table + collapsed expanders of failures grouped by step with per-item reasons — never a bare "N failed". Cancelled runs show as partial. The discovery count is folded back into the run's report so the status line, summary, and dialog all agree.
- **Settings → LoRA Viewer → Metadata Sync**: not-identified retry window (7/14/30/60/90 d, default 30), error retry window (1/3/7 d, default 1), thumbnail download parallelism (1–8, default 4). Values round-trip through settings export/import; `LastLibrarySyncAt` is machine-local and deliberately excluded from both export and the save whitelist.
- **Thumbnails-step bounded parallelism** (deferred here from Plan B): `Parallel.ForEachAsync`, clamp 1–8, Thumbnails **only** — a dedicated test pins that paced Civitai API steps can never parallelize.
- The scroll-time thumbnail gate and the per-tile button now honor the settings-derived retry policy; `SyncPlan.HasWork` fixed (was constant-true); `UploadThumbnailAsync` routed through `ThumbnailWriter` (last path around the one-writer; a user upload now clears a stale failure verdict); 4 additive `AppSettings` columns + migration + self-heal entries; `Doc/LoraViewer.md` updated.

## ⚠ Pre-existing bug found (NOT fixed here — deliberately out of scope)

**Every save from the Settings page nulls `AppSettings.LastBackupAt` in the DB.** The Settings VM never carries the field and `AppSettingsService.SaveSettingsAsync` blind-copies the null onto the tracked entity (`AppSettingsService.cs:305`). Verified real on develop; predates this branch. The new `LastLibrarySyncAt` column is protected from this bug class two ways (VM capture/replay + whitelist omission). Wants its own bugfix PR.

## Notes from the final whole-branch review (no action needed to merge)

- The downloader's post-download completion sync still builds `SyncOptions` without a `RetryPolicy` (uses `Default`) — inert in practice (a fresh model is due under any window); consistency follow-up.
- A rare race can surface "A library sync is already running." as an error in the detail panel (pre-existing WP2 behavior, caught safely).
- Old settings-export files (pre this PR) import the three new settings as their defaults — unavoidable for newly added fields.

## Verification

- 4,725 passed / 0 failed / 2 skipped (opt-in online canaries); UI + IntegrationTests build 0 warnings.
- Every task subagent-reviewed; concurrency + dialog VMs adversarially probed (replan serialization, lost-update, thread-affinity, tally integrity under parallelism — empirically, not by reading); load-bearing guards RED-verified by mutation.

## Manual smokes owed before/at merge (spec §6 items 1–3, 7 preview)

1. Press Download Metadata on the reference library → dialog counts look right; Start runs only checked steps; report groups failures.
2. Press again → up-to-date dialog with last-run stamp, no Start; a Force from that state produces counts and un-hides Start.
3. Settings changes alter the next run's plan (e.g. concurrency, windows).
4. Cancel mid-run → partial report; next plan resumes the remainder.
5. Visual: plan dialog regrows when a force un-hides rows (SizeToContent), Expander styling, report table alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)