### PR TITLE
fix: preserve LastBackupAt across Settings saves (#531) + friendly per-tile sync refusal (#532)

### DIFF
--- a/DiffusionNexus.Service/Services/AppSettingsService.cs
+++ b/DiffusionNexus.Service/Services/AppSettingsService.cs
@@ -302,7 +302,13 @@ public sealed class AppSettingsService : IAppSettingsService
         existingSettings.AutoBackupIntervalHours = settings.AutoBackupIntervalHours;
         existingSettings.AutoBackupLocation = settings.AutoBackupLocation;
         existingSettings.MaxBackups = settings.MaxBackups;
-        existingSettings.LastBackupAt = settings.LastBackupAt;
+        // LastBackupAt is deliberately NOT copied (#531). It is machine-local bookkeeping written
+        // only by UpdateLastBackupAtAsync, and nothing that builds one of these detached snapshots
+        // — the Settings page, SettingsExportService.ImportAsync — has a value for it to carry, so
+        // copying it here wrote the CLR default null over the real stamp on every save: the backup
+        // scheduler then read "never backed up". The freshly loaded tracked entity above already
+        // holds the true value; leaving it alone is the fix. Same rule as LastLibrarySyncAt, which
+        // is absent from this whitelist for exactly the same reason.
         existingSettings.ComfyUiServerUrl = settings.ComfyUiServerUrl;
         existingSettings.LoraUpdateCheckStalenessDays = settings.LoraUpdateCheckStalenessDays;
         existingSettings.SyncNotIdentifiedRetryDays = settings.SyncNotIdentifiedRetryDays;

--- a/DiffusionNexus.Tests/Service/Services/AppSettingsServiceBackupStampTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/AppSettingsServiceBackupStampTests.cs
@@ -1,0 +1,164 @@
+using DiffusionNexus.DataAccess;
+using DiffusionNexus.Domain.Entities;
+using DiffusionNexus.Domain.Services;
+using DiffusionNexus.Service.Services;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace DiffusionNexus.Tests.Service.Services;
+
+/// <summary>
+/// #531. <see cref="AppSettings.LastBackupAt"/> is machine-local bookkeeping with a dedicated
+/// writer (<see cref="IAppSettingsService.UpdateLastBackupAtAsync"/>) — nothing on the Settings
+/// page edits it, so no detached snapshot a caller builds can carry a real value for it. While it
+/// sat in <c>SaveSettingsAsync</c>'s scalar whitelist, every such save copied the snapshot's CLR
+/// default <c>null</c> over the stored timestamp: open Settings, press Save, and the record of the
+/// last backup was gone — <see cref="DiffusionNexus.Service.Services.BackupScheduler"/> then read
+/// "never backed up" and treated a fresh backup as overdue.
+/// <para>
+/// The guarantee is the service's, not any one caller's: it holds however the snapshot was built,
+/// which is why the column was removed from the whitelist rather than carried through the Settings
+/// ViewModel. Same reasoning, same shape as the <see cref="AppSettings.LastLibrarySyncAt"/> pair in
+/// <c>AppSettingsServiceSyncSettingsTests</c>.
+/// </para>
+/// </summary>
+public sealed class AppSettingsServiceBackupStampTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly ServiceProvider _serviceProvider;
+    private readonly DirectoryInfo _tempDir = Directory.CreateTempSubdirectory("dn-appsettings-backup-tests-");
+
+    public AppSettingsServiceBackupStampTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var secureStorageMock = new Mock<ISecureStorage>();
+        secureStorageMock.Setup(s => s.Encrypt(It.IsAny<string?>())).Returns<string?>(v => v);
+        secureStorageMock.Setup(s => s.Decrypt(It.IsAny<string?>())).Returns<string?>(v => v);
+
+        var services = new ServiceCollection();
+        services.AddDataAccessLayer(options => options.UseSqlite(_connection));
+        services.AddSingleton(secureStorageMock.Object);
+        services.AddTransient<IAppSettingsService, AppSettingsService>();
+        services.AddTransient<ISettingsExportService, SettingsExportService>();
+
+        _serviceProvider = services.BuildServiceProvider();
+
+        using var scope = _serviceProvider.CreateScope();
+        var context = scope.ServiceProvider
+            .GetRequiredService<DiffusionNexus.DataAccess.Data.DiffusionNexusCoreDbContext>();
+        context.Database.EnsureCreated();
+    }
+
+    private IAppSettingsService CreateService(IServiceScope scope)
+        => scope.ServiceProvider.GetRequiredService<IAppSettingsService>();
+
+    private ISettingsExportService CreateExportService(IServiceScope scope)
+        => scope.ServiceProvider.GetRequiredService<ISettingsExportService>();
+
+    /// <summary>
+    /// Seeds the singleton row (<c>GetSettingsAsync</c> creates it on first read, as every real
+    /// startup path does) and stamps a backup through the dedicated writer — the state any user
+    /// who has ever run a backup is in.
+    /// </summary>
+    private async Task StampBackupAsync(DateTimeOffset at)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var service = CreateService(scope);
+        await service.GetSettingsAsync();
+        await service.UpdateLastBackupAtAsync(at);
+    }
+
+    [Fact]
+    public async Task SaveSettings_LeavesLastBackupAtUntouched_WhenTheDetachedSnapshotDoesNotCarryIt()
+    {
+        var backedUpAt = new DateTimeOffset(2026, 8, 1, 12, 0, 0, TimeSpan.Zero);
+        await StampBackupAsync(backedUpAt);
+
+        // The Settings page's save command: a detached AppSettings built fresh, with LastBackupAt
+        // left at its default null because the page has no such field to read.
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            await CreateService(scope).SaveSettingsAsync(new AppSettings { Id = 1, MaxBackups = 7 });
+        }
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var settings = await CreateService(scope).GetSettingsAsync();
+
+            settings.LastBackupAt.Should().Be(backedUpAt,
+                "a settings-page save must not erase the backup flow's own stamp — the scheduler reads it " +
+                "to decide staleness, so nulling it silently makes a fresh backup look overdue");
+            settings.MaxBackups.Should().Be(7,
+                "the save must still persist what the page DOES edit");
+        }
+    }
+
+    /// <summary>
+    /// The same guarantee through the second door: <c>SettingsExportService.ImportAsync</c> builds
+    /// its own detached snapshot from the export DTO, which carries no <c>LastBackupAt</c> either.
+    /// </summary>
+    [Fact]
+    public async Task ExportImport_DoesNotDisturbLastBackupAt()
+    {
+        var backedUpAt = new DateTimeOffset(2026, 8, 1, 12, 0, 0, TimeSpan.Zero);
+        var path = Path.Combine(_tempDir.FullName, "backup-stamp-export.json");
+
+        await StampBackupAsync(backedUpAt);
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            await CreateExportService(scope).ExportAsync(path);
+        }
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            await CreateExportService(scope).ImportAsync(path);
+        }
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var settings = await CreateService(scope).GetSettingsAsync();
+
+            settings.LastBackupAt.Should().Be(backedUpAt,
+                "a settings import must not disturb machine-local backup bookkeeping");
+        }
+    }
+
+    /// <summary>
+    /// The column is still writable — the dedicated writer is the one path that may change it, and
+    /// removing it from the save whitelist must not leave it frozen at its first value.
+    /// </summary>
+    [Fact]
+    public async Task UpdateLastBackupAt_StillMovesTheStampForward()
+    {
+        var first = new DateTimeOffset(2026, 8, 1, 12, 0, 0, TimeSpan.Zero);
+        var second = new DateTimeOffset(2026, 8, 20, 6, 30, 0, TimeSpan.Zero);
+
+        await StampBackupAsync(first);
+        await StampBackupAsync(second);
+
+        using var scope = _serviceProvider.CreateScope();
+        var settings = await CreateService(scope).GetSettingsAsync();
+
+        settings.LastBackupAt.Should().Be(second, "the backup flow's own writer still owns this column");
+    }
+
+    public void Dispose()
+    {
+        _serviceProvider.Dispose();
+        _connection.Dispose();
+        try
+        {
+            _tempDir.Delete(recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best effort — never fail a test run on temp-folder cleanup.
+        }
+    }
+}

--- a/DiffusionNexus.Tests/Service/Services/AppSettingsServiceSyncSettingsTests.cs
+++ b/DiffusionNexus.Tests/Service/Services/AppSettingsServiceSyncSettingsTests.cs
@@ -22,8 +22,9 @@ namespace DiffusionNexus.Tests.Service.Services;
 /// only via the dedicated <see cref="IAppSettingsService.UpdateLastLibrarySyncAtAsync"/>
 /// path (Task 5), so it is intentionally left OUT of the whitelist — the freshly
 /// loaded tracked entity already carries the real value, and copying a detached
-/// snapshot's default-initialized value over it would reproduce the same silent-null
-/// bug that already affects <c>LastBackupAt</c> on this exact code path.
+/// snapshot's default-initialized value over it would reproduce the silent-null bug
+/// that <c>LastBackupAt</c> had on this exact code path until #531 took it out of the
+/// whitelist too (see <c>AppSettingsServiceBackupStampTests</c>).
 /// </summary>
 public sealed class AppSettingsServiceSyncSettingsTests : IDisposable
 {

--- a/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
+++ b/DiffusionNexus.Tests/Viewer/LoraViewerViewModelSyncTests.cs
@@ -1540,6 +1540,84 @@ public class LoraViewerViewModelSyncTests
         outcome.FaultReason.Should().Contain("500", "the message must name the failure, not a verdict");
     }
 
+    /// <summary>
+    /// #532 item 2. The entry guard reads <c>SyncInFlight</c>, but the gate is taken inside the
+    /// service — and a download's completion sync can grab it in the window between the two. The
+    /// refusal then arrived as an exception out of this method, which the detail panel's generic
+    /// catch rendered as "Metadata download failed: A library sync is already running." with an
+    /// Error log: a "not now" dressed as a fault. The bulk path has always answered this the
+    /// friendly way; the per-tile path now says the same thing.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMetadataForTile_ARefusalFromTheGateIsNotAFailure()
+    {
+        var vm = CreateViewModel();
+
+        _sync.Setup(s => s.PlanAsync(It.IsAny<SyncScope>(), It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SyncScope s, SyncOptions o, CancellationToken _) => PlanFor(s, o, IdentifyStep(1)));
+        _sync.Setup(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new SyncAlreadyRunningException());
+
+        var outcome = await vm.DownloadMetadataForTileAsync(CreateTile(modelId: 42));
+
+        outcome.Applied.Should().BeFalse("nothing ran");
+        outcome.Faulted.Should().BeFalse("a refusal is not a bug — no error row, no \"see the log\"");
+        outcome.Refused.Should().BeTrue(
+            "the detail panel has to say \"already running\", not \"Nothing to refresh for this model.\"");
+        vm.SyncStatus.Should().Be("A metadata sync is already running.",
+            "the status line says why nothing happened, in the same words the bulk button uses");
+    }
+
+    /// <summary>
+    /// The other refusal door — our own entry guard, when a bulk run is visibly going — must say
+    /// the same thing. It set the status line correctly but returned a bare <c>NotRun</c>, which
+    /// the detail panel renders as "Nothing to refresh for this model.": a claim about the model,
+    /// made when the truth is that the button was busy.
+    /// </summary>
+    [Fact]
+    public async Task DownloadMetadataForTile_TheEntryGuardRefusalIsAlsoARefusal()
+    {
+        var vm = CreateViewModel();
+
+        var entered = new TaskCompletionSource();
+        var release = new TaskCompletionSource();
+        SetupSyncService();
+        _sync.Setup(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()))
+            .Returns(async (SyncPlan p, IProgress<LibrarySyncProgress>? _, CancellationToken _) =>
+            {
+                entered.TrySetResult();
+                await release.Task;
+                return ReportFor(p, discovered: 0, cancelled: false, []);
+            });
+
+        var bulk = vm.DownloadMissingMetadataCommand.ExecuteAsync(null);
+        await entered.Task;   // a run is in flight — the per-tile guard must see it
+
+        var outcome = await vm.DownloadMetadataForTileAsync(CreateTile(modelId: 42));
+
+        outcome.Refused.Should().BeTrue(
+            "being turned away because a run is going is the same answer whichever guard catches it");
+
+        release.TrySetResult();
+        await bulk;
+    }
+
+    /// <summary>The refusal must also leave the flag down, so the next press is not refused by our own guard.</summary>
+    [Fact]
+    public async Task DownloadMetadataForTile_ARefusedRunStillClearsTheInFlightFlag()
+    {
+        var vm = CreateViewModel();
+
+        _sync.Setup(s => s.PlanAsync(It.IsAny<SyncScope>(), It.IsAny<SyncOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SyncScope s, SyncOptions o, CancellationToken _) => PlanFor(s, o, IdentifyStep(1)));
+        _sync.Setup(s => s.ExecuteAsync(It.IsAny<SyncPlan>(), It.IsAny<IProgress<LibrarySyncProgress>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new SyncAlreadyRunningException());
+
+        await vm.DownloadMetadataForTileAsync(CreateTile(modelId: 42));
+
+        vm.IsSyncRunning.Should().BeFalse("the run we started never held the slot; the button must come back");
+    }
+
     // -------------------------------------------------------------------------------- single flight
 
     /// <summary>

--- a/DiffusionNexus.UI/Doc/LoraViewer.md
+++ b/DiffusionNexus.UI/Doc/LoraViewer.md
@@ -534,10 +534,13 @@ timeout, recorded as an ordinary `SyncFailure`, #536; the honest no stays disjoi
 identify records "checked, not on Civitai" as a completed item, never a failure) is checked
 FIRST and wins — a failed ask is not an answer, so it reads
 "Metadata download failed: {reason}" (or, when something was still applied before the failure,
-"Metadata partially refreshed — the run hit an error, see the log."); only then does
-`IdentifyPlanned` separate the two honest-no wordings — "No metadata found on Civitai for this
-file." when the step ran and found nothing, "Nothing to refresh for this model." when it planned
-nothing and therefore asked nobody.
+"Metadata partially refreshed — the run hit an error, see the log."); `Refused` (#532) comes next
+— the single-flight gate turned the press away, through either door (this method's own
+`SyncInFlight` guard, or `SyncAlreadyRunningException` from `ExecuteAsync` when a download's
+completion sync took the slot in between), which is neither a failure nor a verdict and reads
+"A metadata sync is already running."; only then does `IdentifyPlanned` separate the two honest-no
+wordings — "No metadata found on Civitai for this file." when the step ran and found nothing,
+"Nothing to refresh for this model." when it planned nothing and therefore asked nobody.
 
 **One run at a time, and the buttons say so.** The service is single-flight and *throws* on a
 second run rather than queueing it, so both ways in are switched off while one is going:
@@ -561,7 +564,7 @@ dispose the *next* run's token source, after which Cancel cancelled nothing.
 | Hash returns a version but no images | The `FetchImages` step covers it via the version endpoint |
 | Network/disk failure on one item | Recorded as a `SyncFailure` (step, model, reason) and counted in the report; the run continues |
 | `CivitaiId` already owned by another DB row | Only `CivitaiModelPageId` is set (grouping still works), warning logged |
-| A second run started while one is going | Refused before it starts: "A metadata sync is already running." (`ExecuteAsync` throws `SyncAlreadyRunningException` at its gate, before any work — the service is single-flight process-wide) |
+| A second run started while one is going | Refused before it starts: "A metadata sync is already running." (`ExecuteAsync` throws `SyncAlreadyRunningException` at its gate, before any work — the service is single-flight process-wide). Both entry points catch it: the per-tile path returns `TileMetadataSyncResult.AlreadyRunning` so the detail panel says the same thing rather than "Metadata download failed: …" (#532) |
 | An exception escapes outside the item loop (a step's `SelectAsync`, the API-key read) | The run aborts but `ExecuteAsync` still returns its report (#535): completed steps are recorded, `AbortReason` names the failure, the status leads with "Sync aborted — …", and "last full sync" is not stamped |
 | The post-run grid rebuild throws | The verdict and report dialog survive (#539); the `finally` backstop retries once under the overlay, and a second failure appends "grid refresh failed — press Refresh to reload" |
 | Service not registered | Button reports "Library sync not available." |

--- a/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/LoraViewerViewModel.cs
@@ -1970,6 +1970,13 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
                 // may be spoken over it (#535).
                 detail.StatusMessage = $"Metadata download failed: {outcome.FaultReason}";
             }
+            else if (outcome.Refused)
+            {
+                // The single-flight gate turned it down (#532). Nothing was asked and nothing is
+                // wrong, so this is neither a failure nor a verdict about this model — it is
+                // "try again in a moment", in the words the status line already uses.
+                detail.StatusMessage = AlreadyRunningStatus;
+            }
             else
             {
                 // "Nothing found" is a claim about Civitai, so it may only be made when we
@@ -2028,10 +2035,12 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
 
         // The service admits one run at a time (R10): while this one is going, the bulk button is
         // off too, and the detail panel's own button is off from the moment the flag flips.
+        // Refused, not a bare NotRun (#532): this is the same answer the gate gives below, and the
+        // detail panel must not turn "the button is busy" into "nothing to refresh for this model".
         if (SyncInFlight)
         {
             SyncStatus = AlreadyRunningStatus;
-            return TileMetadataSyncResult.NotRun;
+            return TileMetadataSyncResult.AlreadyRunning;
         }
 
         // Discovery is left out — one tile is not a reason to rescan every LoRA source — but the
@@ -2066,6 +2075,17 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
             // the selection queries and the file hash both run inline until the first real yield.
             plan = await Task.Run(() => _librarySync.PlanAsync(SyncScope.ForModels(modelId), options));
             report = await Task.Run(() => _librarySync.ExecuteAsync(plan));
+        }
+        catch (SyncAlreadyRunningException ex)
+        {
+            // The entry guard above reads OUR flag; the gate is the service's, and a download's
+            // completion sync can take it in between (#532). Refusing is not failing: unhandled,
+            // this reached the detail panel's generic catch as "Metadata download failed: …" with
+            // an Error log and a stack trace, for a run that simply has to wait its turn. Same
+            // answer as the bulk path, in the same words — and Refused so the panel can say it too,
+            // rather than falling through to "Nothing to refresh for this model."
+            ReportServiceAlreadyRunning(ex);
+            return TileMetadataSyncResult.AlreadyRunning;
         }
         finally
         {
@@ -2118,10 +2138,19 @@ public partial class LoraViewerViewModel : BusyViewModelBase, IDisposable
     /// The outcome of one per-tile metadata fetch. <paramref name="Report"/> is null only when the
     /// run never started (no sync service, or a tile with no persisted model).
     /// </summary>
-    public sealed record TileMetadataSyncResult(bool Applied, SyncReport? Report)
+    public sealed record TileMetadataSyncResult(bool Applied, SyncReport? Report, bool Refused = false)
     {
         /// <summary>A fetch that never reached the service.</summary>
         public static readonly TileMetadataSyncResult NotRun = new(Applied: false, Report: null);
+
+        /// <summary>
+        /// The service's single-flight gate turned this press down — a bulk run or a download's
+        /// completion sync holds the slot (#532). Distinct from <see cref="NotRun"/>'s other
+        /// causes: nothing is wrong, nothing was asked, and the answer is "try again in a moment"
+        /// rather than "nothing to refresh for this model".
+        /// </summary>
+        public static readonly TileMetadataSyncResult AlreadyRunning =
+            new(Applied: false, Report: null, Refused: true);
 
         /// <summary>
         /// How many models the identify step planned. Zero means it asked Civitai nothing at all,


### PR DESCRIPTION
Closes #531. Closes #532.

The two spin-offs left over from the metadata-sync overhaul (#521), one commit each, TDD throughout — every fix was watched failing first. Suite **4815 / 0 / 2** (+6 tests), IntegrationTests 2/2, UI build 0 warnings, all in Debug (the user's running app locks `bin\Release`; CI builds Release).

## #531 — every Settings save nulled `LastBackupAt` (`c6214464`)

`LastBackupAt` is machine-local bookkeeping with a dedicated writer (`UpdateLastBackupAtAsync`), but it sat in `SaveSettingsAsync`'s scalar whitelist. Nothing that builds one of those detached `AppSettings` snapshots has a value for it — the Settings page has no such field, and the export DTO doesn't carry it — so every save copied the CLR default `null` over the stored timestamp. `BackupScheduler` then read "never backed up" and treated a fresh backup as overdue.

Fixed by removing the column from the whitelist (the issue's preferred option) rather than carrying it through the Settings ViewModel: the guarantee then belongs to the service and holds however the caller built its snapshot — which also closes the same hole in `SettingsExportService.ImportAsync`, a second door the capture/replay alternative would have left open. Same rule and reasoning as `LastLibrarySyncAt`, which Plan E kept out of the whitelist for exactly this reason.

Checked before removing it: the only other caller that saves a snapshot carrying this column (`OutputsFolderRegistrar`) saves a *loaded* entity, so it is unaffected, and `LastBackupAt`/`LastLibrarySyncAt` are the only two dedicated-stamp columns in `IAppSettingsService` — the whitelist has no others of this kind left.

`AppSettingsServiceBackupStampTests` (real SQLite, mirroring the `LastLibrarySyncAt` pair): a Settings-page-shaped save preserves the stamp (RED-verified), an export/import round trip preserves it (RED-verified), and the dedicated writer still moves it forward (guards against over-fixing into a frozen column).

## #532 — the per-tile refusal surfaced as an error (`e74b377c`)

**Item 1 was already closed** by the Plan E fix wave — `BuildCompletionOptionsAsync` resolves the retry policy from settings. Verified in code before writing anything; nothing to do.

**Item 2:** `DownloadMetadataForTileAsync` guarded on its own `SyncInFlight` flag but never caught the gate's `SyncAlreadyRunningException`, and the gate is taken *inside* the service — a download's completion sync can grab it in the window between the two. The refusal escaped into the detail panel's generic catch as "Metadata download failed: A library sync is already running." with an Error log and a stack trace, for a run that simply has to wait its turn.

Now caught and reported exactly as the bulk path reports it (`ReportServiceAlreadyRunning`: status line + Info log, no error row). One addition beyond the issue text: the outcome carries `Refused`, because without it the refusal fell through to **"Nothing to refresh for this model."** — a claim about the model, made when the truth is that the button was busy. The pre-existing entry-guard door returns the same `Refused` outcome for the same reason, so both doors give one answer.

Three tests, all RED-verified (the first failed with the escaping `SyncAlreadyRunningException` at `LoraViewerViewModel.cs:2068`, exactly as the issue predicted): the gate refusal is not a failure and states itself, the entry-guard refusal is the same answer, and a refused run leaves the in-flight flag down so the next press is not refused by our own guard.

`Doc/LoraViewer.md` updated in both places the contract is taught — the per-tile message order and the fallbacks table.

## Not done here

`ModelFileSyncService.FullSyncAsync` still discards `DiscoveryResult.RepointedCount` (noted in the #542 review). It has no callers anywhere in the solution — dead code, and deleting it is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
