### PR TITLE
fix(sync): unwind follow-up wave — total ExecuteAsync, repoint counting, guarded rebuilds (#535-#541)

### DIFF
--- a/DiffusionNexus.Domain/Services/IModelSyncService.cs
+++ b/DiffusionNexus.Domain/Services/IModelSyncService.cs
@@ -22,6 +22,25 @@ public record FileSyncResult
 }
 
 /// <summary>
+/// The outcome of one discovery scan (#537): what it ADDED and what it merely CHANGED. A
+/// hash-matched moved file is re-pointed at its new path in the same SaveChanges that inserts the
+/// new models — a grid-visible change that is not a new file, so it travels as its own count
+/// rather than widening "N new files discovered".
+/// </summary>
+public record DiscoveryResult
+{
+    /// <summary>Genuinely new models, created for files the database did not know.</summary>
+    public IReadOnlyList<Entities.Model> NewModels { get; init; } = [];
+
+    /// <summary>
+    /// Existing <c>ModelFile</c> rows whose path was re-pointed at a moved file (matched by size
+    /// and hash). Repoint candidates are by definition invalid-path rows — the ones the grid
+    /// hides — so a caller deciding whether the grid needs re-projecting must count these as yes.
+    /// </summary>
+    public int RepointedCount { get; init; }
+}
+
+/// <summary>
 /// Progress information for sync operations.
 /// </summary>
 public record SyncProgress
@@ -77,13 +96,15 @@ public interface IModelSyncService
     Task<IReadOnlyList<InstalledModelFile>> LoadCachedFilesAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Scans configured source folders for new safetensor files not yet in the database.
-    /// Creates minimal Model/ModelVersion/ModelFile entries for discovered files.
+    /// Scans configured source folders for model files whose paths the database does not know.
+    /// Creates minimal Model/ModelVersion/ModelFile entries for genuinely new files; a file whose
+    /// size and hash match an existing invalid-path row is a MOVE, and that row is re-pointed at
+    /// the new path instead.
     /// </summary>
     /// <param name="progress">Progress callback.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>Newly discovered models.</returns>
-    Task<IReadOnlyList<Entities.Model>> DiscoverNewFilesAsync(
+    /// <returns>What the scan added and what it changed (#537) — both are grid-visible.</returns>
+    Task<DiscoveryResult> DiscoverNewFilesAsync(
         IProgress<SyncProgress>? progress = null,
         CancellationToken cancellationToken = default);
 

--- a/DiffusionNexus.Domain/Services/Sync/SyncReport.cs
+++ b/DiffusionNexus.Domain/Services/Sync/SyncReport.cs
@@ -18,6 +18,14 @@ public sealed record SyncStepReport(SyncStepKind Kind, int Planned, int Processe
 /// The message of the first such exception, so the status line can name it without the caller
 /// digging through <see cref="Failures"/>. Null when <paramref name="UnexpectedFailures"/> is 0.
 /// </param>
+/// <param name="AbortReason">
+/// Why the run stopped early without being cancelled: an exception escaped <i>outside</i> the item
+/// loop — a step's <c>SelectAsync</c>, or the API-key read — which is a bug, not an item verdict
+/// (#535). The steps that ran are still reported (their work is committed); the steps at and after
+/// the failing one never ran, so they are absent from <paramref name="Steps"/>. Null for a run
+/// that completed or was cancelled. A caller judging "did this run cover everything it was asked
+/// to?" must treat a non-null value as no.
+/// </param>
 public sealed record SyncReport(
     SyncPlan Plan,
     IReadOnlyList<SyncStepReport> Steps,
@@ -26,16 +34,18 @@ public sealed record SyncReport(
     TimeSpan Elapsed,
     int NewFilesDiscovered,
     int UnexpectedFailures = 0,
-    string? FirstUnexpectedError = null)
+    string? FirstUnexpectedError = null,
+    string? AbortReason = null)
 {
-    public string Summary { get; } = BuildSummary(Steps, Cancelled, NewFilesDiscovered);
+    public string Summary { get; } = BuildSummary(Steps, Cancelled, NewFilesDiscovered, AbortReason is not null);
 
-    private static string BuildSummary(IReadOnlyList<SyncStepReport> steps, bool cancelled, int discovered)
+    private static string BuildSummary(IReadOnlyList<SyncStepReport> steps, bool cancelled, int discovered, bool aborted)
     {
         var parts = new List<string> { $"Discovered {discovered}" };
         foreach (var s in steps.Where(s => s.Kind != SyncStepKind.DiscoverFiles && s.Planned > 0))
             parts.Add($"{Label(s.Kind)} {s.Succeeded}/{s.Planned}");
         if (cancelled) parts.Add("(cancelled)");
+        if (aborted) parts.Add("(aborted)");
         return string.Join(" · ", parts);
     }
 

--- a/DiffusionNexus.Domain/Services/Sync/SyncReport.cs
+++ b/DiffusionNexus.Domain/Services/Sync/SyncReport.cs
@@ -26,6 +26,12 @@ public sealed record SyncStepReport(SyncStepKind Kind, int Planned, int Processe
 /// that completed or was cancelled. A caller judging "did this run cover everything it was asked
 /// to?" must treat a non-null value as no.
 /// </param>
+/// <param name="FilesRepointed">
+/// Existing rows the scan re-pointed at moved files (#537) — changed, not added, so it is not
+/// part of <paramref name="NewFilesDiscovered"/> and the "N new files discovered" wording stays
+/// honest. Repoint candidates are invalid-path rows, i.e. exactly the ones the grid hides, so a
+/// caller deciding whether to re-project the grid must treat this as a yes.
+/// </param>
 public sealed record SyncReport(
     SyncPlan Plan,
     IReadOnlyList<SyncStepReport> Steps,
@@ -35,7 +41,8 @@ public sealed record SyncReport(
     int NewFilesDiscovered,
     int UnexpectedFailures = 0,
     string? FirstUnexpectedError = null,
-    string? AbortReason = null)
+    string? AbortReason = null,
+    int FilesRepointed = 0)
 {
     public string Summary { get; } = BuildSummary(Steps, Cancelled, NewFilesDiscovered, AbortReason is not null);
 

--- a/DiffusionNexus.Service/Services/ModelFileSyncService.cs
+++ b/DiffusionNexus.Service/Services/ModelFileSyncService.cs
@@ -194,7 +194,7 @@ public class ModelFileSyncService : IModelSyncService
     }
 
     /// <inheritdoc />
-    public async Task<IReadOnlyList<Model>> DiscoverNewFilesAsync(
+    public async Task<DiscoveryResult> DiscoverNewFilesAsync(
         IProgress<SyncProgress>? progress = null,
         CancellationToken cancellationToken = default)
     {
@@ -217,7 +217,7 @@ public class ModelFileSyncService : IModelSyncService
             {
                 Phase = "No source folders configured - add folders in Settings"
             });
-            return [];
+            return new DiscoveryResult();
         }
 
         progress?.Report(new SyncProgress
@@ -268,7 +268,7 @@ public class ModelFileSyncService : IModelSyncService
 
         if (newFiles.Count == 0)
         {
-            return [];
+            return new DiscoveryResult();
         }
 
         progress?.Report(new SyncProgress
@@ -278,6 +278,7 @@ public class ModelFileSyncService : IModelSyncService
         });
 
         var newModels = new List<Model>();
+        var repointed = 0;
         var processedCount = 0;
 
         foreach (var filePath in newFiles)
@@ -299,11 +300,12 @@ public class ModelFileSyncService : IModelSyncService
 
             if (matchedFile is not null)
             {
-                // Update the existing file's path
+                // Update the existing file's path. Counted (#537): the row was stamped invalid —
+                // hidden from the grid — so this is a grid-visible change, just not a new file.
                 matchedFile.LocalPath = filePath;
                 matchedFile.IsLocalFileValid = true;
                 matchedFile.LocalFileVerifiedAt = DateTimeOffset.UtcNow;
-                // The model already exists, we just updated the path
+                repointed++;
             }
             else
             {
@@ -325,7 +327,7 @@ public class ModelFileSyncService : IModelSyncService
             TotalCount = newFiles.Count
         });
 
-        return newModels;
+        return new DiscoveryResult { NewModels = newModels, RepointedCount = repointed };
     }
 
     /// <inheritdoc />
@@ -473,7 +475,8 @@ public class ModelFileSyncService : IModelSyncService
         var cachedModels = await LoadCachedModelsAsync(cancellationToken);
 
         // Phase 2: Discover new files
-        var newModels = await DiscoverNewFilesAsync(progress, cancellationToken);
+        var discovery = await DiscoverNewFilesAsync(progress, cancellationToken);
+        var newModels = discovery.NewModels;
 
         // Phase 3: Verify existing (background - can be slow)
         _ = Task.Run(async () =>

--- a/DiffusionNexus.Service/Services/Sync/LibrarySyncService.cs
+++ b/DiffusionNexus.Service/Services/Sync/LibrarySyncService.cs
@@ -151,10 +151,15 @@ public sealed class LibrarySyncService : ILibrarySyncService
                     await RunStepAsync(step, planStep, plan, apiKey, progress, tally, ct).ConfigureAwait(false);
                 }
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {
                 // A cancelled run still reports what it managed to do — the stamps are already
                 // committed, so pretending nothing happened would only cause it to be redone.
+                //
+                // Filtered, like its item-level counterpart in ExecuteItemAsync: an OCE arriving
+                // when nobody cancelled — an HttpClient timeout, a linked token — is a step
+                // blowing up in a cancellation costume, and it falls through to the abort catch
+                // below instead of posing as "the user cancelled" (#535's door, cancellation-shaped).
                 cancelled = true;
                 _logger?.Info(LogCategory.Network, LogSource, "Library sync cancelled by the user");
             }

--- a/DiffusionNexus.Service/Services/Sync/LibrarySyncService.cs
+++ b/DiffusionNexus.Service/Services/Sync/LibrarySyncService.cs
@@ -133,6 +133,7 @@ public sealed class LibrarySyncService : ILibrarySyncService
 
         var tally = new RunTally();
         var cancelled = false;
+        string? abortReason = null;
 
         try
         {
@@ -157,12 +158,25 @@ public sealed class LibrarySyncService : ILibrarySyncService
                 cancelled = true;
                 _logger?.Info(LogCategory.Network, LogSource, "Library sync cancelled by the user");
             }
+            catch (Exception ex)
+            {
+                // R5, one level up (#535). ExecuteItemAsync already counts bugs inside items; what
+                // lands here escaped OUTSIDE the item loop — a step's SelectAsync, or the API-key
+                // read. The rule is the same: by now earlier steps' items are committed (one scope
+                // each), so letting this throw destroy the tally would report a partially-synced
+                // library as "nothing happened". The run aborts — the failing step and everything
+                // after it never runs — but what it did is returned, with the reason on the report
+                // for the caller to state out loud.
+                abortReason = $"Unexpected {ex.GetType().Name}: {ex.Message}";
+                _logger?.Error(LogCategory.Network, LogSource,
+                    "Library sync aborted: an exception escaped outside the item loop", ex);
+            }
 
             stopwatch.Stop();
 
             var syncReport = new SyncReport(
                 plan, tally.Steps, tally.Failures, cancelled, stopwatch.Elapsed, tally.Discovered,
-                tally.UnexpectedFailures, tally.FirstUnexpectedError);
+                tally.UnexpectedFailures, tally.FirstUnexpectedError, abortReason);
             _logger?.Info(LogCategory.Network, LogSource, $"Sync finished: {syncReport.Summary} in {Describe(stopwatch.Elapsed)}");
 
             return syncReport;

--- a/DiffusionNexus.Service/Services/Sync/LibrarySyncService.cs
+++ b/DiffusionNexus.Service/Services/Sync/LibrarySyncService.cs
@@ -176,7 +176,7 @@ public sealed class LibrarySyncService : ILibrarySyncService
 
             var syncReport = new SyncReport(
                 plan, tally.Steps, tally.Failures, cancelled, stopwatch.Elapsed, tally.Discovered,
-                tally.UnexpectedFailures, tally.FirstUnexpectedError, abortReason);
+                tally.UnexpectedFailures, tally.FirstUnexpectedError, abortReason, tally.Repointed);
             _logger?.Info(LogCategory.Network, LogSource, $"Sync finished: {syncReport.Summary} in {Describe(stopwatch.Elapsed)}");
 
             return syncReport;
@@ -276,7 +276,11 @@ public sealed class LibrarySyncService : ILibrarySyncService
             // In the finally, not after the loop: a cancelled step still did work, and its counts
             // are the only record that those items must not be redone.
             tally.Steps.Add(new SyncStepReport(step.Kind, planStep.Count, processed, succeeded, skipped, failed));
-            if (step is DiscoverFilesStep discoverStep) tally.Discovered = discoverStep.DiscoveredCount;
+            if (step is DiscoverFilesStep discoverStep)
+            {
+                tally.Discovered = discoverStep.DiscoveredCount;
+                tally.Repointed = discoverStep.RepointedCount;
+            }
 
             _logger?.Info(LogCategory.Network, LogSource,
                 $"{StepLabel(step.Kind)}: {succeeded} succeeded · {skipped} skipped · {failed} failed of {processed} processed");
@@ -289,6 +293,9 @@ public sealed class LibrarySyncService : ILibrarySyncService
         public List<SyncStepReport> Steps { get; } = [];
         public List<SyncFailure> Failures { get; } = [];
         public int Discovered { get; set; }
+
+        /// <summary>Rows the scan re-pointed at moved files — changed, not added (#537).</summary>
+        public int Repointed { get; set; }
 
         /// <summary>Items that failed with an exception no step claimed — bugs, counted rather than fatal (R5).</summary>
         public int UnexpectedFailures { get; set; }

--- a/DiffusionNexus.Service/Services/Sync/Steps/DiscoverFilesStep.cs
+++ b/DiffusionNexus.Service/Services/Sync/Steps/DiscoverFilesStep.cs
@@ -32,6 +32,13 @@ public sealed class DiscoverFilesStep : ISyncStep
     /// <summary>How many new models the last <see cref="ExecuteOneAsync"/> created.</summary>
     public int DiscoveredCount { get; private set; }
 
+    /// <summary>
+    /// How many existing rows the last scan re-pointed at moved files (#537). Those rows were
+    /// stamped invalid — hidden from the grid — so the report has to carry this or a repoint-only
+    /// scan reads as "nothing happened" while twelve models just became visible-in-the-database.
+    /// </summary>
+    public int RepointedCount { get; private set; }
+
     /// <inheritdoc />
     public SyncStepKind Kind => SyncStepKind.DiscoverFiles;
 
@@ -49,6 +56,7 @@ public sealed class DiscoverFilesStep : ISyncStep
     public async Task<SyncItemResult> ExecuteOneAsync(SyncItem item, string? apiKey, CancellationToken ct)
     {
         DiscoveredCount = 0;
+        RepointedCount = 0;
 
         try
         {
@@ -57,9 +65,11 @@ public sealed class DiscoverFilesStep : ISyncStep
             var sync = scope.ServiceProvider.GetRequiredService<IModelSyncService>();
 
             var discovered = await sync.DiscoverNewFilesAsync(progress: null, ct).ConfigureAwait(false);
-            DiscoveredCount = discovered.Count;
+            DiscoveredCount = discovered.NewModels.Count;
+            RepointedCount = discovered.RepointedCount;
 
-            _logger?.Info(LogCategory.FileSystem, LogSource, $"Discovered {DiscoveredCount} new model file(s)");
+            _logger?.Info(LogCategory.FileSystem, LogSource,
+                $"Discovered {DiscoveredCount} new model file(s), re-pointed {RepointedCount} moved");
             return SyncItemResult.Success;
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)

--- a/DiffusionNexus.Tests/Service/ModelFileSyncServiceDiscoveryRepointTests.cs
+++ b/DiffusionNexus.Tests/Service/ModelFileSyncServiceDiscoveryRepointTests.cs
@@ -1,0 +1,137 @@
+using System.Security.Cryptography;
+using DiffusionNexus.DataAccess;
+using DiffusionNexus.DataAccess.UnitOfWork;
+using DiffusionNexus.Domain.Entities;
+using DiffusionNexus.Domain.Enums;
+using DiffusionNexus.Domain.Services;
+using DiffusionNexus.Service.Services;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace DiffusionNexus.Tests.Service;
+
+/// <summary>
+/// Covers the MOVE half of <see cref="ModelFileSyncService.DiscoverNewFilesAsync"/> (#537): a
+/// scanned file whose size and hash match an existing invalid-path row is not a new model — the
+/// row is re-pointed at the new path. That write is committed in the same SaveChanges as the new
+/// models, and repoint candidates are by definition rows the grid hides, so the scan's result has
+/// to say it happened or a repoint-only scan reads as "nothing changed".
+/// </summary>
+public sealed class ModelFileSyncServiceDiscoveryRepointTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly ServiceProvider _serviceProvider;
+    private readonly string _root;
+
+    public ModelFileSyncServiceDiscoveryRepointTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "dn-repoint-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var services = new ServiceCollection();
+        services.AddDataAccessLayer(options => options.UseSqlite(_connection));
+        _serviceProvider = services.BuildServiceProvider();
+
+        using var scope = _serviceProvider.CreateScope();
+        var context = scope.ServiceProvider
+            .GetRequiredService<DiffusionNexus.DataAccess.Data.DiffusionNexusCoreDbContext>();
+        context.Database.EnsureCreated();
+    }
+
+    public void Dispose()
+    {
+        _serviceProvider.Dispose();
+        _connection.Dispose();
+        try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    private IAppSettingsService SettingsWithRoot()
+    {
+        var mock = new Mock<IAppSettingsService>();
+        mock.Setup(s => s.GetEnabledLoraSourcesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([_root]);
+        return mock.Object;
+    }
+
+    private string WriteFile(string name, byte[] content)
+    {
+        var path = Path.Combine(_root, name);
+        File.WriteAllBytes(path, content);
+        return path;
+    }
+
+    /// <summary>
+    /// A model whose file row still points at a path that no longer exists, stamped invalid by a
+    /// verify pass — the state a moved file leaves behind, and the state the grid hides.
+    /// </summary>
+    private async Task SeedMovedAwayModelAsync(string name, byte[] content)
+    {
+        var oldPath = Path.Combine(_root, "old", name);
+
+        var model = new Model { Name = name, Type = ModelType.LORA, Source = DataSource.LocalFile };
+        var version = new ModelVersion { Name = "v1", BaseModelRaw = "???", Model = model };
+        version.Files.Add(new ModelFile
+        {
+            FileName = name,
+            LocalPath = oldPath,
+            HashSHA256 = Convert.ToHexString(SHA256.HashData(content)),
+            FileSizeBytes = content.Length,
+            IsPrimary = true,
+            IsLocalFileValid = false,
+            LocalFileVerifiedAt = DateTimeOffset.UtcNow.AddDays(-1),
+            ModelVersion = version,
+        });
+        model.Versions.Add(version);
+
+        using var scope = _serviceProvider.CreateScope();
+        var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        await uow.Models.AddAsync(model);
+        await uow.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task ARepointOnlyScan_ReportsWhatItChangedNotJustWhatItAdded()
+    {
+        var weights = "moved model weights"u8.ToArray();
+        await SeedMovedAwayModelAsync("moved.safetensors", weights);
+        var newPath = WriteFile("moved.safetensors", weights);
+
+        using var scope = _serviceProvider.CreateScope();
+        var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var sut = new ModelFileSyncService(uow, SettingsWithRoot());
+
+        var result = await sut.DiscoverNewFilesAsync();
+
+        result.NewModels.Should().BeEmpty("the file is a move, not a new model");
+        result.RepointedCount.Should().Be(1,
+            "the row was durably re-pointed in this scan's own commit, and the caller's rebuild decision hangs on knowing it");
+
+        using var verifyScope = _serviceProvider.CreateScope();
+        var verifyUow = verifyScope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var models = await verifyUow.Models.GetModelsWithLocalFilesLightAsync();
+        var file = models.Single().Versions.Single().Files.Single();
+        file.LocalPath.Should().Be(newPath, "the premise: the repoint itself really happened");
+        file.IsLocalFileValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AScanWithGenuinelyNewFiles_DoesNotCountThemAsRepointed()
+    {
+        WriteFile("brand-new.safetensors", "new model weights"u8.ToArray());
+
+        using var scope = _serviceProvider.CreateScope();
+        var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var sut = new ModelFileSyncService(uow, SettingsWithRoot());
+
+        var result = await sut.DiscoverNewFilesAsync();
+
+        result.NewModels.Should().ContainSingle("an unknown file is a new model");
+        result.RepointedCount.Should().Be(0, "nothing moved — the two counts answer different questions");
+    }
+}

--- a/DiffusionNexus.Tests/Sync/Service/LibrarySyncServiceTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/LibrarySyncServiceTests.cs
@@ -382,6 +382,13 @@ public sealed class LibrarySyncServiceTests : IDisposable
             .WithMessage("*already running*");
         (await Record.ExceptionAsync(second)).Should().BeAssignableTo<InvalidOperationException>();
 
+        // #541. The refusal happens at the gate, BEFORE any work — the callers' entire recovery
+        // contract hangs on this ("a refused press wrote nothing", so no rebuild is owed). The
+        // two refused calls above must not have selected or executed anything: the running first
+        // call accounts for one selection (the plan's was its own) and the one blocked item.
+        identify.SelectCalls.Should().Be(2, "plan + the first run's re-selection — the refused calls selected nothing");
+        identify.Executed.Should().HaveCount(1, "only the first run's in-flight item — a refusal that follows work would silently break its callers");
+
         gate.SetResult();
         await first;
 

--- a/DiffusionNexus.Tests/Sync/Service/LibrarySyncServiceTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/LibrarySyncServiceTests.cs
@@ -486,6 +486,49 @@ public sealed class LibrarySyncServiceTests : IDisposable
         report.Steps.Single().Succeeded.Should().Be(1);
     }
 
+    /// <summary>
+    /// #535, R5 one level up. A step's <c>SelectAsync</c> runs outside the per-item try, so a
+    /// non-cancellation throw there used to escape <c>ExecuteAsync</c> entirely — with the prior
+    /// steps' per-item work already committed, the tally was discarded and no report was ever
+    /// built. The user saw only the raw exception message; the record of what HAD been synced was
+    /// gone. The escape is recorded on the report instead: the run aborts, but what it did is
+    /// still stated, and the reason travels as <see cref="SyncReport.AbortReason"/>.
+    /// </summary>
+    [Fact]
+    public async Task Execute_AThrowFromAStepsSelectionAbortsTheRunButKeepsTheReport()
+    {
+        var identify = new FakeStep(SyncStepKind.IdentifyModel)
+            .Selecting([Item(1), Item(2)])
+            .Returning(_ => SyncItemResult.Success);
+        var tags = new FakeStep(SyncStepKind.FetchTags).Selecting([Item(9)]).Returning(_ => SyncItemResult.Success);
+        // Selection #1 is plan time and must succeed; #2 is the run's re-selection, where the
+        // database is suddenly locked. (#3 is the gate-release proof at the bottom.)
+        tags.OnSelect = () => tags.SelectCalls == 2
+            ? throw new InvalidOperationException("database is locked")
+            : Task.FromResult(0);
+
+        var service = NewService([identify, tags]);
+        var plan = await service.PlanAsync(SyncScope.Library, OptionsFor(SyncStepKind.IdentifyModel, SyncStepKind.FetchTags));
+
+        var report = await service.ExecuteAsync(plan);
+
+        report.AbortReason.Should().Contain("database is locked",
+            "the escape is a bug outside the item loop and must be stated as such, not laundered into an item failure");
+        report.Cancelled.Should().BeFalse("nobody pressed Cancel");
+        report.Summary.Should().Contain("(aborted)");
+
+        var identifyReport = report.Steps.Single(s => s.Kind == SyncStepKind.IdentifyModel);
+        identifyReport.Succeeded.Should().Be(2,
+            "the two identified models are committed, and this report is the only record that they were");
+        report.Steps.Should().NotContain(s => s.Kind == SyncStepKind.FetchTags,
+            "the failing step never reached its item loop");
+
+        service.IsRunning.Should().BeFalse();
+
+        // ...and the gate really was released: the next run gets in.
+        (await service.ExecuteAsync(plan)).AbortReason.Should().BeNull();
+    }
+
     // ------------------------------------------------------ Thumbnail parallelism
 
     [Fact]

--- a/DiffusionNexus.Tests/Sync/Service/LibrarySyncServiceTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/LibrarySyncServiceTests.cs
@@ -29,6 +29,7 @@ public sealed class LibrarySyncServiceTests : IDisposable
     private readonly SqliteConnection _connection;
     private readonly ServiceProvider _serviceProvider;
     private readonly List<Model> _discovered = [];
+    private int _repointed;
 
     private const string ApiKey = "test-api-key";
 
@@ -54,7 +55,7 @@ public sealed class LibrarySyncServiceTests : IDisposable
         // resulting count back off the step for the report.
         var modelSync = new Mock<IModelSyncService>();
         modelSync.Setup(s => s.DiscoverNewFilesAsync(It.IsAny<IProgress<SyncProgress>?>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(() => _discovered);
+            .ReturnsAsync(() => new DiscoveryResult { NewModels = _discovered, RepointedCount = _repointed });
         services.AddScoped(_ => modelSync.Object);
 
         _serviceProvider = services.BuildServiceProvider();
@@ -267,6 +268,27 @@ public sealed class LibrarySyncServiceTests : IDisposable
 
         report.NewFilesDiscovered.Should().Be(7);
         report.Summary.Should().StartWith("Discovered 7");
+    }
+
+    /// <summary>
+    /// #537. The scan does two kinds of write in one commit: it ADDS models for unknown files and
+    /// RE-POINTS existing rows at moved files. Only the first was reported, so a repoint-only scan
+    /// said "discovered 0" over durable, grid-visible changes. The repoint count now travels too —
+    /// as its own number, so "N new files discovered" stays honest.
+    /// </summary>
+    [Fact]
+    public async Task Execute_ReportsRepointedFilesFromTheDiscoverStep()
+    {
+        _repointed = 12;
+
+        var discover = new DiscoverFilesStep(Scopes);
+        var service = NewService([discover]);
+        var plan = await service.PlanAsync(SyncScope.Library, OptionsFor(SyncStepKind.DiscoverFiles));
+
+        var report = await service.ExecuteAsync(plan);
+
+        report.NewFilesDiscovered.Should().Be(0, "nothing was added");
+        report.FilesRepointed.Should().Be(12, "twelve rows changed, and the caller's rebuild decision hangs on knowing that");
     }
 
     [Fact]

--- a/DiffusionNexus.Tests/Sync/Service/LibrarySyncServiceTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/LibrarySyncServiceTests.cs
@@ -558,6 +558,42 @@ public sealed class LibrarySyncServiceTests : IDisposable
         (await service.ExecuteAsync(plan)).AbortReason.Should().BeNull();
     }
 
+    /// <summary>
+    /// The outer catch's counterpart to
+    /// <see cref="Execute_ForeignTaskCanceledExceptionIsAnOrdinaryFailure"/>: an OCE escaping a
+    /// step's <c>SelectAsync</c> when nobody cancelled — an HttpClient timeout, a linked token —
+    /// is the same door #535 closed, and must abort loudly. Unfiltered, the cancellation catch
+    /// swallowed it as "the user cancelled": the Cancelled banner over a step that blew up.
+    /// </summary>
+    [Fact]
+    public async Task Execute_AForeignOceFromAStepsSelectionIsAnAbortNotACancellation()
+    {
+        using var unrelated = new CancellationTokenSource();
+        await unrelated.CancelAsync();
+
+        var identify = new FakeStep(SyncStepKind.IdentifyModel)
+            .Selecting([Item(1)])
+            .Returning(_ => SyncItemResult.Success);
+        var tags = new FakeStep(SyncStepKind.FetchTags).Selecting([Item(9)]).Returning(_ => SyncItemResult.Success);
+        // Selection #1 is plan time; #2 is the run's re-selection, where a timeout surfaces as a
+        // cancellation type carrying a token that is not the run's.
+        tags.OnSelect = () => tags.SelectCalls == 2
+            ? throw new TaskCanceledException("timeout", null, unrelated.Token)
+            : Task.FromResult(0);
+
+        var service = NewService([identify, tags]);
+        var plan = await service.PlanAsync(SyncScope.Library, OptionsFor(SyncStepKind.IdentifyModel, SyncStepKind.FetchTags));
+
+        var report = await service.ExecuteAsync(plan);
+
+        report.Cancelled.Should().BeFalse(
+            "nobody pressed Cancel — this OCE is a timeout wearing a cancellation type");
+        report.AbortReason.Should().Contain("TaskCanceledException",
+            "a step that blew up must be stated as such, not laundered into a cancellation");
+        report.Steps.Single(s => s.Kind == SyncStepKind.IdentifyModel).Succeeded.Should().Be(1,
+            "the committed work is still reported");
+    }
+
     // ------------------------------------------------------ Thumbnail parallelism
 
     [Fact]

--- a/DiffusionNexus.Tests/Sync/Service/Steps/DiscoverFilesStepTests.cs
+++ b/DiffusionNexus.Tests/Sync/Service/Steps/DiscoverFilesStepTests.cs
@@ -51,7 +51,7 @@ public sealed class DiscoverFilesStepTests
     {
         var sync = new Mock<IModelSyncService>();
         sync.Setup(s => s.DiscoverNewFilesAsync(It.IsAny<IProgress<SyncProgress>?>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([NewModel("a"), NewModel("b"), NewModel("c")]);
+            .ReturnsAsync(new DiscoveryResult { NewModels = [NewModel("a"), NewModel("b"), NewModel("c")] });
         var (step, provider) = NewStep(sync);
         using var _ = provider;
 
@@ -62,12 +62,34 @@ public sealed class DiscoverFilesStepTests
         step.DiscoveredCount.Should().Be(3);
     }
 
+    /// <summary>
+    /// #537. A repoint — a moved file hash-matched to an existing invalid-path row — is a change
+    /// the scan committed, not a new file. It travels beside the discovered count so a
+    /// repoint-only scan stops reading as "nothing happened".
+    /// </summary>
+    [Fact]
+    public async Task Execute_StoresTheRepointedCountForTheReport()
+    {
+        var sync = new Mock<IModelSyncService>();
+        sync.Setup(s => s.DiscoverNewFilesAsync(It.IsAny<IProgress<SyncProgress>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DiscoveryResult { RepointedCount = 12 });
+        var (step, provider) = NewStep(sync);
+        using var _ = provider;
+
+        var items = await step.SelectAsync(SyncScope.Library, Options(), DateTimeOffset.UtcNow, CancellationToken.None);
+        var result = await step.ExecuteOneAsync(items[0], apiKey: null, CancellationToken.None);
+
+        result.Succeeded.Should().BeTrue();
+        step.DiscoveredCount.Should().Be(0, "nothing was added");
+        step.RepointedCount.Should().Be(12, "but twelve rows changed, and the report is how anyone learns that");
+    }
+
     [Fact]
     public async Task Execute_FailureReportsTheReasonAndLeavesNoStaleCount()
     {
         var sync = new Mock<IModelSyncService>();
         sync.SetupSequence(s => s.DiscoverNewFilesAsync(It.IsAny<IProgress<SyncProgress>?>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([NewModel("a")])
+            .ReturnsAsync(new DiscoveryResult { NewModels = [NewModel("a")], RepointedCount = 2 })
             .ThrowsAsync(new IOException("source folder unavailable"));
         var (step, provider) = NewStep(sync);
         using var _ = provider;
@@ -76,12 +98,14 @@ public sealed class DiscoverFilesStepTests
 
         (await step.ExecuteOneAsync(items[0], apiKey: null, CancellationToken.None)).Succeeded.Should().BeTrue();
         step.DiscoveredCount.Should().Be(1);
+        step.RepointedCount.Should().Be(2);
 
         var failure = await step.ExecuteOneAsync(items[0], apiKey: null, CancellationToken.None);
 
         failure.Succeeded.Should().BeFalse();
         failure.FailureReason.Should().Contain("source folder unavailable");
         step.DiscoveredCount.Should().Be(0);
+        step.RepointedCount.Should().Be(0, "a failed scan may not leave the previous scan's count standing");
     }
 
     [Fact]

--- a/DiffusionNexus.Tests/ViewModels/SyncReportDialogViewModelTests.cs
+++ b/DiffusionNexus.Tests/ViewModels/SyncReportDialogViewModelTests.cs
@@ -11,12 +11,14 @@ public class SyncReportDialogViewModelTests
         IReadOnlyList<SyncStepReport> steps,
         IReadOnlyList<SyncFailure>? failures = null,
         bool cancelled = false,
-        int unexpected = 0)
+        int unexpected = 0,
+        string? abortReason = null)
     {
         var options = new SyncOptions(new HashSet<SyncStepKind> { SyncStepKind.IdentifyModel });
         var plan = new SyncPlan(SyncScope.Library, options, Array.Empty<SyncPlanStep>(), DateTimeOffset.UtcNow);
         return new SyncReport(plan, steps, failures ?? Array.Empty<SyncFailure>(), cancelled,
-            TimeSpan.FromSeconds(90), NewFilesDiscovered: 0, UnexpectedFailures: unexpected);
+            TimeSpan.FromSeconds(90), NewFilesDiscovered: 0, UnexpectedFailures: unexpected,
+            AbortReason: abortReason);
     }
 
     [Fact]
@@ -65,6 +67,23 @@ public class SyncReportDialogViewModelTests
 
         vm.IsPartial.Should().BeTrue();
         vm.PartialText.Should().Contain("Cancelled");
+    }
+
+    /// <summary>
+    /// #535. A run that aborted midway (an exception escaped outside the item loop) is partial in
+    /// the same sense a cancelled one is — the completed items are recorded — but the banner must
+    /// name the failure rather than claim anybody pressed Cancel.
+    /// </summary>
+    [Fact]
+    public void AnAbortedRun_SaysPartialAndNamesTheReason()
+    {
+        var vm = new SyncReportDialogViewModel(
+            Report(new[] { new SyncStepReport(SyncStepKind.IdentifyModel, 10, 10, 10, 0, 0) },
+                abortReason: "Unexpected InvalidOperationException: database is locked"),
+            newFilesDiscovered: 0);
+
+        vm.IsPartial.Should().BeTrue();
+        vm.PartialText.Should().Contain("database is locked").And.NotContain("Cancelled");
     }
 
     /// <summary>

--- a/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
+++ b/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
@@ -189,6 +189,7 @@ public class LoraViewerViewModelSyncTests
         string? discoverAbortReason = null,
         string? runAbortReason = null,
         int repointed = 0,
+        bool runHasNoSteps = false,
         params SyncFailure[] failures)
     {
         _sync.Setup(s => s.PlanAsync(It.IsAny<SyncScope>(), It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()))
@@ -215,7 +216,7 @@ public class LoraViewerViewModelSyncTests
                         discoverUnexpected, discoverUnexpected > 0 ? "scan: NullReferenceException" : null,
                         discoverAbortReason, repointed)
                     : ReportFor(plan, discovered: 0, cancelled, failures, runElapsed,
-                        abortReason: runAbortReason);
+                        abortReason: runAbortReason, noSteps: runHasNoSteps);
             });
     }
 
@@ -247,14 +248,18 @@ public class LoraViewerViewModelSyncTests
         int unexpected = 0,
         string? firstUnexpectedError = null,
         string? abortReason = null,
-        int repointed = 0)
+        int repointed = 0,
+        bool noSteps = false)
         => new(
             plan,
-            plan.Steps.Select(s =>
-            {
-                var failed = failures.Count(f => f.Step == s.Kind);
-                return new SyncStepReport(s.Kind, s.Count, s.Count, Math.Max(0, s.Count - failed), 0, failed);
-            }).ToList(),
+            noSteps
+                // An abort at the API-key read or the first step's selection: no step ever tallied.
+                ? []
+                : plan.Steps.Select(s =>
+                {
+                    var failed = failures.Count(f => f.Step == s.Kind);
+                    return new SyncStepReport(s.Kind, s.Count, s.Count, Math.Max(0, s.Count - failed), 0, failed);
+                }).ToList(),
             failures,
             Cancelled: cancelled,
             Elapsed: elapsed ?? TimeSpan.FromSeconds(12),
@@ -435,6 +440,27 @@ public class LoraViewerViewModelSyncTests
             "the re-pointed rows are valid again and stay invisible until the grid is re-projected");
         vm.SyncStatus.Should().Be(expectedStatus,
             "\"nothing was run\" is false once the scan has re-linked files — it is what the button just did");
+    }
+
+    /// <summary>
+    /// A scan can do both in one pass. The wording was exclusive (`if added … else if re-linked`),
+    /// so a scan that added 3 files AND re-linked 12 told the user about the 3 only — the twelve
+    /// reappeared models were back on screen unexplained, the #537 complaint one branch over.
+    /// </summary>
+    [Theory]
+    [InlineData(3, 12, "Sync cancelled — the scan added 3 new files and re-linked 12 moved files.")]
+    [InlineData(1, 1, "Sync cancelled — the scan added 1 new file and re-linked 1 moved file.")]
+    public async Task DownloadMissingMetadata_CancellingTheDialogAfterAScanThatAddedAndRelinkedStatesBoth(
+        int discovered, int repointed, string expectedStatus)
+    {
+        var vm = CreateViewModel();
+        SetupSyncService(discovered: discovered, repointed: repointed);
+        _planDialogAnswer = _ => Task.FromResult(SyncPlanDialogResult.Cancelled());
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        vm.SyncStatus.Should().Be(expectedStatus,
+            "both of the scan's writes changed what the grid shows, so both belong in the answer");
     }
 
     /// <summary>The same rebuild is owed when the flow leaves through a refusal rather than a cancel.</summary>
@@ -822,6 +848,58 @@ public class LoraViewerViewModelSyncTests
             Times.Never, "a run that died midway did not cover what the user agreed to");
         _modelSync.Verify(s => s.LoadCachedFilesAsync(It.IsAny<CancellationToken>()), Times.Once,
             "the committed work reaches the grid once — the run path's rebuild, no backstop second pass");
+    }
+
+    /// <summary>
+    /// The abort verdict must not drop the run's other bad news. The abort branch used to return
+    /// early with reason + Summary alone, skipping the ` · N failed`, ` · N moved files re-linked`
+    /// and unexpected-failure suffixes — the run where the most went wrong was the one whose
+    /// status line said the least. And Summary already carries "(aborted)", so the word appeared
+    /// twice.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_AnAbortedRunStillStatesItsFailuresAndRepoints()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService(
+            repointed: 5,
+            runAbortReason: "Unexpected InvalidOperationException: database is locked",
+            failures:
+            [
+                new SyncFailure(SyncStepKind.IdentifyModel, 1, "a.safetensors", "timeout"),
+                new SyncFailure(SyncStepKind.IdentifyModel, 2, "b.safetensors", "timeout"),
+            ]);
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        vm.SyncStatus.Should().Be(
+            "Sync aborted — Unexpected InvalidOperationException: database is locked · " +
+            "Discovered 0 · Identified 1/3 · 2 failed · 5 moved files re-linked",
+            "the abort leads, but the failures and repoints the run racked up still follow");
+        (vm.SyncStatus!.Length - vm.SyncStatus.Replace("aborted", "").Length).Should().Be("aborted".Length,
+            "the lead already says aborted; Summary's own \"(aborted)\" marker must not repeat it");
+    }
+
+    /// <summary>
+    /// A run that died before any step tallied — the API-key read, the first step's selection —
+    /// has a report whose table is empty. The status line already leads with the abort; opening a
+    /// modal dialog over an empty table on top of it says nothing the line did not. The aborted
+    /// SCAN path already behaves this way (status line only), and an abort with committed work
+    /// (non-empty steps) or scan failures still opens the dialog, per the test above.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_AnAbortBeforeAnyStepSkipsTheEmptyReportDialog()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService(
+            runAbortReason: "Unexpected InvalidOperationException: database is locked",
+            runHasNoSteps: true);
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        _reportDialogVm.Should().BeNull("there is no row the dialog could show that the status line has not already said");
+        vm.SyncStatus.Should().StartWith("Sync aborted").And.Contain("database is locked",
+            "suppressing the empty dialog must not soften the verdict");
     }
 
     /// <summary>
@@ -1431,6 +1509,35 @@ public class LoraViewerViewModelSyncTests
         var outcome = await vm.DownloadMetadataForTileAsync(CreateTile(modelId: 42));
 
         outcome.Faulted.Should().BeFalse("the run completed cleanly; \"No metadata found\" is the honest message here");
+    }
+
+    /// <summary>
+    /// #536, one notch narrower: an ordinary recorded failure — the step asked and the ask itself
+    /// failed (HTTP 500, timeout, disk error) — is a non-answer too. It is expected (the step
+    /// claimed it, so it is not an UnexpectedFailure) and it is not an abort, so it slipped past
+    /// <c>Faulted</c> and the detail view said "No metadata found on Civitai for this file." over
+    /// a transport failure. Disjointness with the honest no holds in the real step too: identify
+    /// records "checked, not on Civitai" as a success/skip, never as a failure.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMetadataForTile_AnOrdinaryFailedAskIsFaultedNotAVerdictAboutCivitai()
+    {
+        var vm = CreateViewModel();
+
+        _sync.Setup(s => s.PlanAsync(It.IsAny<SyncScope>(), It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SyncScope s, SyncOptions o, CancellationToken _) => PlanFor(s, o, IdentifyStep(1)));
+        _sync.Setup(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SyncPlan p, IProgress<LibrarySyncProgress>? _, CancellationToken _) => new SyncReport(
+                p, [new SyncStepReport(SyncStepKind.IdentifyModel, 1, 1, 0, 0, 1)],
+                [new SyncFailure(SyncStepKind.IdentifyModel, 42, "a.safetensors",
+                    "Response status code does not indicate success: 500")],
+                Cancelled: false, Elapsed: TimeSpan.Zero, NewFilesDiscovered: 0));
+
+        var outcome = await vm.DownloadMetadataForTileAsync(CreateTile(modelId: 42));
+
+        outcome.Applied.Should().BeFalse();
+        outcome.Faulted.Should().BeTrue("a failed ask is not an answer about Civitai");
+        outcome.FaultReason.Should().Contain("500", "the message must name the failure, not a verdict");
     }
 
     // -------------------------------------------------------------------------------- single flight

--- a/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
+++ b/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
@@ -186,6 +186,8 @@ public class LoraViewerViewModelSyncTests
         int discoverUnexpected = 0,
         TimeSpan? discoverElapsed = null,
         TimeSpan? runElapsed = null,
+        string? discoverAbortReason = null,
+        string? runAbortReason = null,
         params SyncFailure[] failures)
     {
         _sync.Setup(s => s.PlanAsync(It.IsAny<SyncScope>(), It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()))
@@ -209,8 +211,10 @@ public class LoraViewerViewModelSyncTests
 
                 return isDiscovery
                     ? ReportFor(plan, discovered, cancelled: false, discoverFailures ?? [], discoverElapsed,
-                        discoverUnexpected, discoverUnexpected > 0 ? "scan: NullReferenceException" : null)
-                    : ReportFor(plan, discovered: 0, cancelled, failures, runElapsed);
+                        discoverUnexpected, discoverUnexpected > 0 ? "scan: NullReferenceException" : null,
+                        discoverAbortReason)
+                    : ReportFor(plan, discovered: 0, cancelled, failures, runElapsed,
+                        abortReason: runAbortReason);
             });
     }
 
@@ -240,7 +244,8 @@ public class LoraViewerViewModelSyncTests
         IReadOnlyList<SyncFailure> failures,
         TimeSpan? elapsed = null,
         int unexpected = 0,
-        string? firstUnexpectedError = null)
+        string? firstUnexpectedError = null,
+        string? abortReason = null)
         => new(
             plan,
             plan.Steps.Select(s =>
@@ -253,7 +258,8 @@ public class LoraViewerViewModelSyncTests
             Elapsed: elapsed ?? TimeSpan.FromSeconds(12),
             NewFilesDiscovered: IsDiscovery(plan.Options) ? discovered : 0,
             UnexpectedFailures: unexpected,
-            FirstUnexpectedError: firstUnexpectedError);
+            FirstUnexpectedError: firstUnexpectedError,
+            AbortReason: abortReason);
 
     /// <summary>The report the run (not the discovery pre-run) produced, as the ViewModel saw it.</summary>
     private SyncReport RunReport() => ReportFor(_executed[^1], discovered: 0, cancelled: false, []);
@@ -396,10 +402,10 @@ public class LoraViewerViewModelSyncTests
 
     /// <summary>
     /// The same rebuild is owed when the RUN dies midway, not only when the scan added rows. Each
-    /// item commits in its own scope, and a step's SelectAsync sits outside the loop's try in
-    /// LibrarySyncService — so a DbException there escapes ExecuteAsync with, say, 200 freshly
-    /// identified models already durable. Gating the backstop on "the scan discovered something"
-    /// left all of that invisible whenever the scan itself came up empty.
+    /// item commits in its own scope, so an ExecuteAsync that escapes leaves, say, 200 freshly
+    /// identified models already durable. The real service no longer escapes (#535 made it total —
+    /// an abort comes back as a report), so what this pins is the ViewModel's own defense: a
+    /// service regression that throws again must still get the committed work onto the grid.
     /// </summary>
     [Fact]
     public async Task DownloadMissingMetadata_RebuildsWhenTheRunDiesMidway()
@@ -640,6 +646,52 @@ public class LoraViewerViewModelSyncTests
         _settings.Verify(s => s.UpdateLastLibrarySyncAtAsync(It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
             Times.Once,
             "after this run the library is as synced as four ticked boxes would have left it");
+    }
+
+    /// <summary>
+    /// #535. ExecuteAsync is total now: a throw outside its item loop comes back as
+    /// <see cref="SyncReport.AbortReason"/> instead of escaping. The flow treats that report as
+    /// what it is — a record of a run that died midway: the report dialog still opens over it and
+    /// the status line names the reason, but "last full sync" is not stamped, however completely
+    /// the kinds were ticked, because the run did not cover what the user agreed to.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_AnAbortedRunShowsItsReportAndDoesNotStampFullSync()
+    {
+        var vm = CreateViewModel();
+        _otherStepCount = 2;   // every kind has work and is ticked — without the abort this stamps
+        SetupSyncService(runAbortReason: "Unexpected InvalidOperationException: database is locked");
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        _reportDialogVm.Should().NotBeNull(
+            "what the run finished before dying is committed, and the report is the only record of it");
+        vm.SyncStatus.Should().StartWith("Sync aborted").And.Contain("database is locked",
+            "the verdict must name the failure, not read like a completed run");
+        _settings.Verify(s => s.UpdateLastLibrarySyncAtAsync(It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
+            Times.Never, "a run that died midway did not cover what the user agreed to");
+        _modelSync.Verify(s => s.LoadCachedFilesAsync(It.IsAny<CancellationToken>()), Times.Once,
+            "the committed work reaches the grid once — the run path's rebuild, no backstop second pass");
+    }
+
+    /// <summary>
+    /// #535. The scan pre-run aborting keeps the abort semantics it had when the service still
+    /// threw: the flow stops before the dialog, because a question built on counts a broken scan
+    /// produced would put the user's yes on bad numbers. (Ordinary scan failures — an unreadable
+    /// folder — still proceed and are folded into the report; an abort is a bug, not a verdict.)
+    /// </summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_AnAbortedScanStopsBeforeTheDialog()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService(discoverAbortReason: "Unexpected InvalidOperationException: database is locked");
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        _calls.Should().NotContain("plan-dialog");
+        vm.SyncStatus.Should().Be("Sync error: Unexpected InvalidOperationException: database is locked");
+        _sync.Verify(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()),
+            Times.Once, "only the scan ran; the flow stopped there exactly as it did when the scan still threw");
     }
 
     [Fact]
@@ -1100,6 +1152,69 @@ public class LoraViewerViewModelSyncTests
 
         outcome.Applied.Should().BeFalse();
         outcome.IdentifyPlanned.Should().Be(0, "nothing was asked, so nothing may be claimed about Civitai");
+    }
+
+    /// <summary>
+    /// #535/#536. ExecuteAsync is total now, so a run that dies midway reaches this path as a
+    /// report with <see cref="SyncReport.AbortReason"/> instead of an exception. That report is a
+    /// failed ask, not an answer — the outcome has to carry the fault out of the ViewModel so the
+    /// detail view can say "failed" rather than "No metadata found on Civitai for this file."
+    /// </summary>
+    [Fact]
+    public async Task DownloadMetadataForTile_AnAbortedRunIsFaultedNotAVerdictAboutCivitai()
+    {
+        var vm = CreateViewModel();
+
+        _sync.Setup(s => s.PlanAsync(It.IsAny<SyncScope>(), It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SyncScope s, SyncOptions o, CancellationToken _) => PlanFor(s, o, IdentifyStep(1)));
+        _sync.Setup(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SyncPlan p, IProgress<LibrarySyncProgress>? _, CancellationToken _) => new SyncReport(
+                p, [], [], Cancelled: false, Elapsed: TimeSpan.Zero, NewFilesDiscovered: 0,
+                AbortReason: "Unexpected InvalidOperationException: database is locked"));
+
+        var outcome = await vm.DownloadMetadataForTileAsync(CreateTile(modelId: 42));
+
+        outcome.Applied.Should().BeFalse("nothing succeeded before the run died");
+        outcome.Faulted.Should().BeTrue("a failed ask is not an answer about Civitai");
+    }
+
+    /// <summary>An item that failed with an exception no step claimed is the same kind of non-answer.</summary>
+    [Fact]
+    public async Task DownloadMetadataForTile_AnUnexpectedItemFailureIsFaultedToo()
+    {
+        var vm = CreateViewModel();
+
+        _sync.Setup(s => s.PlanAsync(It.IsAny<SyncScope>(), It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SyncScope s, SyncOptions o, CancellationToken _) => PlanFor(s, o, IdentifyStep(1)));
+        _sync.Setup(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SyncPlan p, IProgress<LibrarySyncProgress>? _, CancellationToken _) => new SyncReport(
+                p, [new SyncStepReport(SyncStepKind.IdentifyModel, 1, 1, 0, 0, 1)],
+                [new SyncFailure(SyncStepKind.IdentifyModel, 42, "a.safetensors", "Unexpected NullReferenceException: boom")],
+                Cancelled: false, Elapsed: TimeSpan.Zero, NewFilesDiscovered: 0,
+                UnexpectedFailures: 1, FirstUnexpectedError: "Unexpected NullReferenceException: boom"));
+
+        var outcome = await vm.DownloadMetadataForTileAsync(CreateTile(modelId: 42));
+
+        outcome.Applied.Should().BeFalse();
+        outcome.Faulted.Should().BeTrue("a bug in the one item that was asked about is not \"Civitai has nothing\"");
+    }
+
+    /// <summary>A genuine no — the step asked and Civitai had nothing — must NOT read as a fault.</summary>
+    [Fact]
+    public async Task DownloadMetadataForTile_AGenuineNoFromCivitaiIsNotFaulted()
+    {
+        var vm = CreateViewModel();
+
+        _sync.Setup(s => s.PlanAsync(It.IsAny<SyncScope>(), It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SyncScope s, SyncOptions o, CancellationToken _) => PlanFor(s, o, IdentifyStep(1)));
+        _sync.Setup(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SyncPlan p, IProgress<LibrarySyncProgress>? _, CancellationToken _) => new SyncReport(
+                p, [new SyncStepReport(SyncStepKind.IdentifyModel, 1, 1, 0, 1, 0)], [],
+                Cancelled: false, Elapsed: TimeSpan.Zero, NewFilesDiscovered: 0));
+
+        var outcome = await vm.DownloadMetadataForTileAsync(CreateTile(modelId: 42));
+
+        outcome.Faulted.Should().BeFalse("the run completed cleanly; \"No metadata found\" is the honest message here");
     }
 
     // -------------------------------------------------------------------------------- single flight

--- a/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
+++ b/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
@@ -188,6 +188,7 @@ public class LoraViewerViewModelSyncTests
         TimeSpan? runElapsed = null,
         string? discoverAbortReason = null,
         string? runAbortReason = null,
+        int repointed = 0,
         params SyncFailure[] failures)
     {
         _sync.Setup(s => s.PlanAsync(It.IsAny<SyncScope>(), It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()))
@@ -212,7 +213,7 @@ public class LoraViewerViewModelSyncTests
                 return isDiscovery
                     ? ReportFor(plan, discovered, cancelled: false, discoverFailures ?? [], discoverElapsed,
                         discoverUnexpected, discoverUnexpected > 0 ? "scan: NullReferenceException" : null,
-                        discoverAbortReason)
+                        discoverAbortReason, repointed)
                     : ReportFor(plan, discovered: 0, cancelled, failures, runElapsed,
                         abortReason: runAbortReason);
             });
@@ -245,7 +246,8 @@ public class LoraViewerViewModelSyncTests
         TimeSpan? elapsed = null,
         int unexpected = 0,
         string? firstUnexpectedError = null,
-        string? abortReason = null)
+        string? abortReason = null,
+        int repointed = 0)
         => new(
             plan,
             plan.Steps.Select(s =>
@@ -259,7 +261,8 @@ public class LoraViewerViewModelSyncTests
             NewFilesDiscovered: IsDiscovery(plan.Options) ? discovered : 0,
             UnexpectedFailures: unexpected,
             FirstUnexpectedError: firstUnexpectedError,
-            AbortReason: abortReason);
+            AbortReason: abortReason,
+            FilesRepointed: IsDiscovery(plan.Options) ? repointed : 0);
 
     /// <summary>The report the run (not the discovery pre-run) produced, as the ViewModel saw it.</summary>
     private SyncReport RunReport() => ReportFor(_executed[^1], discovered: 0, cancelled: false, []);
@@ -386,6 +389,31 @@ public class LoraViewerViewModelSyncTests
             "\"nothing was run\" is false once the scan has added files — it is what the button just did");
     }
 
+    /// <summary>
+    /// #537. The scan's OTHER write: a moved file hash-matched to an invalid-path row is
+    /// re-pointed, in the same commit that inserts new models — and repoint candidates are exactly
+    /// the rows the grid hides, so the twelve models just came back into the database. Gating the
+    /// rebuild on "discovered > 0" alone left them off screen behind a status line claiming
+    /// nothing was run, until a manual Refresh.
+    /// </summary>
+    [Theory]
+    [InlineData(12, "Sync cancelled — the scan re-linked 12 moved files.")]
+    [InlineData(1, "Sync cancelled — the scan re-linked 1 moved file.")]
+    public async Task DownloadMissingMetadata_CancellingTheDialogStillRebuildsAfterARepointOnlyScan(
+        int repointed, string expectedStatus)
+    {
+        var vm = CreateViewModel();
+        SetupSyncService(repointed: repointed);   // discovered: 0 — the scan only re-pointed
+        _planDialogAnswer = _ => Task.FromResult(SyncPlanDialogResult.Cancelled());
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        _modelSync.Verify(s => s.LoadCachedFilesAsync(It.IsAny<CancellationToken>()), Times.Once,
+            "the re-pointed rows are valid again and stay invisible until the grid is re-projected");
+        vm.SyncStatus.Should().Be(expectedStatus,
+            "\"nothing was run\" is false once the scan has re-linked files — it is what the button just did");
+    }
+
     /// <summary>The same rebuild is owed when the flow leaves through a refusal rather than a cancel.</summary>
     [Fact]
     public async Task DownloadMissingMetadata_RebuildsAfterTheScanEvenWhenTheRunIsRefused()
@@ -437,6 +465,23 @@ public class LoraViewerViewModelSyncTests
 
         _modelSync.Verify(s => s.LoadCachedFilesAsync(It.IsAny<CancellationToken>()), Times.Never,
             "the refusal happened at the gate, before any work — a full grid re-projection would be pure cost");
+    }
+
+    /// <summary>
+    /// #537, the completed-run half: five models just reappeared, so the verdict may not be
+    /// "Library is up to date — nothing to do" even though nothing was planned in any step.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_ARepointOnlyScanIsNotReportedAsUpToDate()
+    {
+        var vm = CreateViewModel();
+        _identifyCount = 0;              // no step has work — only the scan's repoints happened
+        SetupSyncService(repointed: 5);
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        vm.SyncStatus.Should().Contain("5 moved files re-linked",
+            "five models just came back on screen, and the status line is where the user learns why");
     }
 
     /// <summary>And exactly once when the run path already did it — the finally is a backstop, not a second pass.</summary>

--- a/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
+++ b/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
@@ -348,6 +348,29 @@ public class LoraViewerViewModelSyncTests
         vm.IsBusy.Should().BeFalse("the overlay must not come back for a run the user declined");
     }
 
+    /// <summary>
+    /// #541. The pre-run counterpart of the backstop: before the run is reached, only the scan's
+    /// own counts may owe a rebuild. With an empty scan, a cancelled dialog must cost nothing —
+    /// this pins the placement of <c>rebuildOwed = true</c> AFTER the dialog, where the run
+    /// actually starts. Hoisting it up to "the dialog has answered" (a natural reading of "the
+    /// run is confirmed") would buy a full wasted re-projection on every cancel, with no other
+    /// test failing.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_CancellingTheDialogAfterAnEmptyScanDoesNotRebuild()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService();   // discovered: 0, repointed: 0
+        _planDialogAnswer = _ => Task.FromResult(SyncPlanDialogResult.Cancelled());
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        _modelSync.Verify(s => s.LoadCachedFilesAsync(It.IsAny<CancellationToken>()), Times.Never,
+            "nothing changed in the database — a re-projection would be pure cost on every declined dialog");
+        vm.SyncStatus.Should().Be("Sync cancelled — nothing was run.",
+            "and the exit under test is the one that was actually taken");
+    }
+
     /// <summary>Closing an up-to-date dialog is not a cancellation of anything — say what is true instead.</summary>
     [Fact]
     public async Task DownloadMissingMetadata_ClosingAnUpToDateDialogSaysUpToDate()
@@ -465,6 +488,9 @@ public class LoraViewerViewModelSyncTests
 
         _modelSync.Verify(s => s.LoadCachedFilesAsync(It.IsAny<CancellationToken>()), Times.Never,
             "the refusal happened at the gate, before any work — a full grid re-projection would be pure cost");
+        vm.SyncStatus.Should().Be("A metadata sync is already running.",
+            "#541: without this the test passes vacuously — any exit before the run also never rebuilds, " +
+            "so the status proves the refusal catch (the reset under test) actually executed");
     }
 
     /// <summary>
@@ -1224,6 +1250,8 @@ public class LoraViewerViewModelSyncTests
         vm.SyncStatus.Should().Be("Dialog service not available.");
         _sync.Verify(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()),
             Times.Once, "the discovery pre-run had already happened; nothing beyond it may run unasked");
+        _modelSync.Verify(s => s.LoadCachedFilesAsync(It.IsAny<CancellationToken>()), Times.Never,
+            "#541: this door exits before the run too, and the empty scan owes no rebuild");
     }
 
     // ------------------------------------------------------------------------------ the per-tile button

--- a/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
+++ b/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
@@ -783,6 +783,70 @@ public class LoraViewerViewModelSyncTests
     }
 
     /// <summary>
+    /// #539. The run-path rebuild is a DB read at the peak of WAL contention — the run has been
+    /// writing for minutes. Unguarded, its throw landed in the generic catch: a SUCCESSFUL run's
+    /// verdict was replaced by "Sync error: …", the report dialog was skipped (the report lost),
+    /// and the finally then retried the identical rebuild anyway. A failed rebuild costs the
+    /// rebuild: the verdict stands, the report shows, and the backstop gets one deliberate retry.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_AFailedRebuildDoesNotEraseTheRunsVerdict()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService();
+        _modelSync.SetupSequence(s => s.LoadCachedFilesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("database is locked"))
+            .ReturnsAsync(Array.Empty<InstalledModelFile>());
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        _reportDialogVm.Should().NotBeNull("the run succeeded; losing its report to a grid read is out of proportion");
+        vm.SyncStatus.Should().Be(RunReport().Summary,
+            "the verdict belongs to the run, not to the rebuild that failed after it");
+        _modelSync.Verify(s => s.LoadCachedFilesAsync(It.IsAny<CancellationToken>()), Times.Exactly(2),
+            "the backstop gives the failed rebuild one deliberate retry — which here succeeds");
+    }
+
+    /// <summary>
+    /// #539/#541, the OCE door. An OperationCanceledException out of the rebuild (dispatcher
+    /// shutdown mid-swap) is a rebuild failure, not the user cancelling the sync — the shared OCE
+    /// catch used to relabel the whole successful run "Metadata sync cancelled" over it, and the
+    /// owed rebuild still had to happen.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_AnOceFromTheRebuildIsARebuildFailureNotACancelledSync()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService();
+        _modelSync.SetupSequence(s => s.LoadCachedFilesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException())
+            .ReturnsAsync(Array.Empty<InstalledModelFile>());
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        vm.SyncStatus.Should().Be(RunReport().Summary, "nobody cancelled anything");
+        _reportDialogVm.Should().NotBeNull();
+        _modelSync.Verify(s => s.LoadCachedFilesAsync(It.IsAny<CancellationToken>()), Times.Exactly(2),
+            "the backstop still owes — and delivers — the rebuild");
+    }
+
+    /// <summary>When the retry fails too, the user must learn the grid is stale — appended, not replacing the verdict.</summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_ABackstopRebuildFailureIsSaidOutLoud()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService();
+        _modelSync.Setup(s => s.LoadCachedFilesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("database is locked"));
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        vm.SyncStatus.Should().StartWith(RunReport().Summary, "the run's verdict still leads")
+            .And.Contain("grid refresh failed", "a stale grid without a word would read as lost work");
+        _reportDialogVm.Should().NotBeNull("the report itself is intact — only the grid view is behind");
+    }
+
+    /// <summary>
     /// The scan is a separate run, so the run's own report counts none of it — and a report dialog
     /// whose table says "Discovered 0" a few lines above "9 new files discovered" is arguing with
     /// itself, as is a status bar that says the same. The scan's count is folded back into the

--- a/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
+++ b/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
@@ -484,6 +484,85 @@ public class LoraViewerViewModelSyncTests
             "five models just came back on screen, and the status line is where the user learns why");
     }
 
+    /// <summary>
+    /// #540. Task.Run with an already-signalled token never invokes the delegate — an OCE at the
+    /// run's own await proves ExecuteAsync was never entered, because a cancellation INSIDE the
+    /// service comes back as a Cancelled report, not a throw. That proof licenses waiving the
+    /// owed rebuild there and only there: the shared OCE catch must not, because an OCE later in
+    /// the flow (a dispatcher dying mid-swap) can arrive after a fully durable run.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_APreStartCancelDoesNotPayForARebuild()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService();   // discovered: 0 — nothing but the never-started run could owe one
+        _throwOnExecuteCall = 2;
+        _executeThrow = new TaskCanceledException();
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        vm.SyncStatus.Should().Be("Metadata sync cancelled");
+        _modelSync.Verify(s => s.LoadCachedFilesAsync(It.IsAny<CancellationToken>()), Times.Never,
+            "the run never entered the service and the scan was empty — a full re-projection would be pure cost");
+    }
+
+    /// <summary>
+    /// #540. The backstop is a multi-second, UI-thread tile swap on a big library, and it used to
+    /// run after the finally had already dropped the overlay — while both sync buttons still
+    /// refused input. An unattributed dead zone right after a status line said the operation was
+    /// over. The overlay now stays up over the backstop and says what is happening.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMissingMetadata_TheBackstopRebuildRunsUnderTheOverlay()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService();
+        _throwOnExecuteCall = 2;
+        _executeThrow = new InvalidOperationException("database is locked");
+
+        bool? busyDuringBackstop = null;
+        string? messageDuringBackstop = null;
+        _modelSync.Setup(s => s.LoadCachedFilesAsync(It.IsAny<CancellationToken>()))
+            .Callback(() =>
+            {
+                busyDuringBackstop = vm.IsBusy;
+                messageDuringBackstop = vm.BusyMessage;
+            })
+            .ReturnsAsync(Array.Empty<InstalledModelFile>());
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        busyDuringBackstop.Should().BeTrue("a multi-second tile swap with no overlay reads as a hang");
+        messageDuringBackstop.Should().NotBeNullOrEmpty("the overlay must say what it is doing");
+        vm.IsBusy.Should().BeFalse("and it comes down when everything is finished");
+        vm.BusyMessage.Should().BeNull();
+    }
+
+    /// <summary>
+    /// #540. RefreshAsync had no CanExecute, so its button was clickable through a whole sync and
+    /// its unwind — and a press started a second full-library read whose "Loaded N models" then
+    /// overwrote the sync's verdict in the status bar. Off while a sync runs, like both sync
+    /// buttons; the detail-deleted fallback already handles CanExecute being false.
+    /// </summary>
+    [Fact]
+    public async Task Refresh_IsOffWhileASyncRuns()
+    {
+        var vm = CreateViewModel();
+        SetupSyncService();
+
+        var canRefreshDuringSync = true;
+        _planDialogAnswer = dialogVm =>
+        {
+            canRefreshDuringSync = vm.RefreshCommand.CanExecute(null);
+            return Task.FromResult(dialogVm.BuildResult());
+        };
+
+        await vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+
+        canRefreshDuringSync.Should().BeFalse("a refresh mid-sync erases the verdict and doubles the DB load");
+        vm.RefreshCommand.CanExecute(null).Should().BeTrue("and back on the moment the sync is over");
+    }
+
     /// <summary>And exactly once when the run path already did it — the finally is a backstop, not a second pass.</summary>
     [Fact]
     public async Task DownloadMissingMetadata_DoesNotRebuildTwiceWhenTheRunAlreadyDid()

--- a/DiffusionNexus.UI/Doc/LoraViewer.md
+++ b/DiffusionNexus.UI/Doc/LoraViewer.md
@@ -225,8 +225,13 @@ DownloadMissingMetadataAsync                      (every service call runs on Ta
 │      ExecuteAsync itself is TOTAL (#535): an exception escaping outside its item loop (a
 │      step's SelectAsync, the API-key read) comes back as report.AbortReason instead of
 │      throwing — the steps that ran are still reported, the failing one and everything after
-│      it never ran. An aborted run shows its report, leads the status line with
-│      "Sync aborted — {reason}", and never stamps "last full sync".
+│      it never ran. An aborted run shows its report (unless it died before ANY step tallied
+│      and has no failure rows either — an empty table says nothing the status line has not,
+│      so that one case stays on the line, like the aborted-scan path), leads the status with
+│      "Sync aborted — {reason}", and never stamps "last full sync". The service's outer
+│      cancellation catch is filtered like its item-level one: an OCE while the run's token is
+│      NOT cancelled (an HttpClient timeout escaping SelectAsync) aborts rather than posing
+│      as "cancelled by the user".
 │      An OperationCanceledException at THIS await means Task.Run never invoked the delegate
 │      (a cancellation inside the service returns a Cancelled report instead), so the scoped
 │      catch waives the owed rebuild there — and only there (#540).
@@ -252,12 +257,15 @@ DownloadMissingMetadataAsync                      (every service call runs on Ta
 │      Refresh to reload" to the status line instead of replacing the verdict.
 │
 ├── 8. SyncStatus:
-│      report.AbortReason ⇒ "Sync aborted — {reason} · {Summary}"   ← leads with the failure
-│      report.NewFilesDiscovered == 0 && report.FilesRepointed == 0 && every step Planned == 0
+│      NOT aborted && report.NewFilesDiscovered == 0 && report.FilesRepointed == 0
+│        && every step Planned == 0
 │        ⇒ "Library is up to date — nothing to do"   ← the honest verdict, from the report
 │      otherwise report.Summary (+ " · N failed" when report.Failures is non-empty)
 │        (+ " · N moved files re-linked" when report.FilesRepointed > 0)
 │        (+ " · N items failed unexpectedly (see log)" when report.UnexpectedFailures > 0)
+│      report.AbortReason ⇒ "Sync aborted — {reason} · " leads the line above (with Summary's
+│        own "(aborted)" marker dropped — the lead already says it): the run where the most
+│        went wrong keeps its failed/re-linked/unexpected suffixes
 │      (step 1's count is folded back into the run's report the moment it returns — rebuilt
 │       explicitly, never with `with`: Summary is a get-only auto-property and the record
 │       copy constructor would carry the stale one — so the status line, the report table
@@ -520,8 +528,11 @@ not-found outcomes (`NotIdentified`, `Sidecar`, `Header`, `Heuristic`, `Error`) 
 their retry windows, which is the checkbox's purpose.
 
 The method returns `TileMetadataSyncResult(Applied, Report)`: `Applied` (any step succeeded)
-tells the detail view to reload; `Faulted` (the run aborted, or items failed with exceptions no
-step claimed, #535) is checked FIRST and wins — a failed ask is not an answer, so it reads
+tells the detail view to reload; `Faulted` (the run aborted, items failed with exceptions no
+step claimed — #535 — or the ask itself failed in a way the step did claim: an HTTP 500, a
+timeout, recorded as an ordinary `SyncFailure`, #536; the honest no stays disjoint because
+identify records "checked, not on Civitai" as a completed item, never a failure) is checked
+FIRST and wins — a failed ask is not an answer, so it reads
 "Metadata download failed: {reason}" (or, when something was still applied before the failure,
 "Metadata partially refreshed — the run hit an error, see the log."); only then does
 `IdentifyPlanned` separate the two honest-no wordings — "No metadata found on Civitai for this

--- a/DiffusionNexus.UI/Doc/LoraViewer.md
+++ b/DiffusionNexus.UI/Doc/LoraViewer.md
@@ -109,7 +109,10 @@ The "+N more versions" tile badge is computed as
 
 ## 3. Data Flow — Startup / Refresh
 
-When the user opens the LoRA Viewer or clicks **Refresh**, `LoraViewerViewModel.RefreshAsync` executes:
+When the user opens the LoRA Viewer or clicks **Refresh**, `LoraViewerViewModel.RefreshAsync`
+executes. (The button is off while a metadata sync runs, #540 — its "Loaded N models" used to
+overwrite the sync verdict in the status bar; startup calls the command's `ExecuteAsync`
+directly, which does not consult `CanExecute`.)
 
 ```
 RefreshAsync
@@ -121,7 +124,9 @@ RefreshAsync
 │   │   ├── Filters out files already in DB (by LocalPath)
 │   │   ├── For each new file:
 │   │   │   ├── TryMatchByHashAndSize → if a DB record exists with same hash
-│   │   │   │   but invalid path (file was moved), update the path
+│   │   │   │   but invalid path (file was moved), update the path — counted
+│   │   │   │   as DiscoveryResult.RepointedCount (#537): a grid-visible
+│   │   │   │   change that is not a new file
 │   │   │   └── Otherwise → CreateModelFromFile:
 │   │   │       Creates Model + ModelVersion + ModelFile with:
 │   │   │         Source = LocalFile
@@ -181,10 +186,15 @@ DownloadMissingMetadataAsync                      (every service call runs on Ta
 │                                                  SQLite is synchronous, and the planning
 ├── 1. Discovery pre-run                            pass + the folder scan would otherwise
 │      Plan+Execute with steps {DiscoverFiles}      freeze the overlay and the Cancel button)
-│      → report.NewFilesDiscovered
+│      → report.NewFilesDiscovered (added) + report.FilesRepointed (moved files re-linked
+│        to existing rows the grid had hidden — changed, not added, #537)
 │      Runs BEFORE the question, and is the one step nobody is asked about: a scan cannot be
 │      counted in advance, and running it first is what lets every count below include the
 │      files it just found.
+│      A scan whose report carries AbortReason (an exception escaped outside its item loop,
+│      #535) stops the flow here with "Sync error: …" — no question gets asked over counts a
+│      broken scan produced. Ordinary scan failures (an unreadable folder) proceed and are
+│      folded into the run's report.
 │
 ├── 2. PlanAsync(SyncScope.Library, base options)
 │      steps {IdentifyModel, FetchTags, FetchImages, Thumbnails}; RetryPolicy and
@@ -205,31 +215,57 @@ DownloadMissingMetadataAsync                      (every service call runs on Ta
 │      progress → status bar: "{Label} [{index}/{total}] {currentItem}"
 │      steps run in registration order — a file must be discovered before it can be
 │      identified, and only an identified model has the ids tags/images need
-│      InvalidOperationException from the service's single-flight gate (a download's
-│      completion sync can hold it) ⇒ "A metadata sync is already running." — a "not now",
-│      not a fault: no stack trace, no retry loop. Both runs above are guarded.
+│      SyncAlreadyRunningException — the gate's OWN type, thrown at Wait(0) BEFORE any work —
+│      ⇒ "A metadata sync is already running." — a "not now", not a fault: no stack trace, no
+│      retry loop, and no rebuild owed (this press wrote nothing beyond the scan). Both runs
+│      above are guarded. Deliberately NOT a bare InvalidOperationException: a step's
+│      GetRequiredService or Single() raises that too, and catching it here laundered DI/EF
+│      regressions into "already running" — anything else falls to the generic catch and is
+│      reported as "Sync error: …" with the exception logged.
+│      ExecuteAsync itself is TOTAL (#535): an exception escaping outside its item loop (a
+│      step's SelectAsync, the API-key read) comes back as report.AbortReason instead of
+│      throwing — the steps that ran are still reported, the failing one and everything after
+│      it never ran. An aborted run shows its report, leads the status line with
+│      "Sync aborted — {reason}", and never stamps "last full sync".
+│      An OperationCanceledException at THIS await means Task.Run never invoked the delegate
+│      (a cancellation inside the service returns a Cancelled report instead), so the scoped
+│      catch waives the owed rebuild there — and only there (#540).
 │
-├── 6. UpdateLastLibrarySyncAtAsync(UtcNow)   ← only when the run was NOT cancelled, and with
-│                                        CancellationToken.None: it records what already
-│                                        happened, so a just-pressed Cancel must not lose it
+├── 6. UpdateLastLibrarySyncAtAsync(UtcNow)   ← only when the run was NOT cancelled and did
+│                                        NOT abort, and with CancellationToken.None: it
+│                                        records what already happened, so a just-pressed
+│                                        Cancel must not lose it
 │
-├── 7. RebuildTilesFromDatabaseAsync()   ← exactly once, after the run — including after a
-│                                       CANCELLED one: those models are already committed,
+├── 7. RebuildTilesFromDatabaseAsync()   ← once on this run path — including after a
+│                                       CANCELLED run: those models are already committed,
 │                                       and the run's (signalled) token is deliberately not
 │                                       passed here, or the rebuild would be skipped and the
-│                                       report thrown away with it
+│                                       report thrown away with it.
+│                                       Guarded (#539): a rebuild throw costs only the
+│                                       rebuild — the verdict and the report dialog survive,
+│                                       and the finally's backstop retries it once.
+│      The rebuild is NOT exclusive to this step: the finally block re-projects the grid on
+│      every OTHER exit that owes one (#537/#539) — the scan added or re-linked files and the
+│      dialog was cancelled, the run died and its own rebuild never ran, or this step's
+│      rebuild failed. The backstop runs under the busy overlay ("Refreshing library view…",
+│      #540), retries at most once, and a failure appends "· grid refresh failed — press
+│      Refresh to reload" to the status line instead of replacing the verdict.
 │
 ├── 8. SyncStatus:
-│      report.NewFilesDiscovered == 0 && every step Planned == 0
+│      report.AbortReason ⇒ "Sync aborted — {reason} · {Summary}"   ← leads with the failure
+│      report.NewFilesDiscovered == 0 && report.FilesRepointed == 0 && every step Planned == 0
 │        ⇒ "Library is up to date — nothing to do"   ← the honest verdict, from the report
 │      otherwise report.Summary (+ " · N failed" when report.Failures is non-empty)
+│        (+ " · N moved files re-linked" when report.FilesRepointed > 0)
 │        (+ " · N items failed unexpectedly (see log)" when report.UnexpectedFailures > 0)
 │      (step 1's count is folded back into the run's report the moment it returns — rebuilt
 │       explicitly, never with `with`: Summary is a get-only auto-property and the record
 │       copy constructor would carry the stale one — so the status line, the report table
 │       and the dialog's discovered line all say the same number)
 │
-└── 9. SyncReportDialog — per-step counts, failures grouped by step, the discovered count
+└── 9. SyncReportDialog — per-step counts, failures grouped by step, the discovered and
+       re-linked counts; the partial banner covers a cancelled run AND an aborted one
+       (naming report.AbortReason) — either way, completed items are recorded
 ```
 
 ### The steps
@@ -484,9 +520,13 @@ not-found outcomes (`NotIdentified`, `Sidecar`, `Header`, `Heuristic`, `Error`) 
 their retry windows, which is the checkbox's purpose.
 
 The method returns `TileMetadataSyncResult(Applied, Report)`: `Applied` (any step succeeded)
-tells the detail view to reload; `IdentifyPlanned` is what separates the two failure
-wordings — "No metadata found on Civitai for this file." when the step ran and found nothing,
-"Nothing to refresh for this model." when it planned nothing and therefore asked nobody.
+tells the detail view to reload; `Faulted` (the run aborted, or items failed with exceptions no
+step claimed, #535) is checked FIRST and wins — a failed ask is not an answer, so it reads
+"Metadata download failed: {reason}" (or, when something was still applied before the failure,
+"Metadata partially refreshed — the run hit an error, see the log."); only then does
+`IdentifyPlanned` separate the two honest-no wordings — "No metadata found on Civitai for this
+file." when the step ran and found nothing, "Nothing to refresh for this model." when it planned
+nothing and therefore asked nobody.
 
 **One run at a time, and the buttons say so.** The service is single-flight and *throws* on a
 second run rather than queueing it, so both ways in are switched off while one is going:
@@ -510,7 +550,9 @@ dispose the *next* run's token source, after which Cancel cancelled nothing.
 | Hash returns a version but no images | The `FetchImages` step covers it via the version endpoint |
 | Network/disk failure on one item | Recorded as a `SyncFailure` (step, model, reason) and counted in the report; the run continues |
 | `CivitaiId` already owned by another DB row | Only `CivitaiModelPageId` is set (grouping still works), warning logged |
-| A second run started while one is going | Refused before it starts: "A metadata sync is already running." (`ExecuteAsync` would throw — the service is single-flight process-wide) |
+| A second run started while one is going | Refused before it starts: "A metadata sync is already running." (`ExecuteAsync` throws `SyncAlreadyRunningException` at its gate, before any work — the service is single-flight process-wide) |
+| An exception escapes outside the item loop (a step's `SelectAsync`, the API-key read) | The run aborts but `ExecuteAsync` still returns its report (#535): completed steps are recorded, `AbortReason` names the failure, the status leads with "Sync aborted — …", and "last full sync" is not stamped |
+| The post-run grid rebuild throws | The verdict and report dialog survive (#539); the `finally` backstop retries once under the overlay, and a second failure appends "grid refresh failed — press Refresh to reload" |
 | Service not registered | Button reports "Library sync not available." |
 
 ---

--- a/DiffusionNexus.UI/Services/Download/CivitaiModelDownloader.cs
+++ b/DiffusionNexus.UI/Services/Download/CivitaiModelDownloader.cs
@@ -433,7 +433,12 @@ public sealed class CivitaiModelDownloader : ICivitaiModelDownloader
             _logger?.Debug(LogCategory.Download, LogSource, $"Step 9: completing metadata for model {modelId}");
             var options = await BuildCompletionOptionsAsync(ct).ConfigureAwait(false);
             var plan = await _librarySync.PlanAsync(SyncScope.ForModels(modelId), options, ct).ConfigureAwait(false);
-            await _librarySync.ExecuteAsync(plan, progress: null, ct).ConfigureAwait(false);
+            var report = await _librarySync.ExecuteAsync(plan, progress: null, ct).ConfigureAwait(false);
+
+            // ExecuteAsync is total now (#535): what used to surface here as an exception (and be
+            // logged by the catch below) comes back as a report. Same visibility, same non-fatality.
+            if (report.AbortReason is not null)
+                _logger?.Warn(LogCategory.Download, LogSource, $"post-download completion aborted: {report.AbortReason}");
         }
         catch (Exception ex)
         {

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -1185,8 +1185,23 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             // already committed — passing the by-then-signalled token here made Task.Run throw
             // before the rebuild, so the work landed in the database and stayed invisible in the
             // grid, and the report was swallowed by the cancellation catch below.
-            await Task.Run(RebuildTilesFromDatabaseAsync);
-            rebuilt = true;
+            //
+            // Guarded (#539): this is a DB read at the peak of WAL contention, and unguarded its
+            // throw reached the outer catches — a SUCCESSFUL run's verdict became "Sync error: …"
+            // (or, for an OCE off a dying dispatcher, "Metadata sync cancelled") and the report
+            // dialog was skipped, with the timestamp possibly already stamped. A failed rebuild
+            // costs only the rebuild: rebuilt stays false, so the finally's backstop gives it one
+            // deliberate retry — which can genuinely succeed once the post-run contention clears.
+            try
+            {
+                await Task.Run(RebuildTilesFromDatabaseAsync);
+                rebuilt = true;
+            }
+            catch (Exception ex)
+            {
+                _logger?.Warn(LogCategory.Network, "CivitaiSync",
+                    $"Grid rebuild after the run failed (the backstop will retry): {ex.Message}");
+            }
 
             var statusText = DescribeOutcome(report);
             _logger?.Info(LogCategory.Network, "CivitaiSync", statusText);
@@ -1226,10 +1241,11 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             // only by CivitaiModelDownloader, never by DiscoverFilesStep — so without this a
             // cancelled dialog leaves twelve new LoRAs in the database and none of them on screen.
             // rebuildOwed covers the doors the run path's own rebuild can leave open: that rebuild
-            // failing, and a service regression that makes ExecuteAsync escape again (#535 made it
-            // total, so an escape is a bug — but the committed work would still need showing).
-            // Guarded so a failed rebuild costs only the rebuild: the status line above already
-            // says what happened, and an exception here would replace it with a lie.
+            // failing (#539 — this retry is deliberate, and can succeed once the post-run WAL
+            // contention clears), and a service regression that makes ExecuteAsync escape again
+            // (#535 made it total, so an escape is a bug — but the committed work would still
+            // need showing). Guarded so a failed rebuild costs only the rebuild — the verdict
+            // above stands, with the staleness appended rather than replacing it.
             // BEFORE the sync-running flag drops: re-enabling the per-tile button while the tile
             // collection is mid-swap would let a fetch update a tile the rebuild is discarding.
             if ((discovered > 0 || repointed > 0 || rebuildOwed) && !rebuilt)
@@ -1241,7 +1257,8 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
                 catch (Exception ex)
                 {
                     _logger?.Warn(LogCategory.Network, "CivitaiSync",
-                        $"Grid refresh after the scan failed: {ex.Message}");
+                        $"Grid refresh after the sync failed: {ex.Message}");
+                    SyncStatus = $"{SyncStatus} · grid refresh failed — press Refresh to reload";
                 }
             }
 

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -692,9 +692,9 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
         {
             _logger?.Info(LogCategory.General, "LoraReconcile", "Background reconcile started (discover + verify)");
 
-            var (added, missing, moved) = await Task.Run(async () =>
+            var (added, repointed, missing, moved) = await Task.Run(async () =>
             {
-                var newCount = await DiscoverNewFilesAsync();
+                var discovery = await DiscoverNewFilesAsync();
                 await BackfillCivitaiModelPageIdAsync();
 
                 using var scope = App.Services!.GetRequiredService<IServiceScopeFactory>().CreateScope();
@@ -704,14 +704,16 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
                         SyncStatus = p.Phase == "Verification complete" ? null : p.Phase));
 
                 // MissingCount = files gone from disk (now filtered out of LoadCachedFilesAsync);
-                // MovedCount = files whose path changed. Either, or a new file, changes the grid.
+                // MovedCount = files whose path changed. Either, or a new file, changes the grid —
+                // and so does a row the DISCOVERY half re-pointed (#537): the verify pass then sees
+                // a valid path and counts it as merely verified, so its own MovedCount misses it.
                 var result = await syncService.VerifyAndSyncFilesAsync(progress);
-                return (newCount, result.MissingCount, result.MovedCount);
+                return (discovery.NewModels.Count, discovery.RepointedCount, result.MissingCount, result.MovedCount);
             });
 
-            var changed = added > 0 || missing > 0 || moved > 0;
+            var changed = added > 0 || repointed > 0 || missing > 0 || moved > 0;
             _logger?.Info(LogCategory.General, "LoraReconcile",
-                $"Reconcile done: {added} new, {missing} missing (deleted from disk), {moved} moved → rebuild={changed}");
+                $"Reconcile done: {added} new, {repointed} re-pointed, {missing} missing (deleted from disk), {moved} moved → rebuild={changed}");
 
             if (changed)
                 await RebuildTilesFromDatabaseAsync();
@@ -724,12 +726,12 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
     }
 
     /// <summary>
-    /// Discover new files and add them to the database. Returns the number of new models
-    /// discovered so callers can decide whether the grid needs rebuilding.
-    /// Uses a fresh DI scope so the DbContext sees the latest committed data
+    /// Discover new files and add them to the database. Returns what the scan added AND what it
+    /// changed (re-pointed moved files, #537) so callers can decide whether the grid needs
+    /// rebuilding. Uses a fresh DI scope so the DbContext sees the latest committed data
     /// (avoids duplicates when files were already persisted by other operations).
     /// </summary>
-    private async Task<int> DiscoverNewFilesAsync()
+    private async Task<DiscoveryResult> DiscoverNewFilesAsync()
     {
         try
         {
@@ -747,14 +749,14 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
                 });
             });
 
-            var newModels = await syncService.DiscoverNewFilesAsync(progress);
+            var discovery = await syncService.DiscoverNewFilesAsync(progress);
 
             Dispatcher.UIThread.Post(() =>
             {
-                SyncStatus = $"Discovered {newModels.Count} new files";
+                SyncStatus = $"Discovered {discovery.NewModels.Count} new files";
             });
 
-            return newModels.Count;
+            return discovery;
         }
         catch (Exception ex)
         {
@@ -763,7 +765,7 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
                 SyncStatus = $"Discovery error: {ex.Message}";
             });
 
-            return 0;
+            return new DiscoveryResult();
         }
     }
 
@@ -913,12 +915,16 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
 
         var ct = cts.Token;
 
-        // Both live out here because the finally needs them (F3). The scan runs before the dialog
-        // and commits new Model rows straight to the database, so the grid is stale from that
-        // moment on — and only the run path used to rebuild it. Every other exit (the user
-        // cancelling at the dialog, a missing dialog service, either single-flight refusal, the
-        // cancellation catch, the generic catch) left those rows invisible until a manual Refresh.
+        // These four live out here because the finally needs them (F3). The scan runs before the
+        // dialog and commits straight to the database — new Model rows (discovered) and re-pointed
+        // moved files (repointed, #537) — so the grid is stale from that moment on, and only the
+        // run path used to rebuild it. Every other exit (the user cancelling at the dialog, a
+        // missing dialog service, either single-flight refusal, the cancellation catch, the
+        // generic catch) left those rows invisible until a manual Refresh. rebuilt records that
+        // the run path already re-projected; rebuildOwed marks the stretch where the run itself
+        // may have committed work.
         var discovered = 0;
+        var repointed = 0;
         var rebuilt = false;
         var rebuildOwed = false;
         try
@@ -973,6 +979,7 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             }
 
             discovered = discoverReport.NewFilesDiscovered;
+            repointed = discoverReport.FilesRepointed;
 
             // ExecuteAsync is total now (#535): a throw outside its item loop comes back as
             // AbortReason instead of escaping. For the scan that keeps the abort semantics it had
@@ -1029,6 +1036,12 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
                 if (discovered > 0)
                 {
                     SyncStatus = $"Sync cancelled — the scan added {discovered} new file{(discovered == 1 ? "" : "s")}.";
+                }
+                else if (repointed > 0)
+                {
+                    // The scan's other write (#537): nothing added, but moved files were re-linked
+                    // to rows the grid had hidden — those models just came back on screen.
+                    SyncStatus = $"Sync cancelled — the scan re-linked {repointed} moved file{(repointed == 1 ? "" : "s")}.";
                 }
                 else if (discoverReport.Failures.Count > 0)
                 {
@@ -1115,7 +1128,8 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
                 discovered,
                 discoverReport.UnexpectedFailures + report.UnexpectedFailures,
                 discoverReport.FirstUnexpectedError ?? report.FirstUnexpectedError,
-                report.AbortReason);
+                report.AbortReason,
+                discoverReport.FilesRepointed + report.FilesRepointed);
 
             // "Last full sync" is what the next plan dialog tells the user about staleness, so it
             // records a run that actually finished. Deliberately CancellationToken.None: this
@@ -1218,7 +1232,7 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             // says what happened, and an exception here would replace it with a lie.
             // BEFORE the sync-running flag drops: re-enabling the per-tile button while the tile
             // collection is mid-swap would let a fetch update a tile the rebuild is discarding.
-            if ((discovered > 0 || rebuildOwed) && !rebuilt)
+            if ((discovered > 0 || repointed > 0 || rebuildOwed) && !rebuilt)
             {
                 try
                 {
@@ -1524,12 +1538,17 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
         if (report.AbortReason is not null)
             return $"Sync aborted — {report.AbortReason} · {report.Summary}";
 
-        if (report.NewFilesDiscovered == 0 && report.Steps.All(s => s.Planned == 0))
+        // Repoints veto "up to date" too (#537): models the grid had hidden just came back on
+        // screen, and this line is where the user learns why.
+        if (report.NewFilesDiscovered == 0 && report.FilesRepointed == 0 && report.Steps.All(s => s.Planned == 0))
             return UpToDateStatus;
 
         var status = report.Failures.Count > 0
             ? $"{report.Summary} · {report.Failures.Count} failed"
             : report.Summary;
+
+        if (report.FilesRepointed > 0)
+            status += $" · {SyncCopy.DescribeRepointed(report.FilesRepointed)}";
 
         if (report.UnexpectedFailures > 0)
         {

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -287,6 +287,7 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
     /// </remarks>
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(DownloadMissingMetadataCommand))]
+    [NotifyCanExecuteChangedFor(nameof(RefreshCommand))]
     private bool _isSyncRunning;
 
     /// <summary>
@@ -579,7 +580,13 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
     /// <see cref="ReconcileLibraryInBackgroundAsync"/>, which rebuilds the grid only if it
     /// finds a change (a new file appears, a deleted file drops out, a moved file relocates).
     /// </summary>
-    [RelayCommand]
+    /// <remarks>
+    /// Off while a sync runs (#540): a refresh mid-sync starts a second full-library read and its
+    /// "Loaded N models" overwrites the sync's verdict in the status bar. Startup calls it through
+    /// <c>ExecuteAsync</c>, which does not consult CanExecute, and the detail-deleted fallback
+    /// already checks it before falling back to a plain rebuild.
+    /// </remarks>
+    [RelayCommand(CanExecute = nameof(CanRefresh))]
     private async Task RefreshAsync()
     {
         // Design-time or missing services fallback
@@ -1102,6 +1109,17 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
                 ReportServiceAlreadyRunning(ex);
                 return;
             }
+            catch (OperationCanceledException)
+            {
+                // Task.Run with an already-signalled token never invokes the delegate, and a
+                // cancellation INSIDE the service comes back as a Cancelled report — so an OCE at
+                // THIS await proves the run never entered ExecuteAsync (#540). Only here is that
+                // proof available, which is why the flag is lowered in this scoped catch and never
+                // in the shared OCE catch below: an OCE later in the flow (a dispatcher dying
+                // mid-swap) can arrive after a fully durable run that still owes its rebuild.
+                rebuildOwed = false;
+                throw;
+            }
 
             // The scan was its own run; fold ALL of it back in so every projection of this button
             // press agrees. Not `with`: Summary is a get-only auto-property, and the copy
@@ -1227,9 +1245,11 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
         }
         finally
         {
-            IsBusy = false;
+            // The overlay does NOT come down yet (#540): if the backstop below has a rebuild to
+            // do, that is a multi-second UI-thread tile swap on a big library, and dropping the
+            // overlay first left it running unattributed while both sync buttons still refused
+            // input. Cancellable ends here either way — the token source is disposed next.
             IsCancellable = false;
-            BusyMessage = null;
 
             // Only the CTS this call created: clearing the field unconditionally would let a
             // late-finishing run dispose a newer run's token source out from under it.
@@ -1250,6 +1270,8 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             // collection is mid-swap would let a fetch update a tile the rebuild is discarding.
             if ((discovered > 0 || repointed > 0 || rebuildOwed) && !rebuilt)
             {
+                IsBusy = true;
+                BusyMessage = "Refreshing library view…";
                 try
                 {
                     await Task.Run(RebuildTilesFromDatabaseAsync);
@@ -1261,6 +1283,9 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
                     SyncStatus = $"{SyncStatus} · grid refresh failed — press Refresh to reload";
                 }
             }
+
+            IsBusy = false;
+            BusyMessage = null;
 
             _localSyncActive = false;
             RefreshSyncRunning();
@@ -1305,6 +1330,9 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
 
     /// <summary>Both buttons that can start a run are off while one is running — the service takes one at a time.</summary>
     private bool CanStartMetadataSync() => !IsSyncRunning;
+
+    /// <summary>The Refresh button obeys the same rule (#540) — see the remarks on <see cref="RefreshAsync"/>.</summary>
+    private bool CanRefresh() => !IsSyncRunning;
 
     /// <summary>
     /// Requests cancellation of the in-flight metadata sync. Safe no-op when idle.

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -1040,7 +1040,15 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
                 // and a Force toggle re-plans live, so an all-zero `plan` can sit behind a dialog
                 // showing 40 thumbnails. Saying "up to date" over that is a flat contradiction of
                 // the number the user was looking at a second earlier.
-                if (discovered > 0)
+                if (discovered > 0 && repointed > 0)
+                {
+                    // Both of the scan's writes in one pass — additive, not first-wins: the
+                    // re-linked models just reappeared on screen too, and dropping them here is
+                    // the #537 complaint one branch over.
+                    SyncStatus = $"Sync cancelled — the scan added {discovered} new file{(discovered == 1 ? "" : "s")}" +
+                                 $" and re-linked {repointed} moved file{(repointed == 1 ? "" : "s")}.";
+                }
+                else if (discovered > 0)
                 {
                     SyncStatus = $"Sync cancelled — the scan added {discovered} new file{(discovered == 1 ? "" : "s")}.";
                 }
@@ -1148,7 +1156,10 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
                 discovered,
                 discoverReport.UnexpectedFailures + report.UnexpectedFailures,
                 discoverReport.FirstUnexpectedError ?? report.FirstUnexpectedError,
-                report.AbortReason,
+                // The scan's term is unreachable today — an aborted scan returns early above —
+                // but if that abort is ever made non-fatal, dropping it here would lose the
+                // reason silently. The coalesce order matches the other folded fields: scan first.
+                discoverReport.AbortReason ?? report.AbortReason,
                 discoverReport.FilesRepointed + report.FilesRepointed);
 
             // "Last full sync" is what the next plan dialog tells the user about staleness, so it
@@ -1233,7 +1244,14 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             IsCancellable = false;
             BusyMessage = null;
 
-            await dialogService.ShowSyncReportDialogAsync(new SyncReportDialogViewModel(report, discovered));
+            // An abort before any step tallied — the API-key read, the first step's selection —
+            // leaves a report whose table is empty (and, unless the scan recorded failures,
+            // nothing else to show). The status line above already leads with the abort; a modal
+            // over an empty table adds nothing to it, so that one case stays on the status line —
+            // the way the aborted-scan path already behaves. Any committed work or failure row
+            // still opens the dialog.
+            if (report.AbortReason is null || report.Steps.Count > 0 || report.Failures.Count > 0)
+                await dialogService.ShowSyncReportDialogAsync(new SyncReportDialogViewModel(report, discovered));
         }
         catch (OperationCanceledException)
         {
@@ -1580,15 +1598,17 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
     private static string DescribeOutcome(SyncReport report)
     {
         // An aborted run is never "up to date", however empty its plan looked — the run died, and
-        // the verdict has to lead with that (#535). The tally still follows: what completed before
-        // the failure is committed, and this line is where the user learns both facts.
-        if (report.AbortReason is not null)
-            return $"Sync aborted — {report.AbortReason} · {report.Summary}";
-
-        // Repoints veto "up to date" too (#537): models the grid had hidden just came back on
-        // screen, and this line is where the user learns why.
-        if (report.NewFilesDiscovered == 0 && report.FilesRepointed == 0 && report.Steps.All(s => s.Planned == 0))
+        // the verdict has to lead with that (#535). Only the lead differs: the tally AND the
+        // suffixes below still follow, because the run where the most went wrong is exactly the
+        // one whose failures and repoints must not go unsaid.
+        if (report.AbortReason is null
+            && report.NewFilesDiscovered == 0 && report.FilesRepointed == 0
+            && report.Steps.All(s => s.Planned == 0))
+        {
+            // Repoints veto "up to date" too (#537): models the grid had hidden just came back on
+            // screen, and this line is where the user learns why.
             return UpToDateStatus;
+        }
 
         var status = report.Failures.Count > 0
             ? $"{report.Summary} · {report.Failures.Count} failed"
@@ -1601,6 +1621,15 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
         {
             var item = report.UnexpectedFailures == 1 ? "item" : "items";
             status += $" · {report.UnexpectedFailures} {item} failed unexpectedly (see log)";
+        }
+
+        if (report.AbortReason is not null)
+        {
+            // The lead names the abort with its reason, so Summary's own "(aborted)" marker —
+            // right for the log line and the report dialog, where Summary stands alone — would
+            // only repeat it here. The marker is Summary's last part, joined like every other.
+            status = status.Replace(" · (aborted)", string.Empty, StringComparison.Ordinal);
+            return $"Sync aborted — {report.AbortReason} · {status}";
         }
 
         return status;
@@ -2102,16 +2131,22 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             => Report?.Steps.FirstOrDefault(s => s.Kind == SyncStepKind.IdentifyModel)?.Planned ?? 0;
 
         /// <summary>
-        /// Whether the run hit a bug rather than an answer: it aborted midway
-        /// (<see cref="SyncReport.AbortReason"/>) or items failed with exceptions no step claimed
-        /// (<see cref="SyncReport.UnexpectedFailures"/>). "No metadata found on Civitai" may not
-        /// be said over this — a failed ask is not an answer (#535).
+        /// Whether the run hit a failure rather than an answer: it aborted midway
+        /// (<see cref="SyncReport.AbortReason"/>), items failed with exceptions no step claimed
+        /// (<see cref="SyncReport.UnexpectedFailures"/>), or the ask itself failed in a way the
+        /// step did claim — an HTTP 500, a timeout, a disk error recorded as an ordinary
+        /// <see cref="SyncFailure"/> (#536). "No metadata found on Civitai" may not be said over
+        /// any of these — a failed ask is not an answer (#535). The honest no keeps its case:
+        /// identify records "checked, not on Civitai" as a completed item, never as a failure,
+        /// so <see cref="SyncReport.Failures"/> and not-founds are disjoint.
         /// </summary>
         public bool Faulted
-            => Report is not null && (Report.AbortReason is not null || Report.UnexpectedFailures > 0);
+            => Report is not null
+               && (Report.AbortReason is not null || Report.UnexpectedFailures > 0 || Report.Failures.Count > 0);
 
         /// <summary>The failure to show for a <see cref="Faulted"/> outcome, best reason first.</summary>
-        public string? FaultReason => Report?.AbortReason ?? Report?.FirstUnexpectedError;
+        public string? FaultReason
+            => Report?.AbortReason ?? Report?.FirstUnexpectedError ?? Report?.Failures.FirstOrDefault()?.Reason;
     }
 
     /// <summary>

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -1104,7 +1104,9 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             }
             catch (SyncAlreadyRunningException ex)
             {
-                // The gate refused it at Wait(0), before any work — this press wrote nothing.
+                // The gate refused it at Wait(0), before any work — this press wrote nothing
+                // BEYOND THE SCAN, which is exactly why the gate keeps its discovered/repointed
+                // terms: only the run's own debt is being waived here.
                 rebuildOwed = false;
                 ReportServiceAlreadyRunning(ex);
                 return;

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -974,6 +974,20 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
 
             discovered = discoverReport.NewFilesDiscovered;
 
+            // ExecuteAsync is total now (#535): a throw outside its item loop comes back as
+            // AbortReason instead of escaping. For the scan that keeps the abort semantics it had
+            // when the service still threw — stop here, because a question built on counts a
+            // broken scan produced would put the user's yes on bad numbers. Ordinary scan failures
+            // (an unreadable folder) still proceed and are folded into the run's report below; an
+            // abort is a bug, not a verdict. The finally still rebuilds over whatever the scan
+            // committed first, via the discovered term of its gate.
+            if (discoverReport.AbortReason is not null)
+            {
+                SyncStatus = $"Sync error: {discoverReport.AbortReason}";
+                _logger?.Error(LogCategory.Network, "CivitaiSync", $"Sync scan aborted: {discoverReport.AbortReason}");
+                return;
+            }
+
             var baseOptions = new SyncOptions(
                 PlannedStepKinds, RetryPolicy: policy, ThumbnailConcurrency: settings.SyncThumbnailConcurrency);
             var plan = await Task.Run(() => _librarySync.PlanAsync(SyncScope.Library, baseOptions, ct), ct);
@@ -1054,11 +1068,13 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             var progress = new UiProgress<LibrarySyncProgress>(this, p =>
                 SyncStatus = $"{SyncReport.Label(p.Step)} [{p.Index}/{p.Total}] {p.CurrentItem}");
 
-            // From here the run may commit work — each item in its own scope — and a step's
-            // SelectAsync sits outside the loop's try in LibrarySyncService, so a non-cancellation
-            // throw there escapes ExecuteAsync with everything already durable. The finally's
-            // backstop owes a rebuild for that door too, not only for the scan's rows; the cost is
-            // one wasted rebuild when the run dies before writing anything.
+            // From here the run may commit work — each item in its own scope. ExecuteAsync is
+            // total now (#535): a run that dies midway comes back as a report with AbortReason
+            // and flows through the run path's own rebuild below. The flag still backs the
+            // finally's rebuild for the doors that remain — a run-path rebuild that fails (its
+            // local guard under #539 leaves rebuilt false), and a service regression that makes
+            // ExecuteAsync escape again. The cost is one wasted rebuild when the run dies before
+            // writing anything.
             rebuildOwed = true;
 
             SyncReport report;
@@ -1098,7 +1114,8 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
                 discoverReport.Elapsed + report.Elapsed,
                 discovered,
                 discoverReport.UnexpectedFailures + report.UnexpectedFailures,
-                discoverReport.FirstUnexpectedError ?? report.FirstUnexpectedError);
+                discoverReport.FirstUnexpectedError ?? report.FirstUnexpectedError,
+                report.AbortReason);
 
             // "Last full sync" is what the next plan dialog tells the user about staleness, so it
             // records a run that actually finished. Deliberately CancellationToken.None: this
@@ -1119,8 +1136,10 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             // Judged against the dialog's rows, not the four kinds: BuildResult drops zero-count
             // kinds from the chosen set, so demanding all four would mean a library where one step
             // legitimately has nothing to do could never stamp again. A kind with nothing to do is
-            // covered by doing nothing.
-            if (!report.Cancelled && dialogVm.Rows.All(r => r.Count == 0 || chosen.Steps.Contains(r.Kind)))
+            // covered by doing nothing. An aborted run (#535) is excluded outright: the ticked
+            // kinds say what was asked for, not what actually ran before the run died.
+            if (!report.Cancelled && report.AbortReason is null
+                && dialogVm.Rows.All(r => r.Count == 0 || chosen.Steps.Contains(r.Kind)))
             {
                 try
                 {
@@ -1192,8 +1211,9 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             // (F3). Nothing else refreshes it — ILibraryChangeNotifier.ModelDownloaded is raised
             // only by CivitaiModelDownloader, never by DiscoverFilesStep — so without this a
             // cancelled dialog leaves twelve new LoRAs in the database and none of them on screen.
-            // rebuildOwed covers the other door: a run that died midway has committed per-item
-            // work too, and gating on the scan alone left it just as invisible.
+            // rebuildOwed covers the doors the run path's own rebuild can leave open: that rebuild
+            // failing, and a service regression that makes ExecuteAsync escape again (#535 made it
+            // total, so an escape is a bug — but the committed work would still need showing).
             // Guarded so a failed rebuild costs only the rebuild: the status line above already
             // says what happened, and an exception here would replace it with a lie.
             // BEFORE the sync-running flag drops: re-enabling the per-tile button while the tile
@@ -1498,6 +1518,12 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
     /// </remarks>
     private static string DescribeOutcome(SyncReport report)
     {
+        // An aborted run is never "up to date", however empty its plan looked — the run died, and
+        // the verdict has to lead with that (#535). The tally still follows: what completed before
+        // the failure is committed, and this line is where the user learns both facts.
+        if (report.AbortReason is not null)
+            return $"Sync aborted — {report.AbortReason} · {report.Summary}";
+
         if (report.NewFilesDiscovered == 0 && report.Steps.All(s => s.Planned == 0))
             return UpToDateStatus;
 
@@ -1835,8 +1861,19 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
                 // list and repaints description/tags/images.
                 await detail.LoadAsync(tile);
                 // LoadAsync ends by clearing StatusMessage, so a successful refresh used to
-                // leave no trace at all — the bar just closed. Say what happened.
-                detail.StatusMessage = "Metadata refreshed.";
+                // leave no trace at all — the bar just closed. Say what happened — including
+                // when the run also hit a bug partway: what was applied is real, but silence
+                // about the rest would claim a complete refresh (#535).
+                detail.StatusMessage = outcome.Faulted
+                    ? "Metadata partially refreshed — the run hit an error, see the log."
+                    : "Metadata refreshed.";
+            }
+            else if (outcome.Faulted)
+            {
+                // The run hit a bug — it aborted, or the item died on an exception no step
+                // claimed. Neither is an answer from Civitai, so neither of the verdicts below
+                // may be spoken over it (#535).
+                detail.StatusMessage = $"Metadata download failed: {outcome.FaultReason}";
             }
             else
             {
@@ -1997,6 +2034,18 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
         /// </summary>
         public int IdentifyPlanned
             => Report?.Steps.FirstOrDefault(s => s.Kind == SyncStepKind.IdentifyModel)?.Planned ?? 0;
+
+        /// <summary>
+        /// Whether the run hit a bug rather than an answer: it aborted midway
+        /// (<see cref="SyncReport.AbortReason"/>) or items failed with exceptions no step claimed
+        /// (<see cref="SyncReport.UnexpectedFailures"/>). "No metadata found on Civitai" may not
+        /// be said over this — a failed ask is not an answer (#535).
+        /// </summary>
+        public bool Faulted
+            => Report is not null && (Report.AbortReason is not null || Report.UnexpectedFailures > 0);
+
+        /// <summary>The failure to show for a <see cref="Faulted"/> outcome, best reason first.</summary>
+        public string? FaultReason => Report?.AbortReason ?? Report?.FirstUnexpectedError;
     }
 
     /// <summary>

--- a/DiffusionNexus.UI/ViewModels/SyncCopy.cs
+++ b/DiffusionNexus.UI/ViewModels/SyncCopy.cs
@@ -27,6 +27,18 @@ internal static class SyncCopy
     };
 
     /// <summary>
+    /// The scan's other write (#537): existing rows re-pointed at moved files — changed, not
+    /// added, which is why it is not folded into <see cref="DescribeDiscovered"/>. Empty when
+    /// none, for the same hide-the-line reason.
+    /// </summary>
+    public static string DescribeRepointed(int count) => count switch
+    {
+        <= 0 => "",
+        1 => "1 moved file re-linked",
+        _ => $"{count} moved files re-linked",
+    };
+
+    /// <summary>
     /// A predicted duration: "~45 s" under 90 s, "~4 min" under 90 min, else "~1.5 h". The tilde
     /// is load-bearing — this is what a run is expected to take, not what one took.
     /// </summary>

--- a/DiffusionNexus.UI/ViewModels/SyncReportDialogViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/SyncReportDialogViewModel.cs
@@ -64,8 +64,12 @@ public sealed class SyncReportDialogViewModel
             .ToList();
         HasFailures = FailureGroups.Count > 0;
 
-        IsPartial = report.Cancelled;
-        PartialText = "Cancelled — partial run. Completed items are recorded and will not be redone.";
+        // An aborted run (#535) is partial in the same sense a cancelled one is — the completed
+        // items are recorded — but the banner names the failure instead of claiming a Cancel.
+        IsPartial = report.Cancelled || report.AbortReason is not null;
+        PartialText = report.AbortReason is not null
+            ? $"Aborted — {report.AbortReason}. Completed items are recorded and will not be redone."
+            : "Cancelled — partial run. Completed items are recorded and will not be redone.";
 
         SummaryText = report.Summary;
         // The exact formatter, not the plan dialog's estimate one: this is a measurement, and a

--- a/DiffusionNexus.UI/ViewModels/SyncReportDialogViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/SyncReportDialogViewModel.cs
@@ -79,6 +79,9 @@ public sealed class SyncReportDialogViewModel
         HasDiscoveredFiles = newFilesDiscovered > 0;
         DiscoveredText = SyncCopy.DescribeDiscovered(newFilesDiscovered);
 
+        HasRepointedFiles = report.FilesRepointed > 0;
+        RepointedText = SyncCopy.DescribeRepointed(report.FilesRepointed);
+
         HasUnexpected = report.UnexpectedFailures > 0;
         UnexpectedText = report.UnexpectedFailures switch
         {
@@ -97,6 +100,8 @@ public sealed class SyncReportDialogViewModel
     public string ElapsedText { get; }
     public string DiscoveredText { get; }
     public bool HasDiscoveredFiles { get; }
+    public string RepointedText { get; }
+    public bool HasRepointedFiles { get; }
     public string UnexpectedText { get; }
     public bool HasUnexpected { get; }
 

--- a/DiffusionNexus.UI/Views/Dialogs/SyncReportDialog.axaml
+++ b/DiffusionNexus.UI/Views/Dialogs/SyncReportDialog.axaml
@@ -36,6 +36,13 @@
                Foreground="#CCCCCC"
                TextWrapping="Wrap"/>
 
+    <!-- The scan's other write (#537): moved files re-linked to rows the grid had hidden -->
+    <TextBlock Text="{Binding RepointedText}"
+               IsVisible="{Binding HasRepointedFiles}"
+               FontSize="12"
+               Foreground="#CCCCCC"
+               TextWrapping="Wrap"/>
+
     <TextBlock Text="{Binding UnexpectedText}"
                IsVisible="{Binding HasUnexpected}"
                FontSize="12"


### PR DESCRIPTION
The seven follow-ups filed out of the `608b9643` review (PR #530), fixed as one wave — the root cause first, then everything that hung off it. TDD throughout: every behavioral change has a test that was watched failing for the documented reason first (or was perturbation-verified where the pin landed with the fix), one commit per issue.

Closes #535, closes #536, closes #537, closes #538, closes #539, closes #540, closes #541.

## #535 — `ExecuteAsync` is total (root cause) · `e69fb417`

A step's `SelectAsync` and the API-key read sat outside the per-item try, so a non-cancellation throw there escaped with prior steps' per-item work already committed — tally discarded, no report, only `Sync error: <message>`. The R5 rule now holds one level up: the escape is caught, logged at Error with the exception, and returned as **`SyncReport.AbortReason`**. Steps that ran are reported; the failing one and everything after it never runs.

Consumer decisions (the issue's caveats):
- **Aborted scan** keeps its old semantics — the flow stops before the plan dialog ("Sync error: …") rather than asking a question over counts a broken scan produced. Ordinary scan failures still proceed and fold into the report.
- **Aborted run** shows its report dialog (partial banner names the reason), rebuilds on the run path, leads the status with `Sync aborted — {reason}`, and **never stamps "last full sync"** — the ticked kinds say what was asked, not what ran. (Without this, the stamp condition — which judges the dialog's rows against the chosen kinds — would have stamped a run that died at step one.)
- `rebuildOwed` **stays** (caveat 3): it now answers for a failing run-path rebuild and for any service regression that escapes again.
- Downloader completion sync logs the abort it used to learn from its catch.

## #536 — per-tile path · covered by #535, pinned · `e69fb417`

The run returns instead of throwing, so `tile.RefreshModelData` / `detail.LoadAsync` now happen for whatever succeeded before the failure. `TileMetadataSyncResult.Faulted` (abort or unexpected item failures) is consulted **before** the verdict wordings: "Metadata download failed: {reason}" instead of laundering a bug into *"No metadata found on Civitai for this file."* — and an applied-but-faulted run says "partially refreshed" instead of claiming completeness. A genuine no from Civitai stays un-faulted (pinned).

## #537 — repoint-only scans count as changes · `7a23a523`

`DiscoverNewFilesAsync` now returns `DiscoveryResult { NewModels, RepointedCount }`; the repoint count travels `DiscoverFilesStep.RepointedCount` → `SyncReport.FilesRepointed`. As directed, `discovered` was **not** widened — "N new files discovered" stays honest:
- backstop gate is `(discovered > 0 || repointed > 0 || rebuildOwed) && !rebuilt`,
- cancelled dialog: *"Sync cancelled — the scan re-linked N moved files."*,
- completed run: appends *"N moved files re-linked"* and never claims *up to date* over reappeared models,
- report dialog shows the re-linked line; the real-filesystem test proves the count against an actual moved file matched by hash+size.
- Bonus, same hole: the background reconcile's rebuild decision now consults the discovery half's repoints too (the verify pass counts an already-repointed row as merely verified).

## #539 — a failing rebuild degrades instead of lying · `a0380f3c`

The run-path rebuild is guarded: a throw (including an OCE off a dying dispatcher — previously relabeled "Metadata sync cancelled") costs only the rebuild. The verdict and the report dialog survive, and the finally backstop becomes the **deliberate single retry**, which can succeed once post-run WAL contention clears. If the retry fails too: *"· grid refresh failed — press Refresh to reload"* is appended to the verdict, not written over it.

## #540 — unwind polish · `e164b1ca`

1. **Pre-start cancel**: a scoped OCE catch on the run's own `Task.Run` lowers `rebuildOwed` and rethrows — an OCE at that await proves the delegate never ran (a cancellation inside the service returns a Cancelled report). Deliberately **not** in the shared OCE catch, exactly as the issue prescribed.
2. **Attributed backstop**: the overlay now stays up over the backstop ("Refreshing library view…") and drops after it — no more multi-second unattributed tile swap with the sync buttons refusing input. `_localSyncActive` still drops last (the per-tile mid-swap rule is untouched).
3. **Refresh guard**: `RefreshCommand` gets `CanExecute = !IsSyncRunning` — its "Loaded N models" can no longer erase the sync verdict mid-flow. Startup still refreshes (`ExecuteAsync` bypasses CanExecute); the detail-deleted fallback already checked it.

## #541 — the unpinned contracts, pinned · `9304b992` (+ pins in #539/#540 commits)

- `Execute_IsSingleFlight` asserts the refused calls **selected nothing and executed nothing** — the zero-work contract the VM's `rebuildOwed` reset hangs on.
- The refused-run VM test asserts the "already running" status, closing its vacuous-pass hole.
- The pre-run no-rebuild door is pinned where it would regress (cancelled dialog after empty scan) — **perturbation-verified**: hoisting `rebuildOwed = true` to just after the dialog answer fails exactly that test. The missing-dialog-service door asserts the same.
- OCE doors: pre-start-cancel-waives-rebuild (#540 commit) and OCE-from-rebuild-is-not-a-cancelled-sync (#539 commit); the cooperative-cancel rebuild was already pinned.

## #538 — docs teach the current contract · `655ff7e2`

`Doc/LoraViewer.md` step 5 taught the removed `InvalidOperationException` gate contract (the exact misdirection that would re-launder DI regressions into "already running"), step 7 claimed the rebuild runs "exactly once". Both rewritten for the post-wave contract (gate type + why, total ExecuteAsync, repoints, guarded rebuild + backstop, Refresh guard, per-tile Faulted-first rule), plus the fallbacks table rows and the two comment nits (the local-count comment was fixed when #537 grew the group; the refusal catch now says "wrote nothing **beyond the scan**" and why that matters).

## Verification

- Full suite **4,803 passed / 0 failed / 2 skipped** (+21 new tests) at `655ff7e2`; IntegrationTests 2/2; UI builds with 0 warnings.
- Every RED was watched failing for the documented reason (mock throw escaping `ExecuteAsync` at the real line, verdict replaced by "Sync error:", report dialog null, repoint count 0, overlay down during backstop, Refresh enabled mid-sync, …); pins that landed with their fix were perturbation-verified (gate terms removed → exactly the new tests fail; `rebuildOwed` hoisted → exactly the door pin fails).
- Tests ran `-c Debug` locally (the running app instance file-locks `bin\Release`); CI runs Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
