### PR TITLE
fix(civitai-queue): stop a second Start from double-running a gate-waiting job

### DIFF
--- a/DiffusionNexus.Tests/Viewer/CivitaiDownloadQueueStartResumeTests.cs
+++ b/DiffusionNexus.Tests/Viewer/CivitaiDownloadQueueStartResumeTests.cs
@@ -79,7 +79,7 @@ public sealed class CivitaiDownloadQueueStartResumeTests : IDisposable
         }
     }
 
-    private CivitaiDownloadQueue Queue(ICivitaiModelDownloader downloader) => new(
+    private CivitaiDownloadQueue Queue(ICivitaiModelDownloader? downloader) => new(
         downloader, logger: null, civitaiClient: null, destination: null,
         persistPathOverride: Path.Combine(_tempDir, $"q-{Guid.NewGuid():N}.json"));
 
@@ -192,5 +192,52 @@ public sealed class CivitaiDownloadQueueStartResumeTests : IDisposable
 
         downloader.CallsByVersion.GetValueOrDefault(3).Should().Be(1,
             "the gate-waiting job must not be scheduled a second time by a coalescing Start");
+    }
+
+    [Fact]
+    public async Task RetryJobAsync_DoesNotStartAJobAlreadyWaitingForAWorkerSlot()
+    {
+        // Same hazard as the Start/Start case, through the per-tile Retry button: the job is
+        // parked in _gate.WaitAsync and still reads Queued, so an unguarded Retry would reset
+        // its state under the live runner and schedule a second transfer.
+        var downloader = new BlockingDownloader();
+        var queue = Queue(downloader);
+        queue.Jobs.Add(NewJob(versionId: 1));
+        queue.Jobs.Add(NewJob(versionId: 2));
+        var waiting = NewJob(versionId: 3);
+        queue.Jobs.Add(waiting);
+
+        var firstStart = queue.StartAllAsync();
+        await downloader.FirstCallStarted.Task;
+
+        await queue.RetryJobAsync(waiting);
+
+        downloader.Release(8);
+        await firstStart;
+        Dispatcher.UIThread.RunJobs();
+
+        downloader.CallsByVersion.GetValueOrDefault(3).Should().Be(1,
+            "Retry on a job that is already scheduled must not run it a second time");
+    }
+
+    [Fact]
+    public async Task StartAllAsync_WithoutADownloader_FailsCancelledJobsToo()
+    {
+        // Start re-runs Cancelled jobs, so the no-service branch has to report on exactly the
+        // set it would have run. Leaving them Cancelled says "you cancelled this", which is a
+        // lie about why nothing happened.
+        var queue = Queue(null);
+        var queued = NewJob(versionId: 1);
+        var cancelled = NewJob(versionId: 2);
+        cancelled.CancelByUser();
+        cancelled.Status = JobStatus.Cancelled;
+        queue.Jobs.Add(queued);
+        queue.Jobs.Add(cancelled);
+
+        await queue.StartAllAsync();
+
+        queued.Status.Should().Be(JobStatus.Failed);
+        cancelled.Status.Should().Be(JobStatus.Failed);
+        cancelled.StatusMessage.Should().Be("Download service unavailable.");
     }
 }

--- a/DiffusionNexus.Tests/Viewer/CivitaiDownloadQueueStartResumeTests.cs
+++ b/DiffusionNexus.Tests/Viewer/CivitaiDownloadQueueStartResumeTests.cs
@@ -52,6 +52,8 @@ public sealed class CivitaiDownloadQueueStartResumeTests : IDisposable
         private readonly SemaphoreSlim _release = new(0);
         public int CallCount;
         public int CancelledCount;
+        /// <summary>Calls per version id — how the duplicate-run test spots a job started twice.</summary>
+        public readonly System.Collections.Concurrent.ConcurrentDictionary<int, int> CallsByVersion = new();
         public readonly TaskCompletionSource FirstCallStarted =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -61,6 +63,7 @@ public sealed class CivitaiDownloadQueueStartResumeTests : IDisposable
             DownloadRequest request, IProgress<DownloadProgress>? progress = null, CancellationToken ct = default)
         {
             Interlocked.Increment(ref CallCount);
+            CallsByVersion.AddOrUpdate(request.Version.Id, 1, (_, n) => n + 1);
             FirstCallStarted.TrySetResult();
             try
             {
@@ -160,5 +163,34 @@ public sealed class CivitaiDownloadQueueStartResumeTests : IDisposable
         Dispatcher.UIThread.RunJobs();
 
         job.Status.Should().Be(JobStatus.Completed);
+    }
+
+    [Fact]
+    public async Task StartAllAsync_DoesNotStartAJobThatIsAlreadyWaitingForAWorkerSlot()
+    {
+        // The queue's worker pool is two wide, so a third job sits inside RunGatedAsync's
+        // _gate.WaitAsync while its Status is still Queued — Downloading is only set after
+        // the slot is taken. A second Start therefore re-picks it as "pending" and schedules
+        // a SECOND concurrent runner for the same job: two transfers, two coordinator
+        // entries, a collision-renamed duplicate on disk.
+        var downloader = new BlockingDownloader();
+        var queue = Queue(downloader);
+        queue.Jobs.Add(NewJob(versionId: 1));
+        queue.Jobs.Add(NewJob(versionId: 2));
+        queue.Jobs.Add(NewJob(versionId: 3));
+
+        var firstStart = queue.StartAllAsync();
+        await downloader.FirstCallStarted.Task;
+        downloader.CallCount.Should().Be(2, "the pool is two wide; version 3 is queued behind the gate");
+
+        // User hits Start again (e.g. after adding nothing, or from the re-run path).
+        var secondStart = queue.StartAllAsync();
+
+        downloader.Release(8);
+        await Task.WhenAll(firstStart, secondStart);
+        Dispatcher.UIThread.RunJobs();
+
+        downloader.CallsByVersion.GetValueOrDefault(3).Should().Be(1,
+            "the gate-waiting job must not be scheduled a second time by a coalescing Start");
     }
 }

--- a/DiffusionNexus.UI/Services/CivitaiBrowser/CivitaiDownloadQueue.cs
+++ b/DiffusionNexus.UI/Services/CivitaiBrowser/CivitaiDownloadQueue.cs
@@ -355,19 +355,39 @@ public sealed class CivitaiDownloadQueue : ObservableObject
     /// </summary>
     public async Task RetryJobAsync(CivitaiDownloadJob job)
     {
-        if (job.Status is JobStatus.Downloading or JobStatus.Completed) return;
+        // Queued is excluded too: such a job is either already claimed by a runner waiting on
+        // the gate, or the next Start picks it up. Retrying it would only reset state under a
+        // runner that is about to use it.
+        if (job.Status is JobStatus.Downloading or JobStatus.Completed or JobStatus.Queued) return;
         if (_downloader is null) return;
 
-        job.ResetForRetry();
-        Persist();
-        RaiseCountsChanged();
+        // Claim BEFORE ResetForRetry. Resetting first would move the job to Queued and then —
+        // if the claim were lost to a previous runner that has posted its terminal status but
+        // not yet released the claim — leave it Queued with nobody running it.
+        if (!TryClaim(job))
+        {
+            _logger?.Debug(LogCategory.Download, "CivitaiQueue",
+                $"Retry ignored: {job.ModelName} — {job.VersionName} is still claimed by a worker.");
+            return;
+        }
 
-        _runCts ??= new CancellationTokenSource();
-        var ct = _runCts.Token;
+        try
+        {
+            job.ResetForRetry();
+            Persist();
+            RaiseCountsChanged();
 
-        _logger?.Info(LogCategory.Download, "CivitaiQueue",
-            $"Retrying: {job.ModelName} — {job.VersionName}");
-        await RunGatedAsync(job, ct);
+            _runCts ??= new CancellationTokenSource();
+            var ct = _runCts.Token;
+
+            _logger?.Info(LogCategory.Download, "CivitaiQueue",
+                $"Retrying: {job.ModelName} — {job.VersionName}");
+            await RunGatedCoreAsync(job, ct);
+        }
+        finally
+        {
+            Unclaim(job);
+        }
         RaiseCountsChanged();
         Persist();
     }
@@ -387,10 +407,7 @@ public sealed class CivitaiDownloadQueue : ObservableObject
     public void ClearAll()
     {
         var removed = Jobs.Count;
-        _runCts?.Cancel();
-        // Drop the fired CTS so the next Start/Retry creates a fresh run epoch instead
-        // of joining this cancelled one and instantly aborting every new job.
-        _runCts = null;
+        CancelRunEpoch();
         Jobs.Clear();
         Persist();
         RaiseCountsChanged();
@@ -422,8 +439,7 @@ public sealed class CivitaiDownloadQueue : ObservableObject
         // Cancel the run-wide CTS too so any queued jobs still waiting on a
         // semaphore slot exit cleanly. They keep their Queued status (the worker
         // never started touching them) and can be resumed via Start.
-        _runCts?.Cancel();
-        _runCts = null;
+        CancelRunEpoch();
 
         if (stoppedCount > 0)
         {
@@ -435,10 +451,10 @@ public sealed class CivitaiDownloadQueue : ObservableObject
     }
 
     /// <summary>
-    /// Runs all queued jobs through the worker pool, re-queuing Cancelled ones first
-    /// (that's the re-run path <see cref="AbortAllActive"/> promises). Subsequent calls
-    /// coalesce — already-running jobs aren't restarted; only Queued/Cancelled ones are
-    /// picked up.
+    /// Runs every Queued and Cancelled job through the worker pool — re-running the
+    /// Cancelled ones is the path <see cref="AbortAllActive"/> promises. Subsequent calls
+    /// coalesce: a job already claimed by a live runner is skipped, so no job is ever
+    /// scheduled twice, and jobs still waiting on a worker slot are left alone.
     /// </summary>
     public async Task StartAllAsync()
     {
@@ -446,20 +462,14 @@ public sealed class CivitaiDownloadQueue : ObservableObject
         {
             _logger?.Warn(LogCategory.Download, "CivitaiQueue",
                 "StartAll aborted: ICivitaiModelDownloader unavailable. Marking queued jobs as failed.");
-            foreach (var job in Jobs.Where(j => j.Status == JobStatus.Queued))
+            // Same set Start would have run — Cancelled jobs are re-run candidates, so they
+            // must report the unavailable service too rather than sitting silently Cancelled.
+            foreach (var job in Jobs.Where(j => j.Status is JobStatus.Queued or JobStatus.Cancelled))
             {
                 job.Status = JobStatus.Failed;
                 job.StatusMessage = "Download service unavailable.";
             }
             return;
-        }
-
-        // Cancelled jobs re-run on Start. ResetForRetry hands each a fresh un-cancelled
-        // token — the old one is still fired from the Cancel click, and the linked CTS
-        // in RunGatedAsync would otherwise abort them straight back to Cancelled.
-        foreach (var job in Jobs.Where(j => j.Status == JobStatus.Cancelled).ToList())
-        {
-            job.ResetForRetry();
         }
 
         // Join the current run epoch instead of cancelling it. Cancelling here used to
@@ -468,7 +478,11 @@ public sealed class CivitaiDownloadQueue : ObservableObject
         _runCts ??= new CancellationTokenSource();
         var ct = _runCts.Token;
 
-        var pending = Jobs.Where(j => j.Status == JobStatus.Queued).ToList();
+        // Cancelled jobs re-run on Start. The Cancelled -> Queued reset happens inside
+        // RunGatedAsync, under the claim, rather than in a pass here: a job whose previous
+        // runner has posted its terminal status but not yet released its claim would
+        // otherwise be reset to Queued and then skipped, stranding it with no runner.
+        var pending = Jobs.Where(j => j.Status is JobStatus.Queued or JobStatus.Cancelled).ToList();
         _logger?.Info(LogCategory.Download, "CivitaiQueue",
             $"Starting {pending.Count} download(s) (max concurrency: {_maxConcurrency})");
         var tasks = pending.Select(job => RunGatedAsync(job, ct)).ToList();
@@ -476,7 +490,12 @@ public sealed class CivitaiDownloadQueue : ObservableObject
         RaiseCountsChanged();
         Persist();
         var failedCount = ErrorCount;
-        var summary = $"Batch complete — {CompletedCount} done, {failedCount} failed, {ActiveCount} still active.";
+        // The counts are queue-wide, and Start now coalesces rather than cancelling, so
+        // another batch may still be running. Say that instead of implying the queue is done.
+        var stillActive = ActiveCount;
+        var summary = stillActive > 0
+            ? $"Start batch finished — {CompletedCount} done, {failedCount} failed, {stillActive} still active."
+            : $"Batch complete — {CompletedCount} done, {failedCount} failed.";
         // A batch with failures must not read as a routine Info line in the
         // Unified Console — the per-job errors are elsewhere in the scrollback.
         if (failedCount > 0)
@@ -493,15 +512,40 @@ public sealed class CivitaiDownloadQueue : ObservableObject
         // collision-renamed duplicate on disk. Claim the job for exactly one runner.
         // Registered before the first await so the caller's synchronous
         // Select(...).ToList() over pending jobs already sees the claim.
-        if (!TryClaim(job)) return;
+        if (!TryClaim(job))
+        {
+            // Not an error: the job is already owned by a live runner. Logged because the
+            // alternative — a job that silently does nothing on Start — leaves no other trail.
+            _logger?.Debug(LogCategory.Download, "CivitaiQueue",
+                $"Start skipped {job.ModelName} — {job.VersionName}: already claimed by a worker.");
+            return;
+        }
+
         try
         {
+            // Re-run of a cancelled job. ResetForRetry hands it a fresh un-cancelled token —
+            // the old one is still fired from the Cancel click, and the linked CTS in
+            // RunGatedCoreAsync would otherwise abort it straight back to Cancelled. Done
+            // under the claim so the reset and the run that consumes it are inseparable.
+            if (job.Status == JobStatus.Cancelled) job.ResetForRetry();
+
             await RunGatedCoreAsync(job, runCt).ConfigureAwait(false);
         }
         finally
         {
             Unclaim(job);
         }
+    }
+
+    /// <summary>
+    /// Cancels the current run epoch and drops the fired CTS, so the next Start/Retry
+    /// creates a fresh one instead of joining a cancelled epoch and instantly aborting
+    /// every new job. Both halves are the invariant — never cancel without nulling.
+    /// </summary>
+    private void CancelRunEpoch()
+    {
+        _runCts?.Cancel();
+        _runCts = null;
     }
 
     private bool TryClaim(CivitaiDownloadJob job)

--- a/DiffusionNexus.UI/Services/CivitaiBrowser/CivitaiDownloadQueue.cs
+++ b/DiffusionNexus.UI/Services/CivitaiBrowser/CivitaiDownloadQueue.cs
@@ -40,6 +40,14 @@ public sealed class CivitaiDownloadQueue : ObservableObject
     private int _maxConcurrency = 2;
     private CancellationTokenSource? _runCts;
 
+    /// <summary>
+    /// Jobs currently claimed by a worker — from the moment they are scheduled, not from the
+    /// moment they start transferring. Reference identity is what matters (the queue owns one
+    /// instance per job), and the set is touched from pool threads, hence the lock.
+    /// </summary>
+    private readonly HashSet<CivitaiDownloadJob> _scheduled = new();
+    private readonly object _scheduledLock = new();
+
     public CivitaiDownloadQueue(ICivitaiModelDownloader? downloader)
         : this(downloader, null, null, null)
     {
@@ -478,6 +486,35 @@ public sealed class CivitaiDownloadQueue : ObservableObject
     }
 
     private async Task RunGatedAsync(CivitaiDownloadJob job, CancellationToken runCt)
+    {
+        // A job waiting on the gate is still Queued — Downloading is only set once the slot
+        // is taken — so a second Start (or a Retry) re-picks it as "pending" and would run a
+        // second concurrent transfer for the same job: two coordinator entries and a
+        // collision-renamed duplicate on disk. Claim the job for exactly one runner.
+        // Registered before the first await so the caller's synchronous
+        // Select(...).ToList() over pending jobs already sees the claim.
+        if (!TryClaim(job)) return;
+        try
+        {
+            await RunGatedCoreAsync(job, runCt).ConfigureAwait(false);
+        }
+        finally
+        {
+            Unclaim(job);
+        }
+    }
+
+    private bool TryClaim(CivitaiDownloadJob job)
+    {
+        lock (_scheduledLock) return _scheduled.Add(job);
+    }
+
+    private void Unclaim(CivitaiDownloadJob job)
+    {
+        lock (_scheduledLock) _scheduled.Remove(job);
+    }
+
+    private async Task RunGatedCoreAsync(CivitaiDownloadJob job, CancellationToken runCt)
     {
         // Link the run-wide cancel (queue Start cycle / Clear all) with the per-job
         // cancel (user clicked Cancel on this tile). Either firing aborts only this job.


### PR DESCRIPTION
Follow-up review of #545 (already merged).

## The regression

#545 made `StartAllAsync` **join** the current run epoch (`_runCts ??= new`) instead of cancelling it. That correctly fixed Start killing in-flight downloads — but the epoch cancel was also the only thing preventing a job being scheduled twice.

A job parked inside `RunGatedAsync`'s `_gate.WaitAsync` is still `Queued`: `Status = Downloading` is set inside `RunJobAsync`, *after* the slot is taken. So a second `StartAllAsync` re-picks it in `Jobs.Where(j => j.Status == JobStatus.Queued)` and schedules a **second concurrent runner for the same job object**.

- Before #545: the epoch cancel tore the old waiter down, so exactly one runner survived.
- After #545: both survive → two transfers, two `DownloadCoordinator` entries, doubled bandwidth, and a collision-renamed duplicate file on disk.

The worker pool is two wide (`_gate = new(2)`), so **any queue of three or more jobs hits this on a second Start** — including the re-run path #545 itself added.

## Fix

`RunGatedAsync` claims the job in a `_scheduled` set before its first `await` (so the caller's synchronous `Select(...).ToList()` over pending jobs already sees the claim) and releases it in a `finally`. Reference identity; locked, since the release runs on a pool thread. This covers `RetryJobAsync` as well.

## Tests

New `StartAllAsync_DoesNotStartAJobThatIsAlreadyWaitingForAWorkerSlot` — verified to fail on the merged code (`CallsByVersion[3]` was 2, expected 1).

Full suite: **4867 passed, 0 failed, 2 skipped**. `DiffusionNexus.sln` builds clean.

## Rest of #545 reviewed and clean

- `_runCts ??=` epoch join and the `ResetForRetry` re-queue of Cancelled jobs are correct.
- `ClearAll` nulling the fired CTS closes the "new jobs instantly abort" hole; `AbortAllActive` already did the same, so both cancel sites are covered.
- Minor, not changed: `_runCts` is dropped without `Dispose()`. Disposing it while runners still hold linked tokens risks `ObjectDisposedException`, and the linked CTSs are already `using`-disposed, so the leak is a bare CTS with no registrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)