### PR TITLE
feat(workflows): keep run history in the results strip across runs

### DIFF
--- a/DiffusionNexus.Tests/ViewModels/SelectableImageResultsHistoryTests.cs
+++ b/DiffusionNexus.Tests/ViewModels/SelectableImageResultsHistoryTests.cs
@@ -1,0 +1,112 @@
+using System.Collections.ObjectModel;
+using DiffusionNexus.UI.Services;
+using DiffusionNexus.UI.ViewModels.Controls;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace DiffusionNexus.Tests.ViewModels;
+
+/// <summary>
+/// Covers <see cref="SelectableImageResultsViewModel.BeginRun"/> — the clear-vs-keep decision that
+/// lets Workflows accumulate a run history while single-batch hosts keep wiping the strip.
+/// </summary>
+public sealed class SelectableImageResultsHistoryTests
+{
+    private static ImageActionsViewModel MakeActions() =>
+        new(Mock.Of<IDatasetState>(), Mock.Of<IDatasetEventAggregator>());
+
+    private static ImageStatusItemViewModel MakeItem(string name) =>
+        new() { FileName = name, InputPath = $@"C:\in\{name}" };
+
+    [Fact]
+    public void BeginRun_ByDefault_ClearsPreviousItems()
+    {
+        var items = new ObservableCollection<ImageStatusItemViewModel> { MakeItem("a.png"), MakeItem("b.png") };
+        var vm = new SelectableImageResultsViewModel(items, MakeActions());
+
+        vm.BeginRun();
+
+        items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BeginRun_WhenKeepingHistory_RetainsPreviousItems()
+    {
+        var first = MakeItem("a.png");
+        var items = new ObservableCollection<ImageStatusItemViewModel> { first };
+        var vm = new SelectableImageResultsViewModel(items, MakeActions(), clearOnNewRun: false);
+
+        vm.BeginRun();
+        items.Add(MakeItem("b.png"));
+
+        items.Should().HaveCount(2);
+        items[0].Should().BeSameAs(first, "history keeps the oldest run first");
+    }
+
+    [Fact]
+    public void BeginRun_WhenKeepingHistory_DropsSelectionAndPrimaryItem()
+    {
+        var stale = MakeItem("a.png");
+        var items = new ObservableCollection<ImageStatusItemViewModel> { stale };
+        var vm = new SelectableImageResultsViewModel(items, MakeActions(), clearOnNewRun: false);
+        vm.SelectWithModifiers(stale, isShiftPressed: false, isCtrlPressed: false);
+        vm.PrimaryItem.Should().BeSameAs(stale);
+
+        vm.BeginRun();
+
+        stale.IsSelected.Should().BeFalse("a new run must not leave earlier tiles armed for Add/Send");
+        vm.PrimaryItem.Should().BeNull();
+        vm.SelectionCount.Should().Be(0);
+        vm.HasSelection.Should().BeFalse();
+    }
+
+    [Fact]
+    public void BeginRun_WhenKeepingHistory_TrimsOldestBeyondCap()
+    {
+        var items = new ObservableCollection<ImageStatusItemViewModel>();
+        for (var i = 0; i < 5; i++)
+            items.Add(MakeItem($"{i}.png"));
+
+        var vm = new SelectableImageResultsViewModel(items, MakeActions(), clearOnNewRun: false)
+        {
+            MaxHistoryItems = 3,
+        };
+
+        vm.BeginRun();
+
+        items.Should().HaveCount(3);
+        items.Select(i => i.FileName).Should().Equal("2.png", "3.png", "4.png");
+    }
+
+    [Fact]
+    public void BeginRun_WhenKeepingHistoryWithUnlimitedCap_TrimsNothing()
+    {
+        var items = new ObservableCollection<ImageStatusItemViewModel>();
+        for (var i = 0; i < 5; i++)
+            items.Add(MakeItem($"{i}.png"));
+
+        var vm = new SelectableImageResultsViewModel(items, MakeActions(), clearOnNewRun: false)
+        {
+            MaxHistoryItems = 0,
+        };
+
+        vm.BeginRun();
+
+        items.Should().HaveCount(5);
+    }
+
+    [Fact]
+    public void BeginRun_WhenClearing_ResetsPrimaryItem()
+    {
+        var stale = MakeItem("a.png");
+        var items = new ObservableCollection<ImageStatusItemViewModel> { stale };
+        var vm = new SelectableImageResultsViewModel(items, MakeActions());
+        vm.SelectWithModifiers(stale, isShiftPressed: false, isCtrlPressed: false);
+
+        vm.BeginRun();
+
+        vm.PrimaryItem.Should().BeNull();
+        vm.SelectionCount.Should().Be(0);
+    }
+}

--- a/DiffusionNexus.UI/ViewModels/Controls/SelectableImageResultsViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/Controls/SelectableImageResultsViewModel.cs
@@ -20,9 +20,17 @@ namespace DiffusionNexus.UI.ViewModels.Controls;
 public partial class SelectableImageResultsViewModel : ObservableObject
 {
     private ImageStatusItemViewModel? _lastClickedItem;
+    private readonly bool _clearOnNewRun;
 
     /// <summary>The result tiles (owned by the host; this VM only reads + flips <c>IsSelected</c>).</summary>
     public ObservableCollection<ImageStatusItemViewModel> Items { get; }
+
+    /// <summary>
+    /// Upper bound on retained tiles when <c>clearOnNewRun</c> is false, enforced by
+    /// <see cref="BeginRun"/> (oldest trimmed first). Each tile pins a decoded thumbnail, so an
+    /// uncapped history grows unbounded over a long session. Zero or less means no limit.
+    /// </summary>
+    public int MaxHistoryItems { get; set; } = 200;
 
     /// <summary>The reusable Add/Send actions, gated on the current selection.</summary>
     public ImageActionsViewModel Actions { get; }
@@ -40,12 +48,19 @@ public partial class SelectableImageResultsViewModel : ObservableObject
 
     public string SelectionText => SelectionCount == 1 ? "1 selected" : $"{SelectionCount} selected";
 
+    /// <param name="clearOnNewRun">
+    /// Whether <see cref="BeginRun"/> wipes the strip. True (the default) suits hosts that show only
+    /// the batch in flight; false keeps a run history that accumulates across runs, capped by
+    /// <see cref="MaxHistoryItems"/>.
+    /// </param>
     public SelectableImageResultsViewModel(
         ObservableCollection<ImageStatusItemViewModel> items,
-        ImageActionsViewModel actions)
+        ImageActionsViewModel actions,
+        bool clearOnNewRun = true)
     {
         Items = items ?? throw new ArgumentNullException(nameof(items));
         Actions = actions ?? throw new ArgumentNullException(nameof(actions));
+        _clearOnNewRun = clearOnNewRun;
 
         Actions.PathProvider = () => Task.FromResult(new ImageActionPaths(GetSelectedFilePaths()));
 
@@ -53,6 +68,57 @@ public partial class SelectableImageResultsViewModel : ObservableObject
         // state consistent when that happens.
         Items.CollectionChanged += OnItemsCollectionChanged;
         UpdateSelectionState();
+    }
+
+    /// <summary>
+    /// Prepares the strip for a run the host is about to start, then leaves it to append its tiles.
+    /// Wipes everything when the host asked to clear; otherwise keeps prior tiles as history and only
+    /// drops the carried-over selection and <see cref="PrimaryItem"/> — stale tiles must not stay
+    /// armed for Add/Send, and the comparison should follow the new run.
+    /// </summary>
+    public void BeginRun()
+    {
+        if (_clearOnNewRun)
+        {
+            var stale = Items.ToList();
+            Items.Clear();
+            DisposeThumbnails(stale);
+            return;
+        }
+
+        TrimToCap();
+        ClearSelectionSilent();
+        _lastClickedItem = null;
+        PrimaryItem = null;
+        UpdateSelectionState();
+    }
+
+    /// <summary>Drops the oldest tiles until the history fits <see cref="MaxHistoryItems"/>.</summary>
+    private void TrimToCap()
+    {
+        if (MaxHistoryItems <= 0) return;
+
+        var excess = Items.Count - MaxHistoryItems;
+        if (excess <= 0) return;
+
+        var dropped = Items.Take(excess).ToList();
+        for (var i = 0; i < excess; i++)
+            Items.RemoveAt(0);
+        DisposeThumbnails(dropped);
+    }
+
+    /// <summary>
+    /// Releases the decoded thumbnails of tiles already detached from <see cref="Items"/>. Detach
+    /// first, dispose second — disposing a bitmap still bound into the visual tree faults the render.
+    /// </summary>
+    private static void DisposeThumbnails(IEnumerable<ImageStatusItemViewModel> items)
+    {
+        foreach (var item in items)
+        {
+            var thumbnail = item.Thumbnail;
+            item.Thumbnail = null;
+            thumbnail?.Dispose();
+        }
     }
 
     private void OnItemsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)

--- a/DiffusionNexus.UI/ViewModels/Pipelines/PipelineRunViewModel.cs
+++ b/DiffusionNexus.UI/ViewModels/Pipelines/PipelineRunViewModel.cs
@@ -161,7 +161,10 @@ public abstract partial class PipelineRunViewModel : ViewModelBase, IDisposable,
             ShowSendToAnimeToReal = manifest.Id != "anime-to-real",
             ShowSendToImageEdit = manifest.Id != "image-to-image",
         };
-        Results = new SelectableImageResultsViewModel(Outputs, actions);
+        // clearOnNewRun: false — a Workflow's strip is a session run history. Starting another run
+        // appends to it instead of wiping what the previous run produced (Captioning, which shows only
+        // the batch in flight, keeps the clearing default).
+        Results = new SelectableImageResultsViewModel(Outputs, actions, clearOnNewRun: false);
 
         // ImageListInputControl mutates SingleImagePaths in place; subscribe so HasSingleImage + the
         // command CanExecute update (binding alone doesn't notify).
@@ -359,7 +362,7 @@ public abstract partial class PipelineRunViewModel : ViewModelBase, IDisposable,
             InputPath = input,
             Status = ImageProcessingStatus.Processing,
         };
-        Outputs.Clear();
+        Results.BeginRun();
         Outputs.Add(item);
         Results.PrimaryItem = item;
         _ = LoadThumbnailAsync(item);
@@ -437,8 +440,9 @@ public abstract partial class PipelineRunViewModel : ViewModelBase, IDisposable,
         TotalProgress = 0;
 
         // Pre-populate the strip with one pending tile per input, then update each as it runs.
-        Outputs.Clear();
-        Results.PrimaryItem = null;
+        // BeginRun retains earlier runs' tiles (this host keeps a history) but releases their
+        // selection, so PrimaryItem is free for the first result of THIS run to claim below.
+        Results.BeginRun();
         var items = inputs
             .Select(p => new ImageStatusItemViewModel { FileName = Path.GetFileName(p), InputPath = p })
             .ToList();
@@ -485,8 +489,9 @@ public abstract partial class PipelineRunViewModel : ViewModelBase, IDisposable,
                 TotalProgress = (i + 1) * 100.0 / TotalImageCount;
             }
 
-            var done = Outputs.Count(o => o.Status == ImageProcessingStatus.Done);
-            var failed = Outputs.Count(o => o.Status == ImageProcessingStatus.Failed);
+            // Tally this run's tiles, not Outputs — that also carries earlier runs' history now.
+            var done = items.Count(o => o.Status == ImageProcessingStatus.Done);
+            var failed = items.Count(o => o.Status == ImageProcessingStatus.Failed);
             CurrentProcessingStatus = failed > 0
                 ? $"Done — {done} generated, {failed} failed."
                 : $"Done — {done} image(s) generated.";


### PR DESCRIPTION
The Workflows result strip was wiped at the top of every run, so starting another generation destroyed everything the previous one produced. Captioning wants that clearing (it shows only the batch in flight), so the decision moves into the reusable results VM rather than being hardcoded per host.

SelectableImageResultsViewModel gains a `clearOnNewRun` ctor flag (default true, preserving today's behaviour) and a `BeginRun()` the host calls instead of clearing the collection itself. In keep mode BeginRun retains prior tiles but drops their selection and PrimaryItem — stale tiles must not stay armed for Add/Send, and the comparison should follow the new run. A MaxHistoryItems cap (200) trims oldest-first, since each tile pins a decoded thumbnail; thumbnails are detached from the collection before disposal so a bound bitmap is never disposed under the renderer.

PipelineRunViewModel opts in with clearOnNewRun: false. Its end-of-batch summary counted Done/Failed over the whole Outputs collection, which with a retained history would have reported every image generated this session — the tally is now scoped to the current run's tiles.